### PR TITLE
fix(spine): align SpineIntentPayload with CanonicalInput boundary

### DIFF
--- a/lib/spine/types.ts
+++ b/lib/spine/types.ts
@@ -1,4 +1,5 @@
 export type Decision = 'ALLOW' | 'STABILIZE' | 'BLOCK';
+import type { CanonicalInput } from '../runtime/canonical';
 
 export type TruthState = {
   id?: string;
@@ -57,14 +58,16 @@ export type PipelineResult = {
   stages: PipelineStageTrace[];
 };
 
+type CanonicalRecord = { [key: string]: CanonicalInput | undefined };
+
 export type SpineIntentPayload = {
   agentId: string;
   action: string;
-  input: Record<string, unknown>;
-  context: Record<string, unknown>;
+  input: CanonicalRecord;
+  context: CanonicalRecord;
   canonicalRequest: {
     action: string;
-    input: Record<string, unknown>;
-    context: Record<string, unknown>;
+    input: CanonicalRecord;
+    context: CanonicalRecord;
   };
 };


### PR DESCRIPTION
### Motivation
- Tighten the type boundary between Spine and runtime canonical shapes so intent payloads carry `CanonicalInput`-safe values instead of loose `Record<string, unknown>` and avoid callers masking the real boundary with casts.

### Description
- Import `CanonicalInput` from `../runtime/canonical` in `lib/spine/types.ts` and add `type CanonicalRecord = { [key: string]: CanonicalInput | undefined }`.
- Change `SpineIntentPayload.input`, `SpineIntentPayload.context`, and `SpineIntentPayload.canonicalRequest.{input,context}` to use `CanonicalRecord` instead of `Record<string, unknown>`.
- Did not add any casts in `engine.ts` or other places; this patch only moves the type boundary to the spine types file so downstream mismatches surface explicitly.

### Testing
- Ran `npm run typecheck` which failed due to `lib/spine/request.ts` still returning `Record<string, unknown>` from `asRecord()` and therefore not assignable to `CanonicalRecord` (type boundary mismatch), so typecheck failed.
- Ran `npm run build` which failed at the same `lib/spine/request.ts` type error during Next.js type validation.
- Ran `npm test` where the suite mostly passed, but two unit tests in `tests/unit/api/execute-makk8-integration.test.ts` failed with `buildMakk8ActionData is not a function`, which is unrelated to the spine type boundary change; the rest of the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d0282b31c08326b66d2cc1da6354df)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
