### PR TITLE
chore(docs): add MRDR-100 v1.1 unified production spec and expand repo-truth report

### DIFF
--- a/docs/MRDR-100-v1.1-UNIFIED-PRODUCTION-SPEC.md
+++ b/docs/MRDR-100-v1.1-UNIFIED-PRODUCTION-SPEC.md
@@ -1,0 +1,218 @@
+# MRDR-100 v1.1 — Multi-Region Deterministic Replica Architecture
+
+> Status: **Working Architecture Spec** integrated from user-provided blueprint and aligned with current DSG terminology.
+>
+> Evidence boundary:
+> - Formal gate-core properties (Determinism, Safety Invariance, Constant-Time Bound with SMT-LIB v2 + Z3) are treated as verified artifact facts.
+> - Cross-repo runtime/monitor/product-assembly claims remain subject to repository-truth verification.
+
+## 0) นิยามฟันธง
+
+MRDR-100 คือสถาปัตยกรรม Geo-distributed deterministic state machine ที่หลาย region ทำงานพร้อมกันได้ แต่มีความจริงหนึ่งเดียว ผ่านกฎเดียวกัน, ลำดับเดียวกัน, state transition เดียวกัน, execute จริงเพียงครั้งเดียว, และ deterministic replay ได้ทุก region.
+
+## 1) เป้าหมายระบบ
+
+หลาย region ต้องได้ผลลัพธ์เดียวกันภายใต้เงื่อนไขเดียวกัน:
+
+\[
+\forall r_i, r_j,\quad S_t^{r_i} = S_t^{r_j}
+\]
+
+โดยความเท่ากันต้องเป็น **canonical deterministic state equivalence**.
+
+## 2) หลักคณิตศาสตร์
+
+### 2.1 Global State Model
+
+\[
+S_t^{global} = \langle S_t^{r_1}, S_t^{r_2}, \dots, S_t^{r_n} \rangle
+\]
+
+Production transition function:
+
+\[
+\delta := f(
+\text{canonical\_state},
+\text{canonical\_input},
+\text{canonical\_code},
+\text{canonical\_solver},
+\text{canonical\_env}
+)
+\]
+
+### 2.2 Deterministic Ordering
+
+ใช้ Global Logical Clock:
+
+\[
+L_t = \langle epoch, sequence \rangle
+\]
+
+- `epoch` = governance / rule-set version
+- `sequence` = global monotonic order
+
+### 2.3 Canonical Determinism Constraint
+
+1. input ต้อง canonicalized  
+2. state ต้อง canonicalized  
+3. serialization ต้อง deterministic  
+4. runtime artifact ต้อง pin version  
+5. solver/config ต้อง hash ได้  
+6. ห้าม hidden nondeterminism จาก thread/map ordering/float drift/retry timing
+
+## 3) System Architecture
+
+### 3.1 Global Blueprint
+
+- Global Governance (Invariants, Epoch, Config Hash)
+- Regional Full Replicas (Orchestrator, Generator, Entropy, Gate+Z3, Executor, Reward, Local State, State Hasher)
+- Global Log/Ledger (Append-Only, Totally Ordered, Replayable)
+
+### 3.2 Functional Roles
+
+- Global Governance: invariant + epoch + policy evolution
+- Regional Replica: full deterministic stack per region
+- Global Log/Ledger: deterministic backbone และ source-of-truth ของ transition order
+
+## 4) Deterministic Replication Rules
+
+- **Rule 1 — No Local Commit**: commit ได้เมื่อ log entry ถูกยอมรับเท่านั้น
+- **Rule 2 — Same Input, Same Gate, Same Result**: ALLOW/STABILIZE/BLOCK ต้องเหมือนกันภายใต้เงื่อนไข canonical เดียวกัน
+- **Rule 3 — Action Happens Once**: execute จริงเกิดที่ designated region เท่านั้น
+- **Rule 4 — External Effect Must Be Journaled**: decide → append intent → execute → append effect result → mirrors validate
+- **Rule 5 — Drift Is Detectable**: state hash mismatch = `DRIFT_DETECTED` + `STABILIZE`
+
+## 5) Global Log Specification
+
+### 5.1 Properties
+
+append-only, totally ordered, deterministic replay, audit-grade, hash-verifiable, single source of truth
+
+### 5.2 Canonical Log Entry Schema
+
+\[
+e_k = \langle
+k, epoch, input\_hash, prev\_state\_hash, decision, decision\_hash,
+executor, effect\_id, next\_state\_hash
+\rangle
+\]
+
+### 5.3 Allowed Backends
+
+- Allowed: Raft log, etcd (raft-based), Kafka single partition with strict failover, Spanner with strict commit discipline, on-prem raft cluster
+- Not allowed: multi-leader truth source, eventually-consistent DB as primary truth
+
+## 6) Exactly-Once Effect Discipline
+
+\[
+effect\_id = H(epoch, sequence, action, payload\_hash)
+\]
+
+- effect consumed แล้วห้าม re-execute
+- execute สำเร็จแต่ ACK หาย ต้อง recover จาก effect journal
+- mirrors ห้ามยิงซ้ำเอง
+
+## 7) Deterministic Runtime Contract
+
+- Canonical input/state serialization
+- Pinned runtime image + dependencies + solver + config hash + build provenance
+- Numeric safety: prefer integer/fixed-point on critical decision path
+
+## 8) Epoch Transition Protocol
+
+- epoch transition ต้องเป็น ordered log event
+- ห้าม mixed-epoch decision
+- migration ต้อง deterministic
+- replay ของ old epoch ต้อง valid จน cutover
+
+## 9) Deterministic Convergence Theorem
+
+Given:
+1) initial state เท่ากัน
+2) consume log prefix เดียวกัน
+3) deterministic transition บน canonicalized state/input/code/solver/env
+4) external effect journaled + bound to effect_id
+5) epoch transition ordered via log
+
+Then:
+
+\[
+\forall r_i, r_j,\quad Replay(S_0, L[1..t]) = S_t^{r_i} = S_t^{r_j}
+\]
+
+## 10) Failure Model
+
+- Region down → recover by replay
+- Network partition → stop commit
+- Solver failure → BLOCK all regions
+- Drift detection → STABILIZE all regions
+- Executor failure / lost ACK → resolve via effect journal + effect_id
+- Epoch mismatch → BLOCK / refuse transition
+- Log unavailable → read-only or halt (no commit)
+
+### 10.1 Safety Position
+
+**Consistency > Availability**
+
+## 11) Deployment Pattern
+
+- 1 global governance plane
+- 1 global ordered log
+- N regional full replicas
+- designated executor per action class/policy
+
+## 12) Terraform / Ops Blueprint (Normative Example)
+
+```hcl
+module "global_governance" {
+  source                = "./global"
+  epoch_id              = "GEN5-EPOCH-001"
+  entropy_threshold     = 0.72
+  config_hash           = "sha256:governance-config-hash"
+  solver_version        = "z3-4.12.x"
+  runtime_image_digest  = "sha256:deterministic-runtime-image"
+}
+```
+
+Regional modules must inherit same deterministic invariants (`epoch_id`, `config_hash`, `solver_version`, `runtime_image_digest`).
+
+## 13) Execution Flow
+
+1. รับ input  
+2. canonicalize input  
+3. read previous canonical state hash  
+4. evaluate gate + Z3  
+5. produce decision  
+6. append ordered log intent  
+7. designated region executes external action  
+8. append effect result  
+9. compute next state  
+10. compute `state_hash_t`  
+11. compare across regions  
+12. commit mirrored state
+
+## 14) What This Is / Is Not
+
+It is: deterministic replication, global truth machine, replayable distributed state machine, audit-friendly control architecture.
+
+It is not: best-effort active-active, eventual-consistency mesh, local-autonomy-first, multi-leader availability-first topology.
+
+## 15) Final Definition
+
+MRDR-100 v1.1 คือ:
+
+> Geo-distributed deterministic state machine with a single global ordering, canonical execution environment, and journaled external effects.
+
+## Appendices
+
+### A) Mapping to DSG terms used in this repo
+
+- `ALLOW | STABILIZE | BLOCK` decision triad aligns with existing control-plane decision model.
+- Formal gate verification artifact remains bounded to gate core properties only.
+
+### B) Verification Boundary Notes
+
+- จุดนี้ยังยืนยันไม่ได้จากไฟล์และข้อมูลที่มองเห็นอยู่
+- มองไม่เห็น repo/file/config ที่จำเป็นต่อการสรุปจุดนี้
+- ไม่มีหลักฐานพอจะสรุปเป็น fact
+- จะไม่เดาต่อ

