### PR TITLE
Fix billing/webhook typings, agent tools syntax, spine severity, and DSG core health types

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -46,7 +46,7 @@ function getStripeClient() {
   }
 
   return new Stripe(secretKey, {
-    apiVersion: '2023-10-16',
+    apiVersion: '2023-10-16' as Stripe.LatestApiVersion,
   });
 }
 

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
 
@@ -17,7 +18,7 @@ function getStripeClient() {
   }
 
   return new Stripe(secretKey, {
-    apiVersion: '2023-10-16',
+    apiVersion: '2023-10-16' as Stripe.LatestApiVersion,
   });
 }
 
@@ -50,7 +51,7 @@ function toIso(value: number | null | undefined) {
   return new Date(value * 1000).toISOString();
 }
 
-async function resolveOrgIdByEmail(supabase: any, email: string | null) {
+async function resolveOrgIdByEmail(supabase: SupabaseClient, email: string | null) {
   if (!email) return null;
 
   const { data, error } = await supabase
@@ -66,7 +67,7 @@ async function resolveOrgIdByEmail(supabase: any, email: string | null) {
   return String(data[0].org_id);
 }
 
-async function getBillingCustomer(supabase: any, stripeCustomerId: string | null) {
+async function getBillingCustomer(supabase: SupabaseClient, stripeCustomerId: string | null) {
   if (!stripeCustomerId) return null;
 
   const { data, error } = await supabase
@@ -79,7 +80,7 @@ async function getBillingCustomer(supabase: any, stripeCustomerId: string | null
   return data;
 }
 
-async function recordEvent(supabase: any, event: Stripe.Event) {
+async function recordEvent(supabase: SupabaseClient, event: Stripe.Event) {
   const object = event.data.object as any;
 
   const stripeCustomerId =
@@ -108,7 +109,7 @@ async function recordEvent(supabase: any, event: Stripe.Event) {
 }
 
 async function upsertBillingCustomer(
-  supabase: any,
+  supabase: SupabaseClient,
   payload: {
     stripe_customer_id: string | null;
     org_id: string | null;
@@ -146,8 +147,8 @@ function subscriptionToRecord(
   const productId =
     typeof productValue === 'string'
       ? productValue
-      : typeof productValue?.id === 'string'
-        ? productValue.id
+      : productValue && typeof productValue === 'object' && 'id' in productValue
+        ? String(productValue.id)
         : null;
 
   const priceMap = getPriceMap();
@@ -177,7 +178,7 @@ function subscriptionToRecord(
   };
 }
 
-async function upsertBillingSubscription(supabase: any, payload: Record<string, unknown>) {
+async function upsertBillingSubscription(supabase: SupabaseClient, payload: Record<string, unknown>) {
   await supabase.from('billing_subscriptions').upsert(payload, {
     onConflict: 'stripe_subscription_id',
   });

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -64,7 +64,7 @@ export const DSG_TOOLS: AgentTool[] = [
           payload: params.payload || {},
           tool_name: 'agent-chat',
         }),
-        }),
+      }),
   },
   {
     id: 'browser_navigate',

--- a/lib/dsg-core/index.ts
+++ b/lib/dsg-core/index.ts
@@ -10,7 +10,7 @@ import {
   getRemoteDSGCoreLedger,
   getRemoteDSGCoreMetrics,
 } from './remote';
-import type { DSGCoreMode } from './types';
+import type { DSGCoreHealthResult, DSGCoreMode } from './types';
 
 export type {
   DSGCoreAuditEvent,
@@ -47,7 +47,7 @@ export function getDSGCoreConfig() {
   };
 }
 
-export async function getDSGCoreHealth() {
+export async function getDSGCoreHealth(): Promise<DSGCoreHealthResult> {
   const mode = parseMode();
   if (mode === 'internal') return getInternalDSGCoreHealth();
   return getRemoteDSGCoreHealth(getRemoteConfig());

--- a/lib/dsg-core/internal.ts
+++ b/lib/dsg-core/internal.ts
@@ -1,5 +1,5 @@
 import { evaluateGate } from '../runtime/gate';
-import type { DSGCoreExecutionRequest } from './types';
+import type { DSGCoreExecutionRequest, DSGCoreHealthResult } from './types';
 
 function readRiskScore(payload?: Record<string, unknown>) {
   const context = (payload?.context || {}) as Record<string, unknown>;
@@ -11,7 +11,7 @@ function readRiskScore(payload?: Record<string, unknown>) {
   return Math.max(0, Math.min(1, numeric));
 }
 
-export async function getInternalDSGCoreHealth() {
+export async function getInternalDSGCoreHealth(): Promise<DSGCoreHealthResult> {
   return {
     ok: true,
     url: 'internal://runtime-gate',

--- a/lib/dsg-core/remote.ts
+++ b/lib/dsg-core/remote.ts
@@ -1,4 +1,4 @@
-import type { DSGCoreAuditEvent, DSGCoreDeterminism, DSGCoreExecutionRequest } from './types';
+import type { DSGCoreAuditEvent, DSGCoreDeterminism, DSGCoreExecutionRequest, DSGCoreHealthResult } from './types';
 
 type RemoteConfig = {
   url: string;
@@ -16,7 +16,7 @@ function parseError(data: any, status: number) {
   return data?.detail || data?.error || `HTTP ${status}`;
 }
 
-export async function getRemoteDSGCoreHealth(config: RemoteConfig) {
+export async function getRemoteDSGCoreHealth(config: RemoteConfig): Promise<DSGCoreHealthResult> {
   try {
     const response = await fetch(`${config.url}/health`, {
       method: 'GET',

--- a/lib/dsg-core/types.ts
+++ b/lib/dsg-core/types.ts
@@ -28,3 +28,13 @@ export type DSGCoreDeterminism = {
 };
 
 export type DSGCoreMode = 'internal' | 'remote';
+
+export type DSGCoreHealthResult = {
+  ok: boolean;
+  url: string;
+  status?: string | null;
+  version?: string | null;
+  timestamp?: string | null;
+  mode?: string;
+  error?: string;
+};

--- a/lib/spine/pipeline.ts
+++ b/lib/spine/pipeline.ts
@@ -10,7 +10,8 @@ export class SpineInfraError extends Error {
 }
 
 function severity(decision: Decision): number {
-  return { ALLOW: 0, STABILIZE: 1, BLOCK: 2 }[decision];
+  const map: Record<Decision, number> = { ALLOW: 0, STABILIZE: 1, BLOCK: 2 };
+  return map[decision] ?? 0;
 }
 
 function combineDecision(left: Decision, right: Decision): Decision {

--- a/lib/stripe-products.ts
+++ b/lib/stripe-products.ts
@@ -58,7 +58,7 @@ export function getStripeClient(): Stripe {
   if (!secretKey) {
     throw new Error('Missing STRIPE_SECRET_KEY environment variable');
   }
-  return new Stripe(secretKey, { apiVersion: '2023-10-16' });
+  return new Stripe(secretKey, { apiVersion: '2023-10-16' as Stripe.LatestApiVersion });
 }
 
 /**

--- a/types/dsg-core-compat.d.ts
+++ b/types/dsg-core-compat.d.ts
@@ -1,4 +1,4 @@
-declare module "../../../../lib/dsg-core" {
+declare module "*lib/dsg-core" {
   export type DSGCoreDeterminism = {
     sequence: number;
     region_count: number;


### PR DESCRIPTION
### Motivation
- Resolve immediate TypeScript and runtime issues in the billing/webhook flows and tooling that lead to compile errors and a syntax regression. 
- Make DSG core health types explicit so internal and remote health code paths have consistent return types. 
- Prevent latent runtime/typing bugs (Stripe apiVersion mismatch, unsafe Supabase `any`, incorrect product id narrowing, extra brace) that block safe strict-mode adoption.

### Description
- Cast Stripe API version to `Stripe.LatestApiVersion` in checkout, webhook, and `lib/stripe-products.ts` to satisfy SDK typings and avoid version union mismatches. 
- Replace `supabase: any` with `SupabaseClient` in billing webhook helper functions and fix the `price.product` narrowing to avoid accessing `.id` on a `string`. 
- Fix a syntax/closing-brace regression in `lib/agent/tools.ts` so the `execute_action` tool body closes correctly. 
- Make `severity()` total by using `const map: Record<Decision, number> = { ALLOW: 0, STABILIZE: 1, BLOCK: 2 }; return map[decision] ?? 0;`. 
- Add an explicit `DSGCoreHealthResult` type and apply it to `getInternalDSGCoreHealth`, `getRemoteDSGCoreHealth`, and `getDSGCoreHealth` to align returned fields. 
- Adjust `types/dsg-core-compat.d.ts` to a wildcard module declaration (`declare module "*lib/dsg-core"`) to avoid brittle relative-path matching.

### Testing
- Ran `npm run -s typecheck`; overall typecheck still fails due to many pre-existing, unrelated Supabase/Postgrest `never` typing errors across the repo. 
- Verified with a targeted script that the `tsc` output no longer reports errors referencing the modified files by searching the typecheck output for the changed filenames (no matches). 
- Confirmed `tsconfig.typecheck.json`, `tailwind.config.js`, and Tailwind directives were already present in repo and not modified by this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6b37a55148326ac27160f77e4fbb3)