### PR TITLE
Add Spine memory APIs and runtime mission console

### DIFF
--- a/app/api/memory/read/route.ts
+++ b/app/api/memory/read/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { requireActiveAgentFromBearer } from '../../../../lib/agent-auth';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const agentId = url.searchParams.get('agent_id');
+  const memoryKey = url.searchParams.get('memory_key');
+  const limit = Math.min(Math.max(Number(url.searchParams.get('limit') || '20'), 1), 100);
+
+  const access = await requireActiveAgentFromBearer(request, agentId);
+  if (access.ok === false) {
+    return NextResponse.json({ ok: false, error: access.error }, { status: access.status });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  let query = supabase
+    .from('agent_memory')
+    .select('id, request_id, memory_key, memory_value, lineage_hash, created_at')
+    .eq('org_id', access.orgId)
+    .eq('agent_id', access.agentId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (memoryKey) {
+    query = query.eq('memory_key', memoryKey);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    items: data || [],
+  });
+}

--- a/app/api/memory/write/route.ts
+++ b/app/api/memory/write/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import { requireActiveAgentFromBearer } from '../../../../lib/agent-auth';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { computeMemoryLineageHash } from '../../../../lib/runtime/approval';
+import { sha256Hex } from '../../../../lib/runtime/canonical';
+
+export const dynamic = 'force-dynamic';
+
+type MemoryWriteBody = {
+  agent_id?: string;
+  request_id?: string;
+  approval_id?: string;
+  memory_key?: string;
+  memory_value?: unknown;
+};
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as MemoryWriteBody | null;
+
+  if (!body) {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body.request_id || !body.approval_id || !body.memory_key) {
+    return NextResponse.json(
+      { ok: false, error: 'request_id, approval_id, and memory_key are required' },
+      { status: 400 }
+    );
+  }
+
+  const access = await requireActiveAgentFromBearer(request, body.agent_id);
+  if (access.ok === false) {
+    return NextResponse.json({ ok: false, error: access.error }, { status: access.status });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const inputHash = sha256Hex({
+    memory_key: body.memory_key,
+    memory_value: body.memory_value ?? {},
+  });
+
+  const { data: approval, error: approvalError } = await supabase
+    .from('approvals')
+    .select('*')
+    .eq('id', body.approval_id)
+    .eq('org_id', access.orgId)
+    .eq('agent_id', access.agentId)
+    .single();
+
+  if (approvalError || !approval) {
+    return NextResponse.json({ ok: false, error: 'ERR_INVALID_APPROVAL' }, { status: 400 });
+  }
+
+  if (approval.status !== 'issued' || approval.used_at) {
+    return NextResponse.json({ ok: false, error: 'ERR_REPLAY_ATTACK' }, { status: 409 });
+  }
+
+  if (new Date(approval.expires_at).getTime() < Date.now()) {
+    return NextResponse.json({ ok: false, error: 'ERR_EXPIRED' }, { status: 400 });
+  }
+
+  if (approval.request_id !== body.request_id) {
+    return NextResponse.json({ ok: false, error: 'ERR_REQUEST_MISMATCH' }, { status: 400 });
+  }
+
+  const allowedAction = typeof approval.action === 'string' ? approval.action : '';
+
+  if (allowedAction !== 'memory.write') {
+    return NextResponse.json({ ok: false, error: 'ERR_ACTION_MISMATCH' }, { status: 400 });
+  }
+
+  if (approval.input_hash !== inputHash) {
+    return NextResponse.json({ ok: false, error: 'ERR_INTEGRITY_MISMATCH' }, { status: 400 });
+  }
+
+  const lineageHash = computeMemoryLineageHash({
+    orgId: access.orgId,
+    agentId: access.agentId,
+    requestId: body.request_id,
+    memoryKey: body.memory_key,
+    memoryValue: body.memory_value ?? {},
+  });
+
+  const nowIso = new Date().toISOString();
+
+  const { error: memoryInsertError } = await supabase.from('agent_memory').insert({
+    org_id: access.orgId,
+    agent_id: access.agentId,
+    request_id: body.request_id,
+    memory_key: body.memory_key,
+    memory_value: body.memory_value ?? {},
+    lineage_hash: lineageHash,
+    created_at: nowIso,
+  });
+
+  if (memoryInsertError) {
+    return NextResponse.json({ ok: false, error: memoryInsertError.message }, { status: 500 });
+  }
+
+  const { error: approvalUpdateError } = await supabase
+    .from('approvals')
+    .update({
+      status: 'used',
+      used_at: nowIso,
+      metadata: {
+        ...(approval.metadata || {}),
+        memory_key: body.memory_key,
+        lineage_hash: lineageHash,
+        final_status: 'committed',
+      },
+    })
+    .eq('id', approval.id);
+
+  if (approvalUpdateError) {
+    return NextResponse.json({ ok: false, error: approvalUpdateError.message }, { status: 500 });
+  }
+
+  const { error: usageError } = await supabase.from('usage_events').insert({
+    org_id: access.orgId,
+    agent_id: access.agentId,
+    event_type: 'memory_write',
+    quantity: 1,
+    unit: 'write',
+    amount_usd: 0,
+    metadata: {
+      request_id: body.request_id,
+      memory_key: body.memory_key,
+      lineage_hash: lineageHash,
+    },
+    created_at: nowIso,
+  });
+
+  if (usageError) {
+    return NextResponse.json({ ok: false, error: usageError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    request_id: body.request_id,
+    approval_id: approval.id,
+    approval_hash: approval.approval_hash,
+    memory_key: body.memory_key,
+    lineage_hash: lineageHash,
+  });
+}

--- a/app/api/runtime-summary/route.ts
+++ b/app/api/runtime-summary/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import type { RuntimeSummaryCard } from '../../../lib/runtime/dashboard-contract';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,42 +28,84 @@ export async function GET() {
   const admin = getSupabaseAdmin();
   const orgId = String(profile.org_id);
 
-  const [{ data: truth }, { data: approvals }, { data: effects }, { data: ledger }, { data: usage }] =
-    await Promise.all([
-      admin.from('runtime_truth_state').select('*').eq('org_id', orgId).maybeSingle(),
-      admin
-        .from('approvals')
-        .select('id, status, approved_at, expires_at')
-        .eq('org_id', orgId)
-        .order('approved_at', { ascending: false })
-        .limit(20),
-      admin
-        .from('effects')
-        .select('effect_id, action, status, updated_at')
-        .eq('org_id', orgId)
-        .order('updated_at', { ascending: false })
-        .limit(20),
-      admin
-        .from('ledger_entries')
-        .select('sequence, action, decision, reason, entry_hash, created_at')
-        .eq('org_id', orgId)
-        .order('sequence', { ascending: false })
-        .limit(20),
-      admin
-        .from('usage_events')
-        .select('event_type, quantity, created_at')
-        .eq('org_id', orgId)
-        .order('created_at', { ascending: false })
-        .limit(20),
-    ]);
+  const [
+    { data: truth },
+    { data: approvals },
+    { data: effects },
+    { data: ledger },
+    { data: memory },
+    { data: usage },
+    { data: agents },
+  ] = await Promise.all([
+    admin.from('runtime_truth_state').select('*').eq('org_id', orgId).maybeSingle(),
+    admin
+      .from('approvals')
+      .select('id, request_id, action, status, approved_at, expires_at, used_at')
+      .eq('org_id', orgId)
+      .order('approved_at', { ascending: false })
+      .limit(20),
+    admin
+      .from('effects')
+      .select('effect_id, request_id, action, status, updated_at')
+      .eq('org_id', orgId)
+      .order('updated_at', { ascending: false })
+      .limit(20),
+    admin
+      .from('ledger_entries')
+      .select('sequence, action, decision, reason, effect_id, entry_hash, created_at')
+      .eq('org_id', orgId)
+      .order('sequence', { ascending: false })
+      .limit(20),
+    admin
+      .from('agent_memory')
+      .select('id, request_id, memory_key, lineage_hash, created_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+      .limit(20),
+    admin
+      .from('usage_events')
+      .select('event_type, quantity, amount_usd, created_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+      .limit(20),
+    admin
+      .from('agents')
+      .select('id, name, status, last_used_at')
+      .eq('org_id', orgId)
+      .order('updated_at', { ascending: false })
+      .limit(20),
+  ]);
+
+  const approvalItems = approvals || [];
+  const effectItems = effects || [];
+  const ledgerItems = ledger || [];
+
+  const payload: RuntimeSummaryCard = {
+    truth_state: truth || null,
+    approvals: {
+      open: approvalItems.filter((x) => x.status === 'issued').length,
+      used: approvalItems.filter((x) => x.status === 'used').length,
+      revoked: approvalItems.filter((x) => x.status === 'revoked').length,
+      recent: approvalItems,
+    },
+    effects: {
+      committed: effectItems.filter((x) => x.status === 'committed').length,
+      recent: effectItems,
+    },
+    ledger: {
+      count: ledgerItems.length,
+      recent: ledgerItems,
+    },
+    memory: {
+      count: (memory || []).length,
+      recent: memory || [],
+    },
+    usage: usage || [],
+    agents: agents || [],
+  };
 
   return NextResponse.json({
     ok: true,
-    truth_state: truth || null,
-    approvals_open: (approvals || []).filter((x) => x.status === 'issued').length,
-    approvals_recent: approvals || [],
-    effects_recent: effects || [],
-    ledger_recent: ledger || [],
-    usage_recent: usage || [],
+    ...payload,
   });
 }

--- a/app/dashboard/runtime/page.tsx
+++ b/app/dashboard/runtime/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import MissionCards from '../../../components/runtime/mission-cards';
+import StreamConsole from '../../../components/runtime/stream-console';
+import type { RuntimeSummaryCard, StreamConsoleMessage } from '../../../lib/runtime/dashboard-contract';
+
+function asRuntimeMessages(summary: RuntimeSummaryCard): StreamConsoleMessage[] {
+  const fromApprovals: StreamConsoleMessage[] = summary.approvals.recent.map((item) => ({
+    id: `approval-${item.id}`,
+    kind: 'approval',
+    request_id: item.request_id,
+    title: `${item.action} • ${item.status}`,
+    body: `expires ${new Date(item.expires_at).toLocaleString()}`,
+    created_at: item.approved_at,
+  }));
+
+  const fromEffects: StreamConsoleMessage[] = summary.effects.recent.map((item) => ({
+    id: `effect-${item.effect_id}`,
+    kind: 'effect',
+    request_id: item.request_id,
+    title: `${item.action} • ${item.status}`,
+    created_at: item.updated_at,
+  }));
+
+  const fromLedger: StreamConsoleMessage[] = summary.ledger.recent.map((item) => ({
+    id: `ledger-${item.sequence}`,
+    kind: 'decision',
+    request_id: undefined,
+    sequence: item.sequence,
+    title: `${item.action} • ${item.decision}`,
+    body: item.reason,
+    created_at: item.created_at,
+  }));
+
+  const fromMemory: StreamConsoleMessage[] = summary.memory.recent.map((item) => ({
+    id: `memory-${item.id}`,
+    kind: 'memory_write',
+    request_id: item.request_id,
+    title: item.memory_key,
+    body: item.lineage_hash,
+    created_at: item.created_at,
+  }));
+
+  return [...fromApprovals, ...fromEffects, ...fromLedger, ...fromMemory]
+    .sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at))
+    .slice(0, 60);
+}
+
+export default function RuntimePage() {
+  const [summary, setSummary] = useState<RuntimeSummaryCard | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let alive = true;
+
+    async function load() {
+      try {
+        const response = await fetch('/api/runtime-summary', { cache: 'no-store' });
+        const json = await response.json();
+        if (!response.ok) {
+          throw new Error(json.error || 'Failed to load runtime summary');
+        }
+        if (alive) setSummary(json as RuntimeSummaryCard);
+      } catch (err) {
+        if (!alive) return;
+        setError(err instanceof Error ? err.message : 'Failed to load runtime summary');
+      }
+    }
+
+    load();
+    const timer = setInterval(load, 8000);
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const stream = useMemo(() => (summary ? asRuntimeMessages(summary) : []), [summary]);
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-slate-100">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <header>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-400">DSG Runtime</p>
+          <h1 className="mt-2 text-3xl font-semibold">Mission Console</h1>
+          <p className="mt-2 text-slate-400">Truth state, approvals, effects, memory, ledger, and agents in one live view.</p>
+        </header>
+
+        {error ? <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-red-200">{error}</div> : null}
+
+        {summary ? (
+          <>
+            <MissionCards summary={summary} />
+
+            <section className="grid gap-6 xl:grid-cols-3">
+              <div className="xl:col-span-2">
+                <StreamConsole messages={stream} />
+              </div>
+
+              <div className="space-y-6">
+                <section className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+                  <h2 className="text-lg font-semibold">Truth State</h2>
+                  <pre className="mt-2 overflow-x-auto rounded-xl bg-slate-950/70 p-3 text-xs text-slate-300">
+                    {JSON.stringify(summary.truth_state, null, 2)}
+                  </pre>
+                </section>
+
+                <section className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+                  <h2 className="text-lg font-semibold">Agent Status</h2>
+                  <div className="mt-3 space-y-2 text-sm">
+                    {summary.agents.map((agent) => (
+                      <div key={agent.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-2">
+                        <p className="font-medium">{agent.name}</p>
+                        <p className="text-slate-400">{agent.status}</p>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              </div>
+            </section>
+          </>
+        ) : (
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-4 text-slate-400">Loading runtime console...</div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/runtime/mission-cards.tsx
+++ b/components/runtime/mission-cards.tsx
@@ -1,0 +1,28 @@
+import type { RuntimeSummaryCard } from '../../lib/runtime/dashboard-contract';
+
+type MissionCardsProps = {
+  summary: RuntimeSummaryCard;
+};
+
+export default function MissionCards({ summary }: MissionCardsProps) {
+  const cards = [
+    { label: 'Epoch', value: summary.truth_state?.epoch ?? '-' },
+    { label: 'Sequence', value: summary.truth_state?.sequence ?? '-' },
+    { label: 'Approvals Open', value: summary.approvals.open },
+    { label: 'Effects Committed', value: summary.effects.committed },
+    { label: 'Ledger Entries', value: summary.ledger.count },
+    { label: 'Memory Writes', value: summary.memory.count },
+    { label: 'Agents', value: summary.agents.length },
+  ];
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {cards.map((card) => (
+        <div key={card.label} className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+          <p className="text-xs uppercase tracking-wide text-slate-400">{card.label}</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-100">{String(card.value)}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/components/runtime/stream-console.tsx
+++ b/components/runtime/stream-console.tsx
@@ -1,0 +1,48 @@
+import type { StreamConsoleMessage } from '../../lib/runtime/dashboard-contract';
+
+type StreamConsoleProps = {
+  messages: StreamConsoleMessage[];
+};
+
+const kindClass: Record<StreamConsoleMessage['kind'], string> = {
+  intent: 'border-blue-500/30 bg-blue-500/10 text-blue-100',
+  approval: 'border-cyan-500/30 bg-cyan-500/10 text-cyan-100',
+  decision: 'border-violet-500/30 bg-violet-500/10 text-violet-100',
+  tool_call: 'border-amber-500/30 bg-amber-500/10 text-amber-100',
+  tool_result: 'border-orange-500/30 bg-orange-500/10 text-orange-100',
+  effect: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100',
+  memory_write: 'border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-100',
+  alert: 'border-red-500/30 bg-red-500/10 text-red-100',
+};
+
+export default function StreamConsole({ messages }: StreamConsoleProps) {
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+      <h2 className="text-lg font-semibold text-slate-100">Stream Console</h2>
+      <p className="mt-1 text-sm text-slate-400">Recent runtime events from approvals, effects, and ledger.</p>
+      <div className="mt-4 max-h-96 space-y-2 overflow-y-auto">
+        {messages.length === 0 ? (
+          <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-3 text-sm text-slate-400">No events yet.</div>
+        ) : (
+          messages.map((message) => (
+            <article key={message.id} className={`rounded-xl border p-3 ${kindClass[message.kind]}`}>
+              <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide">
+                <span>{message.kind}</span>
+                <span>•</span>
+                <span>{new Date(message.created_at).toLocaleString()}</span>
+                {message.request_id ? (
+                  <>
+                    <span>•</span>
+                    <span>{message.request_id}</span>
+                  </>
+                ) : null}
+              </div>
+              <h3 className="mt-1 text-sm font-semibold">{message.title}</h3>
+              {message.body ? <p className="mt-1 text-xs opacity-90">{message.body}</p> : null}
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/lib/runtime/approval.ts
+++ b/lib/runtime/approval.ts
@@ -50,3 +50,19 @@ export function computeEffectId(params: {
     payload_hash: params.payloadHash,
   });
 }
+
+export function computeMemoryLineageHash(params: {
+  orgId: string;
+  agentId: string;
+  requestId: string;
+  memoryKey: string;
+  memoryValue: unknown;
+}): string {
+  return sha256Hex({
+    org_id: params.orgId,
+    agent_id: params.agentId,
+    request_id: params.requestId,
+    memory_key: params.memoryKey,
+    memory_value: params.memoryValue,
+  });
+}

--- a/lib/runtime/dashboard-contract.ts
+++ b/lib/runtime/dashboard-contract.ts
@@ -1,0 +1,95 @@
+export type RuntimeSummaryCard = {
+  truth_state: {
+    epoch: number;
+    sequence: number;
+    t_t: number;
+    g_t: string;
+    i_t: string;
+    s_star_hash: string;
+    v_t: Record<string, unknown>;
+  } | null;
+
+  approvals: {
+    open: number;
+    used: number;
+    revoked: number;
+    recent: Array<{
+      id: string;
+      request_id: string;
+      action: string;
+      status: string;
+      approved_at: string;
+      expires_at: string;
+      used_at?: string | null;
+    }>;
+  };
+
+  effects: {
+    committed: number;
+    recent: Array<{
+      effect_id: string;
+      request_id: string;
+      action: string;
+      status: string;
+      updated_at: string;
+    }>;
+  };
+
+  ledger: {
+    count: number;
+    recent: Array<{
+      sequence: number;
+      action: string;
+      decision: string;
+      reason: string;
+      effect_id?: string | null;
+      entry_hash: string;
+      created_at: string;
+    }>;
+  };
+
+  memory: {
+    count: number;
+    recent: Array<{
+      id: string;
+      request_id: string;
+      memory_key: string;
+      lineage_hash: string;
+      created_at: string;
+    }>;
+  };
+
+  usage: Array<{
+    event_type: string;
+    quantity: number;
+    amount_usd: number;
+    created_at: string;
+  }>;
+
+  agents: Array<{
+    id: string;
+    name: string;
+    status: string;
+    last_used_at?: string | null;
+  }>;
+};
+
+export type StreamConsoleMessage = {
+  id: string;
+  kind:
+    | 'intent'
+    | 'approval'
+    | 'decision'
+    | 'tool_call'
+    | 'tool_result'
+    | 'effect'
+    | 'memory_write'
+    | 'alert';
+
+  request_id?: string;
+  sequence?: number;
+  title: string;
+  body?: string;
+  created_at: string;
+  meta?: Record<string, unknown>;
+};


### PR DESCRIPTION
### Motivation
- Integrate Spine-backed memory into the control plane so agents can persist and read memory items with approval-based integrity and lineage tracking.
- Provide a single `runtime-summary` payload and a live console UI to observe truth state, approvals, effects, ledger, memory, usage and agent status in one place.
- Keep existing auth patterns and preserve behavior of the current runtime while adding memory and UI observability for productization.

### Description
- Add agent-scoped memory write endpoint `POST /api/memory/write` with bearer agent auth, approval ownership/status/expiry checks, `input_hash` integrity validation, replay protection, deterministic `lineage_hash` computation via `computeMemoryLineageHash`, insert into `agent_memory`, mark approval `used`, and emit a `usage_events` record.
- Add memory read endpoint `GET /api/memory/read` that enforces agent bearer auth, supports `memory_key` filtering, and bounds `limit` to the 1–100 range.
- Extend `lib/runtime/approval.ts` with `computeMemoryLineageHash` and add a shared dashboard contract in `lib/runtime/dashboard-contract.ts` defining `RuntimeSummaryCard` and `StreamConsoleMessage` including the `memory_write` kind.
- Extend `GET /api/runtime-summary` to include `agent_memory` and `agents` in the aggregated payload and return a typed `RuntimeSummaryCard` payload for the dashboard UI.
- Add a live runtime console UI at `app/dashboard/runtime/page.tsx` plus components `components/runtime/mission-cards.tsx` and `components/runtime/stream-console.tsx` which poll `GET /api/runtime-summary` and render cards and a stream of recent events (approvals, effects, ledger, memory writes).

### Testing
- Ran TypeScript checks with `npm run typecheck` and the run completed successfully.
- Ran ESLint via `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cacb15a5808326afc8a9d0c1ba139c)