### PR TITLE
Add core monitoring SSE stream, snapshot collector cron, UI monitor panel, and Vercel cron

### DIFF
--- a/app/api/core/stream/route.ts
+++ b/app/api/core/stream/route.ts
@@ -1,0 +1,163 @@
+import { createClient } from "../../../../lib/supabase/server";
+import { getSupabaseAdmin } from "../../../../lib/supabase-server";
+import {
+  getDSGCoreHealth,
+  getDSGCoreMetrics,
+  getDSGCoreAuditEvents,
+  getDSGCoreDeterminism,
+} from "../../../../lib/dsg-core";
+
+export const dynamic = "force-dynamic";
+
+type AccessResult =
+  | { ok: true; orgId: string }
+  | { ok: false; status: 401 | 403; error: string };
+
+async function requireActiveProfile(): Promise<AccessResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("users")
+    .select("org_id, is_active")
+    .eq("auth_user_id", user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, orgId: String(profile.org_id) };
+}
+
+function sse(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function GET() {
+  const access = await requireActiveProfile();
+  if (access.ok === false) {
+    return new Response(access.error, { status: access.status });
+  }
+
+  const orgId = access.orgId;
+  const admin = getSupabaseAdmin();
+
+  let stopStream: (() => void) | null = null;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      let closed = false;
+
+      const send = (event: string, data: unknown) => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(sse(event, data)));
+      };
+
+      const tick = async () => {
+        try {
+          const [health, metrics, audit, executionsRes] = await Promise.all([
+            getDSGCoreHealth(),
+            getDSGCoreMetrics(),
+            getDSGCoreAuditEvents(5),
+            admin
+              .from("executions")
+              .select("id, decision, latency_ms, created_at")
+              .eq("org_id", orgId)
+              .order("created_at", { ascending: false })
+              .limit(5),
+          ]);
+
+          send("core_health", health);
+          send("core_metrics", metrics);
+          send("audit_update", audit);
+
+          if (executionsRes.error) {
+            send("alert", {
+              level: "error",
+              code: "EXECUTION_FEED_FAILED",
+              message: executionsRes.error.message,
+            });
+          } else {
+            send("execution_update", executionsRes.data || []);
+          }
+
+          const latestSequence =
+            audit.ok && Array.isArray(audit.items) && audit.items.length > 0
+              ? Number(audit.items[0]?.sequence || 0)
+              : 0;
+
+          const determinism =
+            latestSequence > 0
+              ? await getDSGCoreDeterminism(latestSequence)
+              : { ok: false as const, error: "No sequence available" };
+
+          send("determinism_update", determinism);
+
+          const ready = !!health.ok && !!metrics.ok && !!audit.ok && !!determinism.ok;
+          const status = ready ? "ready" : health.ok ? "degraded" : "down";
+
+          send("readiness_update", {
+            ready,
+            status,
+            generated_at: new Date().toISOString(),
+          });
+        } catch (error) {
+          send("alert", {
+            level: "error",
+            code: "STREAM_FAILURE",
+            message: error instanceof Error ? error.message : "Unknown stream error",
+          });
+        }
+      };
+
+      send("connected", {
+        ok: true,
+        org_id: orgId,
+        connected_at: new Date().toISOString(),
+      });
+
+      void tick();
+      const updateTimer = setInterval(() => {
+        void tick();
+      }, 3000);
+
+      const heartbeatTimer = setInterval(() => {
+        send("heartbeat", { ts: new Date().toISOString() });
+      }, 15000);
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(updateTimer);
+        clearInterval(heartbeatTimer);
+        try {
+          controller.close();
+        } catch {
+          // no-op
+        }
+      };
+
+      stopStream = close;
+    },
+    cancel() {
+      stopStream?.();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/api/internal/collect-monitor-snapshot/route.ts
+++ b/app/api/internal/collect-monitor-snapshot/route.ts
@@ -1,0 +1,417 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "../../../../lib/supabase-server";
+import {
+  getDSGCoreHealth,
+  getDSGCoreMetrics,
+  getDSGCoreLedger,
+  getDSGCoreAuditEvents,
+  getDSGCoreDeterminism,
+} from "../../../../lib/dsg-core";
+
+export const dynamic = "force-dynamic";
+
+type AlertLevel = "warning" | "error";
+
+type MonitorAlert = {
+  level: AlertLevel;
+  code: string;
+  message: string;
+};
+
+async function recordAlertsForOrg(args: {
+  orgId: string;
+  snapshotId: number;
+  alerts: MonitorAlert[];
+}) {
+  const { orgId, snapshotId, alerts } = args;
+  const admin = getSupabaseAdmin();
+
+  for (const alert of alerts) {
+    const { data: existing, error: existingError } = await admin
+      .from("alert_events")
+      .select("id, occurrence_count")
+      .eq("org_id", orgId)
+      .eq("code", alert.code)
+      .eq("status", "open")
+      .order("last_seen_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (existingError) throw new Error(existingError.message);
+
+    if (existing?.id) {
+      const { error: updateError } = await admin
+        .from("alert_events")
+        .update({
+          message: alert.message,
+          level: alert.level,
+          last_seen_at: new Date().toISOString(),
+          occurrence_count: Number(existing.occurrence_count || 0) + 1,
+          context: { source_snapshot_id: snapshotId },
+        })
+        .eq("id", existing.id);
+
+      if (updateError) throw new Error(updateError.message);
+      continue;
+    }
+
+    const nowIso = new Date().toISOString();
+    const { error: insertError } = await admin.from("alert_events").insert({
+      org_id: orgId,
+      level: alert.level,
+      code: alert.code,
+      message: alert.message,
+      source: "core",
+      status: "open",
+      first_seen_at: nowIso,
+      last_seen_at: nowIso,
+      occurrence_count: 1,
+      severity_score: alert.level === "error" ? 85 : 60,
+      fingerprint: `${orgId}:${alert.code}`,
+      payload: alert,
+      context: { source_snapshot_id: snapshotId },
+    });
+
+    if (insertError) throw new Error(insertError.message);
+  }
+}
+
+function monthKey() {
+  return new Date().toISOString().slice(0, 7);
+}
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseBearerToken(req: Request) {
+  const header = req.headers.get("authorization") || "";
+  const [scheme, value] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !value) return null;
+  return value;
+}
+
+function requireCronAuth(req: Request) {
+  const configuredSecret = process.env.CRON_SECRET;
+  if (!configuredSecret) {
+    if (process.env.NODE_ENV === "production") {
+      return {
+        ok: false as const,
+        status: 500,
+        error: "CRON_SECRET is required in production",
+      };
+    }
+    return { ok: true as const };
+  }
+
+  const provided = parseBearerToken(req);
+  if (provided !== configuredSecret) {
+    return { ok: false as const, status: 401, error: "Unauthorized" };
+  }
+
+  return { ok: true as const };
+}
+
+function formatReadinessStatus(args: {
+  coreHealthOk: boolean;
+  coreMetricsOk: boolean;
+  ledgerOk: boolean;
+  auditOk: boolean;
+  determinismOk: boolean;
+}) {
+  const reasons: string[] = [];
+
+  if (!args.coreHealthOk) reasons.push("CORE_HEALTH_DOWN");
+  if (!args.coreMetricsOk) reasons.push("CORE_METRICS_UNAVAILABLE");
+  if (!args.ledgerOk) reasons.push("CORE_LEDGER_UNAVAILABLE");
+  if (!args.auditOk) reasons.push("CORE_AUDIT_UNAVAILABLE");
+  if (!args.determinismOk) reasons.push("CORE_DETERMINISM_UNAVAILABLE");
+
+  const ready = reasons.length === 0;
+  const status = ready ? "ready" : args.coreHealthOk ? "degraded" : "down";
+  const score = Math.max(0, 100 - reasons.length * 18);
+
+  return { ready, status, score, reasons };
+}
+
+async function collectOrgSnapshot(args: {
+  orgId: string;
+  billingPeriod: string;
+  today: string;
+  coreHealth: Awaited<ReturnType<typeof getDSGCoreHealth>>;
+  coreMetrics: Awaited<ReturnType<typeof getDSGCoreMetrics>>;
+  coreLedger: Awaited<ReturnType<typeof getDSGCoreLedger>>;
+  coreAudit: Awaited<ReturnType<typeof getDSGCoreAuditEvents>>;
+  determinism: Awaited<ReturnType<typeof getDSGCoreDeterminism>> | { ok: false; error: string };
+}) {
+  const admin = getSupabaseAdmin();
+  const { orgId, billingPeriod, today, coreHealth, coreMetrics, coreLedger, coreAudit, determinism } =
+    args;
+
+  const [executionsRes, activeAgentsRes, usageCountersRes] = await Promise.all([
+    admin.from("executions").select("decision, latency_ms, created_at").eq("org_id", orgId),
+    admin
+      .from("agents")
+      .select("*", { count: "exact", head: true })
+      .eq("org_id", orgId)
+      .eq("status", "active"),
+    admin
+      .from("usage_counters")
+      .select("included_executions, overage_executions, projected_amount_usd, executions")
+      .eq("org_id", orgId)
+      .eq("billing_period", billingPeriod),
+  ]);
+
+  if (executionsRes.error) throw new Error(executionsRes.error.message);
+  if (activeAgentsRes.error) throw new Error(activeAgentsRes.error.message);
+  if (usageCountersRes.error) throw new Error(usageCountersRes.error.message);
+
+  const executions = executionsRes.data || [];
+  const todayExecutions = executions.filter((row) =>
+    String(row.created_at || "").startsWith(today)
+  );
+
+  const total = todayExecutions.length;
+  const allow = todayExecutions.filter((row) => row.decision === "ALLOW").length;
+  const block = todayExecutions.filter((row) => row.decision === "BLOCK").length;
+  const stabilize = todayExecutions.filter((row) => row.decision === "STABILIZE").length;
+
+  const avgLatencyMs = total
+    ? Number(
+        (
+          todayExecutions.reduce((sum, row) => sum + Number(row.latency_ms || 0), 0) / total
+        ).toFixed(3)
+      )
+    : 0;
+
+  const usageRows = usageCountersRes.data || [];
+  const executionsThisMonth = usageRows.reduce(
+    (sum, row) => sum + Number(row.executions || 0),
+    0
+  );
+  const includedExecutions = usageRows.reduce(
+    (sum, row) => sum + Number(row.included_executions || 0),
+    0
+  );
+  const overageExecutions = usageRows.reduce(
+    (sum, row) => sum + Number(row.overage_executions || 0),
+    0
+  );
+  const projectedAmountUsd = usageRows.reduce(
+    (sum, row) => sum + Number(row.projected_amount_usd || 0),
+    0
+  );
+
+  const readiness = formatReadinessStatus({
+    coreHealthOk: !!coreHealth.ok,
+    coreMetricsOk: !!coreMetrics.ok,
+    ledgerOk: !!coreLedger.ok,
+    auditOk: !!coreAudit.ok,
+    determinismOk: !!determinism.ok,
+  });
+
+  const alerts: MonitorAlert[] = [
+    ...(!coreHealth.ok
+      ? [
+          {
+            level: "error" as const,
+            code: "CORE_DOWN",
+            message: ("error" in coreHealth ? coreHealth.error : null) || "DSG core is unavailable",
+          },
+        ]
+      : []),
+    ...(!coreMetrics.ok
+      ? [
+          {
+            level: "warning" as const,
+            code: "CORE_METRICS_UNAVAILABLE",
+            message: ("error" in coreMetrics ? coreMetrics.error : null) || "Core metrics unavailable",
+          },
+        ]
+      : []),
+    ...(!determinism.ok
+      ? [
+          {
+            level: "warning" as const,
+            code: "DETERMINISM_UNAVAILABLE",
+            message: "error" in determinism ? determinism.error : "Latest determinism probe unavailable",
+          },
+        ]
+      : []),
+  ];
+
+  const determinismData =
+    determinism.ok && "data" in determinism ? determinism.data : null;
+
+  const snapshotPayload = {
+    org_id: orgId,
+    snapshot_at: new Date().toISOString(),
+    window_seconds: 60,
+    core_health_ok: !!coreHealth.ok,
+    core_metrics_ok: !!coreMetrics.ok,
+    ledger_ok: !!coreLedger.ok,
+    audit_ok: !!coreAudit.ok,
+    determinism_ok: !!determinism.ok,
+    health_source_path: "/api/core/health",
+    metrics_source_path: "/api/core/metrics",
+    ledger_source_path: "/api/core/ledger",
+    audit_source_path: "/api/core/audit",
+    determinism_source_path: "/api/core/determinism",
+    latest_sequence: coreAudit.ok ? Number(coreAudit.items?.[0]?.sequence || 0) : null,
+    deterministic: determinismData ? Boolean(determinismData.deterministic) : null,
+    region_count: determinismData ? Number(determinismData.region_count || 0) : null,
+    unique_state_hashes: determinismData
+      ? Number(determinismData.unique_state_hashes || 0)
+      : null,
+    max_entropy: determinismData ? Number(determinismData.max_entropy || 0) : null,
+    gate_action: determinismData ? determinismData.gate_action || null : null,
+    requests_today: total,
+    allow_count_today: allow,
+    block_count_today: block,
+    stabilize_count_today: stabilize,
+    allow_rate: total ? allow / total : 0,
+    block_rate: total ? block / total : 0,
+    stabilize_rate: total ? stabilize / total : 0,
+    avg_latency_ms: avgLatencyMs,
+    active_agents: Number(activeAgentsRes.count || 0),
+    executions_this_month: executionsThisMonth,
+    included_executions: includedExecutions,
+    overage_executions: overageExecutions,
+    projected_amount_usd: projectedAmountUsd,
+    readiness_status: readiness.status,
+    readiness_score: readiness.score,
+    readiness_reasons: readiness.reasons,
+    alerts_count: alerts.length,
+    alerts,
+    raw_core_metrics: coreMetrics,
+    raw_health: coreHealth,
+    raw_ledger_summary: coreLedger,
+    raw_audit_summary: coreAudit,
+    raw_determinism: determinism,
+  };
+
+  const { data: snapshot, error: snapshotError } = await admin
+    .from("core_monitor_snapshots")
+    .insert(snapshotPayload)
+    .select("id")
+    .single();
+
+  if (snapshotError) throw new Error(snapshotError.message);
+
+  const { error: readinessError } = await admin.from("readiness_history").insert({
+    org_id: orgId,
+    recorded_at: new Date().toISOString(),
+    status: readiness.status,
+    score: readiness.score,
+    core_health_ok: !!coreHealth.ok,
+    core_metrics_ok: !!coreMetrics.ok,
+    ledger_ok: !!coreLedger.ok,
+    audit_ok: !!coreAudit.ok,
+    determinism_ok: !!determinism.ok,
+    reason_codes: readiness.reasons,
+    details: {
+      source_snapshot_id: snapshot.id,
+      requests_today: total,
+      active_agents: Number(activeAgentsRes.count || 0),
+      alerts_count: alerts.length,
+    },
+  });
+
+  if (readinessError) throw new Error(readinessError.message);
+
+  if (alerts.length > 0) {
+    await recordAlertsForOrg({ orgId, snapshotId: snapshot.id, alerts });
+  }
+
+  return {
+    orgId,
+    snapshotId: snapshot.id,
+    readiness: readiness.status,
+    alerts: alerts.length,
+  };
+}
+
+export async function GET(req: Request) {
+  try {
+    const auth = requireCronAuth(req);
+    if (!auth.ok) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+
+    const admin = getSupabaseAdmin();
+    const { data: users, error: usersError } = await admin
+      .from("users")
+      .select("org_id")
+      .eq("is_active", true)
+      .not("org_id", "is", null);
+
+    if (usersError) {
+      return NextResponse.json({ error: usersError.message }, { status: 500 });
+    }
+
+    const orgIds = Array.from(new Set((users || []).map((row) => String(row.org_id))));
+
+    if (orgIds.length === 0) {
+      return NextResponse.json({ ok: true, processed: 0, snapshots: [] });
+    }
+
+    const [coreHealth, coreMetrics, coreLedger, coreAudit] = await Promise.all([
+      getDSGCoreHealth(),
+      getDSGCoreMetrics(),
+      getDSGCoreLedger(10),
+      getDSGCoreAuditEvents(10),
+    ]);
+
+    const latestSequence =
+      coreAudit.ok && Array.isArray(coreAudit.items) && coreAudit.items.length > 0
+        ? Number(coreAudit.items[0]?.sequence || 0)
+        : 0;
+
+    const determinism =
+      latestSequence > 0
+        ? await getDSGCoreDeterminism(latestSequence)
+        : ({ ok: false, error: "No sequence available" } as const);
+
+    const billingPeriod = monthKey();
+    const today = todayKey();
+
+    const settled = await Promise.allSettled(
+      orgIds.map((orgId) =>
+        collectOrgSnapshot({
+          orgId,
+          billingPeriod,
+          today,
+          coreHealth,
+          coreMetrics,
+          coreLedger,
+          coreAudit,
+          determinism,
+        })
+      )
+    );
+
+    const snapshots = settled
+      .filter((entry): entry is PromiseFulfilledResult<{ orgId: string; snapshotId: number; readiness: string; alerts: number }> => entry.status === "fulfilled")
+      .map((entry) => entry.value);
+
+    const failures = settled
+      .filter((entry): entry is PromiseRejectedResult => entry.status === "rejected")
+      .map((entry) =>
+        entry.reason instanceof Error ? entry.reason.message : "Unknown org snapshot failure"
+      );
+
+    return NextResponse.json({
+      ok: failures.length === 0,
+      processed: snapshots.length,
+      failed: failures.length,
+      snapshots,
+      failures,
+      generated_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unexpected error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/app-shell/page.tsx
+++ b/app/app-shell/page.tsx
@@ -1,6 +1,27 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+
+type StreamStatus = 'connecting' | 'live' | 'error';
+
+type StreamState = {
+  streamStatus: StreamStatus;
+  connectedAt: string | null;
+  lastHeartbeat: string | null;
+  readinessStatus: 'ready' | 'degraded' | 'down' | null;
+  latestExecutions: Array<{
+    id: string;
+    decision: 'ALLOW' | 'STABILIZE' | 'BLOCK' | string;
+    latency_ms: number | null;
+    created_at: string;
+  }>;
+  activeAlerts: Array<{
+    level: 'warning' | 'error' | string;
+    code: string;
+    message: string;
+  }>;
+};
 
 const links = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -14,12 +35,117 @@ const links = [
   { href: '/dashboard/audit', label: 'Audit' },
 ];
 
+const initialState: StreamState = {
+  streamStatus: 'connecting',
+  connectedAt: null,
+  lastHeartbeat: null,
+  readinessStatus: null,
+  latestExecutions: [],
+  activeAlerts: [],
+};
+
+function parseEventData<T>(data: string): T | null {
+  try {
+    return JSON.parse(data) as T;
+  } catch {
+    return null;
+  }
+}
+
 export default function AppShellPage() {
+  const [stream, setStream] = useState<StreamState>(initialState);
+
+  useEffect(() => {
+    const source = new EventSource('/api/core/stream');
+
+    const onConnected = (event: MessageEvent) => {
+      const payload = parseEventData<{ connected_at?: string }>(event.data);
+      if (!payload) return;
+      setStream((prev) => ({
+        ...prev,
+        streamStatus: 'live',
+        connectedAt: payload.connected_at || new Date().toISOString(),
+      }));
+    };
+
+    const onReadiness = (event: MessageEvent) => {
+      const payload = parseEventData<{ status?: 'ready' | 'degraded' | 'down' }>(event.data);
+      if (!payload) return;
+      setStream((prev) => ({
+        ...prev,
+        readinessStatus: payload.status || null,
+      }));
+    };
+
+    const onExecutions = (event: MessageEvent) => {
+      const payload = parseEventData<StreamState['latestExecutions']>(event.data);
+      if (!payload) return;
+      setStream((prev) => ({
+        ...prev,
+        latestExecutions: Array.isArray(payload) ? payload : prev.latestExecutions,
+      }));
+    };
+
+    const onHeartbeat = (event: MessageEvent) => {
+      const payload = parseEventData<{ ts?: string }>(event.data);
+      if (!payload) return;
+      setStream((prev) => ({
+        ...prev,
+        lastHeartbeat: payload.ts || new Date().toISOString(),
+      }));
+    };
+
+    const onAlert = (event: MessageEvent) => {
+      const payload = parseEventData<StreamState['activeAlerts'][number]>(event.data);
+      if (!payload) return;
+      setStream((prev) => ({
+        ...prev,
+        activeAlerts: [payload, ...prev.activeAlerts].slice(0, 5),
+      }));
+    };
+
+    source.onopen = () => {
+      setStream((prev) => ({ ...prev, streamStatus: 'live' }));
+    };
+
+    source.addEventListener('connected', onConnected);
+    source.addEventListener('readiness_update', onReadiness);
+    source.addEventListener('execution_update', onExecutions);
+    source.addEventListener('heartbeat', onHeartbeat);
+    source.addEventListener('alert', onAlert);
+    source.onerror = () => {
+      setStream((prev) => ({ ...prev, streamStatus: 'error' }));
+    };
+
+    return () => {
+      source.removeEventListener('connected', onConnected);
+      source.removeEventListener('readiness_update', onReadiness);
+      source.removeEventListener('execution_update', onExecutions);
+      source.removeEventListener('heartbeat', onHeartbeat);
+      source.removeEventListener('alert', onAlert);
+      source.close();
+    };
+  }, []);
+
+  const streamBadge = useMemo(() => {
+    if (stream.streamStatus === 'live') return 'LIVE';
+    if (stream.streamStatus === 'error') return 'ERROR';
+    return 'CONNECTING';
+  }, [stream.streamStatus]);
+
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-6xl">
-        <h1 className="text-3xl font-semibold">DSG ONE App Shell</h1>
-        <p className="mt-2 text-slate-400">Unified entry page for the live command center routes.</p>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold">DSG ONE App Shell</h1>
+            <p className="mt-2 text-slate-400">Unified entry page with live monitor stream from /api/core/stream.</p>
+          </div>
+          <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-4 py-1 text-sm font-semibold text-emerald-300">
+            {streamBadge}
+          </span>
+        </div>
+
         <div className="mt-8 grid gap-4 md:grid-cols-3">
           {links.map((link) => (
             <Link key={link.href} href={link.href} className="rounded-2xl border border-slate-800 bg-slate-900 p-6 font-semibold text-slate-100 hover:border-emerald-400">
@@ -27,6 +153,57 @@ export default function AppShellPage() {
             </Link>
           ))}
         </div>
+
+        <section className="mt-8 grid gap-4 md:grid-cols-3">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Readiness</p>
+            <p className="mt-2 text-2xl font-semibold">{stream.readinessStatus ?? '-'}</p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Connected At</p>
+            <p className="mt-2 text-sm text-slate-200">{stream.connectedAt ?? '-'}</p>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Last Heartbeat</p>
+            <p className="mt-2 text-sm text-slate-200">{stream.lastHeartbeat ?? '-'}</p>
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-6 md:grid-cols-2">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
+            <h2 className="text-lg font-semibold">Latest Executions</h2>
+            {stream.latestExecutions.length === 0 ? (
+              <p className="mt-3 text-sm text-slate-400">Waiting for execution_update events…</p>
+            ) : (
+              <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                {stream.latestExecutions.map((execution) => (
+                  <li key={execution.id} className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 px-3 py-2">
+                    <span className="font-mono text-xs text-slate-400">{execution.id}</span>
+                    <span>{execution.decision}</span>
+                    <span>{execution.latency_ms ?? 0} ms</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
+            <h2 className="text-lg font-semibold">Active Alerts</h2>
+            {stream.activeAlerts.length === 0 ? (
+              <p className="mt-3 text-sm text-slate-400">No alerts from stream.</p>
+            ) : (
+              <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                {stream.activeAlerts.map((alert, index) => (
+                  <li key={`${alert.code}-${index}`} className="rounded-lg border border-slate-800 px-3 py-2">
+                    <span className={alert.level === 'error' ? 'text-red-300' : 'text-amber-300'}>
+                      [{String(alert.level).toUpperCase()}]
+                    </span>{' '}
+                    {alert.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/internal/collect-monitor-snapshot",
+      "schedule": "*/2 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a live operational feed of DSG core health, metrics, audit, determinism and recent executions to the dashboard UI.
- Periodically collect and persist per-organization monitor snapshots and surface alerts into the database for historical readiness and alerting.
- Expose a lightweight UI in the app shell to surface readiness, executions and active alerts in real time.

### Description

- Added a server-sent events endpoint `app/api/core/stream/route.ts` that authenticates the user, polls core endpoints and the DB every 3s, and streams named events (`connected`, `core_health`, `core_metrics`, `audit_update`, `execution_update`, `determinism_update`, `readiness_update`, `heartbeat`, `alert`) with `text/event-stream` headers.
- Added an internal cron endpoint `app/api/internal/collect-monitor-snapshot/route.ts` that requires `CRON_SECRET`, aggregates core health/metrics/ledger/audit/determinism and org usage data, inserts snapshots into `core_monitor_snapshots`, writes readiness records to `readiness_history`, and records/upserts alert events to `alert_events` for each active org.
- Updated the app shell `app/app-shell/page.tsx` to consume `/api/core/stream` via `EventSource`, maintain stream state (status, connected time, heartbeat, readiness, latest executions, active alerts) and render a small monitoring panel and lists of recent executions and alerts.
- Added `vercel.json` with a cron entry to call `/api/internal/collect-monitor-snapshot` on the schedule `*/2 * * * *`.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c97854d2b88326acce30a5f4fd9910)