### PR TITLE
Add trial signup page and /auth/signup handler

### DIFF
--- a/app/auth/signup/route.ts
+++ b/app/auth/signup/route.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { createClient } from '../../../lib/supabase/server';
+
+function getSafeNext(value: string | null) {
+  if (!value || !value.startsWith('/')) return '/quickstart';
+  return value;
+}
+
+function toSlug(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const email = String(formData.get('email') || '').trim().toLowerCase();
+  const workspaceName = String(formData.get('workspace_name') || '').trim();
+  const fullName = String(formData.get('full_name') || '').trim();
+  const next = getSafeNext(String(formData.get('next') || ''));
+
+  const redirectToSignup = new URL('/signup', request.url);
+  redirectToSignup.searchParams.set('next', next);
+
+  if (!email) {
+    redirectToSignup.searchParams.set('error', 'missing-email');
+    return NextResponse.redirect(redirectToSignup, { status: 302 });
+  }
+
+  if (!workspaceName) {
+    redirectToSignup.searchParams.set('error', 'missing-workspace');
+    return NextResponse.redirect(redirectToSignup, { status: 302 });
+  }
+
+  try {
+    const admin = getSupabaseAdmin();
+
+    const { data: existingUser, error: existingUserErr } = await admin
+      .from('users')
+      .select('id, org_id, is_active')
+      .eq('email', email)
+      .maybeSingle();
+
+    if (existingUserErr) {
+      throw existingUserErr;
+    }
+
+    if (existingUser?.org_id && existingUser.is_active) {
+      redirectToSignup.searchParams.set('error', 'already-provisioned');
+      return NextResponse.redirect(redirectToSignup, { status: 302 });
+    }
+
+    const baseSlug = toSlug(workspaceName) || 'workspace';
+    const slug = `${baseSlug}-${randomUUID().slice(0, 8)}`;
+    const orgId = `org_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+
+    const { error: orgErr } = await admin.from('organizations').insert({
+      id: orgId,
+      name: workspaceName,
+      slug,
+      plan: 'trial',
+      status: 'active',
+    });
+
+    if (orgErr) {
+      throw orgErr;
+    }
+
+    if (existingUser?.id) {
+      const { error: updateUserErr } = await admin
+        .from('users')
+        .update({ org_id: orgId, is_active: true, role: 'owner' })
+        .eq('id', existingUser.id);
+
+      if (updateUserErr) {
+        throw updateUserErr;
+      }
+    } else {
+      const { error: insertUserErr } = await admin.from('users').insert({
+        email,
+        org_id: orgId,
+        role: 'owner',
+        is_active: true,
+      });
+
+      if (insertUserErr) {
+        throw insertUserErr;
+      }
+    }
+
+    const supabase = await createClient();
+    const confirmUrl = new URL('/auth/confirm', request.nextUrl.origin);
+    confirmUrl.searchParams.set('next', next);
+
+    const { error: otpErr } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: confirmUrl.toString(),
+        shouldCreateUser: true,
+        data: {
+          full_name: fullName || undefined,
+          workspace_name: workspaceName,
+        },
+      },
+    });
+
+    if (otpErr) {
+      throw otpErr;
+    }
+
+    redirectToSignup.searchParams.set('message', 'check-email');
+    return NextResponse.redirect(redirectToSignup, { status: 302 });
+  } catch (err) {
+    console.log('[signup] failed:', err);
+    redirectToSignup.searchParams.set('error', 'signup-failed');
+    return NextResponse.redirect(redirectToSignup, { status: 302 });
+  }
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,182 @@
+import Link from 'next/link';
+
+function getSafeNext(value?: string) {
+  if (!value || !value.startsWith('/')) return '/quickstart';
+  return value;
+}
+
+function getMessage(message?: string, error?: string) {
+  if (message === 'check-email') {
+    return {
+      tone: 'success',
+      text: 'Trial magic link sent. Open the email you entered to finish creating your workspace.',
+    };
+  }
+
+  if (error === 'missing-email') {
+    return {
+      tone: 'error',
+      text: 'Enter your email before starting the free trial.',
+    };
+  }
+
+  if (error === 'missing-workspace') {
+    return {
+      tone: 'error',
+      text: 'Enter a workspace name so DSG can create your trial organization.',
+    };
+  }
+
+  if (error === 'signup-failed') {
+    return {
+      tone: 'error',
+      text: 'We could not start the free trial. Try again or check signup provisioning settings.',
+    };
+  }
+
+  if (error === 'already-provisioned') {
+    return {
+      tone: 'success',
+      text: 'This email already has access. Sign in instead and continue in the control plane.',
+    };
+  }
+
+  return null;
+}
+
+export default function SignupPage({
+  searchParams,
+}: {
+  searchParams?: { error?: string; message?: string; next?: string };
+}) {
+  const next = getSafeNext(searchParams?.next);
+  const notice = getMessage(searchParams?.message, searchParams?.error);
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-white">
+      <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[1fr_0.95fr]">
+        <section className="rounded-[2rem] border border-white/10 bg-white/5 p-8 backdrop-blur-sm">
+          <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Start Free Trial</p>
+          <h1 className="mt-4 text-4xl font-bold">Try DSG before you commit</h1>
+          <p className="mt-4 text-base leading-7 text-slate-300">
+            Create a trial workspace, generate your first agent, run a real execution, and open the live mission monitor in minutes.
+          </p>
+
+          {notice ? (
+            <div
+              className={[
+                'mt-6 rounded-2xl border p-4 text-sm',
+                notice.tone === 'success'
+                  ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100'
+                  : 'border-red-500/30 bg-red-500/10 text-red-200',
+              ].join(' ')}
+            >
+              {notice.text}
+            </div>
+          ) : null}
+
+          <form action="/auth/signup" method="post" className="mt-8 space-y-4">
+            <input type="hidden" name="next" value={next} />
+
+            <div>
+              <label htmlFor="email" className="mb-2 block text-sm font-medium text-slate-200">
+                Work email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                placeholder="name@company.com"
+                className="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-4 text-slate-100 outline-none placeholder:text-slate-500"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="workspace_name" className="mb-2 block text-sm font-medium text-slate-200">
+                Workspace name
+              </label>
+              <input
+                id="workspace_name"
+                name="workspace_name"
+                type="text"
+                required
+                placeholder="Acme Security Lab"
+                className="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-4 text-slate-100 outline-none placeholder:text-slate-500"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="full_name" className="mb-2 block text-sm font-medium text-slate-200">
+                Full name <span className="text-slate-500">(optional)</span>
+              </label>
+              <input
+                id="full_name"
+                name="full_name"
+                type="text"
+                placeholder="Thanawat Suparongsuwan"
+                className="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-4 text-slate-100 outline-none placeholder:text-slate-500"
+              />
+            </div>
+
+            <button className="w-full rounded-2xl bg-emerald-400 px-5 py-4 font-semibold text-slate-950 transition hover:scale-[1.01]">
+              Start free trial
+            </button>
+          </form>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-3">
+            <div className="rounded-[1.5rem] border border-white/10 bg-slate-950/50 p-5">
+              <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Trial</p>
+              <p className="mt-3 text-2xl font-semibold">14 days</p>
+              <p className="mt-2 text-sm text-slate-300">Start with a real workspace instead of a fake demo account.</p>
+            </div>
+            <div className="rounded-[1.5rem] border border-white/10 bg-slate-950/50 p-5">
+              <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Included</p>
+              <p className="mt-3 text-2xl font-semibold">1000 exec</p>
+              <p className="mt-2 text-sm text-slate-300">Enough to create an agent, test policies, and validate monitor flows.</p>
+            </div>
+            <div className="rounded-[1.5rem] border border-white/10 bg-slate-950/50 p-5">
+              <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Outcome</p>
+              <p className="mt-3 text-2xl font-semibold">Quickstart</p>
+              <p className="mt-2 text-sm text-slate-300">Create your first agent and open the live entropy monitor right away.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[2rem] border border-white/10 bg-slate-900/70 p-8 shadow-2xl shadow-emerald-950/20">
+          <div className="rounded-[1.5rem] border border-emerald-400/20 bg-slate-950/90 p-6">
+            <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">What you get</p>
+            <div className="mt-6 grid gap-4">
+              {[
+                'Trial workspace auto-provisioned after email confirmation.',
+                'Starter agent generation and first execution walkthrough.',
+                'Live command workspace with monitor, readiness, and alerts.',
+                'Trial quota and billing state visible from day one.',
+              ].map((item, index) => (
+                <div key={item} className="flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-slate-200">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-emerald-400/10 font-semibold text-emerald-200">
+                    {index + 1}
+                  </div>
+                  <p className="text-sm leading-7">{item}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 rounded-[1.5rem] border border-white/10 bg-slate-900/70 p-5 text-sm text-slate-300">
+              <p className="font-semibold text-white">Already provisioned?</p>
+              <p className="mt-2 leading-7">
+                If your team already set up your DSG operator account, use the existing login flow instead of creating a new trial workspace.
+              </p>
+              <Link
+                href="/login"
+                className="mt-4 inline-flex rounded-2xl border border-white/10 px-4 py-3 font-semibold text-slate-100"
+              >
+                Sign in instead
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/E2E_AUTH_MONITOR_VERIFICATION_2026-03-29.md
+++ b/docs/E2E_AUTH_MONITOR_VERIFICATION_2026-03-29.md
@@ -1,0 +1,52 @@
+# E2E Verification — auth/login, auth/signup, api/core/monitor (2026-03-29)
+
+## Scope
+- POST `/auth/login`
+- POST `/auth/signup`
+- GET `/api/core/monitor` (after login)
+
+## Method
+1. Inspect route handlers and dependency chain.
+2. Confirm required runtime dependencies for true end-to-end behavior.
+3. Check repository notes for implementation state.
+
+## Verified facts from code
+
+### 1) POST `/auth/login`
+- Route exists and accepts `formData` (`email`, `next`).
+- Route queries `users` table for an active profile with non-null `org_id` before sending OTP.
+- Route calls `supabase.auth.signInWithOtp` with `shouldCreateUser: false`.
+- On success returns HTTP 302 redirect with `message=check-email`; on failure returns error redirect.
+
+### 2) POST `/auth/signup`
+- Route exists and accepts `formData` (`email`, `workspace_name`, `full_name`, `next`).
+- Route writes organization/user records via service-role Supabase client.
+- Route then calls `supabase.auth.signInWithOtp` with `shouldCreateUser: true`.
+- On success returns HTTP 302 redirect with `message=check-email`; on failure returns `error=signup-failed` redirect.
+
+### 3) GET `/api/core/monitor` (after login)
+- Route exists and requires authenticated Supabase user + active profile (`users.auth_user_id`, `org_id`, `is_active`).
+- On authorized access, route aggregates:
+  - DSG core health/metrics/ledger/audit/determinism calls.
+  - Supabase rows from `executions`, `agents`, `usage_counters`, `billing_subscriptions`.
+- Returns JSON payload with readiness/core/control_plane/billing/alerts.
+
+## End-to-end status judgment
+
+### Environment gate for real E2E
+- Both auth routes and monitor route hard-require Supabase env vars.
+- Missing env vars throw runtime errors (`Missing Supabase public environment variables` / `Missing Supabase server environment variables`).
+- `.env.example` leaves these values empty, so this repo alone does not provide runnable E2E by itself.
+
+### Repository declared state
+- README states this repo is currently a blueprint and the next milestone is wiring persistence/billing.
+
+## Verdict (strictly from visible repo evidence)
+- POST `/auth/login` **implemented at route level but E2E cannot be confirmed from visible local setup alone**.
+- POST `/auth/signup` **implemented at route level but E2E cannot be confirmed from visible local setup alone**.
+- `/api/core/monitor` **implemented and returns real aggregated data only when valid auth session + Supabase data/core dependencies are available; full E2E cannot be confirmed from visible local setup alone**.
+
+## Mandatory uncertainty statements
+- จุดนี้ยังยืนยันไม่ได้จากไฟล์และข้อมูลที่มองเห็นอยู่
+- มองไม่เห็น repo/file/config ที่จำเป็นต่อการสรุปจุดนี้
+- ไม่มีหลักฐานพอจะสรุปเป็น fact


### PR DESCRIPTION
### Motivation
- Enable a complete trial signup flow: the signup form needed a route to provision a trial org, create/update the user row, send a magic link, and redirect with user-visible message states.
- Provide a safe `next` redirect and basic validation so users receive actionable errors (`missing-email`, `missing-workspace`, `already-provisioned`, `signup-failed`, `check-email`).

### Description
- Added the signup UI at `app/signup/page.tsx` with fields `email`, `workspace_name`, optional `full_name`, hidden `next`, trial cards, and notice rendering for the expected message/error states.
- Implemented POST handler at `app/auth/signup/route.ts` which validates inputs, ensures a safe `next` (defaults to `/quickstart`), and checks for an existing provisioned user to return `already-provisioned` when appropriate.
- The route provisions a trial organization (`organizations`), either updates an existing unprovisioned `users` row or inserts a new owner row, then calls Supabase `signInWithOtp` to send a magic link (using `shouldCreateUser: true` and passing `full_name` / `workspace_name` as data), and redirects back to `/signup` with `message` or `error` query params.
- Utility behavior includes slug generation for the org via `toSlug(...)` and generation of stable unique `orgId` / `slug` values for created organizations.

### Testing
- Ran TypeScript type check with `npm run typecheck`, and it completed successfully.
- No other automated runtime tests were executed in this environment, so runtime behavior (Supabase OTP flow and DB inserts) was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9816d65f8832695196815081373c9)