### PR TITLE
Harden spine pipeline normalization and runtime RPC error mapping

### DIFF
--- a/lib/spine/engine.ts
+++ b/lib/spine/engine.ts
@@ -18,6 +18,35 @@ function rpcErrorMessage(error: unknown): string {
   return '';
 }
 
+function mapRpcError(error: unknown) {
+  const message = rpcErrorMessage(error);
+  if (message.includes('agent_quota_exceeded')) {
+    return { status: 429, body: { error: 'Agent monthly quota exceeded' } };
+  }
+  if (message.includes('org_quota_exceeded')) {
+    return { status: 429, body: { error: 'Organization execution quota exceeded' } };
+  }
+  if (message.includes('approval_request_expired')) {
+    return { status: 409, body: { error: 'Runtime intent expired' } };
+  }
+  if (message.includes('approval_request_not_pending')) {
+    return { status: 409, body: { error: 'Runtime intent is not pending' } };
+  }
+  if (message.includes('approval_request_not_found')) {
+    return { status: 409, body: { error: 'Runtime intent not found' } };
+  }
+  if (message.includes('approval_consumed_without_ledger_lineage')) {
+    return { status: 500, body: { error: 'Approval consumed without ledger lineage' } };
+  }
+  if (message.includes('approval_consumption_failed')) {
+    return { status: 409, body: { error: 'Approval consumption failed' } };
+  }
+  if (message.includes('invalid_decision')) {
+    return { status: 500, body: { error: 'Pipeline returned invalid decision' } };
+  }
+  return { status: 500, body: { error: 'Internal server error' } };
+}
+
 async function resolveActiveAgent(orgId: string, agentId: string, apiKey: string) {
   const agent = await resolveAgentFromApiKey(agentId, apiKey);
   if (!agent || agent.org_id !== orgId) {
@@ -196,7 +225,7 @@ export async function executeSpineIntent(params: {
     return { ok: false as const, status: 429, body: { error: 'Organization execution quota exceeded' } };
   }
 
-  const { data: latestTruthRow } = await supabase
+  const { data: latestTruthRow, error: truthReadError } = await supabase
     .from('runtime_truth_states')
     .select('id, canonical_hash, canonical_json, created_at')
     .eq('org_id', agent.org_id)
@@ -204,6 +233,10 @@ export async function executeSpineIntent(params: {
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();
+
+  if (truthReadError) {
+    return { ok: false as const, status: 500, body: { error: 'Internal server error' } };
+  }
 
   const truthState = (latestTruthRow || null) as TruthState;
   const pipeline = await runPipeline({
@@ -234,8 +267,10 @@ export async function executeSpineIntent(params: {
     decision: pipeline.final_decision,
     policy_version: pipeline.final_policy_version,
     reason: pipeline.final_reason,
+    authoritative_plugin_id: pipeline.authoritative_plugin_id,
     pipeline_trace: pipeline.stages,
     proof_hash: pipeline.proof.proof_hash,
+    proof_version: pipeline.proof.proof_version,
   };
 
   const auditEvidence = {
@@ -245,7 +280,14 @@ export async function executeSpineIntent(params: {
     proof: pipeline.proof,
     authoritative_plugin_id: pipeline.authoritative_plugin_id,
     pipeline_trace: pipeline.stages,
-    anti_replay: { approval_request_id: approvalRequest.id },
+    anti_replay: {
+      approval_request_id: approvalRequest.id,
+      approval_key: approvalKey,
+    },
+    spine: {
+      billing_period: billingPeriod,
+      received_at: nowIso,
+    },
   };
 
   const { data: commitResult, error: rpcError } = await supabase.rpc('runtime_commit_execution', {
@@ -279,14 +321,8 @@ export async function executeSpineIntent(params: {
   });
 
   if (rpcError) {
-    const message = rpcErrorMessage(rpcError);
-    if (message.includes('agent_quota_exceeded')) {
-      return { ok: false as const, status: 429, body: { error: 'Agent monthly quota exceeded' } };
-    }
-    if (message.includes('org_quota_exceeded')) {
-      return { ok: false as const, status: 429, body: { error: 'Organization execution quota exceeded' } };
-    }
-    return { ok: false as const, status: 500, body: { error: 'Internal server error' } };
+    const mapped = mapRpcError(rpcError);
+    return { ok: false as const, status: mapped.status, body: mapped.body };
   }
 
   const commitRow = Array.isArray(commitResult) ? commitResult[0] : commitResult;

--- a/lib/spine/pipeline.ts
+++ b/lib/spine/pipeline.ts
@@ -1,13 +1,15 @@
 import { registry } from './plugin';
 import { ensureSpinePluginsRegistered } from './register-defaults';
-import type { Decision, PipelineResult, PluginOutput, PluginInput } from './types';
+import type { Decision, PipelineResult, PluginInput, PluginOutput } from './types';
 
-function severity(decision: Decision): number {
-  return { ALLOW: 0, STABILIZE: 1, BLOCK: 2 }[decision];
-}
+const DECISION_SEVERITY: Record<Decision, number> = {
+  ALLOW: 0,
+  STABILIZE: 1,
+  BLOCK: 2,
+};
 
 function combineDecision(left: Decision, right: Decision): Decision {
-  return severity(left) >= severity(right) ? left : right;
+  return DECISION_SEVERITY[left] >= DECISION_SEVERITY[right] ? left : right;
 }
 
 function defaultProof(): PluginOutput['proof'] {
@@ -19,17 +21,74 @@ function defaultProof(): PluginOutput['proof'] {
   };
 }
 
+function normalizeDecision(value: unknown): Decision {
+  if (value === 'ALLOW' || value === 'STABILIZE' || value === 'BLOCK') {
+    return value;
+  }
+  return 'BLOCK';
+}
+
 function pluginError(pluginId: string, error: unknown): PluginOutput {
   return {
     decision: 'BLOCK',
-    reason: `${pluginId}:PLUGIN_EVALUATION_ERROR`,
+    reason: 'PLUGIN_EVALUATION_ERROR',
     policy_version: `${pluginId}:error`,
     latency_ms: 0,
     proof: defaultProof(),
     metrics: {
+      plugin_id: pluginId,
       error: error instanceof Error ? error.message : 'unknown',
     },
   };
+}
+
+function normalizeOutput(pluginId: string, output: PluginOutput): PluginOutput {
+  return {
+    ...output,
+    decision: normalizeDecision(output.decision),
+    reason: String(output.reason || `${pluginId}:NO_REASON`),
+    policy_version: String(output.policy_version || `${pluginId}:unknown`),
+    latency_ms: Math.max(0, Number(output.latency_ms || 0)),
+    proof: output.proof || defaultProof(),
+    metrics: output.metrics || {},
+  };
+}
+
+function buildBlockedPipeline(pluginId: string, reason: string): PipelineResult {
+  return {
+    final_decision: 'BLOCK',
+    final_reason: reason,
+    final_policy_version: `${pluginId}:missing`,
+    total_latency_ms: 0,
+    proof: defaultProof(),
+    authoritative_plugin_id: pluginId,
+    stages: [
+      {
+        plugin_id: pluginId,
+        decision: 'BLOCK',
+        reason,
+        latency_ms: 0,
+        proof_hash: null,
+      },
+    ],
+  };
+}
+
+async function evaluatePlugin(pluginId: string, input: PluginInput): Promise<PluginOutput> {
+  const plugin = registry.get(pluginId);
+  if (!plugin) {
+    return {
+      decision: 'BLOCK',
+      reason: 'PLUGIN_NOT_FOUND',
+      policy_version: `${pluginId}:missing`,
+      latency_ms: 0,
+      proof: defaultProof(),
+      metrics: { plugin_id: pluginId },
+    };
+  }
+
+  const output = await plugin.evaluate(input).catch((error) => pluginError(plugin.id, error));
+  return normalizeOutput(plugin.id, output);
 }
 
 export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
@@ -46,10 +105,10 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
   const gateId = process.env.DSG_SPINE_GATE_PLUGIN || 'dsg-gate-bridge-v1';
   const gatePlugin = registry.get(gateId);
   if (!gatePlugin || gatePlugin.kind !== 'gate') {
-    throw new Error(`Spine gate plugin not found: ${gateId}`);
+    return buildBlockedPipeline(gateId, 'GATE_PLUGIN_NOT_FOUND');
   }
 
-  const gateOutput = await gatePlugin.evaluate(input).catch((error) => pluginError(gatePlugin.id, error));
+  const gateOutput = await evaluatePlugin(gatePlugin.id, input);
   totalLatency += gateOutput.latency_ms;
   finalDecision = gateOutput.decision;
   finalReason = gateOutput.reason;
@@ -67,7 +126,7 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
   if (gateOutput.decision !== 'BLOCK') {
     const arbiters = registry.getByKind('arbiter').sort((a, b) => a.id.localeCompare(b.id));
     for (const arbiter of arbiters) {
-      const output = await arbiter.evaluate(input).catch((error) => pluginError(arbiter.id, error));
+      const output = await evaluatePlugin(arbiter.id, input);
       totalLatency += output.latency_ms;
       stages.push({
         plugin_id: arbiter.id,
@@ -78,7 +137,7 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
       });
 
       const combined = combineDecision(finalDecision, output.decision);
-      if (combined !== finalDecision && severity(output.decision) >= severity(finalDecision)) {
+      if (combined !== finalDecision) {
         finalDecision = combined;
         finalReason = output.reason;
         finalPolicyVersion = output.policy_version;
@@ -86,6 +145,19 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
         authoritativeProof = output.proof;
       }
     }
+  }
+
+  const observers = registry.getByKind('observer').sort((a, b) => a.id.localeCompare(b.id));
+  for (const observer of observers) {
+    const output = await evaluatePlugin(observer.id, input);
+    totalLatency += output.latency_ms;
+    stages.push({
+      plugin_id: observer.id,
+      decision: output.decision,
+      reason: output.reason,
+      latency_ms: output.latency_ms,
+      proof_hash: output.proof.proof_hash,
+    });
   }
 
   return {


### PR DESCRIPTION
### Motivation
- Make the spine pipeline fail-closed and deterministic when plugins misbehave or return unexpected outputs.
- Prevent plugin exceptions from crashing the runtime by converting them into structured PluginOutput errors.
- Provide deterministic HTTP mappings for Postgres/RPC errors so callers receive stable status codes and messages.
- Enrich audit/canonical payloads and harden truth-state reads to improve auditability and robustness.

### Description
- lib/spine/pipeline.ts: add deterministic normalization (`normalizeDecision`, `normalizeOutput`) and safe defaults (`defaultProof`), a `pluginError` helper, and a shared `evaluatePlugin` wrapper that handles missing plugins and plugin exceptions; return a blocked pipeline result when the gate plugin is missing instead of throwing, and add an `observer` stage to record non-authoritative plugin traces.
- lib/spine/engine.ts: add `mapRpcError()` to translate RPC/Postgres error messages into explicit HTTP `status`/`body` responses, check and fail on truth-state read errors before running the pipeline, and include `authoritative_plugin_id` and `proof_version` in canonical/audit payloads for richer evidence.
- Overall: pipeline now accumulates normalized stage outputs and totals latency safely, and engine maps RPC failures deterministically rather than returning a generic 500.

### Testing
- Ran the full unit test command `npm run test:unit -- tests/unit/runtime/recovery.test.ts` which in this repo invoked the whole unit suite and surfaced unrelated pre-existing failures (two failing tests in `tests/unit/api/execute-makk8-integration.test.ts` reporting `buildMakk8ActionData is not a function`).
- Ran focused tests with `npx vitest run tests/unit/runtime/gate.test.ts tests/unit/runtime/recovery.test.ts` and those targeted runtime tests passed.
- Summary: modified runtime tests (gate/recovery) passed in isolation; full unit suite run failed due to unrelated test errors present in the repository, not due to the spine changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d022a433048326a5e8b0c4af41397e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
