### PR TITLE
feat: batch 4 enterprise hardening and go-live controls (domains, audit export, quotas, lockout safety, readiness)

### DIFF
--- a/app/api/access/request/route.ts
+++ b/app/api/access/request/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { consumeRateLimit } from '../../../../lib/security/rate-limit';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const email = String(body.email || '').trim().toLowerCase();
+  const orgId = String(body.org_id || '').trim();
+  if (!email || !orgId) return NextResponse.json({ error: 'email and org_id are required' }, { status: 400 });
+  const rl = await consumeRateLimit({ scope: 'access_request_by_email', keyType: 'email', keyValue: email, windowSeconds: 86400, maxAttempts: 3 });
+  if (!rl.allowed) return NextResponse.json({ error: 'Too many access requests. Please retry later.', retry_after_seconds: rl.retryAfterSeconds }, { status: 429, headers: { 'retry-after': String(rl.retryAfterSeconds) } });
+  const admin = getSupabaseAdmin();
+  const { error } = await admin.from('access_requests').insert({ org_id: orgId, email, reason: body.reason || null, status: 'pending' });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/execute/route.ts
+++ b/app/api/execute/route.ts
@@ -6,6 +6,7 @@ import { buildApprovalKey } from '../../../lib/runtime/approval';
 import { canonicalHash, canonicalJson } from '../../../lib/runtime/canonical';
 import { requireOrgRole } from '../../../lib/authz';
 import { RuntimeRouteRoles } from '../../../lib/runtime/permissions';
+import { buildQuotaSummary } from '../../../lib/billing/quota-policy';
 
 export const dynamic = 'force-dynamic';
 
@@ -128,8 +129,9 @@ export async function POST(request: Request) {
     if (orgCounterError) return NextResponse.json({ error: orgCounterError.message }, { status: 500 });
 
     const orgExecutions = (orgCounters || []).reduce((sum, row) => sum + Number(row.executions || 0), 0);
+    const quotaSummary = buildQuotaSummary(subscription?.plan_key || 'trial', orgExecutions);
     if (orgExecutions >= getIncludedExecutions(subscription?.plan_key || 'trial')) {
-      return NextResponse.json({ error: 'Organization execution quota exceeded' }, { status: 429 });
+      return NextResponse.json({ error: 'Organization execution quota exceeded', quota_summary: quotaSummary }, { status: 429 });
     }
 
     const coreResult = await executeOnDSGCore({
@@ -229,6 +231,7 @@ export async function POST(request: Request) {
       ledger_sequence: Number(commitRow.ledger_sequence || 0),
       truth_sequence: Number(commitRow.truth_sequence || 0),
       core: { decision: coreResult.decision, evaluated_at: coreResult.evaluated_at },
+      quota_summary: quotaSummary,
     });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Unexpected error' }, { status: 500 });

--- a/app/api/settings/domains/[id]/route.ts
+++ b/app/api/settings/domains/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const body = await req.json().catch(() => ({}));
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin.from('org_domains').update({ status: body.status, claim_mode: body.claim_mode, auto_join_mode: body.auto_join_mode, notes: body.notes ?? null, updated_at: new Date().toISOString() }).eq('id', params.id).eq('org_id', access.orgId).select('*').single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data });
+}

--- a/app/api/settings/domains/route.ts
+++ b/app/api/settings/domains/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { requireOrgRole } from '../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { normalizeDomain } from '../../../../lib/auth/domain-governance';
+
+export async function GET() {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin.from('org_domains').select('*').eq('org_id', access.orgId).order('created_at', { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ items: data || [] });
+}
+
+export async function POST(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const body = await req.json().catch(() => ({}));
+  const domain = normalizeDomain(body.domain);
+  if (!domain) return NextResponse.json({ error: 'Domain is required' }, { status: 400 });
+  const admin = getSupabaseAdmin();
+  const token = `dsg-verify-${randomUUID()}`;
+  const payload = { org_id: access.orgId, domain, status: body.status || 'approved', claim_mode: body.claim_mode || 'manual', auto_join_mode: body.auto_join_mode || 'disabled', verification_method: 'dns_txt', verification_token: token, notes: body.notes || null };
+  const { data, error } = await admin.from('org_domains').insert(payload).select('*').single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data, verification_step: 'Human verification required. Publish token via DNS and complete ops review.' }, { status: 201 });
+}

--- a/app/api/settings/go-live/export/route.ts
+++ b/app/api/settings/go-live/export/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { buildGoLiveReadinessReport } from '../../../../../lib/readiness/go-live';
+
+export async function GET(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const format = new URL(req.url).searchParams.get('format') || 'json';
+  const report = await buildGoLiveReadinessReport(access.orgId);
+  if (format === 'md') {
+    const md = `# Go-live readiness\n\nStatus: **${report.status}**\n\n## Blockers\n${report.blockers.map((b: string) => `- ${b}`).join('\n') || '- None'}\n\n## Warnings\n${report.warnings.map((w: string) => `- ${w}`).join('\n') || '- None'}\n`;
+    return new NextResponse(md, { headers: { 'content-type': 'text/markdown; charset=utf-8' } });
+  }
+  return NextResponse.json(report);
+}

--- a/app/api/settings/go-live/route.ts
+++ b/app/api/settings/go-live/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../lib/authz';
+import { buildGoLiveReadinessReport } from '../../../../lib/readiness/go-live';
+
+export async function GET() {
+  const access = await requireOrgRole(['org_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const report = await buildGoLiveReadinessReport(access.orgId);
+  return NextResponse.json(report, { headers: { 'cache-control': 'no-store' } });
+}

--- a/app/api/settings/members/[userId]/route.ts
+++ b/app/api/settings/members/[userId]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+import { preventRemovingLastOwner } from '../../../../../lib/auth/admin-safety';
+
+export async function PATCH(req: NextRequest, { params }: { params: { userId: string } }) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const body = await req.json().catch(() => ({}));
+  const role = String(body.role || '').trim();
+  if (!role) return NextResponse.json({ error: 'role is required' }, { status: 400 });
+  if (role === 'guest_auditor_admin') return NextResponse.json({ error: 'Guest auditor cannot receive admin/security permissions.' }, { status: 400 });
+  const admin = getSupabaseAdmin();
+  try {
+    await preventRemovingLastOwner(admin, access.orgId, params.userId, role);
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Owner safety check failed.' }, { status: 409 });
+  }
+  const { data, error } = await admin.from('users').update({ role, updated_at: new Date().toISOString() }).eq('org_id', access.orgId).eq('id', params.userId).select('id,role').single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data });
+}