--- a/docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md
+++ b/docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md
@@ -2,50 +2,144 @@
 
 GITHUB_CONTEXT: NOT_READY
 
-## Why not ready
+## 1) Current Verified Reality
 
-- Attempted to open remote repository refs with:
-  - `git ls-remote --heads https://github.com/tdealer01-crypto/DSG-ONE.git`
-- Result in this environment: `HTTP 403` from GitHub remote.
-- Therefore, cross-repo verification against the required remote repositories is not currently possible from this runtime.
+Progress update:
+- budget usage (this run, local evidence path): search=0, read=9, write=0
+- mode: normal
+- dropped to protect quota: all cross-org exploratory GitHub search and any non-essential remote scans
+- confirmed: local runtime/app/schema/docs reality in this repository
+- not yet confirmed: remote-repo code truth for the scan-first set
 
-## Local verified scope
+Verified from local files only (`/workspace/tdealer01-crypto-dsg-control-plane`):
+- Product shell is a Next.js control-plane app with dashboard pages and API routes.
+- README still marks product state as blueprint/handoff and names Supabase/Stripe wiring as next milestone.
+- `/api/execute` performs API-key auth, agent lookup, quota checks, core execution call, and persistence into executions/audit/usage tables.
+- Local Supabase SQL contains organization/user/agent/execution/audit/usage/billing structures.
 
