### PR TITLE
fix: permanently narrow audit determinism result types

### DIFF
--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -38,11 +38,21 @@ export async function GET(request: Request) {
     const determinismResults = await Promise.all(
       sequences.map(async (sequence) => {
         const result = await getDSGCoreDeterminism(sequence);
+
+        if (result.ok && "data" in result) {
+          return {
+            sequence,
+            ok: true,
+            data: result.data,
+            error: null,
+          };
+        }
+
         return {
           sequence,
-          ok: result.ok,
-          data: result.ok ? result.data : null,
-          error: result.ok ? null : result.error,
+          ok: false,
+          data: null,
+          error: "error" in result ? result.error : "Unknown error",
         };
       })
     );

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
Permanently fix the TypeScript narrowing in `app/api/audit/route.ts` for the `getDSGCoreDeterminism` result, and remove the temporary Next.js TypeScript build bypass in the same PR.

## Why
The project previously required `typescript.ignoreBuildErrors = true` in `next.config.js` to get past a type error in the audit route. This PR fixes the narrowing directly so the build can pass without relying on that bypass.

## Scope
- fix type narrowing for `getDSGCoreDeterminism` results in `app/api/audit/route.ts`
- stop accessing `result.data` directly on the original union
- remove `typescript.ignoreBuildErrors` from `next.config.js`
- no auth flow changes
- no billing webhook changes
- no Next.js upgrade in this PR

## Implementation
- add an explicit branch using `result.ok && "data" in result` before reading `result.data`
- return a normalized error object when the determinism call is not successful
- restore `next.config.js` to a normal config without the temporary TypeScript bypass

## Expected result
The project should build successfully without `typescript.ignoreBuildErrors`, while preserving the existing audit API behavior.
