### PR TITLE
Add checkpoint helper and runtime verify/replay-state APIs; wire checkpoint writes into Spine

### DIFF
--- a/app/api/execute/route.ts
+++ b/app/api/execute/route.ts
@@ -4,6 +4,7 @@ import { getSupabaseAdmin } from '../../../lib/supabase-server';
 import { executeOnDSGCore } from '../../../lib/dsg-core';
 import { computeEffectId, computeInputHash, type IntentEnvelope } from '../../../lib/runtime/approval';
 import { sha256Hex } from '../../../lib/runtime/canonical';
+import { maybeWriteCheckpoint } from '../../../lib/runtime/checkpoints';
 import { evaluateUDGGate, type TruthState } from '../../../lib/runtime/gate';
 
 export const dynamic = 'force-dynamic';
@@ -372,6 +373,29 @@ async function runSpineExecution(params: {
 
   if (usageInsert.error) {
     return { ok: false as const, status: 500, error: usageInsert.error.message };
+  }
+
+  if (gate.decision === 'ALLOW') {
+    await maybeWriteCheckpoint({
+      orgId: agent.org_id,
+      sequence: nextSequence,
+      epoch: truthState.epoch,
+      entryHash: entryHash,
+      truthState: {
+        epoch: truthState.epoch,
+        sequence: nextSequence,
+        v_t: {
+          ...body.next_v,
+          last_direction: Math.sign(
+            Number(body.next_v.balance ?? 0) - Number((truthState.v_t as any).balance || 0)
+          ),
+        },
+        t_t: Number(body.next_t),
+        g_t: body.next_g,
+        i_t: body.next_i,
+        s_star_hash: sha256Hex(body.next_v),
+      },
+    });
   }
 
   return {

--- a/app/api/replay-state/[sequence]/route.ts
+++ b/app/api/replay-state/[sequence]/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { sha256Hex } from '../../../../lib/runtime/canonical';
+
+export const dynamic = 'force-dynamic';
+
+type ReplayTruthState = {
+  epoch: number;
+  sequence: number;
+  v_t: Record<string, unknown>;
+  t_t: number;
+  g_t: string;
+  i_t: string;
+  s_star_hash: string;
+};
+
+function initialTruthState(): ReplayTruthState {
+  const v_t = {
+    balance: 1000000,
+    invariant_tag: 'transfer',
+    last_direction: 0,
+  };
+
+  return {
+    epoch: 1,
+    sequence: 0,
+    v_t,
+    t_t: 0,
+    g_t: 'zone:origin',
+    i_t: 'net:bootstrap',
+    s_star_hash: sha256Hex(v_t),
+  };
+}
+
+function hashTruthState(state: ReplayTruthState): string {
+  return sha256Hex({
+    epoch: state.epoch,
+    sequence: state.sequence,
+    v_t: state.v_t,
+    t_t: state.t_t,
+    g_t: state.g_t,
+    i_t: state.i_t,
+    s_star_hash: state.s_star_hash,
+  });
+}
+
+export async function GET(_request: Request, { params }: { params: { sequence: string } }) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const targetSequence = Number(params.sequence);
+  if (!Number.isFinite(targetSequence) || targetSequence < 0) {
+    return NextResponse.json({ ok: false, error: 'Invalid sequence' }, { status: 400 });
+  }
+
+  const admin = getSupabaseAdmin();
+  const orgId = String(profile.org_id);
+
+  const { data: checkpoint } = await admin
+    .from('state_checkpoints')
+    .select('sequence, snapshot, state_hash')
+    .eq('org_id', orgId)
+    .lte('sequence', targetSequence)
+    .order('sequence', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  let replayState: ReplayTruthState = checkpoint?.snapshot
+    ? {
+        epoch: Number(checkpoint.snapshot.epoch),
+        sequence: Number(checkpoint.snapshot.sequence),
+        v_t: checkpoint.snapshot.v_t || {},
+        t_t: Number(checkpoint.snapshot.t_t),
+        g_t: String(checkpoint.snapshot.g_t),
+        i_t: String(checkpoint.snapshot.i_t),
+        s_star_hash: String(checkpoint.snapshot.s_star_hash),
+      }
+    : initialTruthState();
+
+  const startSequence = checkpoint ? Number(checkpoint.sequence) + 1 : 1;
+
+  const { data: entries, error: entriesError } = await admin
+    .from('ledger_entries')
+    .select('sequence, request_id, decision, next_state_hash, entry_hash')
+    .eq('org_id', orgId)
+    .gte('sequence', startSequence)
+    .lte('sequence', targetSequence)
+    .order('sequence', { ascending: true });
+
+  if (entriesError) {
+    return NextResponse.json({ ok: false, error: entriesError.message }, { status: 500 });
+  }
+
+  let executionByRequestId = new Map<string, any>();
+  if ((entries || []).length > 0) {
+    const { data: executions, error: execError } = await admin
+      .from('executions')
+      .select('request_payload, context_payload, created_at')
+      .eq('org_id', orgId)
+      .in('context_payload->>entry_hash', (entries || []).map((e) => e.entry_hash));
+
+    if (execError) {
+      return NextResponse.json({ ok: false, error: execError.message }, { status: 500 });
+    }
+
+    executionByRequestId = new Map(
+      (executions || []).map((row: any) => [String(row.context_payload?.entry_hash || ''), row])
+    );
+  }
+
+  for (const entry of entries || []) {
+    if (entry.decision !== 'ALLOW') {
+      continue;
+    }
+
+    const execution = executionByRequestId.get(entry.entry_hash);
+    const payload = execution?.request_payload;
+
+    if (!payload) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Missing execution payload for sequence ${entry.sequence}`,
+        },
+        { status: 500 }
+      );
+    }
+
+    replayState = {
+      epoch: replayState.epoch,
+      sequence: Number(entry.sequence),
+      v_t: payload.next_v || replayState.v_t,
+      t_t: Number(payload.next_t ?? replayState.t_t),
+      g_t: String(payload.next_g ?? replayState.g_t),
+      i_t: String(payload.next_i ?? replayState.i_t),
+      s_star_hash: sha256Hex(payload.next_v || replayState.v_t),
+    };
+  }
+
+  const replayedStateHash = hashTruthState(replayState);
+
+  const { data: targetEntry, error: targetError } = await admin
+    .from('ledger_entries')
+    .select('sequence, next_state_hash, decision, entry_hash')
+    .eq('org_id', orgId)
+    .eq('sequence', targetSequence)
+    .maybeSingle();
+
+  if (targetError) {
+    return NextResponse.json({ ok: false, error: targetError.message }, { status: 500 });
+  }
+
+  if (!targetEntry) {
+    return NextResponse.json({ ok: false, error: 'SEQ_NOT_FOUND' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    sequence: targetSequence,
+    replayed_state: replayState,
+    replayed_state_hash: replayedStateHash,
+    expected_next_state_hash: targetEntry.next_state_hash,
+    matches: replayedStateHash === targetEntry.next_state_hash,
+    checkpoint_used: checkpoint || null,
+    replay_entries: entries || [],
+  });
+}

--- a/app/api/verify/[sequence]/route.ts
+++ b/app/api/verify/[sequence]/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { sha256Hex } from '../../../../lib/runtime/canonical';
+
+export const dynamic = 'force-dynamic';
+
+function buildEntryHash(entry: any) {
+  return sha256Hex({
+    org_id: entry.org_id,
+    agent_id: entry.agent_id,
+    request_id: entry.request_id,
+    approval_hash: entry.approval_hash,
+    sequence: entry.sequence,
+    epoch: entry.epoch,
+    action: entry.action,
+    input_hash: entry.input_hash,
+    decision: entry.decision,
+    reason: entry.reason,
+    prev_state_hash: entry.prev_state_hash,
+    next_state_hash: entry.next_state_hash,
+    effect_id: entry.effect_id,
+    logical_ts: entry.logical_ts,
+    prev_entry_hash: entry.prev_entry_hash,
+    metadata: entry.metadata || {},
+  });
+}
+
+export async function GET(_request: Request, { params }: { params: { sequence: string } }) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const sequence = Number(params.sequence);
+  if (!Number.isFinite(sequence) || sequence < 0) {
+    return NextResponse.json({ ok: false, error: 'Invalid sequence' }, { status: 400 });
+  }
+
+  const admin = getSupabaseAdmin();
+  const orgId = String(profile.org_id);
+
+  const { data: entry, error: entryError } = await admin
+    .from('ledger_entries')
+    .select('*')
+    .eq('org_id', orgId)
+    .eq('sequence', sequence)
+    .single();
+
+  if (entryError || !entry) {
+    return NextResponse.json({ ok: false, error: 'SEQ_NOT_FOUND' }, { status: 404 });
+  }
+
+  const expectedEntryHash = buildEntryHash(entry);
+  const entryHashValid = expectedEntryHash === entry.entry_hash;
+
+  let chainValid = entry.prev_entry_hash === 'GENESIS';
+  let previousEntry: any = null;
+
+  if (entry.sequence > 0) {
+    const { data: prev, error: prevError } = await admin
+      .from('ledger_entries')
+      .select('sequence, entry_hash')
+      .eq('org_id', orgId)
+      .eq('sequence', entry.sequence - 1)
+      .maybeSingle();
+
+    if (!prevError && prev) {
+      previousEntry = prev;
+      chainValid = prev.entry_hash === entry.prev_entry_hash;
+    } else {
+      chainValid = false;
+    }
+  }
+
+  const { data: execution } = await admin
+    .from('executions')
+    .select('id, request_payload, context_payload, decision, reason, created_at')
+    .eq('org_id', orgId)
+    .contains('context_payload', { entry_hash: entry.entry_hash })
+    .maybeSingle();
+
+  const { data: checkpoint } = await admin
+    .from('state_checkpoints')
+    .select('sequence, state_hash, entry_hash, created_at')
+    .eq('org_id', orgId)
+    .eq('sequence', entry.sequence)
+    .maybeSingle();
+
+  return NextResponse.json({
+    ok: true,
+    sequence: entry.sequence,
+    verified: entryHashValid && chainValid,
+    entry_hash_valid: entryHashValid,
+    chain_valid: chainValid,
+    entry,
+    previous_entry: previousEntry,
+    execution: execution || null,
+    checkpoint: checkpoint || null,
+    expected_entry_hash: expectedEntryHash,
+  });
+}

--- a/lib/runtime/checkpoints.ts
+++ b/lib/runtime/checkpoints.ts
@@ -1,0 +1,62 @@
+import { getSupabaseAdmin } from '../supabase-server';
+import { sha256Hex } from './canonical';
+import type { TruthState } from './gate';
+
+export const CHECKPOINT_INTERVAL = 25;
+
+export function hashTruthState(state: TruthState): string {
+  return sha256Hex({
+    epoch: state.epoch,
+    sequence: state.sequence,
+    v_t: state.v_t,
+    t_t: state.t_t,
+    g_t: state.g_t,
+    i_t: state.i_t,
+    s_star_hash: state.s_star_hash,
+  });
+}
+
+export async function maybeWriteCheckpoint(params: {
+  orgId: string;
+  sequence: number;
+  epoch: number;
+  entryHash: string;
+  truthState: TruthState;
+  force?: boolean;
+}) {
+  const shouldWrite = params.force || params.sequence === 0 || params.sequence % CHECKPOINT_INTERVAL === 0;
+  if (!shouldWrite) {
+    return { written: false };
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { error } = await supabase
+    .from('state_checkpoints')
+    .upsert(
+      {
+        org_id: params.orgId,
+        sequence: params.sequence,
+        epoch: params.epoch,
+        state_hash: hashTruthState(params.truthState),
+        entry_hash: params.entryHash,
+        snapshot: {
+          epoch: params.truthState.epoch,
+          sequence: params.truthState.sequence,
+          v_t: params.truthState.v_t,
+          t_t: params.truthState.t_t,
+          g_t: params.truthState.g_t,
+          i_t: params.truthState.i_t,
+          s_star_hash: params.truthState.s_star_hash,
+        },
+        created_at: new Date().toISOString(),
+      },
+      { onConflict: 'org_id,sequence' }
+    );
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return { written: true };
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic checkpointing to make state replay efficient and auditable.  
- Expose verification and replay endpoints so operators can validate ledger entries and reconstruct runtime state from checkpoints and executions.  
- Integrate checkpoint writes into the Spine execution path so successful `ALLOW` decisions persist snapshots automatically.

### Description
- Added `lib/runtime/checkpoints.ts` which exports `CHECKPOINT_INTERVAL`, `hashTruthState`, and `maybeWriteCheckpoint` that upserts snapshots into the `state_checkpoints` table and only writes at configured intervals (or when forced).  
- Added `GET /api/verify/[sequence]` implemented in `app/api/verify/[sequence]/route.ts` that recomputes an entry hash, validates the prev-link chain, and returns associated execution and checkpoint context.  
- Added `GET /api/replay-state/[sequence]` implemented in `app/api/replay-state/[sequence]/route.ts` that finds the nearest checkpoint (or bootstraps genesis), replays `ALLOW` entries using execution payloads, recomputes the state hash, and compares it to the ledger `next_state_hash`.  
- Wired checkpoint persistence into the Spine flow by importing `maybeWriteCheckpoint` and calling it after successful `usage_events` insertion in `app/api/execute/route.ts` when `gate.decision === 'ALLOW'`, passing a shaped `truthState` (including computed `last_direction` and `s_star_hash`).

### Testing
- Ran `npm run typecheck` and the TypeScript type-check completed successfully.  
- No additional automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cac9f4c84c8326a933fcf257e7b6c3)