### PR TITLE
Self-serve onboarding, usage summary, and server env validation

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -79,7 +79,10 @@ export async function GET() {
       })
     );
 
-    return NextResponse.json({ items });
+    return NextResponse.json({
+      items,
+      agents: items,
+    });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Unexpected error' },

--- a/app/api/usage/route.ts
+++ b/app/api/usage/route.ts
@@ -93,6 +93,17 @@ export async function GET() {
       (sum, row) => sum + Number(row.executions || 0),
       0
     );
+    const { count: agentCount, error: agentCountError } = await supabase
+      .from('agents')
+      .select('id', { count: 'exact', head: true })
+      .eq('org_id', profile.org_id);
+
+    if (
+      agentCountError &&
+      !/relation .* does not exist/i.test(agentCountError.message)
+    ) {
+      return NextResponse.json({ error: agentCountError.message }, { status: 500 });
+    }
 
     const planKey = String(subscription?.plan_key || 'trial').toLowerCase();
     const includedExecutions =
@@ -101,7 +112,7 @@ export async function GET() {
     const overageExecutions = Math.max(0, executions - includedExecutions);
     const projectedAmountUsd = Number((overageExecutions * 0.001).toFixed(3));
 
-    return NextResponse.json({
+    const payload = {
       plan: formatPlanLabel(planKey, subscription?.billing_interval || null),
       subscription_status: subscription?.status || 'trialing',
       billing_period: formatBillingPeriod(
@@ -116,6 +127,23 @@ export async function GET() {
       included_executions: includedExecutions,
       overage_executions: overageExecutions,
       projected_amount_usd: projectedAmountUsd,
+    };
+
+    return NextResponse.json({
+      ...payload,
+      summary: {
+        billing_period: payload.billing_period,
+        agent_count: Number(agentCount || 0),
+        execution_count: payload.executions,
+        monthly_executions: payload.executions,
+        subscription: {
+          plan: payload.plan,
+          status: payload.subscription_status,
+          current_period_start: payload.current_period_start,
+          current_period_end: payload.current_period_end,
+          updated_at: subscription?.updated_at || new Date().toISOString(),
+        },
+      },
     });
   } catch (error) {
     return NextResponse.json(

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,11 +1,30 @@
 import { type EmailOtpType } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
 import { createClient } from '../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
 
 function getSafeNext(value: string | null) {
   if (!value || !value.startsWith('/')) return '/workspace';
   return value;
+}
+
+function buildOrgId() {
+  return `org_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+}
+
+function buildOrgName(email: string) {
+  const localPart = email.split('@')[0] || 'dsg';
+  return `${localPart}-org`;
+}
+
+function buildOrgSlug(email: string) {
+  const localPart = (email.split('@')[0] || 'dsg')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32);
+  return `${localPart || 'dsg'}-${randomUUID().slice(0, 8)}`;
 }
 
 export async function GET(request: NextRequest) {
@@ -42,13 +61,79 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(redirectToLogin, { status: 302 });
   }
 
-  const admin = getSupabaseAdmin();
+  let admin;
+  try {
+    admin = getSupabaseAdmin();
+  } catch {
+    redirectToLogin.searchParams.set('error', 'server-misconfigured');
+    return NextResponse.redirect(redirectToLogin, { status: 302 });
+  }
 
-  await admin
+  const { data: existingProfile } = await admin
     .from('users')
-    .update({ auth_user_id: user.id })
+    .select('id, org_id, is_active, auth_user_id')
     .eq('email', user.email)
-    .is('auth_user_id', null);
+    .maybeSingle();
+
+  if (existingProfile?.id) {
+    let orgId = existingProfile.org_id || null;
+    if (!orgId) {
+      orgId = buildOrgId();
+      const orgName = buildOrgName(user.email);
+      const orgSlug = buildOrgSlug(user.email);
+      const { error: orgError } = await admin.from('organizations').insert({
+        id: orgId,
+        name: orgName,
+        slug: orgSlug,
+        plan: 'trial',
+        status: 'active',
+      });
+      if (orgError) {
+        redirectToLogin.searchParams.set('error', 'self-serve-failed');
+        return NextResponse.redirect(redirectToLogin, { status: 302 });
+      }
+    }
+
+    await admin
+      .from('users')
+      .update({
+        auth_user_id: existingProfile.auth_user_id || user.id,
+        org_id: orgId,
+        is_active: true,
+      })
+      .eq('id', existingProfile.id);
+  } else {
+    const orgId = buildOrgId();
+    const orgName = buildOrgName(user.email);
+    const orgSlug = buildOrgSlug(user.email);
+
+    const { error: orgError } = await admin.from('organizations').insert({
+      id: orgId,
+      name: orgName,
+      slug: orgSlug,
+      plan: 'trial',
+      status: 'active',
+    });
+
+    if (orgError) {
+      redirectToLogin.searchParams.set('error', 'self-serve-failed');
+      return NextResponse.redirect(redirectToLogin, { status: 302 });
+    }
+
+    const { error: userError } = await admin.from('users').insert({
+      auth_user_id: user.id,
+      org_id: orgId,
+      email: user.email,
+      role: 'owner',
+      auth_provider: 'magic_link',
+      is_active: true,
+    });
+
+    if (userError) {
+      redirectToLogin.searchParams.set('error', 'self-serve-failed');
+      return NextResponse.redirect(redirectToLogin, { status: 302 });
+    }
+  }
 
   const { data: profile } = await admin
     .from('users')

--- a/app/auth/login/route.ts
+++ b/app/auth/login/route.ts
@@ -25,72 +25,13 @@ export async function POST(request: NextRequest) {
     confirmUrl.searchParams.set('next', next);
 
     console.log('[magic-link] input:', { email });
-
-    const { data: anyActiveRow, error: anyActiveErr } = await supabase
-      .from('users')
-      .select('id, email, is_active, org_id, auth_user_id')
-      .eq('email', email)
-      .eq('is_active', true)
-      .maybeSingle();
-
-    console.log('[magic-link] ANY ACTIVE:', {
-      ok: !anyActiveErr,
-      anyActiveErrMessage: anyActiveErr?.message ?? null,
-      userRowPresent: !!anyActiveRow,
-      userRow: anyActiveRow
-        ? {
-            id: anyActiveRow.id,
-            email: anyActiveRow.email,
-            is_active: anyActiveRow.is_active,
-            org_id: anyActiveRow.org_id ?? null,
-            auth_user_id: anyActiveRow.auth_user_id ?? null,
-          }
-        : null,
-    });
-
-    const { data: userRow, error: userErr } = await supabase
-      .from('users')
-      .select('id, email, is_active, org_id, auth_user_id')
-      .eq('email', email)
-      .eq('is_active', true)
-      .not('org_id', 'is', null)
-      .maybeSingle();
-
-    if (userErr) {
-      console.log('[magic-link] FINAL validation query failed:', {
-        message: userErr.message,
-        details: userErr.details ?? null,
-        hint: userErr.hint ?? null,
-      });
-      throw userErr;
-    }
-
-    console.log('[magic-link] FINAL validation:', {
-      operatorAllowed: !!userRow,
-      userRow: userRow
-        ? {
-            id: userRow.id,
-            email: userRow.email,
-            is_active: userRow.is_active,
-            org_id: userRow.org_id ?? null,
-            auth_user_id: userRow.auth_user_id ?? null,
-          }
-        : null,
-    });
-
-    if (!userRow) {
-      console.log('[magic-link] BLOCKED BEFORE OTP');
-      redirectToLogin.searchParams.set('error', 'send-failed');
-      return NextResponse.redirect(redirectToLogin, { status: 302 });
-    }
-
-    console.log('[magic-link] calling signInWithOtp...');
+    console.log('[magic-link] calling signInWithOtp (self-serve enabled)...');
 
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
         emailRedirectTo: confirmUrl.toString(),
-        shouldCreateUser: false,
+        shouldCreateUser: true,
       },
     });
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -128,9 +128,25 @@ export default function DashboardPage() {
         if (!healthRes.ok) throw new Error(healthJson.error || "Failed to load control-plane health");
         if (!alive) return;
 
-        setAgents(agentsJson.agents || []);
+        setAgents(agentsJson.items || agentsJson.agents || []);
         setExecutions(executionsJson.executions || []);
-        setSummary(usageJson.summary || null);
+        setSummary(
+          usageJson.summary || {
+            billing_period: usageJson.billing_period || new Date().toISOString().slice(0, 7),
+            agent_count: (agentsJson.items || agentsJson.agents || []).length,
+            execution_count: usageJson.executions || 0,
+            monthly_executions: usageJson.executions || 0,
+            subscription: usageJson.plan
+              ? {
+                  plan: usageJson.plan,
+                  status: usageJson.subscription_status || "trialing",
+                  current_period_start: usageJson.current_period_start || null,
+                  current_period_end: usageJson.current_period_end || null,
+                  updated_at: new Date().toISOString(),
+                }
+              : null,
+          }
+        );
         setHealth(healthJson || null);
 
         if (auditRes.ok) {

--- a/app/dashboard/policies/page.tsx
+++ b/app/dashboard/policies/page.tsx
@@ -6,7 +6,7 @@ type PolicyRow = {
   id: string;
   name: string;
   version: string;
-  status: "active" | "draft" | "archived";
+  status: "preview" | "draft" | "archived";
   description: string;
   thresholds: {
     block_risk_score: number;
@@ -19,8 +19,8 @@ const seedPolicies: PolicyRow[] = [
     id: "policy_default",
     name: "Default DSG Policy",
     version: "v1",
-    status: "active",
-    description: "Baseline execution policy used for deterministic risk gating.",
+    status: "preview",
+    description: "Baseline reference policy shown for review only (not runtime-writable).",
     thresholds: {
       block_risk_score: 0.8,
       stabilize_risk_score: 0.4,
@@ -56,9 +56,13 @@ export default function PoliciesPage() {
           </p>
           <h1 className="text-4xl font-bold">Policy Management</h1>
           <p className="mt-3 max-w-2xl text-slate-300">
-            Review policy versions, inspect current thresholds, and prepare the
-            next policy workflow for DB-backed approvals.
+            Unfinished governance surface for policy review. This page is not
+            the active governance runtime surface.
           </p>
+        </div>
+        <div className="mt-6 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
+          Governance status: unfinished + preview-only. Runtime ALLOW/STABILIZE/BLOCK decisions
+          are enforced by server-side gate contracts, not by edits on this screen.
         </div>
 
         <div className="mt-8 grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
@@ -107,8 +111,8 @@ export default function PoliciesPage() {
             <div className="mt-6 rounded-2xl border border-slate-800 bg-slate-950 p-5 text-sm text-slate-300">
               <p className="font-semibold text-white">Next step</p>
               <p className="mt-2">
-                Wire this page to a real policies table plus approval history so
-                policy versioning becomes auditable end-to-end.
+                Wire this page to DB-backed policies, approval history, and
+                controlled rollout gates before promoting it to an active governance runtime surface.
               </p>
             </div>
           </section>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -34,6 +34,13 @@ function getMessage(message?: string, error?: string) {
     };
   }
 
+  if (error === 'invite-only') {
+    return {
+      tone: 'error',
+      text: 'Invite-only mode is disabled. If you still see this, refresh and try again.',
+    };
+  }
+
   if (error === 'not-provisioned') {
     return {
       tone: 'error',
@@ -55,6 +62,20 @@ function getMessage(message?: string, error?: string) {
     };
   }
 
+  if (error === 'server-misconfigured') {
+    return {
+      tone: 'error',
+      text: 'Server auth callback is missing required Supabase environment variables.',
+    };
+  }
+
+  if (error === 'self-serve-failed') {
+    return {
+      tone: 'error',
+      text: 'Account provisioning failed after login confirmation. Please retry or contact support.',
+    };
+  }
+
   return null;
 }
 
@@ -73,7 +94,7 @@ export default function LoginPage({
           <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Operator Access</p>
           <h1 className="mt-4 text-4xl font-bold">Sign in to the DSG Control Plane</h1>
           <p className="mt-4 text-base leading-7 text-slate-300">
-            Use your approved operator email to receive a magic link. After confirmation, you will be redirected into the protected dashboard.
+            Self-serve access. Enter your email to receive a magic link; on first login we auto-provision your trial workspace.
           </p>
 
           {notice ? (
@@ -112,7 +133,7 @@ export default function LoginPage({
           <div className="mt-8 rounded-[1.5rem] border border-white/10 bg-slate-950/50 p-5 text-sm text-slate-300">
             <p className="font-semibold text-white">Provisioning rule</p>
             <p className="mt-2 leading-7">
-              Login alone is not enough. Your email must also map to an active row in the <code>users</code> table with a valid <code>org_id</code>.
+              First successful confirmation auto-creates your organization and owner profile in <code>organizations</code> and <code>users</code>.
             </p>
           </div>
         </div>
@@ -124,8 +145,8 @@ export default function LoginPage({
               {[
                 'We send a magic link through Supabase Auth.',
                 'The callback verifies the link and creates a cookie session.',
-                'If your email already exists in users, the app links auth_user_id automatically.',
-                'Protected dashboard routes unlock only when org_id and is_active are valid.',
+                'If this is your first login, we auto-create organization + owner profile.',
+                'Protected dashboard routes unlock after org_id and is_active are provisioned.',
               ].map((item, index) => (
                 <div key={item} className="flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-slate-200">
                   <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-emerald-400/10 font-semibold text-emerald-200">

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,12 +1,24 @@
 import { createClient } from '@supabase/supabase-js';
 
-export function getSupabaseAdmin() {
+function assertSupabaseServerEnv() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url || !serviceRoleKey) {
-    throw new Error('Missing Supabase server environment variables');
+    const missing = [
+      !url ? 'NEXT_PUBLIC_SUPABASE_URL' : null,
+      !serviceRoleKey ? 'SUPABASE_SERVICE_ROLE_KEY' : null,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    throw new Error(`Missing Supabase server environment variables: ${missing}`);
   }
+
+  return { url, serviceRoleKey };
+}
+
+export function getSupabaseAdmin() {
+  const { url, serviceRoleKey } = assertSupabaseServerEnv();
 
   return createClient(url, serviceRoleKey, {
     auth: {


### PR DESCRIPTION
### Motivation
- Enable self-serve operator onboarding so first-time users can sign in with a magic link and get an auto-provisioned organization and owner profile.
- Surface richer usage/summary data to the dashboard and provide backwards-compatible payloads for the agents endpoint.
- Improve server-side config validation and clearer error handling when Supabase server env vars are missing.

### Description
- Implemented self-serve onboarding in the auth confirm flow by creating `organizations` and `users` rows when needed and linking `auth_user_id`, with helper builders `buildOrgId`, `buildOrgName`, and `buildOrgSlug` to generate IDs and slugs. Added explicit error redirects for `server-misconfigured` and `self-serve-failed` cases. (files: `app/auth/confirm/route.ts`, `app/auth/login/route.ts`, `app/login/page.tsx`).
- Switched the magic-link sign-in to allow creating users by setting `shouldCreateUser: true` and simplified the login POST flow for self-serve. (file: `app/auth/login/route.ts`).
- Augmented the `usage` API to compute an `agent_count` and return a `summary` object with billing and subscription details; added defensive handling for missing `agents` relation. (file: `app/api/usage/route.ts`).
- Adjusted the `agents` API to return both `items` and an `agents` alias to remain compatible with callers. (file: `app/api/agents/route.ts`).
- Updated dashboard client to consume the new /api payloads and provide a fallback `summary` when the new `summary` object is not present. (file: `app/dashboard/page.tsx`).
- Marked the policies UI as preview-only and adjusted copy and status enums to `preview` for the reference policy. (file: `app/dashboard/policies/page.tsx`).
- Improved server env validation in `getSupabaseAdmin()` by adding `assertSupabaseServerEnv()` to list missing env vars and throw a clearer error message. (file: `lib/supabase-server.ts`).
- Added several user-facing messages and error codes to the login page for the new provisioning and config failure flows. (file: `app/login/page.tsx`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69caed8261988326bb2de20d45cd2ff8)