### PR TITLE
Add reservation lifecycle and quota RPCs for /api/execute (reserve + finalize)

### DIFF
--- a/app/api/execute/route.ts
+++ b/app/api/execute/route.ts
@@ -6,6 +6,7 @@ import { executeOnDSGCore } from '../../../lib/dsg-core';
 export const dynamic = 'force-dynamic';
 
 type Decision = 'ALLOW' | 'STABILIZE' | 'BLOCK';
+type ReservationStatus = 'consumed' | 'failed_refunded' | 'failed_not_refunded';
 
 const INCLUDED_EXECUTIONS: Record<string, number> = {
   trial: 1000,
@@ -14,9 +15,23 @@ const INCLUDED_EXECUTIONS: Record<string, number> = {
   enterprise: 1000000,
 };
 
+const PLAN_REFUND_POLICY: Record<string, 'refund_on_failure' | 'no_refund_on_failure'> = {
+  trial: 'refund_on_failure',
+  pro: 'refund_on_failure',
+  business: 'refund_on_failure',
+  enterprise: 'no_refund_on_failure',
+};
+
+const REFUND_POLICY_SOURCE = 'app/api/execute/route.ts:PLAN_REFUND_POLICY';
+
 function getIncludedExecutions(planKey?: string | null) {
   const normalized = String(planKey || 'trial').toLowerCase();
   return INCLUDED_EXECUTIONS[normalized] || INCLUDED_EXECUTIONS.trial;
+}
+
+function getRefundPolicy(planKey?: string | null) {
+  const normalized = String(planKey || 'trial').toLowerCase();
+  return PLAN_REFUND_POLICY[normalized] || PLAN_REFUND_POLICY.trial;
 }
 
 export async function POST(request: Request) {
@@ -124,7 +139,9 @@ export async function POST(request: Request) {
       (sum, row) => sum + Number(row.executions || 0),
       0
     );
-    const includedExecutions = getIncludedExecutions(subscription?.plan_key || 'trial');
+    const planKey = String(subscription?.plan_key || 'trial').toLowerCase();
+    const includedExecutions = getIncludedExecutions(planKey);
+    const refundPolicy = getRefundPolicy(planKey);
 
     if (orgExecutions >= includedExecutions) {
       return NextResponse.json(
@@ -135,7 +152,7 @@ export async function POST(request: Request) {
             billing_period: orgBillingPeriod,
             executions: orgExecutions,
             included_executions: includedExecutions,
-            plan_key: String(subscription?.plan_key || 'trial').toLowerCase(),
+            plan_key: planKey,
             subscription_status: subscription?.status || 'trialing',
           },
         },
@@ -143,14 +160,81 @@ export async function POST(request: Request) {
       );
     }
 
-    const coreResult = await executeOnDSGCore({
-      agent_id: agentId,
-      action,
-      payload: {
-        input,
-        context,
+    const { data: reserveRows, error: reserveError } = await supabase.rpc('reserve_execution_quota', {
+      p_org_id: agent.org_id,
+      p_agent_id: agent.id,
+      p_billing_period: billingPeriod,
+      p_org_billing_period: orgBillingPeriod,
+      p_agent_monthly_limit: monthlyLimit,
+      p_org_included_executions: includedExecutions,
+      p_plan_key: planKey,
+      p_refund_policy: refundPolicy,
+      p_policy_source: REFUND_POLICY_SOURCE,
+      p_metadata: {
+        action,
+        refund_policy: refundPolicy,
+        policy_source: REFUND_POLICY_SOURCE,
       },
     });
+
+    if (reserveError) {
+      return NextResponse.json({ error: reserveError.message }, { status: 500 });
+    }
+
+    const reserveResult = Array.isArray(reserveRows) ? reserveRows[0] : null;
+    if (!reserveResult?.ok || !reserveResult?.reservation_id) {
+      const quotaStatus = reserveResult?.error_code === 'agent_quota_exceeded' || reserveResult?.error_code === 'org_quota_exceeded'
+        ? 429
+        : 400;
+      return NextResponse.json(
+        {
+          error: reserveResult?.error_message || 'Unable to reserve execution quota',
+          reservation: reserveResult ?? null,
+        },
+        { status: quotaStatus }
+      );
+    }
+
+    const reservationId = String(reserveResult.reservation_id);
+
+    let coreResult: Awaited<ReturnType<typeof executeOnDSGCore>>;
+    try {
+      coreResult = await executeOnDSGCore({
+        agent_id: agentId,
+        action,
+        payload: {
+          input,
+          context,
+        },
+      });
+    } catch (coreError) {
+      const failedStatus: ReservationStatus = refundPolicy === 'refund_on_failure'
+        ? 'failed_refunded'
+        : 'failed_not_refunded';
+
+      await supabase.rpc('finalize_execution_reservation', {
+        p_reservation_id: reservationId,
+        p_status: failedStatus,
+        p_metadata: {
+          stage: 'core_execution',
+          refund_reason: refundPolicy === 'refund_on_failure'
+            ? 'DSG core execution failed and plan policy allows refund.'
+            : 'DSG core execution failed but plan policy denies refund.',
+          policy_source: REFUND_POLICY_SOURCE,
+          core_error: coreError instanceof Error ? coreError.message : String(coreError),
+        },
+      });
+
+      return NextResponse.json(
+        {
+          error: coreError instanceof Error ? coreError.message : 'DSG core execution failed',
+          reservation_id: reservationId,
+          reservation_status: failedStatus,
+          refund_policy: refundPolicy,
+        },
+        { status: 502 }
+      );
+    }
 
     const decision = String(coreResult.decision || 'BLOCK') as Decision;
     const latencyMs = Number(coreResult.latency_ms || 0);
@@ -180,6 +264,22 @@ export async function POST(request: Request) {
       .single();
 
     if (executionError || !execution) {
+      const failedStatus: ReservationStatus = refundPolicy === 'refund_on_failure'
+        ? 'failed_refunded'
+        : 'failed_not_refunded';
+      await supabase.rpc('finalize_execution_reservation', {
+        p_reservation_id: reservationId,
+        p_status: failedStatus,
+        p_metadata: {
+          stage: 'execution_insert',
+          refund_reason: refundPolicy === 'refund_on_failure'
+            ? 'Execution insert failed; quota reservation refunded by plan policy.'
+            : 'Execution insert failed; plan policy configured to keep reservation consumed.',
+          policy_source: REFUND_POLICY_SOURCE,
+          db_error: executionError?.message || 'Failed to insert execution',
+        },
+      });
+
       return NextResponse.json(
         { error: executionError?.message || 'Failed to insert execution' },
         { status: 500 }
@@ -208,48 +308,48 @@ export async function POST(request: Request) {
       .single();
 
     if (auditError) {
+      const failedStatus: ReservationStatus = refundPolicy === 'refund_on_failure'
+        ? 'failed_refunded'
+        : 'failed_not_refunded';
+      await supabase.rpc('finalize_execution_reservation', {
+        p_reservation_id: reservationId,
+        p_status: failedStatus,
+        p_execution_id: execution.id,
+        p_metadata: {
+          stage: 'audit_insert',
+          refund_reason: refundPolicy === 'refund_on_failure'
+            ? 'Audit insert failed; reservation refunded per plan policy.'
+            : 'Audit insert failed; reservation kept per plan policy.',
+          policy_source: REFUND_POLICY_SOURCE,
+          db_error: auditError.message,
+        },
+      });
       return NextResponse.json({ error: auditError.message }, { status: 500 });
     }
 
-    const { error: usageEventError } = await supabase
-      .from('usage_events')
-      .insert({
-        org_id: agent.org_id,
-        agent_id: agent.id,
-        execution_id: execution.id,
-        event_type: 'execution',
-        quantity: 1,
-        unit: 'execution',
-        amount_usd: 0.001,
-        metadata: { decision, stability_score: stabilityScore },
-        created_at: nowIso,
-      });
+    const { data: finalizeRows, error: finalizeError } = await supabase.rpc('finalize_execution_reservation', {
+      p_reservation_id: reservationId,
+      p_status: 'consumed',
+      p_execution_id: execution.id,
+      p_metadata: {
+        stage: 'execution_consumed',
+        policy_source: REFUND_POLICY_SOURCE,
+        refund_reason: 'Execution succeeded; reservation consumed with no refund.',
+        decision,
+        stability_score: stabilityScore,
+      },
+    });
 
-    if (usageEventError) {
-      return NextResponse.json({ error: usageEventError.message }, { status: 500 });
+    if (finalizeError) {
+      return NextResponse.json({ error: finalizeError.message }, { status: 500 });
     }
 
-    if (counter?.id) {
-      const { error: counterUpdateError } = await supabase
-        .from('usage_counters')
-        .update({ executions: currentAgentExecutions + 1, updated_at: nowIso })
-        .eq('id', counter.id);
-      if (counterUpdateError) {
-        return NextResponse.json({ error: counterUpdateError.message }, { status: 500 });
-      }
-    } else {
-      const { error: counterInsertError } = await supabase
-        .from('usage_counters')
-        .insert({
-          org_id: agent.org_id,
-          agent_id: agent.id,
-          billing_period: billingPeriod,
-          executions: 1,
-          updated_at: nowIso,
-        });
-      if (counterInsertError) {
-        return NextResponse.json({ error: counterInsertError.message }, { status: 500 });
-      }
+    const finalizeResult = Array.isArray(finalizeRows) ? finalizeRows[0] : null;
+    if (!finalizeResult?.ok) {
+      return NextResponse.json(
+        { error: finalizeResult?.error_message || 'Failed to finalize reservation as consumed' },
+        { status: 500 }
+      );
     }
 
     const { error: agentUpdateError } = await supabase
@@ -271,6 +371,10 @@ export async function POST(request: Request) {
         stability_score: stabilityScore,
         audit_id: auditRow?.id ?? null,
         usage_counted: true,
+        reservation_id: reservationId,
+        reservation_status: 'consumed',
+        refund_policy: refundPolicy,
+        policy_source: REFUND_POLICY_SOURCE,
         core: {
           decision: coreResult.decision,
           evaluated_at: coreResult.evaluated_at,

--- a/supabase/migrations/20260330110000_execution_reservations.sql
+++ b/supabase/migrations/20260330110000_execution_reservations.sql
@@ -1,0 +1,224 @@
+create table if not exists public.usage_reservations (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references public.organizations(id) on delete cascade,
+  agent_id text not null references public.agents(id) on delete cascade,
+  execution_id uuid references public.executions(id) on delete set null,
+  billing_period text not null,
+  org_billing_period text not null,
+  status text not null
+    check (status in ('reserved', 'consumed', 'failed_refunded', 'failed_not_refunded')),
+  quantity integer not null default 1 check (quantity > 0),
+  plan_key text not null,
+  refund_policy text not null
+    check (refund_policy in ('refund_on_failure', 'no_refund_on_failure')),
+  policy_source text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  finalized_at timestamptz
+);
+
+create index if not exists idx_usage_reservations_org_created_at
+  on public.usage_reservations (org_id, created_at desc);
+
+create index if not exists idx_usage_reservations_agent_created_at
+  on public.usage_reservations (agent_id, created_at desc);
+
+create or replace function public.reserve_execution_quota(
+  p_org_id text,
+  p_agent_id text,
+  p_billing_period text,
+  p_org_billing_period text,
+  p_agent_monthly_limit integer,
+  p_org_included_executions integer,
+  p_plan_key text,
+  p_refund_policy text,
+  p_policy_source text,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns table(
+  ok boolean,
+  reservation_id uuid,
+  status text,
+  error_code text,
+  error_message text,
+  agent_executions integer,
+  org_executions integer
+)
+language plpgsql
+as $$
+declare
+  v_agent_counter_id uuid;
+  v_agent_executions integer := 0;
+  v_org_executions integer := 0;
+  v_reservation_id uuid;
+begin
+  if p_refund_policy not in ('refund_on_failure', 'no_refund_on_failure') then
+    return query select false, null::uuid, null::text, 'invalid_refund_policy', 'Unsupported refund policy', null::integer, null::integer;
+    return;
+  end if;
+
+  if p_billing_period !~ '^\d{4}-\d{2}$' or p_org_billing_period !~ '^\d{4}-\d{2}$' then
+    return query select false, null::uuid, null::text, 'invalid_billing_period', 'Billing period must follow YYYY-MM', null::integer, null::integer;
+    return;
+  end if;
+
+  select id, executions
+  into v_agent_counter_id, v_agent_executions
+  from public.usage_counters
+  where agent_id = p_agent_id
+    and billing_period = p_billing_period
+  for update;
+
+  if v_agent_counter_id is null then
+    insert into public.usage_counters (org_id, agent_id, billing_period, executions, updated_at)
+    values (p_org_id, p_agent_id, p_billing_period, 0, now())
+    returning id, executions into v_agent_counter_id, v_agent_executions;
+  end if;
+
+  perform 1
+  from public.usage_counters
+  where org_id = p_org_id
+    and billing_period = p_org_billing_period
+  for update;
+
+  select coalesce(sum(executions), 0)::integer
+  into v_org_executions
+  from public.usage_counters
+  where org_id = p_org_id
+    and billing_period = p_org_billing_period;
+
+  if p_agent_monthly_limit > 0 and v_agent_executions >= p_agent_monthly_limit then
+    return query select false, null::uuid, null::text, 'agent_quota_exceeded', 'Agent monthly quota exceeded', v_agent_executions, v_org_executions;
+    return;
+  end if;
+
+  if p_org_included_executions > 0 and v_org_executions >= p_org_included_executions then
+    return query select false, null::uuid, null::text, 'org_quota_exceeded', 'Organization execution quota exceeded', v_agent_executions, v_org_executions;
+    return;
+  end if;
+
+  update public.usage_counters
+  set executions = executions + 1,
+      updated_at = now()
+  where id = v_agent_counter_id;
+
+  insert into public.usage_reservations (
+    org_id,
+    agent_id,
+    billing_period,
+    org_billing_period,
+    status,
+    quantity,
+    plan_key,
+    refund_policy,
+    policy_source,
+    metadata
+  )
+  values (
+    p_org_id,
+    p_agent_id,
+    p_billing_period,
+    p_org_billing_period,
+    'reserved',
+    1,
+    lower(coalesce(p_plan_key, 'trial')),
+    p_refund_policy,
+    p_policy_source,
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  returning id into v_reservation_id;
+
+  return query select true, v_reservation_id, 'reserved', null::text, null::text, v_agent_executions + 1, v_org_executions + 1;
+end;
+$$;
+
+create or replace function public.finalize_execution_reservation(
+  p_reservation_id uuid,
+  p_status text,
+  p_execution_id uuid default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns table(
+  ok boolean,
+  reservation_id uuid,
+  status text,
+  refunded boolean,
+  error_code text,
+  error_message text
+)
+language plpgsql
+as $$
+declare
+  v_reservation public.usage_reservations%rowtype;
+  v_refunded boolean := false;
+begin
+  if p_status not in ('consumed', 'failed_refunded', 'failed_not_refunded') then
+    return query select false, p_reservation_id, null::text, false, 'invalid_status', 'Unsupported final reservation status';
+    return;
+  end if;
+
+  select *
+  into v_reservation
+  from public.usage_reservations
+  where id = p_reservation_id
+  for update;
+
+  if v_reservation.id is null then
+    return query select false, p_reservation_id, null::text, false, 'not_found', 'Reservation not found';
+    return;
+  end if;
+
+  if v_reservation.status <> 'reserved' then
+    return query select false, p_reservation_id, v_reservation.status, false, 'already_finalized', 'Reservation already finalized';
+    return;
+  end if;
+
+  if p_status = 'failed_refunded' then
+    update public.usage_counters
+    set executions = greatest(executions - v_reservation.quantity, 0),
+        updated_at = now()
+    where agent_id = v_reservation.agent_id
+      and billing_period = v_reservation.billing_period;
+
+    v_refunded := true;
+  end if;
+
+  update public.usage_reservations
+  set status = p_status,
+      execution_id = coalesce(p_execution_id, execution_id),
+      finalized_at = now(),
+      metadata = coalesce(metadata, '{}'::jsonb) || coalesce(p_metadata, '{}'::jsonb)
+  where id = p_reservation_id;
+
+  insert into public.usage_events (
+    org_id,
+    agent_id,
+    execution_id,
+    event_type,
+    quantity,
+    unit,
+    amount_usd,
+    metadata,
+    created_at
+  )
+  values (
+    v_reservation.org_id,
+    v_reservation.agent_id,
+    coalesce(p_execution_id, v_reservation.execution_id),
+    case when p_status = 'consumed' then 'execution' else 'execution_failed' end,
+    v_reservation.quantity,
+    'execution',
+    case when p_status = 'consumed' then 0.001 else 0 end,
+    jsonb_build_object(
+      'reservation_id', p_reservation_id,
+      'reservation_status', p_status,
+      'refunded', v_refunded,
+      'refund_policy', v_reservation.refund_policy,
+      'policy_source', v_reservation.policy_source
+    ) || coalesce(p_metadata, '{}'::jsonb),
+    now()
+  );
+
+  return query select true, p_reservation_id, p_status, v_refunded, null::text, null::text;
+end;
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -73,6 +73,23 @@ create table if not exists usage_events (
   created_at timestamptz default now()
 );
 
+create table if not exists usage_reservations (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organizations(id) on delete cascade,
+  agent_id text not null references agents(id) on delete cascade,
+  execution_id uuid references executions(id) on delete set null,
+  billing_period text not null,
+  org_billing_period text not null,
+  status text not null check (status in ('reserved', 'consumed', 'failed_refunded', 'failed_not_refunded')),
+  quantity integer not null default 1 check (quantity > 0),
+  plan_key text not null,
+  refund_policy text not null check (refund_policy in ('refund_on_failure', 'no_refund_on_failure')),
+  policy_source text not null,
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamptz default now(),
+  finalized_at timestamptz
+);
+
 create table if not exists usage_counters (
   id uuid primary key default gen_random_uuid(),
   org_id text not null references organizations(id) on delete cascade,
@@ -129,6 +146,7 @@ create index if not exists idx_executions_agent_id on executions(agent_id);
 create index if not exists idx_executions_created_at on executions(created_at desc);
 create index if not exists idx_audit_logs_org_id on audit_logs(org_id);
 create index if not exists idx_usage_events_org_id on usage_events(org_id);
+create index if not exists idx_usage_reservations_org_created_at on usage_reservations(org_id, created_at desc);
 create index if not exists idx_usage_counters_org_period on usage_counters(org_id, billing_period);
 create index if not exists idx_billing_subscriptions_org_id on billing_subscriptions(org_id);
 create index if not exists idx_billing_events_customer on billing_events(stripe_customer_id);


### PR DESCRIPTION
### Motivation
- Ensure execution quota is reserved atomically before calling the DSG core so failures can be refunded or kept according to plan policy.
- Provide explicit reservation lifecycle states (`reserved`, `consumed`, `failed_refunded`, `failed_not_refunded`) to enable clear audit trails and correct usage counters.
- Persist refund decision rationale and the policy source in reservation metadata so post-incident audits can verify why a refund was or was not applied.

### Description
- Add `usage_reservations` table and index to `supabase/schema.sql` and a new migration `supabase/migrations/20260330110000_execution_reservations.sql` to track reservation lifecycle, plan key, refund policy, policy source and metadata.
- Implement RPC `reserve_execution_quota` to atomically check quotas, lock/increment `usage_counters`, and insert a `'reserved'` reservation row, and `finalize_execution_reservation` to transition reservations to `consumed` / `failed_refunded` / `failed_not_refunded`, apply refunds by decrementing counters when needed, and emit `usage_events` with reservation metadata for audit.
- Update `/app/api/execute/route.ts` to follow the new flow: call `reserve_execution_quota` RPC, call `executeOnDSGCore`, and then call `finalize_execution_reservation` with `consumed` on success or `failed_refunded` / `failed_not_refunded` on failure; the route now exposes `reservation_id`, `reservation_status`, `refund_policy`, and `policy_source` in responses.
- Define `PLAN_REFUND_POLICY` and `REFUND_POLICY_SOURCE` in the execute route as the code-level source-of-truth for refund behavior and include the source + decision text in reservation metadata written by the RPCs.

### Testing
- Ran `npm run typecheck` (which executes `tsc --noEmit -p tsconfig.typecheck.json`) and it completed successfully.
- Ran `npm run lint` (Next.js ESLint) and it reported no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca2f97e9e88326bf9eff4f4fda02fd)