-The findings below are verified from this local repository only:
-`/workspace/tdealer01-crypto-dsg-control-plane`.
+## 2) Verified Formal Core
 
-## Current verified reality (local repo)
+Locked verified artifact facts (accepted as verified core):
+- Determinism
+- Safety Invariance
+- Constant-Time Bound
+- proof format: SMT-LIB v2
+- solver: Z3
+- expected consistency result: `sat`
 
-- Product shell is a Next.js app with dashboard + API routes and Supabase/Stripe dependencies.
-- README declares product routes, API surface, and that current status is blueprint + handoff with Supabase/Stripe wiring as next milestone.
-- `execute` route enforces API key, agent status, per-agent and per-org quota, calls DSG core, and writes execution/audit/usage records.
-- Supabase schema includes organizations/users/agents/executions/audit/usage/billing tables.
+Boundary that remains true:
+- This verified scope is formal gate core only, not end-to-end runtime/monitor/product assembly verification.
 
-## Verified formal core
+## 3) Source of Truth Map
 
-- Local integration status and repo truth docs explicitly record formal verification claims for the DSG gate core:
-  - Determinism
-  - Safety Invariance
-  - Constant-Time Bound
-  - SMT-LIB v2 artifact checked by Z3 expecting `sat`
-- Scope boundary is explicitly limited to formal gate core and excludes end-to-end runtime/monitor/billing assembly verification.
-
-## Local source-of-truth map (as declared in this repo)
-
+From local `integration-status` + repo-truth documentation:
 - product shell: `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`
 - canonical gate: `tdealer01-crypto/DSG-Deterministic-Safety-Gate`
 - runtime: `tdealer01-crypto/DSG-ONE`
 - audit: `tdealer01-crypto/dsg-deterministic-audit`
 
-## Gap: formal gate vs runtime implementation (local evidence)
+## 4) Repo Classification
 
-- The control plane calls runtime-like endpoints (`/execute`, `/ledger`, `/audit/events`) via adapter code.
-- Compatibility probing code shows two profiles (`canonical_gate` vs `dsg_one_runtime`) and notes that execute-path mapping is inferred from read-only probes.
-- Local code therefore acknowledges contract-shape drift and requires cross-repo verification to confirm canonical runtime contract alignment.
+Based on local declared topology (remote verification pending):
+- `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`: canonical (product shell)
+- `tdealer01-crypto/DSG-Deterministic-Safety-Gate`: canonical (formal gate core)
+- `tdealer01-crypto/DSG-ONE`: canonical/supporting (runtime execution plane)
+- `tdealer01-crypto/dsg-deterministic-audit`: supporting (audit monitoring surface)
+- other listed repos: unclear until remote open succeeds
 
