### PR TITLE
Harden API error responses and add structured server logging

### DIFF
--- a/app/api/demo/bootstrap/route.ts
+++ b/app/api/demo/bootstrap/route.ts
@@ -4,6 +4,7 @@ import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { canonicalHash, canonicalJson } from '../../../../lib/runtime/canonical';
 import { buildCheckpointHash } from '../../../../lib/runtime/checkpoint';
 import { getOverageRateUsd } from '../../../../lib/billing/overage-config';
+import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
 
 function demoEnabled(request: Request) {
   if (process.env.NODE_ENV === 'production') return false;
@@ -74,7 +75,8 @@ export async function POST(request: Request) {
     });
 
     if (commitError) {
-      return NextResponse.json({ error: commitError.message }, { status: 500 });
+      logApiError('api/demo/bootstrap', commitError, { stage: 'runtime-commit' });
+      return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
 
     const commitRow = Array.isArray(commit) ? commit[0] : commit;
@@ -118,6 +120,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ org_id: orgId, agent_id: agentId, execution_id: commitRow.execution_id, demo_mode: true });
   } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Unexpected error' }, { status: 500 });
+    logApiError('api/demo/bootstrap', error, { stage: 'unhandled' });
+    return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
   }
 }

--- a/app/api/ledger/route.ts
+++ b/app/api/ledger/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "../../../lib/supabase/server";
 import { getDSGCoreLedger } from "../../../lib/dsg-core";
 import { fetchAuditLogsForExport } from "../../../lib/security/audit-export";
+import { internalErrorMessage, logApiError } from "../../../lib/security/api-error";
 
 export const dynamic = "force-dynamic";
 
@@ -41,7 +42,8 @@ export async function GET(request: Request) {
         return NextResponse.json({ error: "Audit export is temporarily unavailable because audit_logs relation is missing." }, { status: 503 });
       }
 
-      return NextResponse.json({ error: "message" in auditExport ? auditExport.message : "Failed to load audit export." }, { status: 500 });
+      logApiError("api/ledger", "message" in auditExport ? auditExport.message : "Audit export failed", { stage: "audit-export" });
+      return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
 
     const items = (auditExport.rows || []).map((row: any) => ({
@@ -71,8 +73,9 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
+    logApiError("api/ledger", error, { stage: "unhandled" });
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unexpected error" },
+      { error: internalErrorMessage() },
       { status: 500 }
     );
   }

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { internalErrorMessage, logApiError } from '../../../lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
 
@@ -46,7 +47,8 @@ export async function GET() {
       .gte('created_at', todayStart.toISOString());
 
     if (executionsError) {
-      return NextResponse.json({ error: executionsError.message }, { status: 500 });
+      logApiError('api/metrics', executionsError, { stage: 'executions-query' });
+      return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
 
     const { count: activeAgents, error: agentError } = await supabase
@@ -56,7 +58,8 @@ export async function GET() {
       .eq('status', 'active');
 
     if (agentError) {
-      return NextResponse.json({ error: agentError.message }, { status: 500 });
+      logApiError('api/metrics', agentError, { stage: 'agents-query' });
+      return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
 
     const total = (executions || []).length;
@@ -78,7 +81,8 @@ export async function GET() {
       active_agents: Number(activeAgents || 0),
       avg_latency_ms: avgLatencyMs,
     });
-  } catch {
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  } catch (error) {
+    logApiError('api/metrics', error, { stage: 'unhandled' });
+    return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
   }
 }

--- a/app/api/replay/[executionId]/route.ts
+++ b/app/api/replay/[executionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "../../../../lib/supabase/server";
 import { getDSGCoreLedger } from "../../../../lib/dsg-core";
+import { internalErrorMessage, logApiError } from "../../../../lib/security/api-error";
 
 export const dynamic = "force-dynamic";
 
@@ -69,11 +70,13 @@ export async function GET(
     ]);
 
     if (executionError) {
-      return NextResponse.json({ error: executionError.message }, { status: 500 });
+      logApiError("api/replay/[executionId]", executionError, { stage: "execution-query" });
+      return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
 
     if (auditError) {
-      return NextResponse.json({ error: auditError.message }, { status: 500 });
+      logApiError("api/replay/[executionId]", auditError, { stage: "audit-query" });
+      return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
 
     if (!execution) {
@@ -96,8 +99,9 @@ export async function GET(
       },
     });
   } catch (error) {
+    logApiError("api/replay/[executionId]", error, { stage: "unhandled" });
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unexpected error" },
+      { error: internalErrorMessage() },
       { status: 500 }
     );
   }


### PR DESCRIPTION
### Motivation
- Reduce information leakage by replacing client-facing `error.message` responses with a generic internal error for sensitive API endpoints.
- Add structured server-side logging to ensure backend errors are captured with context while preventing sensitive details from being returned to clients.

### Description
- Replace direct `error.message` responses with `internalErrorMessage()` and add `logApiError()` calls in `app/api/replay/[executionId]/route.ts` to hide DB/internal query failures and log them with context.
- Replace direct `error.message` responses with `internalErrorMessage()` and add `logApiError()` calls in `app/api/metrics/route.ts` to hide execution/agent query errors and log them.
- Replace direct `error.message` responses with `internalErrorMessage()` and add `logApiError()` calls in `app/api/ledger/route.ts` to hide audit-export failures and log them.
- Replace direct `error.message` responses with `internalErrorMessage()` and add `logApiError()` calls in `app/api/demo/bootstrap/route.ts` to hide runtime-commit/unhandled errors and log them.

### Testing
- Ran `npm run typecheck` which completed successfully with no type errors.
- Ran `npm run lint` which completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cfb3f939f083268da57d75588d785f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
