### PR TITLE
chore: add .gitignore and refresh multi-agent repo-truth report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.env.local

--- a/docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md
+++ b/docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md
@@ -2,50 +2,111 @@
 
 GITHUB_CONTEXT: NOT_READY
 
-## Why not ready
+## Coordinator status
+- Mode: normal
+- Estimated budget used (this run):
+  - Search queries: 0
+  - Read fetches: 9 local file reads + 1 remote ref probe
+  - Write actions: 2 local file writes (this report + `.gitignore`)
+- Quota protection decisions:
+  - Skipped broad org/repo-wide remote scans after first remote ref probe failed with HTTP 403.
+  - Continued with local repository truth only.
 
-- Attempted to open remote repository refs with:
-  - `git ls-remote --heads https://github.com/tdealer01-crypto/DSG-ONE.git`
-- Result in this environment: `HTTP 403` from GitHub remote.
-- Therefore, cross-repo verification against the required remote repositories is not currently possible from this runtime.
+## 1) Current Verified Reality
+- This repository is a Next.js control-plane application (`next@14`) with API routes, dashboard pages, Supabase persistence wiring, and Stripe dependency present in package dependencies.
+- The README explicitly marks the current state as blueprint/handoff with remaining work to wire complete Supabase and Stripe flows.
+- `/api/execute` enforces bearer auth, agent status checks, quota checks, DSG core execution, and persistence into executions/audit/usage tables.
 
-## Local verified scope
+## 2) Verified Formal Core
+- Verified artifact status is represented in-code as:
+  - solver `Z3`
+  - artifact format `SMT-LIB v2`
+  - expected result `sat`
+  - properties: Determinism, Safety Invariance, Constant-Time Bound.
+- Scope boundary is explicitly limited to formal gate core and does not claim complete runtime/monitor/billing/product-loop verification.
 
-The findings below are verified from this local repository only:
-`/workspace/tdealer01-crypto-dsg-control-plane`.
-
-## Current verified reality (local repo)
-
-- Product shell is a Next.js app with dashboard + API routes and Supabase/Stripe dependencies.
-- README declares product routes, API surface, and that current status is blueprint + handoff with Supabase/Stripe wiring as next milestone.
-- `execute` route enforces API key, agent status, per-agent and per-org quota, calls DSG core, and writes execution/audit/usage records.
-- Supabase schema includes organizations/users/agents/executions/audit/usage/billing tables.
-
-## Verified formal core
-
-- Local integration status and repo truth docs explicitly record formal verification claims for the DSG gate core:
-  - Determinism
-  - Safety Invariance
-  - Constant-Time Bound
-  - SMT-LIB v2 artifact checked by Z3 expecting `sat`
-- Scope boundary is explicitly limited to formal gate core and excludes end-to-end runtime/monitor/billing assembly verification.
-
-## Local source-of-truth map (as declared in this repo)
-
+## 3) Source of Truth Map
+From local `lib/integration-status.ts` declarations:
 - product shell: `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`
 - canonical gate: `tdealer01-crypto/DSG-Deterministic-Safety-Gate`
 - runtime: `tdealer01-crypto/DSG-ONE`
 - audit: `tdealer01-crypto/dsg-deterministic-audit`
 
-## Gap: formal gate vs runtime implementation (local evidence)
+## 4) Repo Classification
+- `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`: canonical (for dashboard/API/billing shell in local truth).
+- `tdealer01-crypto/DSG-Deterministic-Safety-Gate`: canonical (for formal gate core, per local source-of-truth mapping).
+- `tdealer01-crypto/DSG-ONE`: supporting/canonical runtime candidate (declared runtime authority in local mapping; not re-verified remotely in this run).
+- `tdealer01-crypto/dsg-deterministic-audit`: supporting (audit surface in local mapping).
+- Remaining requested repos: unclear (not remotely accessible from this environment in this run).
 
-- The control plane calls runtime-like endpoints (`/execute`, `/ledger`, `/audit/events`) via adapter code.
-- Compatibility probing code shows two profiles (`canonical_gate` vs `dsg_one_runtime`) and notes that execute-path mapping is inferred from read-only probes.
-- Local code therefore acknowledges contract-shape drift and requires cross-repo verification to confirm canonical runtime contract alignment.
+## 5) Problems Actually Found
+- Cross-repo remote verification is blocked from this runtime for required GitHub repos:
+  - `git ls-remote --heads https://github.com/tdealer01-crypto/DSG-ONE.git`
+  - result: HTTP 403 / ref-list failure.
+- This prevents direct confirmation of multi-repo architecture truth from live remote code in this run.
 
