### PR TITLE
Add Live Runtime UI and ledger verify/replay API endpoints

### DIFF
--- a/app/api/effects/route.ts
+++ b/app/api/effects/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const effectId = url.searchParams.get('effect_id');
+  const admin = getSupabaseAdmin();
+
+  let query = admin
+    .from('effects')
+    .select('effect_id, request_id, action, status, payload_hash, external_receipt, updated_at')
+    .eq('org_id', profile.org_id)
+    .order('updated_at', { ascending: false })
+    .limit(20);
+
+  if (effectId) {
+    query = query.eq('effect_id', effectId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    items: data || [],
+  });
+}

--- a/app/api/ledger/replay/[sequence]/route.ts
+++ b/app/api/ledger/replay/[sequence]/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+
+type Params = { params: { sequence: string } };
+
+export const dynamic = 'force-dynamic';
+
+function toSequence(raw: string): number | null {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) return null;
+  return value;
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const sequence = toSequence(params.sequence);
+  if (sequence === null) {
+    return NextResponse.json({ ok: false, error: 'Invalid sequence' }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const admin = getSupabaseAdmin();
+
+  const [{ data: checkpoint, error: checkpointError }, { data: target, error: targetError }] =
+    await Promise.all([
+      admin
+        .from('state_checkpoints')
+        .select('sequence, epoch, state_hash, entry_hash, snapshot, created_at')
+        .eq('org_id', profile.org_id)
+        .lte('sequence', sequence)
+        .order('sequence', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      admin
+        .from('ledger_entries')
+        .select('sequence, prev_state_hash, next_state_hash')
+        .eq('org_id', profile.org_id)
+        .eq('sequence', sequence)
+        .maybeSingle(),
+    ]);
+
+  if (checkpointError) {
+    return NextResponse.json({ ok: false, error: checkpointError.message }, { status: 500 });
+  }
+  if (targetError) {
+    return NextResponse.json({ ok: false, error: targetError.message }, { status: 500 });
+  }
+  if (!target) {
+    return NextResponse.json({ ok: false, error: 'Sequence not found' }, { status: 404 });
+  }
+
+  const startSequence = checkpoint?.sequence ? Number(checkpoint.sequence) + 1 : 1;
+
+  const { data: replayEntries, error: replayError } = await admin
+    .from('ledger_entries')
+    .select(
+      'sequence, action, decision, reason, prev_state_hash, next_state_hash, entry_hash, prev_entry_hash, metadata, created_at'
+    )
+    .eq('org_id', profile.org_id)
+    .gte('sequence', startSequence)
+    .lte('sequence', sequence)
+    .order('sequence', { ascending: true });
+
+  if (replayError) {
+    return NextResponse.json({ ok: false, error: replayError.message }, { status: 500 });
+  }
+
+  let currentStateHash = checkpoint?.state_hash || target.prev_state_hash;
+  let chainConsistent = true;
+
+  for (const item of replayEntries || []) {
+    if (item.prev_state_hash !== currentStateHash) {
+      chainConsistent = false;
+      break;
+    }
+    currentStateHash = item.next_state_hash;
+  }
+
+  return NextResponse.json({
+    ok: true,
+    sequence,
+    replayed_state_hash: currentStateHash,
+    expected_next_state_hash: target.next_state_hash,
+    matches: chainConsistent && currentStateHash === target.next_state_hash,
+    replayed_state: checkpoint?.snapshot || null,
+    checkpoint_used: checkpoint || null,
+    replay_entries: replayEntries || [],
+  });
+}

--- a/app/api/ledger/verify/[sequence]/route.ts
+++ b/app/api/ledger/verify/[sequence]/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+import { computeLedgerEntryHash } from '../../../../../lib/runtime/ledger';
+
+type Params = { params: { sequence: string } };
+
+export const dynamic = 'force-dynamic';
+
+function toSequence(raw: string): number | null {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) return null;
+  return value;
+}
+
+export async function GET(_request: Request, { params }: Params) {
+  const sequence = toSequence(params.sequence);
+  if (sequence === null) {
+    return NextResponse.json({ ok: false, error: 'Invalid sequence' }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const admin = getSupabaseAdmin();
+
+  const [{ data: entry, error: entryError }, { data: checkpoint, error: checkpointError }] =
+    await Promise.all([
+      admin
+        .from('ledger_entries')
+        .select(
+          'id, agent_id, request_id, approval_hash, sequence, epoch, action, input_hash, decision, reason, prev_state_hash, next_state_hash, effect_id, logical_ts, prev_entry_hash, entry_hash, metadata, created_at'
+        )
+        .eq('org_id', profile.org_id)
+        .eq('sequence', sequence)
+        .maybeSingle(),
+      admin
+        .from('state_checkpoints')
+        .select('sequence, epoch, state_hash, entry_hash, snapshot, created_at')
+        .eq('org_id', profile.org_id)
+        .lte('sequence', sequence)
+        .order('sequence', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+  if (entryError) {
+    return NextResponse.json({ ok: false, error: entryError.message }, { status: 500 });
+  }
+  if (checkpointError) {
+    return NextResponse.json({ ok: false, error: checkpointError.message }, { status: 500 });
+  }
+  if (!entry) {
+    return NextResponse.json({ ok: false, error: 'Sequence not found' }, { status: 404 });
+  }
+
+  const { data: previousEntry, error: previousError } = await admin
+    .from('ledger_entries')
+    .select(
+      'id, agent_id, request_id, approval_hash, sequence, epoch, action, input_hash, decision, reason, prev_state_hash, next_state_hash, effect_id, logical_ts, prev_entry_hash, entry_hash, metadata, created_at'
+    )
+    .eq('org_id', profile.org_id)
+    .eq('sequence', sequence - 1)
+    .maybeSingle();
+
+  if (previousError) {
+    return NextResponse.json({ ok: false, error: previousError.message }, { status: 500 });
+  }
+
+  const expectedEntryHash = computeLedgerEntryHash({
+    org_id: profile.org_id,
+    agent_id: entry.agent_id,
+    request_id: entry.request_id,
+    approval_hash: entry.approval_hash,
+    sequence: Number(entry.sequence),
+    epoch: Number(entry.epoch),
+    action: entry.action,
+    input_hash: entry.input_hash,
+    decision: entry.decision,
+    reason: entry.reason,
+    prev_state_hash: entry.prev_state_hash,
+    next_state_hash: entry.next_state_hash,
+    effect_id: entry.effect_id,
+    logical_ts: Number(entry.logical_ts),
+    prev_entry_hash: entry.prev_entry_hash,
+    metadata: entry.metadata || {},
+  });
+
+  const entryHashValid = expectedEntryHash === entry.entry_hash;
+  const expectedPrevHash = sequence === 1 ? 'GENESIS' : previousEntry?.entry_hash;
+  const chainValid = expectedPrevHash ? entry.prev_entry_hash === expectedPrevHash : false;
+
+  return NextResponse.json({
+    ok: true,
+    sequence,
+    verified: entryHashValid && chainValid,
+    entry_hash_valid: entryHashValid,
+    chain_valid: chainValid,
+    expected_entry_hash: expectedEntryHash,
+    entry,
+    previous_entry: previousEntry || null,
+    execution: null,
+    checkpoint: checkpoint || null,
+  });
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ const NAV = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/dashboard/command-center', label: 'Command Center' },
   { href: '/dashboard/mission', label: 'Mission' },
+  { href: '/dashboard/live', label: 'Live' },
   { href: '/dashboard/operations', label: 'Operations' },
   { href: '/dashboard/executions', label: 'Executions' },
   { href: '/dashboard/proofs', label: 'Proofs' },

--- a/app/dashboard/live/page.tsx
+++ b/app/dashboard/live/page.tsx
@@ -1,0 +1,22 @@
+import { VerifyPanel } from '../../../components/runtime/verify-panel';
+import { ReplayPanel } from '../../../components/runtime/replay-panel';
+import { EffectInspector } from '../../../components/runtime/effect-inspector';
+
+export default function LivePage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
+      <div className="mx-auto max-w-7xl">
+        <h1 className="text-3xl font-semibold">Live Runtime</h1>
+        <p className="mt-2 text-slate-400">
+          Verify ledger sequence integrity, replay deterministic state transitions, and inspect effect lineage.
+        </p>
+
+        <div className="mt-6 grid gap-6 xl:grid-cols-3">
+          <VerifyPanel />
+          <ReplayPanel />
+          <EffectInspector />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/runtime/effect-inspector.tsx
+++ b/components/runtime/effect-inspector.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+
+type EffectResponse = {
+  ok: boolean;
+  items?: Array<{
+    effect_id: string;
+    request_id: string;
+    action: string;
+    status: string;
+    payload_hash: string;
+    external_receipt: Record<string, unknown>;
+    updated_at: string;
+  }>;
+  error?: string;
+};
+
+export function EffectInspector() {
+  const [effectId, setEffectId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<EffectResponse | null>(null);
+
+  async function inspectNow() {
+    try {
+      setLoading(true);
+      setResult(null);
+
+      const url = effectId
+        ? `/api/effects?effect_id=${encodeURIComponent(effectId)}`
+        : '/api/effects';
+
+      const res = await fetch(url, { cache: 'no-store' });
+      const json = await res.json();
+      setResult(json);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+      <div className="mb-4">
+        <p className="text-xs uppercase tracking-[0.22em] text-emerald-400">Effects</p>
+        <h3 className="mt-2 text-lg font-medium">Effect Inspector</h3>
+      </div>
+
+      <div className="grid gap-4">
+        <label className="grid gap-2 text-sm">
+          <span className="text-neutral-400">Effect ID</span>
+          <input
+            value={effectId}
+            onChange={(e) => setEffectId(e.target.value)}
+            placeholder="leave empty to list recent effects"
+            className="rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-white"
+          />
+        </label>
+
+        <button
+          onClick={inspectNow}
+          disabled={loading}
+          className="rounded-2xl bg-emerald-500 px-4 py-3 font-medium text-black transition hover:bg-emerald-400 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Inspect Effect'}
+        </button>
+
+        {result ? (
+          <div className="space-y-3">
+            {(result.items || []).map((item) => (
+              <div key={item.effect_id} className="rounded-2xl border border-white/10 bg-black/25 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="font-medium">{item.action}</div>
+                  <div className="text-xs uppercase text-neutral-400">{item.status}</div>
+                </div>
+
+                <div className="mt-2 text-xs text-neutral-400">req {item.request_id}</div>
+
+                <div className="mt-2 break-all font-mono text-xs text-neutral-300">{item.effect_id}</div>
+
+                <details className="mt-3 rounded-2xl bg-white/5 p-3">
+                  <summary className="cursor-pointer text-xs uppercase tracking-[0.18em] text-neutral-400">
+                    external receipt
+                  </summary>
+                  <pre className="mt-3 overflow-x-auto text-xs text-neutral-300">
+                    {JSON.stringify(item.external_receipt, null, 2)}
+                  </pre>
+                </details>
+              </div>
+            ))}
+
+            {!result.items || result.items.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-white/10 p-4 text-sm text-neutral-500">
+                No effects found.
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/runtime/replay-panel.tsx
+++ b/components/runtime/replay-panel.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+
+type ReplayResponse = {
+  ok: boolean;
+  sequence?: number;
+  replayed_state_hash?: string;
+  expected_next_state_hash?: string;
+  matches?: boolean;
+  replayed_state?: Record<string, unknown>;
+  checkpoint_used?: Record<string, unknown> | null;
+  replay_entries?: Array<Record<string, unknown>>;
+  error?: string;
+};
+
+export function ReplayPanel() {
+  const [sequence, setSequence] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ReplayResponse | null>(null);
+
+  async function replayNow() {
+    try {
+      setLoading(true);
+      setResult(null);
+
+      const res = await fetch(`/api/ledger/replay/${sequence}`, { cache: 'no-store' });
+      const json = await res.json();
+      setResult(json);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+      <div className="mb-4">
+        <p className="text-xs uppercase tracking-[0.22em] text-violet-400">Replay</p>
+        <h3 className="mt-2 text-lg font-medium">State Replay Inspector</h3>
+      </div>
+
+      <div className="grid gap-4">
+        <label className="grid gap-2 text-sm">
+          <span className="text-neutral-400">Target Sequence</span>
+          <input
+            value={sequence}
+            onChange={(e) => setSequence(e.target.value)}
+            placeholder="e.g. 42"
+            className="rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-white"
+          />
+        </label>
+
+        <button
+          onClick={replayNow}
+          disabled={loading || !sequence}
+          className="rounded-2xl bg-violet-500 px-4 py-3 font-medium text-white transition hover:bg-violet-400 disabled:opacity-50"
+        >
+          {loading ? 'Replaying…' : 'Replay Sequence'}
+        </button>
+
+        {result ? (
+          <div className="space-y-3">
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="rounded-2xl bg-black/25 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Match</div>
+                <div className="mt-2 text-2xl font-semibold text-white">{String(Boolean(result.matches))}</div>
+              </div>
+
+              <div className="rounded-2xl bg-black/25 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Replay Hash</div>
+                <div className="mt-2 break-all font-mono text-xs text-neutral-300">{result.replayed_state_hash || '-'}</div>
+              </div>
+
+              <div className="rounded-2xl bg-black/25 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Expected Hash</div>
+                <div className="mt-2 break-all font-mono text-xs text-neutral-300">{result.expected_next_state_hash || '-'}</div>
+              </div>
+            </div>
+
+            <pre className="overflow-x-auto rounded-2xl bg-black/30 p-4 text-xs text-neutral-300">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/runtime/verify-panel.tsx
+++ b/components/runtime/verify-panel.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+
+type VerifyResponse = {
+  ok: boolean;
+  sequence?: number;
+  verified?: boolean;
+  entry_hash_valid?: boolean;
+  chain_valid?: boolean;
+  expected_entry_hash?: string;
+  entry?: Record<string, unknown>;
+  previous_entry?: Record<string, unknown> | null;
+  execution?: Record<string, unknown> | null;
+  checkpoint?: Record<string, unknown> | null;
+  error?: string;
+};
+
+export function VerifyPanel() {
+  const [sequence, setSequence] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<VerifyResponse | null>(null);
+
+  async function verifyNow() {
+    try {
+      setLoading(true);
+      setResult(null);
+
+      const res = await fetch(`/api/ledger/verify/${sequence}`, { cache: 'no-store' });
+      const json = await res.json();
+      setResult(json);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+      <div className="mb-4">
+        <p className="text-xs uppercase tracking-[0.22em] text-cyan-400">Verify</p>
+        <h3 className="mt-2 text-lg font-medium">Sequence Verifier</h3>
+      </div>
+
+      <div className="grid gap-4">
+        <label className="grid gap-2 text-sm">
+          <span className="text-neutral-400">Sequence</span>
+          <input
+            value={sequence}
+            onChange={(e) => setSequence(e.target.value)}
+            placeholder="e.g. 42"
+            className="rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-white"
+          />
+        </label>
+
+        <button
+          onClick={verifyNow}
+          disabled={loading || !sequence}
+          className="rounded-2xl bg-cyan-500 px-4 py-3 font-medium text-black transition hover:bg-cyan-400 disabled:opacity-50"
+        >
+          {loading ? 'Verifying…' : 'Verify Sequence'}
+        </button>
+
+        {result ? (
+          <div className="space-y-3">
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="rounded-2xl bg-black/25 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Verified</div>
+                <div className="mt-2 text-2xl font-semibold text-white">{String(Boolean(result.verified))}</div>
+              </div>
+
+              <div className="rounded-2xl bg-black/25 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Entry Hash</div>
+                <div className="mt-2 text-2xl font-semibold text-emerald-300">{String(Boolean(result.entry_hash_valid))}</div>
+              </div>
+
+              <div className="rounded-2xl bg-black/25 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Chain</div>
+                <div className="mt-2 text-2xl font-semibold text-amber-300">{String(Boolean(result.chain_valid))}</div>
+              </div>
+            </div>
+
+            <pre className="overflow-x-auto rounded-2xl bg-black/30 p-4 text-xs text-neutral-300">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a Live Runtime area that lets operators inspect effects, verify ledger sequence integrity, and replay deterministic state transitions.
- Expose secure API endpoints to fetch recent effects and to perform sequence `verify` and `replay` operations scoped to the authenticated user's organization.

### Description

- Added a dashboard route and UI: new page at `app/dashboard/live/page.tsx` and a navigation entry in `app/dashboard/layout.tsx` to surface the Live Runtime tools.
- Introduced three client UI components `VerifyPanel`, `ReplayPanel`, and `EffectInspector` in `components/runtime/*` that call the new APIs and render results interactively in the dashboard.
- Implemented server API endpoints: `GET /api/effects` in `app/api/effects/route.ts`, `GET /api/ledger/verify/:sequence` in `app/api/ledger/verify/[sequence]/route.ts`, and `GET /api/ledger/replay/:sequence` in `app/api/ledger/replay/[sequence]/route.ts`, each enforcing authentication, organization membership and `is_active` checks via the Supabase client and using the Supabase admin client for read-only ledger/checkpoint data.
- The verify endpoint computes expected entry hashes using `computeLedgerEntryHash` and validates chain links against previous entries, while the replay endpoint loads the nearest checkpoint and replays entries to report replayed/expected state hashes and whether they match.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cace1fd45083268dd59d97a5a475af)