### PR TITLE
Add runtime ledger utility and harden intent approval route

### DIFF
--- a/app/api/intent/route.ts
+++ b/app/api/intent/route.ts
@@ -1,19 +1,28 @@
 import { NextResponse } from 'next/server';
+import { requireActiveAgentFromBearer } from '../../../lib/agent-auth';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
-import { requireActiveAgentFromBearer, type AgentAccess } from '../../../lib/agent-auth';
-import { computeApprovalHash, computeInputHash, type IntentEnvelope } from '../../../lib/runtime/approval';
+import {
+  computeApprovalHash,
+  computeInputHash,
+  type IntentEnvelope,
+} from '../../../lib/runtime/approval';
 
 export const dynamic = 'force-dynamic';
 
 const APPROVAL_TTL_MS = 10 * 60 * 1000;
 
 type IntentBody = IntentEnvelope & {
-  agent_id: string;
+  agent_id?: string;
 };
 
 export async function POST(request: Request) {
   const body = (await request.json().catch(() => null)) as IntentBody | null;
-  if (!body?.request_id || !body?.action) {
+
+  if (!body) {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body.request_id || !body.action) {
     return NextResponse.json(
       { ok: false, error: 'request_id and action are required' },
       { status: 400 }
@@ -21,25 +30,25 @@ export async function POST(request: Request) {
   }
 
   const access = await requireActiveAgentFromBearer(request, body.agent_id);
-  if (!access.ok) {
-    const denied = access as Extract<AgentAccess, { ok: false }>;
-    return NextResponse.json({ ok: false, error: denied.error }, { status: denied.status });
+  if (access.ok === false) {
+    return NextResponse.json({ ok: false, error: access.error }, { status: access.status });
   }
 
   const supabase = getSupabaseAdmin();
 
-  const { data: currentState, error: stateError } = await supabase
+  const { data: truthState, error: truthError } = await supabase
     .from('runtime_truth_state')
     .select('epoch')
     .eq('org_id', access.orgId)
     .maybeSingle();
 
-  if (stateError) {
-    return NextResponse.json({ ok: false, error: stateError.message }, { status: 500 });
+  if (truthError) {
+    return NextResponse.json({ ok: false, error: truthError.message }, { status: 500 });
   }
 
-  const epoch = Number(currentState?.epoch || 1);
+  const epoch = Number(truthState?.epoch || 1);
   const inputHash = computeInputHash(body);
+
   const approvalHash = computeApprovalHash({
     orgId: access.orgId,
     agentId: access.agentId,
@@ -51,7 +60,7 @@ export async function POST(request: Request) {
 
   const expiresAt = new Date(Date.now() + APPROVAL_TTL_MS).toISOString();
 
-  const { data, error } = await supabase
+  const { data: approval, error: approvalError } = await supabase
     .from('approvals')
     .upsert(
       {
@@ -61,6 +70,7 @@ export async function POST(request: Request) {
         action: body.action,
         input_hash: inputHash,
         approval_hash: approvalHash,
+        approved_at: new Date().toISOString(),
         expires_at: expiresAt,
         epoch,
         status: 'issued',
@@ -69,25 +79,27 @@ export async function POST(request: Request) {
           next_i: body.next_i,
         },
       },
-      { onConflict: 'org_id,request_id' }
+      {
+        onConflict: 'org_id,request_id',
+      }
     )
     .select('id, approval_hash, expires_at, epoch, status')
     .single();
 
-  if (error || !data) {
+  if (approvalError || !approval) {
     return NextResponse.json(
-      { ok: false, error: error?.message || 'Failed to issue approval' },
+      { ok: false, error: approvalError?.message || 'Failed to issue approval' },
       { status: 500 }
     );
   }
 
   return NextResponse.json({
     ok: true,
-    approval_id: data.id,
-    approval_hash: data.approval_hash,
+    approval_id: approval.id,
+    approval_hash: approval.approval_hash,
     input_hash: inputHash,
-    expires_at: data.expires_at,
-    epoch: data.epoch,
-    status: data.status,
+    expires_at: approval.expires_at,
+    epoch: approval.epoch,
+    status: approval.status,
   });
 }

--- a/lib/runtime/approval.ts
+++ b/lib/runtime/approval.ts
@@ -9,6 +9,15 @@ export type IntentEnvelope = {
   next_i: string;
 };
 
+export type ApprovalSeed = {
+  orgId: string;
+  agentId: string;
+  requestId: string;
+  action: string;
+  inputHash: string;
+  epoch: number;
+};
+
 export function computeInputHash(intent: IntentEnvelope): string {
   return sha256Hex({
     action: intent.action,
@@ -19,21 +28,14 @@ export function computeInputHash(intent: IntentEnvelope): string {
   });
 }
 
-export function computeApprovalHash(params: {
-  orgId: string;
-  agentId: string;
-  requestId: string;
-  action: string;
-  inputHash: string;
-  epoch: number;
-}): string {
+export function computeApprovalHash(seed: ApprovalSeed): string {
   return sha256Hex({
-    org_id: params.orgId,
-    agent_id: params.agentId,
-    request_id: params.requestId,
-    action: params.action,
-    input_hash: params.inputHash,
-    epoch: params.epoch,
+    org_id: seed.orgId,
+    agent_id: seed.agentId,
+    request_id: seed.requestId,
+    action: seed.action,
+    input_hash: seed.inputHash,
+    epoch: seed.epoch,
   });
 }
 
@@ -48,5 +50,21 @@ export function computeEffectId(params: {
     sequence: params.sequence,
     action: params.action,
     payload_hash: params.payloadHash,
+  });
+}
+
+export function computeMemoryLineageHash(params: {
+  orgId: string;
+  agentId: string | null;
+  requestId: string | null;
+  memoryKey: string;
+  memoryValue: unknown;
+}): string {
+  return sha256Hex({
+    org_id: params.orgId,
+    agent_id: params.agentId,
+    request_id: params.requestId,
+    memory_key: params.memoryKey,
+    memory_value: params.memoryValue,
   });
 }

--- a/lib/runtime/ledger.ts
+++ b/lib/runtime/ledger.ts
@@ -1,0 +1,67 @@
+import { sha256Hex } from './canonical';
+import type { DSGDecision } from './gate';
+
+export type LedgerSeed = {
+  orgId: string;
+  agentId: string;
+  requestId: string;
+  approvalHash: string | null;
+  sequence: number;
+  epoch: number;
+  action: string;
+  inputHash: string;
+  decision: DSGDecision;
+  reason: string;
+  prevStateHash: string;
+  nextStateHash: string;
+  effectId: string | null;
+  logicalTs: number;
+  prevEntryHash: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type LedgerRecord = {
+  org_id: string;
+  agent_id: string;
+  request_id: string;
+  approval_hash: string | null;
+  sequence: number;
+  epoch: number;
+  action: string;
+  input_hash: string;
+  decision: DSGDecision;
+  reason: string;
+  prev_state_hash: string;
+  next_state_hash: string;
+  effect_id: string | null;
+  logical_ts: number;
+  prev_entry_hash: string;
+  metadata: Record<string, unknown>;
+  entry_hash: string;
+};
+
+export function buildLedgerEntry(seed: LedgerSeed): LedgerRecord {
+  const base = {
+    org_id: seed.orgId,
+    agent_id: seed.agentId,
+    request_id: seed.requestId,
+    approval_hash: seed.approvalHash,
+    sequence: seed.sequence,
+    epoch: seed.epoch,
+    action: seed.action,
+    input_hash: seed.inputHash,
+    decision: seed.decision,
+    reason: seed.reason,
+    prev_state_hash: seed.prevStateHash,
+    next_state_hash: seed.nextStateHash,
+    effect_id: seed.effectId,
+    logical_ts: seed.logicalTs,
+    prev_entry_hash: seed.prevEntryHash,
+    metadata: seed.metadata || {},
+  };
+
+  return {
+    ...base,
+    entry_hash: sha256Hex(base),
+  };
+}


### PR DESCRIPTION
### Motivation
- Introduce canonical helpers and stronger intent issuance primitives to support the runtime spine and upcoming `execute` surgery.
- Ensure approval issuance is integrity-preserving and avoids malformed requests by tightening input validation and stamping approval metadata.

### Description
- Add `lib/runtime/ledger.ts` with `LedgerSeed`/`LedgerRecord` types and `buildLedgerEntry()` which computes `entry_hash` using `sha256Hex` for canonical ledger records.
- Extend `lib/runtime/approval.ts` with an explicit `ApprovalSeed` type and `computeMemoryLineageHash()` helper, and keep existing `computeInputHash`, `computeApprovalHash`, and `computeEffectId` helpers using `sha256Hex` canonicalization.
- Harden `app/api/intent/route.ts` to reject invalid JSON bodies up-front, allow `agent_id` to be optional, compute and use `input_hash`/`approval_hash`, and set `approved_at` on upserted approvals while propagating clearer error handling.

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cac64f51c48326b23a12a12376703a)