### PR TITLE
Add Spine Live Room UI, stream components, channel contracts and `/api/memory/recent`

### DIFF
--- a/app/api/memory/recent/route.ts
+++ b/app/api/memory/recent/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.org_id || !profile.is_active) {
+    return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const admin = getSupabaseAdmin();
+
+  const { data, error } = await admin
+    .from('agent_memory')
+    .select('id, request_id, memory_key, memory_value, lineage_hash, created_at')
+    .eq('org_id', profile.org_id)
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    items: data || [],
+  });
+}

--- a/app/app-shell/page.tsx
+++ b/app/app-shell/page.tsx
@@ -55,6 +55,7 @@ const links = [
   { href: '/dashboard/executions', label: 'Executions' },
   { href: '/dashboard/proofs', label: 'Proofs' },
   { href: '/dashboard/ledger', label: 'Ledger' },
+  { href: '/dashboard/live', label: 'Live Room' },
   { href: '/dashboard/capacity', label: 'Capacity' },
   { href: '/dashboard/billing', label: 'Billing' },
   { href: '/dashboard/audit', label: 'Audit' },

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ const NAV = [
   { href: '/dashboard/executions', label: 'Executions' },
   { href: '/dashboard/proofs', label: 'Proofs' },
   { href: '/dashboard/ledger', label: 'Ledger' },
+  { href: '/dashboard/live', label: 'Live Room' },
   { href: '/dashboard/capacity', label: 'Capacity' },
   { href: '/dashboard/billing', label: 'Billing' },
   { href: '/dashboard/audit', label: 'Audit' },

--- a/app/dashboard/live/page.tsx
+++ b/app/dashboard/live/page.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { LiveRoom } from '../../../components/runtime/live-room';
+import type { RuntimeSummaryCard, StreamConsoleMessage } from '../../../lib/runtime/dashboard-contract';
+
+type MemoryRecentResponse = {
+  ok: boolean;
+  items: Array<{
+    id: string;
+    request_id?: string | null;
+    memory_key: string;
+    memory_value: Record<string, unknown>;
+    lineage_hash: string;
+    created_at: string;
+  }>;
+};
+
+type RuntimeSummaryResponse = {
+  ok: boolean;
+  truth_state: RuntimeSummaryCard['truth_state'];
+  approvals_open: number;
+  approvals_recent: NonNullable<RuntimeSummaryCard['approvals']>['recent'];
+  effects_recent: NonNullable<RuntimeSummaryCard['effects']>['recent'];
+  ledger_recent: NonNullable<RuntimeSummaryCard['ledger']>['recent'];
+};
+
+function normalizeSummary(input: RuntimeSummaryResponse | null): RuntimeSummaryCard | null {
+  if (!input) return null;
+
+  return {
+    truth_state: input.truth_state,
+    approvals: {
+      open: input.approvals_open || 0,
+      recent: input.approvals_recent || [],
+    },
+    effects: {
+      committed: (input.effects_recent || []).filter((item) => item.status === 'committed').length,
+      recent: input.effects_recent || [],
+    },
+    ledger: {
+      recent: input.ledger_recent || [],
+    },
+  };
+}
+
+function buildLiveStream(summary: RuntimeSummaryCard | null): StreamConsoleMessage[] {
+  const items: StreamConsoleMessage[] = [];
+
+  for (const entry of summary?.ledger?.recent || []) {
+    items.push({
+      id: `ledger-${entry.entry_hash}`,
+      kind: 'decision',
+      sequence: entry.sequence,
+      title: `${entry.decision} • seq ${entry.sequence}`,
+      body: `${entry.action} • ${entry.reason}`,
+      created_at: entry.created_at,
+      meta: entry,
+    });
+  }
+
+  for (const entry of summary?.effects?.recent || []) {
+    items.push({
+      id: `effect-${entry.effect_id}`,
+      kind: 'effect',
+      request_id: entry.request_id,
+      title: `Effect ${entry.status.toUpperCase()}`,
+      body: `${entry.action} • ${entry.effect_id}`,
+      created_at: entry.updated_at,
+      meta: entry,
+    });
+  }
+
+  for (const entry of summary?.approvals?.recent || []) {
+    items.push({
+      id: `approval-${entry.id}`,
+      kind: 'approval',
+      request_id: entry.request_id,
+      title: `Approval ${entry.status.toUpperCase()}`,
+      body: `${entry.action || 'action'} • expires ${new Date(entry.expires_at).toLocaleString()}`,
+      created_at: entry.used_at || entry.approved_at || entry.expires_at,
+      meta: entry as Record<string, unknown>,
+    });
+  }
+
+  return items.sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at)).slice(0, 50);
+}
+
+export default function LiveDashboardPage() {
+  const [summary, setSummary] = useState<RuntimeSummaryCard | null>(null);
+  const [memoryRecent, setMemoryRecent] = useState<MemoryRecentResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadAll() {
+    try {
+      setError(null);
+
+      const [summaryRes, memoryRes] = await Promise.all([
+        fetch('/api/runtime-summary', { cache: 'no-store' }),
+        fetch('/api/memory/recent', { cache: 'no-store' }),
+      ]);
+
+      const summaryJson = await summaryRes.json();
+      const memoryJson = await memoryRes.json();
+
+      if (!summaryRes.ok) {
+        throw new Error(summaryJson?.error || 'Failed to load runtime summary');
+      }
+
+      if (!memoryRes.ok) {
+        throw new Error(memoryJson?.error || 'Failed to load memory feed');
+      }
+
+      setSummary(normalizeSummary(summaryJson));
+      setMemoryRecent(memoryJson);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unexpected error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadAll();
+    const id = window.setInterval(loadAll, 3000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const summaryWithMemory = useMemo(() => {
+    if (!summary) return null;
+    return {
+      ...summary,
+      memory_recent: memoryRecent?.items || [],
+    };
+  }, [summary, memoryRecent]);
+
+  const streamItems = useMemo(() => buildLiveStream(summary), [summary]);
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-white">
+      <div className="mx-auto max-w-7xl px-4 py-6 md:px-6">
+        <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.24em] text-fuchsia-400">DSG ONE Live Mode</p>
+            <h1 className="mt-2 text-3xl font-semibold">Voice / CLI / Browser Room</h1>
+            <p className="mt-2 max-w-3xl text-sm text-neutral-400">
+              ห้องเดียวสำหรับดู channel ทั้งหมดที่วิ่งผ่าน Spine: chat, CLI, remote browser,
+              voice live, MCP, tools, and operator interventions.
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-neutral-300">
+            <div>Status: {loading ? 'Loading…' : 'Live'}</div>
+            <div>Refresh: every 3s</div>
+            {summary?.truth_state ? (
+              <div>Epoch {summary.truth_state.epoch} • Seq {summary.truth_state.sequence}</div>
+            ) : (
+              <div>No truth state</div>
+            )}
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mb-6 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</div>
+        ) : null}
+
+        <LiveRoom summary={summaryWithMemory} streamItems={streamItems} />
+      </div>
+    </div>
+  );
+}