--- a/app/api/settings/security/audit-events/route.ts
+++ b/app/api/settings/security/audit-events/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { exportAuditEventsAsJson } from '../../../../../lib/security/audit-export';
+
+export async function GET(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const sp = new URL(req.url).searchParams;
+  const page = Math.max(1, Number(sp.get('page') || '1'));
+  const pageSize = Math.min(100, Math.max(1, Number(sp.get('page_size') || '20')));
+  const items = await exportAuditEventsAsJson(access.orgId, { start_date: sp.get('start_date'), end_date: sp.get('end_date'), event_type: sp.get('event_type'), email: sp.get('email') });
+  const start = (page - 1) * pageSize;
+  return NextResponse.json({ items: items.slice(start, start + pageSize), page, page_size: pageSize, total: items.length });
+}

--- a/app/api/settings/security/audit-export/route.ts
+++ b/app/api/settings/security/audit-export/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { exportAuditEventsAsCsv, exportAuditEventsAsJson } from '../../../../../lib/security/audit-export';
+
+export async function GET(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const sp = new URL(req.url).searchParams;
+  const format = sp.get('format') || 'json';
+  const filters = { start_date: sp.get('start_date'), end_date: sp.get('end_date'), event_type: sp.get('event_type'), email: sp.get('email') };
+  if (format === 'csv') {
+    const csv = await exportAuditEventsAsCsv(access.orgId, filters);
+    return new NextResponse(csv, { headers: { 'content-type': 'text/csv; charset=utf-8', 'content-disposition': 'attachment; filename="audit-export.csv"' } });
+  }
+  return NextResponse.json({ items: await exportAuditEventsAsJson(access.orgId, filters) }, { headers: { 'cache-control': 'no-store' } });
+}

--- a/app/api/settings/security/route.ts
+++ b/app/api/settings/security/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { preventDisablingAllRecoveryPaths } from '../../../../lib/auth/admin-safety';
+
+export async function PATCH(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const body = await req.json().catch(() => ({}));
+  const admin = getSupabaseAdmin();
+
+  if (body.sso_enforced === true) {
+    try { await preventDisablingAllRecoveryPaths(admin, access.orgId); }
+    catch (e) { return NextResponse.json({ error: e instanceof Error ? e.message : 'Cannot enforce SSO.' }, { status: 409 }); }
+  }
+
+  const { data, error } = await admin
+    .from('org_security_settings')
+    .upsert({ org_id: access.orgId, sso_enabled: Boolean(body.sso_enabled), sso_enforced: Boolean(body.sso_enforced), break_glass_email_enabled: body.break_glass_email_enabled !== false, sso_metadata: body.sso_metadata || {}, updated_at: new Date().toISOString() }, { onConflict: 'org_id' })
+    .select('*')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data });
+}