-## Mandatory missing-data statements
+## 5) Problems Actually Found
+
+- Remote repo verification path is blocked in this runtime (prior GitHub remote open returned HTTP 403 in this environment).
+- Local control-plane explicitly documents contract-shape drift between canonical gate and richer control-plane/runtime expectations.
+- Compatibility probing is read-only and inference-based; it does not prove write-path or full runtime contract correctness.
+
+## 6) Cross-Agent Synthesis
+
+Agent A (Repo Mapper):
+- Local repo mapped: Next.js app + Supabase migrations + API routes + docs.
+
+Agent B (Architecture / SoT):
+- Local architecture points to polyrepo topology (product shell, gate, runtime, audit split).
+
+Agent C (API/DB/Event):
+- API and DB artifacts exist locally for execution/audit/usage/billing path.
+
+Agent D (Mission Control / Live):
+- Dashboard/mission-like pages exist locally; live pipeline truth across repos not verifiable here.
+
+Agent E (Safety/Proof/Ledger):
+- Formal gate claims recorded locally; runtime ledger/proof integration remains cross-repo gap.
+
+Agent F (Runtime/Sandbox/Mirror):
+- Runtime authority appears externalized via DSG core adapter; sandbox/mirror truth not provable from this repo alone.
+
+Agent G (Auth/Billing/Usage):
+- Auth/billing/usage endpoints and schema scaffolding are present locally.
+
+Agent H (Integrator):
+- Best verified output is local-truth consolidation + explicit GITHUB_CONTEXT: NOT_READY.
+
+## 7) Unification Plan
+
+Minimal verified-first sequence:
+1. Restore remote read access to scan-first repos.
+2. Verify canonical runtime contracts directly in `DSG-ONE` and gate contracts in `DSG-Deterministic-Safety-Gate`.
+3. Align execute/ledger/audit contract map from inferred profiles to proven runtime routes.
+4. Keep control-plane as product shell; minimize contract changes until remote truth is proven.
+
+## 8) Files / Repos To Change
+
+Changed now (local, minimal):
+- `docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md` (structured one-shot report refresh)
+- `docs/MRDR-100-v1.1-UNIFIED-PRODUCTION-SPEC.md` (merged deterministic multi-region production spec document)
+
+No cross-repo write actions executed in this runtime.
+
+## 9) Exact Changes
+
+- Replaced prior short note with required 15-section execution-format report.
+- Added explicit budget/mode/what-was-cut statements.
+- Added MRDR-100 v1.1 merged production-spec document requested in latest review cycle.
+- Preserved strict fact-vs-inference boundary and missing-data mandatory statements.
+
+## 10) Git Actions Performed
+
+- local branch used: `unify/dsg-repo-truth`
+- staged report + MRDR spec files
+- committed documentation updates
+- PR draft prepared via tool after commit
+
+## 11) Commit Message
+
+`chore: add MRDR-100 unified production spec and link from repo-truth report`
+
+## 12) PR Draft
+
+Title:
+- `chore: add MRDR-100 unified production spec and link from repo-truth report`
+
+Body sections included:
+- Summary
+- Verified Reality
+- Source of Truth Decisions
+- Formal Gate vs Runtime Gap
+- Changes
+- Risks
+- Unknowns
+
+## 13) Risks / Impact
+
+- No runtime code path changed; this is documentation-only.
+- Main risk is stale assumptions if remote repos differ from local declared topology.
+- Report now explicitly prevents over-claiming beyond local evidence.
+
+## 14) Missing Info But Continued Anyway
 
 - จุดนี้ยังยืนยันไม่ได้จากไฟล์และข้อมูลที่มองเห็นอยู่
 - มองไม่เห็น repo/file/config ที่จำเป็นต่อการสรุปจุดนี้
 - ไม่มีหลักฐานพอจะสรุปเป็น fact
 - จะไม่เดาต่อ
+
+## 15) Hard Blockers
+
+- Remote GitHub repository read verification for scan-first set is blocked in this runtime path.


### PR DESCRIPTION
### Motivation
- Add a single, normative production-spec document for the MRDR-100 v1.1 deterministic multi-region replica architecture to capture canonical execution rules and deployment guidance. 
- Make the repo-truth report explicit about local verification boundaries, evidence limits, and the gap between the formal gate and runtime assemblies.

### Description
- Add `docs/MRDR-100-v1.1-UNIFIED-PRODUCTION-SPEC.md` containing the unified MRDR-100 v1.1 spec, including global log schema, deterministic constraints, epoch transition protocol, failure model, and deployment/ops examples. 
- Expand `docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md` to a structured, multi-section report that records local verified facts, repo classification, verification gaps, a unification plan, exact changes, and risk/impact notes. 
- Preserve strict fact-vs-inference boundaries and include provenance notes such as expected solver/proof format and the blocked remote verification status.

### Testing
- This is a documentation-only change and no automated tests were executed as part of this rollout. 
- No runtime code paths were modified and no CI failures were observed related to docs formatting in the local commit step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8ebffeed083268fc2a7295a4d92ab)