### PR TITLE
Add auth preflight checks, session probe endpoint, and magic-link polling UX

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,20 @@
+import { createClient } from '../../../../lib/supabase/server';
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    return Response.json({
+      authenticated: Boolean(user),
+      email: user?.email ?? null,
+    });
+  } catch {
+    return Response.json({
+      authenticated: false,
+      email: null,
+    });
+  }
+}

--- a/app/auth/continue/route.ts
+++ b/app/auth/continue/route.ts
@@ -6,6 +6,7 @@ import { resolveLoginContext } from '../../../lib/auth/login-context';
 import { resolveAccessModeForEmail } from '../../../lib/auth/access-policy';
 import { logSignInEvent } from '../../../lib/auth/sign-in-events';
 import { applyRateLimit, getRateLimitKey } from '../../../lib/security/rate-limit';
+import { validateAuthConfig } from '../../../lib/auth/preflight';
 
 const AUTH_CONTINUE_RATE_LIMIT = 8;
 const AUTH_CONTINUE_RATE_WINDOW_MS = 60 * 1000;
@@ -91,6 +92,18 @@ export async function POST(request: NextRequest) {
 
   if (!rateLimit.allowed) {
     redirectToLogin.searchParams.set('error', 'rate-limited');
+    return NextResponse.redirect(redirectToLogin, { status: 302 });
+  }
+
+  const preflight = validateAuthConfig();
+  if (preflight.warnings.length) {
+    console.warn('[auth-continue] preflight warnings:', preflight.warnings);
+  }
+
+  if (!preflight.ok) {
+    const firstError = preflight.errors[0];
+    console.error('[auth-continue] preflight failed:', preflight.errors);
+    redirectToLogin.searchParams.set('error', firstError ? firstError.code : 'unexpected');
     return NextResponse.redirect(redirectToLogin, { status: 302 });
   }
 

--- a/app/auth/login/route.ts
+++ b/app/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
 import { applyRateLimit, getRateLimitKey } from '../../../lib/security/rate-limit';
+import { validateAuthConfig } from '../../../lib/auth/preflight';
 
 const AUTH_LOGIN_RATE_LIMIT = 8;
 const AUTH_LOGIN_RATE_WINDOW_MS = 60 * 1000;
@@ -49,6 +50,18 @@ export async function POST(request: NextRequest) {
 
   if (!rateLimit.allowed) {
     redirectToLogin.searchParams.set('error', 'rate-limited');
+    return NextResponse.redirect(redirectToLogin, { status: 302 });
+  }
+
+  const preflight = validateAuthConfig();
+  if (preflight.warnings.length) {
+    console.warn('[magic-link] preflight warnings:', preflight.warnings);
+  }
+
+  if (!preflight.ok) {
+    const firstError = preflight.errors[0];
+    console.error('[magic-link] preflight failed:', preflight.errors);
+    redirectToLogin.searchParams.set('error', firstError ? firstError.code : 'unexpected');
     return NextResponse.redirect(redirectToLogin, { status: 302 });
   }
 

--- a/app/auth/signup/route.ts
+++ b/app/auth/signup/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { validateAuthConfig } from '../../../lib/auth/preflight';
 
 function getSafeNext(value: string | null) {
   if (!value || !value.startsWith('/')) return '/quickstart';
@@ -39,6 +40,18 @@ export async function POST(request: NextRequest) {
 
   if (!workspaceName) {
     redirectToSignup.searchParams.set('error', 'missing-workspace');
+    return NextResponse.redirect(redirectToSignup, { status: 302 });
+  }
+
+  const preflight = validateAuthConfig({ requireAppUrl: true });
+  if (preflight.warnings.length) {
+    console.warn('[trial-signup] preflight warnings:', preflight.warnings);
+  }
+
+  if (!preflight.ok) {
+    const firstError = preflight.errors[0];
+    console.error('[trial-signup] preflight failed:', preflight.errors);
+    redirectToSignup.searchParams.set('error', firstError ? firstError.code : 'signup-failed');
     return NextResponse.redirect(redirectToSignup, { status: 302 });
   }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Suspense } from 'react';
 import LoginForm from '../../components/LoginForm';
 import { resolveLoginContext } from '../../lib/auth/login-context';
 
@@ -23,6 +24,10 @@ function getMessage(message?: string, error?: string) {
   if (error === 'rate-limited') return { tone: 'error', text: 'Too many login attempts. Wait 1 minute, then try again.' };
   if (error === 'sso-unavailable') return { tone: 'error', text: 'Single sign-on is not available for this login right now.' };
   if (error === 'org-self-serve-disabled') return { tone: 'error', text: 'Your company does not allow self-serve access for this login path.' };
+  if (error === 'missing-supabase-url') return { tone: 'error', text: 'Server configuration error: Supabase URL is not configured. Contact your admin.' };
+  if (error === 'missing-anon-key') return { tone: 'error', text: 'Server configuration error: Supabase API key is not configured. Contact your admin.' };
+  if (error === 'missing-service-key') return { tone: 'error', text: 'Server configuration error: Supabase service key is not configured. Contact your admin.' };
+  if (error === 'missing-app-url') return { tone: 'error', text: 'Server configuration error: Application URL is not configured. Contact your admin.' };
   if (error === 'unexpected') return { tone: 'error', text: 'Unexpected auth error. Check server logs and auth configuration.' };
   return null;
 }
@@ -65,7 +70,9 @@ export default async function LoginPage({
 
           {!ssoOnly && (
             <div className="mt-8">
-              <LoginForm next={next} orgSlug={context.org?.slug} ssoFirst={ssoFirst} />
+              <Suspense fallback={null}>
+                <LoginForm next={next} orgSlug={context.org?.slug} ssoFirst={ssoFirst} />
+              </Suspense>
             </div>
           )}
         </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -43,6 +43,34 @@ function getMessage(message?: string, error?: string) {
     };
   }
 
+  if (error === 'missing-supabase-url') {
+    return {
+      tone: 'error',
+      text: 'Server configuration error: Supabase URL is not configured. Contact your admin.',
+    };
+  }
+
+  if (error === 'missing-anon-key') {
+    return {
+      tone: 'error',
+      text: 'Server configuration error: Supabase API key is not configured. Contact your admin.',
+    };
+  }
+
+  if (error === 'missing-service-key') {
+    return {
+      tone: 'error',
+      text: 'Server configuration error: Supabase service key is not configured. Contact your admin.',
+    };
+  }
+
+  if (error === 'missing-app-url') {
+    return {
+      tone: 'error',
+      text: 'Server configuration error: Application URL is not configured. Contact your admin.',
+    };
+  }
+
   if (error === 'signup-failed') {
     return {
       tone: 'error',

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 type Props = {
   next: string;
@@ -10,6 +11,48 @@ type Props = {
 
 export default function LoginForm({ next, orgSlug, ssoFirst }: Props) {
   const [mode, setMode] = useState<'login' | 'trial'>('login');
+  const searchParams = useSearchParams();
+  const isWaitingForEmail = searchParams?.get('message') === 'check-email';
+
+  useEffect(() => {
+    if (!isWaitingForEmail) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const checkSession = async () => {
+      try {
+        const response = await fetch('/api/auth/session', {
+          method: 'GET',
+          cache: 'no-store',
+          credentials: 'same-origin',
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as { authenticated?: boolean };
+
+        if (!cancelled && data.authenticated) {
+          window.location.href = next;
+        }
+      } catch {
+        // No-op. Keep polling until session is established.
+      }
+    };
+
+    void checkSession();
+    const intervalId = window.setInterval(() => {
+      void checkSession();
+    }, 3000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [isWaitingForEmail, next]);
 
   return (
     <div>

--- a/lib/auth/preflight.ts
+++ b/lib/auth/preflight.ts
@@ -1,0 +1,69 @@
+export type PreflightErrorCode =
+  | 'missing-supabase-url'
+  | 'missing-anon-key'
+  | 'missing-service-key'
+  | 'missing-app-url';
+
+export type PreflightWarningCode = 'missing-app-url';
+
+type ValidateAuthConfigOptions = {
+  requireAppUrl?: boolean;
+};
+
+export type PreflightResult = {
+  ok: boolean;
+  errors: Array<{ code: PreflightErrorCode; message: string }>;
+  warnings: Array<{ code: PreflightWarningCode; message: string }>;
+};
+
+export function validateAuthConfig(options: ValidateAuthConfigOptions = {}): PreflightResult {
+  const errors: PreflightResult['errors'] = [];
+  const warnings: PreflightResult['warnings'] = [];
+
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+    errors.push({
+      code: 'missing-supabase-url',
+      message: 'NEXT_PUBLIC_SUPABASE_URL is not set',
+    });
+  }
+
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY &&
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    errors.push({
+      code: 'missing-anon-key',
+      message:
+        'NEXT_PUBLIC_SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY is not set',
+    });
+  }
+
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    errors.push({
+      code: 'missing-service-key',
+      message: 'SUPABASE_SERVICE_ROLE_KEY is not set',
+    });
+  }
+
+  if (!process.env.APP_URL && !process.env.NEXT_PUBLIC_APP_URL) {
+    const appUrlIssue = {
+      code: 'missing-app-url' as const,
+      message: 'APP_URL or NEXT_PUBLIC_APP_URL is not set',
+    };
+
+    if (options.requireAppUrl) {
+      errors.push(appUrlIssue);
+    } else {
+      warnings.push({
+        ...appUrlIssue,
+        message: `${appUrlIssue.message} — falling back to request origin`,
+      });
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+  };
+}

--- a/tests/integration/api/auth-continue-org-sso.test.ts
+++ b/tests/integration/api/auth-continue-org-sso.test.ts
@@ -8,8 +8,19 @@ function buildReq() {
   return new Request('http://localhost/auth/continue', { method: 'POST', body: form });
 }
 
+
+function setAuthEnv() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+  process.env.APP_URL = 'http://localhost';
+}
+
 describe('/auth/continue org-scoped sso', () => {
-  beforeEach(() => vi.resetModules());
+  beforeEach(() => {
+    vi.resetModules();
+    setAuthEnv();
+  });
 
   it('blocks email flow when break-glass is disabled', async () => {
     vi.doMock('../../../lib/auth/login-context', () => ({ resolveLoginContext: vi.fn(async () => ({ mode: 'sso-only', org: { slug: 'acme' } })) }));

--- a/tests/integration/api/auth-continue.test.ts
+++ b/tests/integration/api/auth-continue.test.ts
@@ -12,6 +12,14 @@ function buildFormRequest(fields: Record<string, string>) {
 }
 
 /** Build a chainable Supabase query builder mock where every method returns `this` and the terminal resolves to `result`. */
+
+function setAuthEnv() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+  process.env.APP_URL = 'http://localhost';
+}
+
 function chainMock(result: { data: unknown; error: unknown }) {
   const resolved = Promise.resolve(result);
   const chain: Record<string, unknown> = {};
@@ -32,7 +40,7 @@ function chainMock(result: { data: unknown; error: unknown }) {
 describe('/auth/continue', () => {
   beforeEach(() => {
     vi.resetModules();
-    process.env.APP_URL = 'http://localhost';
+    setAuthEnv();
     process.env.APPROVED_APPROVAL_DOMAINS = '';
     vi.doMock('../../../lib/auth/sign-in-events', () => ({ logSignInEvent: vi.fn(async () => {}) }));
     vi.doMock('../../../lib/auth/access-policy', async () => {

--- a/tests/integration/api/auth-login.test.ts
+++ b/tests/integration/api/auth-login.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from 'next/server';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 function buildFormRequest(fields: Record<string, string>) {
@@ -5,7 +6,7 @@ function buildFormRequest(fields: Record<string, string>) {
   for (const [key, value] of Object.entries(fields)) {
     form.set(key, value);
   }
-  return new Request('http://localhost/auth/login', {
+  return new NextRequest('http://localhost/auth/login', {
     method: 'POST',
     body: form,
   });
@@ -28,10 +29,23 @@ function chainMock(result: { data: unknown; error: unknown }) {
   return new Proxy({}, handler);
 }
 
+function setAuthEnv({ includeAppUrl = true }: { includeAppUrl?: boolean } = {}) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+  if (includeAppUrl) {
+    process.env.APP_URL = 'http://localhost';
+  } else {
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  }
+}
+
 describe('/auth/login', () => {
   beforeEach(() => {
     vi.resetModules();
-    process.env.APP_URL = 'http://localhost';
+    setAuthEnv();
   });
 
   it('returns rate-limited when the limiter blocks the request', async () => {
@@ -88,5 +102,39 @@ describe('/auth/login', () => {
     expect(location).toContain('/login');
     expect(location).toContain('message=check-email');
     expect(signInWithOtp).toHaveBeenCalledOnce();
+  });
+
+  it('does not block when APP_URL is missing and falls back to request origin', async () => {
+    const signInWithOtp = vi.fn().mockResolvedValue({ error: null });
+
+    setAuthEnv({ includeAppUrl: false });
+
+    vi.doMock('../../../lib/security/rate-limit', () => ({
+      applyRateLimit: vi.fn(async () => ({ allowed: true, remaining: 7, resetAt: Date.now() + 60000 })),
+      getRateLimitKey: vi.fn(() => 'auth-login:test'),
+    }));
+
+    vi.doMock('../../../lib/supabase/server', () => ({
+      createClient: vi.fn(async () => ({ auth: { signInWithOtp } })),
+    }));
+
+    vi.doMock('../../../lib/supabase-server', () => ({
+      getSupabaseAdmin: vi.fn(() => ({
+        from: vi.fn(() =>
+          chainMock({
+            data: { id: 'u1', email: 'op@co.com', is_active: true, org_id: 'org1', auth_user_id: 'au1' },
+            error: null,
+          }),
+        ),
+      })),
+    }));
+
+    const { POST } = await import('../../../app/auth/login/route');
+    const res = await POST(buildFormRequest({ email: 'op@co.com', next: '/dashboard' }) as never);
+
+    expect(res.status).toBe(302);
+    expect(signInWithOtp).toHaveBeenCalledOnce();
+    const firstCall = signInWithOtp.mock.calls[0]?.[0] as { options?: { emailRedirectTo?: string } };
+    expect(firstCall.options?.emailRedirectTo).toContain('http://localhost/auth/confirm');
   });
 });

--- a/tests/integration/api/auth-session.test.ts
+++ b/tests/integration/api/auth-session.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('/api/auth/session', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns authenticated=false when no user session exists', async () => {
+    vi.doMock('../../../lib/supabase/server', () => ({
+      createClient: vi.fn(async () => ({
+        auth: {
+          getUser: vi.fn(async () => ({ data: { user: null } })),
+        },
+      })),
+    }));
+
+    const { GET } = await import('../../../app/api/auth/session/route');
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ authenticated: false, email: null });
+  });
+
+  it('returns 200 with authenticated=false when createClient throws', async () => {
+    vi.doMock('../../../lib/supabase/server', () => ({
+      createClient: vi.fn(async () => {
+        throw new Error('Missing env');
+      }),
+    }));
+
+    const { GET } = await import('../../../app/api/auth/session/route');
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ authenticated: false, email: null });
+  });
+});

--- a/tests/integration/api/sign-in-events.test.ts
+++ b/tests/integration/api/sign-in-events.test.ts
@@ -11,6 +11,14 @@ function buildFormRequest(fields: Record<string, string>) {
   });
 }
 
+
+function setAuthEnv() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+  process.env.APP_URL = 'http://localhost';
+}
+
 function chainMock(result: { data: unknown; error: unknown }) {
   const resolved = Promise.resolve(result);
   const chain: Record<string, unknown> = {};
@@ -31,7 +39,7 @@ function chainMock(result: { data: unknown; error: unknown }) {
 describe('sign in event instrumentation', () => {
   beforeEach(() => {
     vi.resetModules();
-    process.env.APP_URL = 'http://localhost';
+    setAuthEnv();
   });
 
   it('logs event for successful magic link request', async () => {

--- a/tests/unit/auth-preflight.test.ts
+++ b/tests/unit/auth-preflight.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { validateAuthConfig } from '../../lib/auth/preflight';
+
+const ENV_KEYS = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'APP_URL',
+  'NEXT_PUBLIC_APP_URL',
+] as const;
+
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+function resetEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (typeof value === 'undefined') {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function applyValidBaseline() {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+  process.env.APP_URL = 'https://app.example.com';
+  delete process.env.NEXT_PUBLIC_APP_URL;
+}
+
+afterEach(() => {
+  resetEnv();
+});
+
+describe('validateAuthConfig', () => {
+  it('returns ok=true when required auth config is present', () => {
+    applyValidBaseline();
+
+    const result = validateAuthConfig();
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('returns missing-supabase-url error when Supabase URL is missing', () => {
+    applyValidBaseline();
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    const result = validateAuthConfig();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((entry) => entry.code === 'missing-supabase-url')).toBe(true);
+  });
+
+  it('returns missing-anon-key error when anon/publishable keys are both missing', () => {
+    applyValidBaseline();
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+    const result = validateAuthConfig();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((entry) => entry.code === 'missing-anon-key')).toBe(true);
+  });
+
+  it('returns missing-service-key error when service role key is missing', () => {
+    applyValidBaseline();
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const result = validateAuthConfig();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((entry) => entry.code === 'missing-service-key')).toBe(true);
+  });
+
+  it('returns missing-app-url as warning by default, not as blocking error', () => {
+    applyValidBaseline();
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    const result = validateAuthConfig();
+
+    expect(result.ok).toBe(true);
+    expect(result.errors.some((entry) => entry.code === 'missing-app-url')).toBe(false);
+    expect(result.warnings.some((entry) => entry.code === 'missing-app-url')).toBe(true);
+  });
+
+  it('returns missing-app-url as blocking error when requireAppUrl=true', () => {
+    applyValidBaseline();
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    const result = validateAuthConfig({ requireAppUrl: true });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((entry) => entry.code === 'missing-app-url')).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation

- Ensure server-side auth configuration (Supabase keys and app URL) is validated before sending magic links or starting signups to avoid silent failures.  
- Improve login UX by polling for an authenticated session after a magic link is sent so the app can redirect automatically.  

### Description

- Add `lib/auth/preflight.ts` which validates required auth environment variables and returns structured `ok`, `errors`, and `warnings`.  
- Integrate `validateAuthConfig` into `app/auth/login/route.ts`, `app/auth/continue/route.ts`, and `app/auth/signup/route.ts`, with `requireAppUrl` enforced for signup; log warnings and surface the first preflight error as a redirect error.  
- Add a lightweight session probe API at `app/api/auth/session/route.ts` that returns `{ authenticated, email }` and handles client-side failures gracefully.  
- Improve client behavior by adding polling in `components/LoginForm.tsx` to call `/api/auth/session` when `message=check-email` is present and redirect when a session is established, and wrap `LoginForm` in `Suspense` in `app/login/page.tsx`.  
- Update `app/login/page.tsx` and `app/signup/page.tsx` to show user-facing error messages for the new preflight error codes.  
- Add unit tests for `validateAuthConfig` and integration tests for the new session endpoint and updated auth flows, and update existing tests to set necessary auth env vars.  

### Testing

- Ran the test suite with `vitest` including new unit tests for `validateAuthConfig` and the updated integration tests, and all tests passed.  
- Added integration tests that exercise the `/api/auth/session` endpoint and the login/signup preflight behavior, which succeeded under the CI test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d1f591687c8326a3038af874f2add5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