--- a/components/runtime/live-room.tsx
+++ b/components/runtime/live-room.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { CHANNEL_BADGES } from '../../lib/runtime/channel-contract';
+import type { RuntimeSummaryCard, StreamConsoleMessage } from '../../lib/runtime/dashboard-contract';
+import { StreamConsole } from './stream-console';
+
+type LiveRoomProps = {
+  summary: (RuntimeSummaryCard & { memory_recent?: any[] }) | null;
+  streamItems: StreamConsoleMessage[];
+};
+
+export function LiveRoom({ summary, streamItems }: LiveRoomProps) {
+  return (
+    <div className="grid gap-6 xl:grid-cols-[1.35fr_0.65fr]">
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.24em] text-cyan-400">Live Runtime Feed</p>
+            <h2 className="mt-2 text-xl font-semibold">Spine Stream Room</h2>
+          </div>
+
+          <div className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300">live</div>
+        </div>
+
+        <div className="mb-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {CHANNEL_BADGES.map((item) => (
+            <div key={item.channel} className="rounded-2xl border border-white/10 bg-black/20 p-3">
+              <div
+                className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.18em] ${item.color_class}`}
+              >
+                {item.label}
+              </div>
+              <div className="mt-2 text-sm text-neutral-300">{item.description}</div>
+            </div>
+          ))}
+        </div>
+
+        <StreamConsole items={streamItems} />
+      </div>
+
+      <div className="space-y-6">
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+          <h3 className="mb-4 text-lg font-medium">Spine Truth Snapshot</h3>
+          <div className="grid gap-3">
+            <div className="rounded-2xl bg-black/25 p-3">
+              <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Epoch</div>
+              <div className="mt-2 text-2xl font-semibold text-cyan-300">{summary?.truth_state?.epoch ?? '-'}</div>
+            </div>
+
+            <div className="rounded-2xl bg-black/25 p-3">
+              <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Sequence</div>
+              <div className="mt-2 text-2xl font-semibold text-white">{summary?.truth_state?.sequence ?? '-'}</div>
+            </div>
+
+            <div className="rounded-2xl bg-black/25 p-3">
+              <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Open Approvals</div>
+              <div className="mt-2 text-2xl font-semibold text-amber-300">{summary?.approvals?.open ?? 0}</div>
+            </div>
+
+            <div className="rounded-2xl bg-black/25 p-3">
+              <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Committed Effects</div>
+              <div className="mt-2 text-2xl font-semibold text-emerald-300">{summary?.effects?.committed ?? 0}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+          <h3 className="mb-4 text-lg font-medium">Recent Memory Writes</h3>
+          <div className="space-y-3">
+            {(summary?.memory_recent || []).length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-white/10 p-4 text-sm text-neutral-500">No memory writes surfaced yet.</div>
+            ) : (
+              (summary?.memory_recent || []).map((item: any) => (
+                <div key={item.id} className="rounded-2xl border border-white/5 bg-black/20 p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="font-medium">{item.memory_key}</div>
+                    <div className="text-xs text-neutral-500">{new Date(item.created_at).toLocaleTimeString()}</div>
+                  </div>
+                  <div className="mt-2 break-all font-mono text-xs text-neutral-400">{item.lineage_hash}</div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-2xl">
+          <h3 className="mb-4 text-lg font-medium">Live Room Notes</h3>
+          <ul className="space-y-2 text-sm text-neutral-400">
+            <li>• ทุก channel ต้องวิ่งเข้า Spine ก่อนเสมอ</li>
+            <li>• Tool / MCP result ต้องกลับเข้า Spine ก่อน commit truth</li>
+            <li>• Dashboard อ่านจาก Spine truth เดียว</li>
+            <li>• Agent คิดได้อิสระ แต่เปลี่ยนความจริงเองไม่ได้</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/runtime/stream-console.tsx
+++ b/components/runtime/stream-console.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { StreamConsoleMessage } from '../../lib/runtime/dashboard-contract';
+
+type StreamConsoleProps = {
+  items: StreamConsoleMessage[];
+};
+
+export function StreamConsole({ items }: StreamConsoleProps) {
+  if (!items.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-white/10 p-4 text-sm text-neutral-500">
+        No live stream events yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-h-[560px] space-y-3 overflow-y-auto pr-1">
+      {items.map((item) => (
+        <div key={item.id} className="rounded-2xl border border-white/10 bg-black/30 p-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm font-semibold text-neutral-100">{item.title}</div>
+            <div className="text-xs text-neutral-500">{new Date(item.created_at).toLocaleTimeString()}</div>
+          </div>
+          <div className="mt-2 text-sm text-neutral-300">{item.body}</div>
+          {item.request_id ? <div className="mt-2 text-xs text-neutral-500">request: {item.request_id}</div> : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/runtime/channel-contract.ts
+++ b/lib/runtime/channel-contract.ts
@@ -1,0 +1,92 @@
+export type RuntimeChannel =
+  | 'chat'
+  | 'cli'
+  | 'remote_browser'
+  | 'voice_live'
+  | 'mcp'
+  | 'tool'
+  | 'operator';
+
+export type ChannelIntentEnvelope = {
+  channel: RuntimeChannel;
+  request_id: string;
+  action: string;
+  payload: Record<string, unknown>;
+  context?: Record<string, unknown>;
+};
+
+export type ChannelBadge = {
+  channel: RuntimeChannel;
+  label: string;
+  color_class: string;
+  description: string;
+};
+
+export const CHANNEL_BADGES: ChannelBadge[] = [
+  {
+    channel: 'chat',
+    label: 'Chat',
+    color_class: 'bg-sky-500/15 text-sky-300 border-sky-500/20',
+    description: 'Standard conversational agent input',
+  },
+  {
+    channel: 'cli',
+    label: 'CLI',
+    color_class: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/20',
+    description: 'Terminal or script-driven command channel',
+  },
+  {
+    channel: 'remote_browser',
+    label: 'Remote Browser',
+    color_class: 'bg-violet-500/15 text-violet-300 border-violet-500/20',
+    description: 'Browser automation / remote operator surface',
+  },
+  {
+    channel: 'voice_live',
+    label: 'Voice Live',
+    color_class: 'bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/20',
+    description: 'Live spoken interaction loop',
+  },
+  {
+    channel: 'mcp',
+    label: 'MCP',
+    color_class: 'bg-amber-500/15 text-amber-300 border-amber-500/20',
+    description: 'Model Context Protocol tool surface',
+  },
+  {
+    channel: 'tool',
+    label: 'Tool',
+    color_class: 'bg-cyan-500/15 text-cyan-300 border-cyan-500/20',
+    description: 'External effect / execution surface',
+  },
+  {
+    channel: 'operator',
+    label: 'Operator',
+    color_class: 'bg-orange-500/15 text-orange-300 border-orange-500/20',
+    description: 'Manual control / intervention channel',
+  },
+];
+
+export function normalizeRuntimeChannel(value: unknown): RuntimeChannel {
+  const input = String(value || '')
+    .trim()
+    .toLowerCase();
+
+  if (
+    input === 'chat' ||
+    input === 'cli' ||
+    input === 'remote_browser' ||
+    input === 'voice_live' ||
+    input === 'mcp' ||
+    input === 'tool' ||
+    input === 'operator'
+  ) {
+    return input;
+  }
+
+  return 'chat';
+}
+
+export function channelLabel(channel: RuntimeChannel): string {
+  return CHANNEL_BADGES.find((item) => item.channel === channel)?.label || channel;
+}

--- a/lib/runtime/dashboard-contract.ts
+++ b/lib/runtime/dashboard-contract.ts
@@ -1,0 +1,49 @@
+export type RuntimeSummaryCard = {
+  truth_state?: {
+    epoch?: number;
+    sequence?: number;
+  } | null;
+  approvals?: {
+    open?: number;
+    recent?: Array<{
+      id: string;
+      status: string;
+      request_id?: string | null;
+      action?: string | null;
+      approved_at?: string | null;
+      used_at?: string | null;
+      expires_at: string;
+    }>;
+  };
+  effects?: {
+    committed?: number;
+    recent?: Array<{
+      effect_id: string;
+      request_id?: string | null;
+      action: string;
+      status: string;
+      updated_at: string;
+    }>;
+  };
+  ledger?: {
+    recent?: Array<{
+      sequence: number;
+      action: string;
+      decision: string;
+      reason: string;
+      entry_hash: string;
+      created_at: string;
+    }>;
+  };
+};
+
+export type StreamConsoleMessage = {
+  id: string;
+  kind: 'decision' | 'effect' | 'approval';
+  request_id?: string | null;
+  sequence?: number;
+  title: string;
+  body: string;
+  created_at: string;
+  meta?: Record<string, unknown>;
+};


### PR DESCRIPTION
### Motivation
- Provide a single Live Room surface that shows all runtime channels (chat / CLI / remote browser / voice_live / MCP / tool / operator) flowing into the Spine single-truth control plane.
- Define lightweight runtime/channel contracts so UI and future channel-aware routes share types and labels for consistent Spine-first behavior.
- Surface recent memory writes to the Live Room via a scoped API so the dashboard can show memory lineage alongside truth/ledger/effects.

### Description
- Add channel runtime types and helpers in `lib/runtime/channel-contract.ts` and the dashboard data contract in `lib/runtime/dashboard-contract.ts` for shared typing across UI and API.
- Implement stream UI and room layout components in `components/runtime/stream-console.tsx` and `components/runtime/live-room.tsx` to render channel badges, stream items, truth snapshot and recent memory writes.
- Add the Live Room page at `app/dashboard/live/page.tsx` which polls `/api/runtime-summary` and the new `/api/memory/recent` to build a Spine-first stream and snapshot view.
- Add the `/api/memory/recent` route at `app/api/memory/recent/route.ts` with auth/org checks and a scoped query against `agent_memory`, and add navigation links for `Live Room` in `app/dashboard/layout.tsx` and `app/app-shell/page.tsx`.

### Testing
- Ran TypeScript checks with `npm run typecheck` and they completed successfully.
- Ran linting with `npm run lint` (Next.js ESLint) and there were no ESLint errors.
- No browser/manual UI screenshot tests were run in this session (no headless/browser validation performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cacc8af554832695a3c726a17954e0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