-## Mandatory missing-data statements
+## 6) Cross-Agent Synthesis
+- Agent A (Repo Mapper): local repo map complete; remote scan blocked.
+- Agent B (Architecture/SoT): source-of-truth map available locally, but cross-repo confirmation blocked.
+- Agent C (API/DB/Event): `/api/execute` plus Supabase tables show real contract/persistence path in local repo.
+- Agent D (UI/Mission Control): dashboard/app route surface exists in local repo structure.
+- Agent E (Safety/Proof/Ledger): formal core claims + compatibility probes exist; runtime linkage is inferred via read probes.
+- Agent F (Runtime/Sandbox/Mirror): runtime authority likely external repo; cannot verify from remote in this run.
+- Agent G (Auth/Billing/Usage): auth and usage/billing APIs exist locally.
+- Agent H (Integrator): continue with verified local evidence and explicitly mark remote unknowns.
 
+## 7) Unification Plan
+1. Keep formal core truth anchored in canonical gate repo.
+2. Define/lock one runtime contract profile (canonical gate vs DSG-ONE runtime) with executable conformance tests.
+3. Treat control-plane adapter as compatibility boundary until one runtime profile is promoted.
+4. Add remote-verified repo matrix once GitHub access succeeds.
+
+## 8) Files / Repos To Change
+- Changed in this run:
+  - `.gitignore`
+  - `docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md`
+- No cross-repo writes were attempted.
+
+## 9) Exact Changes
+- Added root `.gitignore` to prevent accidental inclusion of local runtime artifacts (`node_modules`, `.next`, `.env.local`).
+- Rewrote report with coordinator/budget status, evidence-only findings, explicit unknown boundaries, and multi-agent synthesis based on local files + one remote probe.
+
+## 10) Git Actions Performed
+- Pending commit on current local branch.
+- PR creation should be done after commit.
+
+## 11) Commit Message
+- `chore: update multi-agent repo truth report and ignore local build artifacts`
+
+## 12) PR Draft
+- Summary:
+  - add baseline ignore rules for local artifacts
+  - refresh 2026-03-29 multi-agent repo-truth report with evidence-only status and quota-safe execution notes
+- Verified Reality:
+  - local control-plane API/UI/persistence path is present
+  - formal-core claims recorded with explicit scope boundary
+- Source of Truth Decisions:
+  - retain local source-of-truth mapping as working map, without upgrading unverified remote claims to fact
+- Formal Gate vs Runtime Gap:
+  - runtime compatibility is inferred by read probes and requires remote repo verification for closure
+- Changes:
+  - `.gitignore`
+  - `docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md`
+- Risks:
+  - remote 403 limits cross-repo certainty
+- Unknowns:
+  - unresolved role/classification of non-local repos beyond declared mapping
+
+## 13) Risks / Impact
+- Low runtime risk (docs + ignore rules only).
+- Positive workflow impact by avoiding accidental `node_modules` tracking.
+- Architecture certainty remains partial until remote repo reads are possible.
+
+## 14) Missing Info But Continued Anyway
 - จุดนี้ยังยืนยันไม่ได้จากไฟล์และข้อมูลที่มองเห็นอยู่
 - มองไม่เห็น repo/file/config ที่จำเป็นต่อการสรุปจุดนี้
 - ไม่มีหลักฐานพอจะสรุปเป็น fact
 - จะไม่เดาต่อ
+
+## 15) Hard Blockers
+- Remote GitHub ref/content access failure (HTTP 403) in this environment for required cross-repo verification.


### PR DESCRIPTION
### Motivation
- Prevent accidental check-in of local build artifacts and record an evidence-only, quota-safe multi-agent repo-truth snapshot that documents local verified reality and cross-repo access blockers.

### Description
- Add a root `.gitignore` (`node_modules/`, `.next/`, `.env.local`) and update `docs/MULTI_AGENT_REPO_TRUTH_2026-03-29.md` to include coordinator status, local source-of-truth mapping, repo classification, known gaps (remote access blocked), and a unification plan.

### Testing
- Ran `npm run -s typecheck` which invoked `tsc` and failed due to missing `tsconfig.json` (typecheck did not complete), and no other automated test failures were introduced by these documentation/ignore-file changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8f09f7e508326b31f1af5ff98df22)