### PR TITLE
spine: harden pipeline and engine error handling

### DIFF
--- a/lib/spine/engine.ts
+++ b/lib/spine/engine.ts
@@ -2,7 +2,7 @@ import { resolveAgentFromApiKey } from '../agent-auth';
 import { getOverageRateUsd, INCLUDED_EXECUTIONS } from '../billing/overage-config';
 import { getSupabaseAdmin } from '../supabase-server';
 import { buildApprovalKey } from '../runtime/approval';
-import { canonicalHash, canonicalJson } from '../runtime/canonical';
+import { canonicalHash, canonicalJson, type CanonicalInput } from '../runtime/canonical';
 import { runPipeline } from './pipeline';
 import type { SpineIntentPayload, TruthState } from './types';
 
@@ -16,6 +16,35 @@ function rpcErrorMessage(error: unknown): string {
     return String((error as { message?: unknown }).message || '');
   }
   return '';
+}
+
+function mapRpcError(error: unknown): { status: number; body: { error: string } } {
+  const message = rpcErrorMessage(error);
+  if (message.includes('agent_quota_exceeded')) {
+    return { status: 429, body: { error: 'Agent monthly quota exceeded' } };
+  }
+  if (message.includes('org_quota_exceeded')) {
+    return { status: 429, body: { error: 'Organization execution quota exceeded' } };
+  }
+  if (message.includes('approval_request_expired')) {
+    return { status: 409, body: { error: 'Runtime intent expired' } };
+  }
+  if (message.includes('approval_request_not_pending')) {
+    return { status: 409, body: { error: 'Runtime intent is not pending' } };
+  }
+  if (message.includes('approval_request_not_found')) {
+    return { status: 409, body: { error: 'Runtime intent not found' } };
+  }
+  if (message.includes('approval_consumed_without_ledger_lineage')) {
+    return { status: 500, body: { error: 'Approval consumed without ledger lineage' } };
+  }
+  if (message.includes('approval_consumption_failed')) {
+    return { status: 409, body: { error: 'Approval consumption failed' } };
+  }
+  if (message.includes('invalid_decision')) {
+    return { status: 500, body: { error: 'Pipeline returned invalid decision' } };
+  }
+  return { status: 500, body: { error: 'Internal server error' } };
 }
 
 async function resolveActiveAgent(orgId: string, agentId: string, apiKey: string) {
@@ -41,7 +70,7 @@ export async function issueSpineIntent(params: {
   const approvalKey = buildApprovalKey({
     orgId: resolved.agent.org_id,
     agentId: resolved.agent.id,
-    request: params.payload.canonicalRequest,
+    request: params.payload.canonicalRequest as CanonicalInput,
   });
 
   const { data: prior, error: priorError } = await supabase
@@ -118,7 +147,7 @@ export async function executeSpineIntent(params: {
   const approvalKey = buildApprovalKey({
     orgId: agent.org_id,
     agentId: agent.id,
-    request: params.payload.canonicalRequest,
+    request: params.payload.canonicalRequest as CanonicalInput,
   });
 
   const { data: approvalRequest, error: approvalError } = await supabase
@@ -196,7 +225,7 @@ export async function executeSpineIntent(params: {
     return { ok: false as const, status: 429, body: { error: 'Organization execution quota exceeded' } };
   }
 
-  const { data: latestTruthRow } = await supabase
+  const { data: latestTruthRow, error: truthReadError } = await supabase
     .from('runtime_truth_states')
     .select('id, canonical_hash, canonical_json, created_at')
     .eq('org_id', agent.org_id)
@@ -204,6 +233,9 @@ export async function executeSpineIntent(params: {
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();
+  if (truthReadError) {
+    return { ok: false as const, status: 500, body: { error: 'Internal server error' } };
+  }
 
   const truthState = (latestTruthRow || null) as TruthState;
   const pipeline = await runPipeline({
@@ -236,6 +268,8 @@ export async function executeSpineIntent(params: {
     reason: pipeline.final_reason,
     pipeline_trace: pipeline.stages,
     proof_hash: pipeline.proof.proof_hash,
+    proof_version: pipeline.proof.proof_version,
+    authoritative_plugin_id: pipeline.authoritative_plugin_id,
   };
 
   const auditEvidence = {
@@ -245,7 +279,11 @@ export async function executeSpineIntent(params: {
     proof: pipeline.proof,
     authoritative_plugin_id: pipeline.authoritative_plugin_id,
     pipeline_trace: pipeline.stages,
-    anti_replay: { approval_request_id: approvalRequest.id },
+    anti_replay: { approval_request_id: approvalRequest.id, approval_key: approvalKey },
+    spine: {
+      billing_period: billingPeriod,
+      received_at: nowIso,
+    },
   };
 
   const { data: commitResult, error: rpcError } = await supabase.rpc('runtime_commit_execution', {
@@ -259,8 +297,8 @@ export async function executeSpineIntent(params: {
       authoritative_plugin_id: pipeline.authoritative_plugin_id,
       pipeline_trace: pipeline.stages,
     },
-    p_canonical_hash: canonicalHash(canonical),
-    p_canonical_json: JSON.parse(canonicalJson(canonical)),
+    p_canonical_hash: canonicalHash(canonical as CanonicalInput),
+    p_canonical_json: JSON.parse(canonicalJson(canonical as CanonicalInput)),
     p_latency_ms: pipeline.total_latency_ms,
     p_request_payload: params.payload.input,
     p_context_payload: {
@@ -279,14 +317,8 @@ export async function executeSpineIntent(params: {
   });
 
   if (rpcError) {
-    const message = rpcErrorMessage(rpcError);
-    if (message.includes('agent_quota_exceeded')) {
-      return { ok: false as const, status: 429, body: { error: 'Agent monthly quota exceeded' } };
-    }
-    if (message.includes('org_quota_exceeded')) {
-      return { ok: false as const, status: 429, body: { error: 'Organization execution quota exceeded' } };
-    }
-    return { ok: false as const, status: 500, body: { error: 'Internal server error' } };
+    const mapped = mapRpcError(rpcError);
+    return { ok: false as const, status: mapped.status, body: mapped.body };
   }
 
   const commitRow = Array.isArray(commitResult) ? commitResult[0] : commitResult;

--- a/lib/spine/pipeline.ts
+++ b/lib/spine/pipeline.ts
@@ -2,8 +2,14 @@ import { registry } from './plugin';
 import { ensureSpinePluginsRegistered } from './register-defaults';
 import type { Decision, PipelineResult, PluginOutput, PluginInput } from './types';
 
+const DECISION_SEVERITY: Record<Decision, number> = {
+  ALLOW: 0,
+  STABILIZE: 1,
+  BLOCK: 2,
+};
+
 function severity(decision: Decision): number {
-  return { ALLOW: 0, STABILIZE: 1, BLOCK: 2 }[decision];
+  return DECISION_SEVERITY[decision];
 }
 
 function combineDecision(left: Decision, right: Decision): Decision {
@@ -19,17 +25,84 @@ function defaultProof(): PluginOutput['proof'] {
   };
 }
 
+function normalizeDecision(value: unknown): Decision {
+  if (value === 'ALLOW' || value === 'STABILIZE' || value === 'BLOCK') {
+    return value;
+  }
+  return 'BLOCK';
+}
+
 function pluginError(pluginId: string, error: unknown): PluginOutput {
+  const message = error instanceof Error ? error.message : 'unknown';
   return {
     decision: 'BLOCK',
-    reason: `${pluginId}:PLUGIN_EVALUATION_ERROR`,
+    reason: 'PLUGIN_EVALUATION_ERROR',
     policy_version: `${pluginId}:error`,
     latency_ms: 0,
     proof: defaultProof(),
     metrics: {
-      error: error instanceof Error ? error.message : 'unknown',
+      plugin_id: pluginId,
+      error: message,
     },
   };
+}
+
+function normalizeOutput(pluginId: string, output: Partial<PluginOutput> | undefined): PluginOutput {
+  const latencyValue = Number(output?.latency_ms);
+  return {
+    decision: normalizeDecision(output?.decision),
+    reason: output?.reason || `${pluginId}:NO_REASON`,
+    policy_version: output?.policy_version || `${pluginId}:unknown`,
+    latency_ms: Number.isFinite(latencyValue) ? Math.max(0, latencyValue) : 0,
+    proof: output?.proof || defaultProof(),
+    metrics: output?.metrics || {},
+  };
+}
+
+function buildBlockedPipeline(pluginId: string, reason: string): PipelineResult {
+  const output = normalizeOutput(pluginId, {
+    decision: 'BLOCK',
+    reason,
+    policy_version: `${pluginId}:missing`,
+    latency_ms: 0,
+    proof: defaultProof(),
+    metrics: { plugin_id: pluginId },
+  });
+
+  return {
+    final_decision: output.decision,
+    final_reason: output.reason,
+    final_policy_version: output.policy_version,
+    total_latency_ms: output.latency_ms,
+    proof: output.proof,
+    authoritative_plugin_id: pluginId,
+    stages: [
+      {
+        plugin_id: pluginId,
+        decision: output.decision,
+        reason: output.reason,
+        latency_ms: output.latency_ms,
+        proof_hash: output.proof.proof_hash,
+      },
+    ],
+  };
+}
+
+async function evaluatePlugin(pluginId: string, input: PluginInput): Promise<PluginOutput> {
+  const plugin = registry.get(pluginId);
+  if (!plugin) {
+    return normalizeOutput(pluginId, {
+      decision: 'BLOCK',
+      reason: 'PLUGIN_NOT_FOUND',
+      policy_version: `${pluginId}:missing`,
+      latency_ms: 0,
+      proof: defaultProof(),
+      metrics: { plugin_id: pluginId },
+    });
+  }
+
+  const output = await plugin.evaluate(input).catch((error) => pluginError(pluginId, error));
+  return normalizeOutput(pluginId, output);
 }
 
 export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
@@ -46,10 +119,10 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
   const gateId = process.env.DSG_SPINE_GATE_PLUGIN || 'dsg-gate-bridge-v1';
   const gatePlugin = registry.get(gateId);
   if (!gatePlugin || gatePlugin.kind !== 'gate') {
-    throw new Error(`Spine gate plugin not found: ${gateId}`);
+    return buildBlockedPipeline(gateId, 'GATE_PLUGIN_NOT_FOUND');
   }
 
-  const gateOutput = await gatePlugin.evaluate(input).catch((error) => pluginError(gatePlugin.id, error));
+  const gateOutput = await evaluatePlugin(gatePlugin.id, input);
   totalLatency += gateOutput.latency_ms;
   finalDecision = gateOutput.decision;
   finalReason = gateOutput.reason;
@@ -67,7 +140,7 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
   if (gateOutput.decision !== 'BLOCK') {
     const arbiters = registry.getByKind('arbiter').sort((a, b) => a.id.localeCompare(b.id));
     for (const arbiter of arbiters) {
-      const output = await arbiter.evaluate(input).catch((error) => pluginError(arbiter.id, error));
+      const output = await evaluatePlugin(arbiter.id, input);
       totalLatency += output.latency_ms;
       stages.push({
         plugin_id: arbiter.id,
@@ -85,6 +158,19 @@ export async function runPipeline(input: PluginInput): Promise<PipelineResult> {
         authoritativePluginId = arbiter.id;
         authoritativeProof = output.proof;
       }
+    }
+
+    const observers = registry.getByKind('observer').sort((a, b) => a.id.localeCompare(b.id));
+    for (const observer of observers) {
+      const output = await evaluatePlugin(observer.id, input);
+      totalLatency += output.latency_ms;
+      stages.push({
+        plugin_id: observer.id,
+        decision: output.decision,
+        reason: output.reason,
+        latency_ms: output.latency_ms,
+        proof_hash: output.proof.proof_hash,
+      });
     }
   }
 


### PR DESCRIPTION
### Motivation
- Reduce risk from malformed or missing plugin outputs by normalizing decisions and outputs and failing safe when gate plugins are unavailable. 
- Improve error mapping for spine engine RPC failures and make truth-state reads and audit payloads more robust for observability and anti-replay protection.

### Description
- Added `DECISION_SEVERITY` and `normalizeDecision()` to ensure only `ALLOW`/`STABILIZE`/`BLOCK` are accepted and default to `BLOCK` otherwise. 
- Added `pluginError()`, `normalizeOutput()`, `evaluatePlugin()`, and `buildBlockedPipeline()` helpers and updated `runPipeline()` to evaluate gate, arbiters, and observers via `evaluatePlugin()` while ensuring observers cannot overwrite the final decision. 
- Preserved `PipelineResult` shape (`final_decision`, `final_reason`, `final_policy_version`, `total_latency_ms`, `proof`, `authoritative_plugin_id`, `stages`). 
- Added `mapRpcError()` to `lib/spine/engine.ts`, checked for `truthReadError` when reading `runtime_truth_states`, expanded canonical object to include `authoritative_plugin_id` and `proof_version`, and expanded `auditEvidence` to include `anti_replay.approval_key`, `spine.billing_period`, and `spine.received_at`, and used `mapRpcError()` to map `runtime_commit_execution` failures to proper HTTP statuses.

### Testing
- Ran `npm ci` which completed successfully. 
- Ran `npm run typecheck` which failed due to a pre-existing test import issue (`buildMakk8ActionData` is not exported from `app/api/execute/route`), not caused by the spine changes. 
- Ran `npm test` which showed the same two failing tests complaining `buildMakk8ActionData is not a function`, indicating the failures are due to the pre-existing missing export and not the spine edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d024aba9b8832683505174e280672d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