--- a/app/api/usage/route.ts
+++ b/app/api/usage/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '../../../lib/supabase/server';
+import { buildQuotaSummary } from '../../../lib/billing/quota-policy';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,7 +42,8 @@ export async function GET() {
     } = await supabase.auth.getUser();
 
     if (userError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { data: profile, error: profileError } = await supabase
@@ -51,7 +53,8 @@ export async function GET() {
       .maybeSingle();
 
     if (profileError || !profile?.org_id || !profile.is_active) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     const { data: subscription, error: subscriptionError } = await supabase
@@ -86,7 +89,8 @@ export async function GET() {
       .eq('billing_period', billingPeriodKey);
 
     if (usageError) {
-      return NextResponse.json({ error: usageError.message }, { status: 500 });
+
+    return NextResponse.json({ error: usageError.message }, { status: 500 });
     }
 
     const executions = (usageCounters || []).reduce(
@@ -100,6 +104,7 @@ export async function GET() {
 
     const overageExecutions = Math.max(0, executions - includedExecutions);
     const projectedAmountUsd = Number((overageExecutions * 0.001).toFixed(3));
+    const quota = buildQuotaSummary(planKey, executions);
 
     return NextResponse.json({
       plan: formatPlanLabel(planKey, subscription?.billing_interval || null),
@@ -116,6 +121,7 @@ export async function GET() {
       included_executions: includedExecutions,
       overage_executions: overageExecutions,
       projected_amount_usd: projectedAmountUsd,
+      quota_summary: quota,
     });
   } catch (error) {
     return NextResponse.json(

--- a/app/auth/continue/route.ts
+++ b/app/auth/continue/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { consumeRateLimit } from '../../../lib/security/rate-limit';
 
 function getSafeNext(value: string | null) {
   if (!value || !value.startsWith('/')) return '/dashboard/executions';
@@ -40,6 +41,14 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const rate = await consumeRateLimit({ scope: 'auth_continue_email', keyType: 'email', keyValue: email, windowSeconds: 900, maxAttempts: 5 });
+    if (!rate.allowed) {
+      redirectToLogin.searchParams.set('error', 'rate-limited');
+      redirectToLogin.searchParams.set('retry_after', String(rate.retryAfterSeconds));
+      return NextResponse.redirect(redirectToLogin, { status: 302, headers: { 'retry-after': String(rate.retryAfterSeconds), 'x-rate-limit-key': clientIp } });
+    }
+
     const authClient = await createClient();
     const admin = getSupabaseAdmin();
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -11,6 +11,9 @@ const NAV = [
   { href: '/dashboard/capacity', label: 'Capacity' },
   { href: '/dashboard/billing', label: 'Billing' },
   { href: '/dashboard/audit', label: 'Audit' },
+  { href: '/dashboard/settings/domains', label: 'Domains' },
+  { href: '/dashboard/settings/security', label: 'Security' },
+  { href: '/dashboard/settings/go-live', label: 'Go-live' },
   { href: '/app-shell', label: 'App Shell' },
 ];
 

--- a/app/dashboard/settings/domains/page.tsx
+++ b/app/dashboard/settings/domains/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Domain = { id: string; domain: string; status: string; claim_mode: string; auto_join_mode: string; verification_token: string | null; notes: string | null };
+
+export default function DomainsSettingsPage() {
+  const [items, setItems] = useState<Domain[]>([]);
+  const [domain, setDomain] = useState('');
+  const [loading, setLoading] = useState(false);
+  const load = async () => { const res = await fetch('/api/settings/domains', { cache: 'no-store' }); const j = await res.json(); setItems(j.items || []); };
+  useEffect(() => { void load(); }, []);
+  async function add() { setLoading(true); await fetch('/api/settings/domains', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ domain }) }); setDomain(''); setLoading(false); await load(); }
+  return <main className="min-h-screen bg-slate-950 text-white p-8"><h1 className="text-3xl font-semibold">Domain Governance</h1><p className="text-slate-300 mt-2">Verified domains assert ownership. Approved domains enable policy evaluation.</p><div className="mt-6 flex gap-2"><input value={domain} onChange={(e)=>setDomain(e.target.value)} placeholder="example.com" className="bg-slate-900 border border-slate-700 rounded px-3 py-2"/><button onClick={()=>void add()} disabled={loading} className="bg-emerald-400 text-slate-950 px-4 py-2 rounded">Add domain</button></div><div className="mt-8 space-y-3">{items.map((d)=><div key={d.id} className="border border-slate-800 bg-slate-900 rounded p-4"><p className="font-semibold">{d.domain} <span className="text-xs text-slate-400">({d.status})</span></p><p className="text-sm text-slate-300">Claim mode: {d.claim_mode} · Auto-join mode: {d.auto_join_mode}</p><p className="text-xs text-slate-400 mt-1">Verification token: {d.verification_token || 'pending generation'}</p></div>)}</div><div className="mt-8 text-sm text-slate-400"><p>Verification is an ops/human step in Batch 4. No automated DNS verification is performed.</p></div></main>;
+}

--- a/app/dashboard/settings/go-live/page.tsx
+++ b/app/dashboard/settings/go-live/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function GoLivePage() {
+  const [report, setReport] = useState<any>(null);
+  useEffect(() => { fetch('/api/settings/go-live', { cache: 'no-store' }).then((r) => r.json()).then(setReport).catch(() => setReport(null)); }, []);
+  return <main className="min-h-screen bg-slate-950 text-white p-8"><h1 className="text-3xl font-semibold">Go-live readiness</h1><p className="text-slate-300 mt-2">Structured checklist for enterprise rollout.</p>{!report ? <p className="mt-4">Loading...</p> : <div className="mt-6"><div className="rounded border border-slate-700 bg-slate-900 p-4"><p className="text-sm text-slate-300">Overall status</p><p className="text-2xl font-semibold">{report.status}</p></div><div className="mt-6 grid gap-4 md:grid-cols-2">{(report.categories || []).map((c: any)=><div key={c.name} className="rounded border border-slate-800 bg-slate-900 p-4"><p className="font-semibold">{c.name}</p>{(c.items||[]).map((i:any)=><p key={i.key} className="text-sm text-slate-300">{i.ok ? '✅' : '⚠️'} {i.key}</p>)}</div>)}</div><div className="mt-6"><p className="font-semibold">Blockers</p>{(report.blockers||[]).map((b:string)=><p key={b} className="text-sm text-red-300">• {b}</p>) || <p>None</p>}<p className="font-semibold mt-4">Warnings</p>{(report.warnings||[]).map((w:string)=><p key={w} className="text-sm text-amber-300">• {w}</p>) || <p>None</p>}</div><div className="mt-4"><a className="border border-slate-700 rounded px-3 py-2" href="/api/settings/go-live/export?format=json">Export JSON</a> <a className="border border-slate-700 rounded px-3 py-2" href="/api/settings/go-live/export?format=md">Export Markdown</a></div></div>}</main>;
+}

--- a/app/dashboard/settings/security/page.tsx
+++ b/app/dashboard/settings/security/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function SecuritySettingsPage() {
+  const [items, setItems] = useState<any[]>([]);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const load = async () => { const qs = new URLSearchParams(); if (start) qs.set('start_date', start); if (end) qs.set('end_date', end); const r = await fetch(`/api/settings/security/audit-events?${qs.toString()}`, { cache: 'no-store' }); const j = await r.json(); setItems(j.items || []); };
+  useEffect(() => { void load(); }, []);
+  return <main className="min-h-screen bg-slate-950 text-white p-8"><h1 className="text-3xl font-semibold">Security Settings</h1><p className="text-slate-300 mt-2">Recent security events and org-scoped audit export.</p><div className="mt-4 flex gap-2"><input type="date" value={start} onChange={(e)=>setStart(e.target.value)} className="bg-slate-900 border border-slate-700 rounded px-3 py-2"/><input type="date" value={end} onChange={(e)=>setEnd(e.target.value)} className="bg-slate-900 border border-slate-700 rounded px-3 py-2"/><button onClick={()=>void load()} className="border border-slate-700 rounded px-3 py-2">Filter</button><a href={`/api/settings/security/audit-export?format=json&start_date=${start}&end_date=${end}`} className="border border-slate-700 rounded px-3 py-2">Export JSON</a><a href={`/api/settings/security/audit-export?format=csv&start_date=${start}&end_date=${end}`} className="border border-slate-700 rounded px-3 py-2">Export CSV</a></div><div className="mt-6 space-y-2">{items.map((item, idx)=><div key={idx} className="border border-slate-800 bg-slate-900 rounded p-3 text-sm"><p>{item.event_type} · {item.email || 'n/a'}</p><p className="text-slate-400">{item.created_at}</p></div>)}</div><p className="mt-6 text-sm text-slate-400">Exports are org-scoped, exclude secrets, and are intended for offline review / SIEM ingest.</p></main>;
+}

--- a/lib/auth/access-policy.ts
+++ b/lib/auth/access-policy.ts
@@ -1,0 +1,10 @@
+import { resolveDomainGovernance } from './domain-governance';
+
+export async function resolveAccessPolicyForEmail(email: string, orgId?: string | null) {
+  const domain = String(email.split('@')[1] || '').toLowerCase();
+  const governance = await resolveDomainGovernance(domain, orgId);
+
+  if (governance.auto_join_mode === 'auto_join') return { mode: 'auto_join', source: governance.source, governance };
+  if (governance.auto_join_mode === 'require_approval') return { mode: 'require_approval', source: governance.source, governance };
+  return { mode: 'manual_review', source: governance.source, governance };
+}

--- a/lib/auth/admin-safety.ts
+++ b/lib/auth/admin-safety.ts
@@ -1,0 +1,27 @@
+export async function ensureOrgHasOwner(admin: any, orgId: string) {
+  const { data, error } = await admin.from('users').select('id').eq('org_id', orgId).eq('role', 'owner').eq('is_active', true);
+  if (error) throw error;
+  if (!data || data.length === 0) throw new Error('Organization must always have at least one owner.');
+  return true;
+}
+
+export async function preventRemovingLastOwner(admin: any, orgId: string, userId: string, targetRole: string) {
+  if (targetRole === 'owner') return true;
+  const { data, error } = await admin.from('users').select('id').eq('org_id', orgId).eq('role', 'owner').eq('is_active', true);
+  if (error) throw error;
+  if ((data || []).length <= 1 && (data || [])[0]?.id === userId) throw new Error('Cannot remove or demote the last owner. Add another owner first.');
+  return true;
+}
+
+export async function canEnforceSsoSafely(admin: any, orgId: string) {
+  const { data: config } = await admin.from('org_security_settings').select('sso_enabled,sso_metadata,break_glass_email_enabled').eq('org_id', orgId).maybeSingle();
+  const hasSsoConfig = Boolean(config?.sso_enabled && config?.sso_metadata && Object.keys(config.sso_metadata || {}).length > 0);
+  const hasBreakGlass = Boolean(config?.break_glass_email_enabled);
+  return { ok: hasSsoConfig || hasBreakGlass, hasSsoConfig, hasBreakGlass };
+}
+
+export async function preventDisablingAllRecoveryPaths(admin: any, orgId: string) {
+  const { ok } = await canEnforceSsoSafely(admin, orgId);
+  if (!ok) throw new Error('Cannot enforce SSO yet. Configure SSO or keep break-glass email sign-in enabled for owners.');
+  return true;
+}

--- a/lib/auth/domain-governance.ts
+++ b/lib/auth/domain-governance.ts
@@ -1,0 +1,19 @@
+import { getSupabaseAdmin } from '../supabase-server';
+export type OrgDomainStatus = 'approved' | 'verified' | 'disabled';
+export type ClaimMode = 'manual' | 'automatic';
+export type AutoJoinMode = 'disabled' | 'auto_join' | 'require_approval';
+export function normalizeDomain(value: string | null | undefined) { return String(value || '').trim().toLowerCase().replace(/^@+/, ''); }
+export async function getOrgDomains(orgId: string) { const admin = getSupabaseAdmin(); const { data, error } = await admin.from('org_domains').select('*').eq('org_id', orgId).order('domain', { ascending: true }); if (error) throw error; return data || []; }
+export async function findMatchingOrgDomain(emailDomain: string) { const domain = normalizeDomain(emailDomain); if (!domain) return null; const admin = getSupabaseAdmin(); const { data, error } = await admin.from('org_domains').select('*').eq('domain', domain).in('status', ['approved', 'verified']); if (error) throw error; const rows = data || []; return rows.find((r: any) => r.status === 'verified') || rows[0] || null; }
+function envList(name: string) { return String(process.env[name] || '').split(',').map(normalizeDomain).filter(Boolean); }
+export async function resolveDomainGovernance(emailDomain: string, orgId?: string | null) {
+  const domain = normalizeDomain(emailDomain);
+  if (!domain) return { source: 'default', domain, status: 'disabled', claim_mode: 'manual', auto_join_mode: 'disabled', org_id: orgId || null, is_managed_identity: false };
+  let dbRule: any = null;
+  if (orgId) { const rows = await getOrgDomains(orgId); dbRule = rows.find((r: any) => r.domain === domain && r.status !== 'disabled') || null; }
+  if (!dbRule) dbRule = await findMatchingOrgDomain(domain);
+  if (dbRule) return { source: 'db', domain, status: dbRule.status, claim_mode: dbRule.claim_mode, auto_join_mode: dbRule.auto_join_mode, org_id: dbRule.org_id, is_managed_identity: dbRule.claim_mode === 'automatic' || dbRule.status === 'verified', verification_token: dbRule.verification_token };
+  if (envList('APPROVED_AUTO_JOIN_DOMAINS').includes(domain) || envList('APPROVED_DOMAINS').includes(domain)) return { source: 'env', domain, status: 'approved', claim_mode: 'manual', auto_join_mode: 'auto_join', org_id: orgId || null, is_managed_identity: false };
+  if (envList('APPROVAL_REQUIRED_DOMAINS').includes(domain)) return { source: 'env', domain, status: 'approved', claim_mode: 'manual', auto_join_mode: 'require_approval', org_id: orgId || null, is_managed_identity: false };
+  return { source: 'default', domain, status: 'disabled', claim_mode: 'manual', auto_join_mode: 'disabled', org_id: orgId || null, is_managed_identity: false };
+}

--- a/lib/billing/quota-policy.ts
+++ b/lib/billing/quota-policy.ts
@@ -1,0 +1,27 @@
+const DEFAULTS = { trial: 1000, pro: 10000, business: 100000, enterprise: 1000000 };
+
+function envInt(name: string, fallback: number) { const n = Number(process.env[name] || ''); return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback; }
+
+export function getPlanQuotaPolicy(planKey: string | null | undefined) {
+  const key = String(planKey || 'trial').toLowerCase();
+  return {
+    planKey: key,
+    executionsPer30Days: key === 'trial' ? envInt('QUOTA_TRIAL_EXECUTIONS', DEFAULTS.trial) : key === 'pro' ? envInt('QUOTA_PRO_EXECUTIONS', DEFAULTS.pro) : key === 'business' ? envInt('QUOTA_BUSINESS_EXECUTIONS', DEFAULTS.business) : envInt('QUOTA_ENTERPRISE_EXECUTIONS', DEFAULTS.enterprise),
+    windowDays: 30,
+  };
+}
+
+export async function getEffectiveExecutionQuotaForOrg(orgId: string, adminClient: any) {
+  const { data } = await adminClient.from('billing_subscriptions').select('plan_key').eq('org_id', orgId).order('updated_at', { ascending: false }).limit(1).maybeSingle();
+  return getPlanQuotaPolicy(data?.plan_key || 'trial');
+}
+
+export function isQuotaExceeded(currentExecutions: number, quota: { executionsPer30Days: number }) {
+  return currentExecutions >= quota.executionsPer30Days;
+}
+
+export function buildQuotaSummary(planKey: string | null | undefined, currentExecutions: number) {
+  const policy = getPlanQuotaPolicy(planKey);
+  const remaining = Math.max(0, policy.executionsPer30Days - currentExecutions);
+  return { planKey: policy.planKey, executionsPer30Days: policy.executionsPer30Days, currentExecutions, remaining, nearLimit: currentExecutions >= Math.floor(policy.executionsPer30Days * 0.8), exceeded: isQuotaExceeded(currentExecutions, policy) };
+}

--- a/lib/readiness/go-live.ts
+++ b/lib/readiness/go-live.ts
@@ -1,0 +1,61 @@
+import { getSupabaseAdmin } from '../supabase-server';
+import { getPlanQuotaPolicy } from '../billing/quota-policy';
+
+export async function buildGoLiveReadinessReport(orgId: string) {
+  const admin = getSupabaseAdmin();
+  const [owners, sso, domains, subs, signIns, requests, grants, onboarding] = await Promise.all([
+    admin.from('users').select('id').eq('org_id', orgId).eq('role', 'owner').eq('is_active', true),
+    admin.from('org_security_settings').select('sso_enabled,sso_enforced,break_glass_email_enabled,sso_metadata').eq('org_id', orgId).maybeSingle(),
+    admin.from('org_domains').select('status,claim_mode').eq('org_id', orgId),
+    admin.from('billing_subscriptions').select('plan_key').eq('org_id', orgId).order('updated_at', { ascending: false }).limit(1).maybeSingle(),
+    admin.from('sign_in_events').select('id').eq('org_id', orgId).limit(1),
+    admin.from('access_requests').select('id').eq('org_id', orgId).limit(1),
+    admin.from('guest_access_grants').select('id').eq('org_id', orgId).limit(1),
+    admin.from('onboarding_states').select('id').eq('org_id', orgId).limit(1),
+  ]);
+
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  const ownerCount = (owners.data || []).length;
+  if (ownerCount < 1) blockers.push('At least one active owner is required.');
+  const ssoConfigured = Boolean(sso.data?.sso_enabled && sso.data?.sso_metadata && Object.keys(sso.data.sso_metadata || {}).length > 0);
+  if (sso.data?.sso_enforced && !ssoConfigured && !sso.data?.break_glass_email_enabled) blockers.push('SSO is enforced without valid SSO config or break-glass path.');
+  const hasVerified = (domains.data || []).some((d: any) => d.status === 'verified');
+  const hasApproved = (domains.data || []).some((d: any) => d.status === 'approved' || d.status === 'verified');
+  if (!hasApproved) warnings.push('No approved domains configured yet.');
+
+  const categories = [
+    { name: 'Identity & access', items: [
+      { key: 'login_entry_unified', ok: true },
+      { key: 'access_mode_resolved', ok: true },
+      { key: 'sso_configured', ok: ssoConfigured },
+      { key: 'sso_enforced', ok: Boolean(sso.data?.sso_enforced) },
+      { key: 'break_glass_configured', ok: Boolean(sso.data?.break_glass_email_enabled) },
+      { key: 'owner_count_valid', ok: ownerCount > 0 },
+    ]},
+    { name: 'Domain governance', items: [
+      { key: 'verified_domains_present', ok: hasVerified },
+      { key: 'approved_domains_present', ok: hasApproved },
+      { key: 'claim_mode_defined', ok: (domains.data || []).length > 0 },
+    ]},
+    { name: 'Billing & quota', items: [
+      { key: 'billing_policy_exists', ok: Boolean(subs.data?.plan_key) },
+      { key: 'quota_policy_resolvable', ok: Boolean(getPlanQuotaPolicy(subs.data?.plan_key).executionsPer30Days > 0) },
+      { key: 'seat_activation_model_active', ok: true },
+    ]},
+    { name: 'Security & audit', items: [
+      { key: 'sign_in_events_logging_active', ok: (signIns.data || []).length > 0 },
+      { key: 'audit_export_available', ok: true },
+      { key: 'request_access_logging_active', ok: (requests.data || []).length > 0 },
+      { key: 'guest_access_visible', ok: (grants.data || []).length > 0 },
+    ]},
+    { name: 'Onboarding', items: [
+      { key: 'onboarding_state_exists', ok: (onboarding.data || []).length > 0 },
+      { key: 'quickstart_checklist_available', ok: true },
+      { key: 'starter_bootstrap_path_available', ok: true },
+    ]},
+  ];
+
+  const status = blockers.length > 0 ? 'not-ready' : warnings.length > 0 ? 'needs-attention' : 'ready';
+  return { org_id: orgId, status, blockers, warnings, categories, recommended_next_steps: ['Configure verified domains', 'Review SSO/break-glass policy', 'Export and archive weekly audit logs'] };
+}

--- a/lib/security/audit-export.ts
+++ b/lib/security/audit-export.ts
@@ -1,0 +1,36 @@
+import { getSupabaseAdmin } from '../supabase-server';
+
+export function buildAuditExportQuery(orgId: string, filters: { start_date?: string | null; end_date?: string | null; event_type?: string | null; email?: string | null }) {
+  return { orgId, ...filters };
+}
+
+async function collectEvents(orgId: string, filters: any) {
+  const admin = getSupabaseAdmin();
+  const events: any[] = [];
+  const applyDate = (q: any, col = 'created_at') => {
+    let out = q.eq('org_id', orgId);
+    if (filters.start_date) out = out.gte(col, filters.start_date);
+    if (filters.end_date) out = out.lte(col, filters.end_date);
+    return out;
+  };
+  const [signIn, requests, grants, auditLogs] = await Promise.all([
+    applyDate(admin.from('sign_in_events').select('*')).limit(2000),
+    applyDate(admin.from('access_requests').select('*')).limit(2000),
+    applyDate(admin.from('guest_access_grants').select('*')).limit(2000),
+    applyDate(admin.from('audit_logs').select('id,org_id,created_at,decision,reason')).limit(2000),
+  ]);
+  for (const row of signIn.data || []) events.push({ event_type: 'sign_in_event', created_at: row.created_at, email: row.email, payload: row });
+  for (const row of requests.data || []) events.push({ event_type: 'access_request', created_at: row.created_at, email: row.email, payload: row });
+  for (const row of grants.data || []) events.push({ event_type: 'guest_access_grant', created_at: row.created_at, email: row.email, payload: row });
+  for (const row of auditLogs.data || []) events.push({ event_type: 'audit_log', created_at: row.created_at, email: null, payload: row });
+  return events.filter((e) => (!filters.event_type || e.event_type === filters.event_type) && (!filters.email || String(e.email || '').toLowerCase() === String(filters.email).toLowerCase())).sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+}
+
+export async function exportAuditEventsAsJson(orgId: string, filters: any) { return collectEvents(orgId, filters); }
+
+export async function exportAuditEventsAsCsv(orgId: string, filters: any) {
+  const events = await collectEvents(orgId, filters);
+  const rows = ['event_type,created_at,email,payload'];
+  for (const e of events) rows.push([e.event_type, e.created_at, e.email || '', JSON.stringify(e.payload).replaceAll('"', '""')].map((v) => `"${String(v)}"`).join(','));
+  return rows.join('\n');
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -1,0 +1,24 @@
+import { getSupabaseAdmin } from '../supabase-server';
+
+type KeyType = 'ip' | 'email' | 'org_id';
+
+export async function consumeRateLimit(input: { scope: string; keyType: KeyType; keyValue: string; windowSeconds: number; maxAttempts: number }) {
+  const admin = getSupabaseAdmin();
+  const now = Date.now();
+  const windowStart = new Date(now - input.windowSeconds * 1000).toISOString();
+  const { data, error } = await admin.from('rate_limit_events').select('id,created_at').eq('scope', input.scope).eq('key_type', input.keyType).eq('key_value', input.keyValue).gte('created_at', windowStart).order('created_at', { ascending: true });
+  if (error) throw error;
+  const count = (data || []).length;
+  if (count >= input.maxAttempts) {
+    const first = (data || [])[0] as any;
+    const retryAfterSeconds = Math.max(1, Math.ceil((new Date(first.created_at).getTime() + input.windowSeconds * 1000 - now) / 1000));
+    return { allowed: false, count, remaining: 0, retryAfterSeconds };
+  }
+  const { error: insertError } = await admin.from('rate_limit_events').insert({ scope: input.scope, key_type: input.keyType, key_value: input.keyValue });
+  if (insertError) throw insertError;
+  return { allowed: true, count: count + 1, remaining: Math.max(0, input.maxAttempts - count - 1), retryAfterSeconds: 0 };
+}
+
+export function rateLimitJson(status: number, message: string, retryAfterSeconds: number) {
+  return new Response(JSON.stringify({ error: message, retry_after_seconds: retryAfterSeconds }), { status, headers: { 'content-type': 'application/json', 'retry-after': String(retryAfterSeconds) } });
+}

--- a/supabase/migrations/20260401_batch4_enterprise_hardening.sql
+++ b/supabase/migrations/20260401_batch4_enterprise_hardening.sql
@@ -1,0 +1,83 @@
+create extension if not exists pgcrypto;
+
+create table if not exists org_domains (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  domain text not null,
+  status text not null default 'approved' check (status in ('approved','verified','disabled')),
+  verification_method text null,
+  verification_token text null,
+  verified_at timestamptz null,
+  claim_mode text not null default 'manual' check (claim_mode in ('manual','automatic')),
+  auto_join_mode text not null default 'disabled' check (auto_join_mode in ('disabled','auto_join','require_approval')),
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, domain)
+);
+create index if not exists idx_org_domains_domain_status on org_domains(domain, status);
+
+create table if not exists sign_in_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  email text not null,
+  result text not null default 'success',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists access_requests (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  email text not null,
+  reason text,
+  status text not null default 'pending',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists guest_access_grants (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  email text not null,
+  scope text,
+  expires_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists onboarding_states (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null unique,
+  checklist jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists org_security_settings (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null unique,
+  sso_enabled boolean not null default false,
+  sso_enforced boolean not null default false,
+  break_glass_email_enabled boolean not null default true,
+  sso_metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists security_event_stream_configs (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null unique,
+  destination_type text not null default 'webhook' check (destination_type in ('webhook')),
+  webhook_url text null,
+  is_enabled boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists rate_limit_events (
+  id uuid primary key default gen_random_uuid(),
+  scope text not null,
+  key_type text not null check (key_type in ('ip','email','org_id')),
+  key_value text not null,
+  created_at timestamptz not null default now()
+);
+create index if not exists idx_rate_limit_events_lookup on rate_limit_events(scope, key_type, key_value, created_at desc);

--- a/tests/integration/api/access-request-rate-limit.test.ts
+++ b/tests/integration/api/access-request-rate-limit.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('/api/access/request rate limit', () => {
+  it('blocks duplicate spam after threshold', async () => {
+    const consume = vi.fn().mockResolvedValueOnce({ allowed: true, retryAfterSeconds: 0 }).mockResolvedValueOnce({ allowed: true, retryAfterSeconds: 0 }).mockResolvedValueOnce({ allowed: true, retryAfterSeconds: 0 }).mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 60 });
+    vi.doMock('../../../lib/security/rate-limit', () => ({ consumeRateLimit: consume }));
+    vi.doMock('../../../lib/supabase-server', () => ({ getSupabaseAdmin: () => ({ from: () => ({ insert: async () => ({ error: null }) }) }) }));
+    const { POST } = await import('../../../app/api/access/request/route');
+    for (let i = 0; i < 3; i++) { const ok = await POST(new Request('http://localhost/api/access/request', { method: 'POST', body: JSON.stringify({ email: 'x@a.com', org_id: 'org1' }) }) as any); expect(ok.status).toBe(200); }
+    const blocked = await POST(new Request('http://localhost/api/access/request', { method: 'POST', body: JSON.stringify({ email: 'x@a.com', org_id: 'org1' }) }) as any);
+    expect(blocked.status).toBe(429);
+  });
+});

--- a/tests/integration/api/audit-export.test.ts
+++ b/tests/integration/api/audit-export.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('audit export route', () => {
+  it('returns org-scoped json and csv', async () => {
+    vi.doMock('../../../lib/authz', () => ({ requireOrgRole: vi.fn(async () => ({ ok: true, orgId: 'org1' })) }));
+    vi.doMock('../../../lib/security/audit-export', () => ({
+      exportAuditEventsAsJson: vi.fn(async () => ([{ event_type: 'sign_in_event', created_at: '2026-04-01', email: 'a@b.com' }])),
+      exportAuditEventsAsCsv: vi.fn(async () => 'event_type,created_at\n"sign_in_event","2026-04-01"'),
+    }));
+    const { GET } = await import('../../../app/api/settings/security/audit-export/route');
+    const jsonRes = await GET(new Request('http://localhost/api/settings/security/audit-export?format=json') as any);
+    expect(jsonRes.status).toBe(200);
+    const json = await jsonRes.json();
+    expect(json.items[0].event_type).toBe('sign_in_event');
+    const csvRes = await GET(new Request('http://localhost/api/settings/security/audit-export?format=csv') as any);
+    expect(csvRes.status).toBe(200);
+    expect(await csvRes.text()).toContain('event_type');
+  });
+});

--- a/tests/integration/api/auth-continue.test.ts
+++ b/tests/integration/api/auth-continue.test.ts
@@ -172,4 +172,26 @@ describe('/auth/continue', () => {
     expect(location).toContain('error=send-failed');
     expect(signInWithOtp).toHaveBeenCalledOnce();
   });
+
+
+  it('blocks excessive attempts by email', async () => {
+    vi.doMock('../../../lib/security/rate-limit', () => ({
+      consumeRateLimit: vi.fn(async () => ({ allowed: false, retryAfterSeconds: 120 })),
+    }));
+
+    vi.doMock('../../../lib/supabase/server', () => ({
+      createClient: vi.fn(async () => ({ auth: { signInWithOtp: vi.fn() } })),
+    }));
+
+    vi.doMock('../../../lib/supabase-server', () => ({
+      getSupabaseAdmin: vi.fn(() => ({ from: vi.fn(() => chainMock({ data: null, error: null })) })),
+    }));
+
+    const { POST } = await import('../../../app/auth/continue/route');
+    const req = buildFormRequest({ email: 'op@co.com', next: '/dashboard' });
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location') || '').toContain('error=rate-limited');
+  });
 });

--- a/tests/unit/auth/access-policy.test.ts
+++ b/tests/unit/auth/access-policy.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('access policy domain precedence', () => {
+  it('DB-backed domain rules override env fallback', async () => {
+    process.env.APPROVED_AUTO_JOIN_DOMAINS = 'example.com';
+    vi.doMock('../../../lib/auth/domain-governance', () => ({ resolveDomainGovernance: vi.fn(async () => ({ source: 'db', auto_join_mode: 'require_approval', status: 'verified', claim_mode: 'automatic' })) }));
+    const { resolveAccessPolicyForEmail } = await import('../../../lib/auth/access-policy');
+    const result = await resolveAccessPolicyForEmail('user@example.com', 'org-1');
+    expect(result.mode).toBe('require_approval');
+    expect(result.source).toBe('db');
+  });
+});

--- a/tests/unit/auth/admin-safety.test.ts
+++ b/tests/unit/auth/admin-safety.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { preventRemovingLastOwner, preventDisablingAllRecoveryPaths } from '../../../lib/auth/admin-safety';
+
+function adminMock(ownerCount = 1, security: any = { sso_enabled: false, sso_metadata: {}, break_glass_email_enabled: false }) {
+  return { from: (table: string) => ({ select: () => ({ eq: () => ({ eq: () => ({ eq: async () => ({ data: table === 'users' ? Array.from({ length: ownerCount }).map((_, i) => ({ id: i === 0 ? 'u1' : `u${i + 1}` })) : [], error: null }), maybeSingle: async () => ({ data: security, error: null }) }), maybeSingle: async () => ({ data: security, error: null }) }) }) }) } as any;
+}
+
+describe('admin safety', () => {
+  it('blocks removing last owner', async () => { await expect(preventRemovingLastOwner(adminMock(1), 'org1', 'u1', 'member')).rejects.toThrow(/last owner/i); });
+  it('blocks unsafe sso enforcement', async () => { await expect(preventDisablingAllRecoveryPaths(adminMock(2, { sso_enabled: false, sso_metadata: {}, break_glass_email_enabled: false }), 'org1')).rejects.toThrow(/Cannot enforce SSO yet/i); });
+});

--- a/tests/unit/billing/quota-policy.test.ts
+++ b/tests/unit/billing/quota-policy.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuotaSummary } from '../../../lib/billing/quota-policy';
+
+describe('quota policy defaults', () => {
+  it('resolves trial defaults and near-limit', () => {
+    const summary = buildQuotaSummary('trial', 900);
+    expect(summary.executionsPer30Days).toBe(1000);
+    expect(summary.nearLimit).toBe(true);
+    expect(summary.exceeded).toBe(false);
+  });
+});

--- a/tests/unit/readiness/go-live.test.ts
+++ b/tests/unit/readiness/go-live.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('go-live readiness', () => {
+  it('returns blockers/warnings classification', async () => {
+    vi.doMock('../../../lib/supabase-server', () => ({ getSupabaseAdmin: () => ({ from: (table: string) => ({ select: () => ({ eq: () => ({ eq: () => ({ eq: async () => ({ data: table === 'users' ? [] : [{ id: 'x' }], error: null }), limit: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }), limit: () => ({ maybeSingle: async () => ({ data: null, error: null }) }), maybeSingle: async () => ({ data: null, error: null }), order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) }), order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) }) }) }) }));
+    const { buildGoLiveReadinessReport } = await import('../../../lib/readiness/go-live');
+    const report = await buildGoLiveReadinessReport('org1');
+    expect(report.status).toBe('not-ready');
+    expect(report.blockers.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add foundation-level enterprise controls so orgs can manage domain governance, export security/audit logs, surface plan-aware quotas, protect admin owners from lockout, and assess go-live readiness.
- Prefer DB-backed, explicit, and human-ops-friendly flows (no automated DNS verification or outbound SIEM delivery in this batch).
- Keep existing auth/session patterns and UI visual language while preserving backward compatibility.

### Description
- Database and schema: added migration `supabase/migrations/20260401_batch4_enterprise_hardening.sql` to create `org_domains`, `sign_in_events`, `access_requests`, `guest_access_grants`, `onboarding_states`, `org_security_settings`, `security_event_stream_configs` (config-only), and `rate_limit_events` for deterministic rate-limiting storage.
- Domain governance: new library `lib/auth/domain-governance.ts` with `normalizeDomain`, `getOrgDomains`, `findMatchingOrgDomain`, and `resolveDomainGovernance`; DB-backed rules take precedence over env fallback; admin endpoints `GET/POST /api/settings/domains` and `PATCH /api/settings/domains/[id]` and UI at `app/dashboard/settings/domains/page.tsx` created; verification token is generated/stored and shown (manual ops step).
- Audit export: added `lib/security/audit-export.ts` with `buildAuditExportQuery`, `exportAuditEventsAsJson`, and `exportAuditEventsAsCsv` that include real tables (`sign_in_events`, `access_requests`, `guest_access_grants`, `audit_logs`); added API routes `GET /api/settings/security/audit-events` (paginated) and `GET /api/settings/security/audit-export` (JSON/CSV); UI at `app/dashboard/settings/security/page.tsx` with date filters and export links.
- Quota & rate-limit foundations: new `lib/billing/quota-policy.ts` (`getPlanQuotaPolicy`, `getEffectiveExecutionQuotaForOrg`, `isQuotaExceeded`, `buildQuotaSummary`) with env overrides (`QUOTA_TRIAL_EXECUTIONS`, `QUOTA_PRO_EXECUTIONS`, `QUOTA_BUSINESS_EXECUTIONS`, `QUOTA_ENTERPRISE_EXECUTIONS`); `lib/security/rate-limit.ts` implements a DB-backed deterministic store and retry-after info; applied limits to `/auth/continue` (5 / 15 min by email) and `/api/access/request` (3 / 24h by email); quota summaries surfaced in `/api/usage` and `/api/execute` responses.
- Admin safety: new `lib/auth/admin-safety.ts` with `ensureOrgHasOwner`, `preventRemovingLastOwner`, `preventDisablingAllRecoveryPaths`, `canEnforceSsoSafely`; applied to role update route `PATCH /api/settings/members/[userId]` and security settings `PATCH /api/settings/security` to block unsafe actions with clear product-friendly messages.
- Go-live readiness: new `lib/readiness/go-live.ts` exporting `buildGoLiveReadinessReport(orgId)`, API `GET /api/settings/go-live` and export `GET /api/settings/go-live/export` (JSON/MD), and UI `app/dashboard/settings/go-live/page.tsx` rendering category cards, blockers, warnings, status (`ready|needs-attention|not-ready`), and recommended next steps.
- Navigation: dashboard nav updated to expose the new settings surfaces; no speculative third-party integrations included; `security_event_stream_configs` is config-only and does not deliver outbound webhooks.

### Testing
- Unit & integration tests added and run covering required acceptance points: DB-backed domain precedence, audit export JSON/CSV behavior, `/auth/continue` rate-limit, `/api/access/request` rate-limit, anti-lockout protections, unsafe SSO enforcement blocking, readiness report classification, and quota summary defaults; all tests passed locally.
- Commands executed: ran targeted test suite with `npm test` (the set of newly added unit and integration tests) and `npm run typecheck`; both completed successfully (tests green and `tsc` typecheck passed).
- Representative test files executed include `tests/unit/auth/access-policy.test.ts`, `tests/integration/api/audit-export.test.ts`, `tests/integration/api/access-request-rate-limit.test.ts`, `tests/integration/api/auth-continue.test.ts`, `tests/unit/auth/admin-safety.test.ts`, `tests/unit/readiness/go-live.test.ts`, and `tests/unit/billing/quota-policy.test.ts` and they validated the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc89bd57f88326873d572d631a8065)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
