### PR TITLE
Improve dashboard resilience for partial API failures and align command-center payload types

### DIFF
--- a/app/dashboard/command-center/page.tsx
+++ b/app/dashboard/command-center/page.tsx
@@ -18,19 +18,17 @@ type CapacityPayload = {
   remaining_executions: number;
   utilization: number;
   projected_amount_usd: number;
-  period: string;
+  billing_period: string;
 };
 
 type UsagePayload = {
-  summary?: {
-    billing_period?: string;
-    execution_count?: number;
-    monthly_executions?: number;
-    subscription?: {
-      plan?: string;
-      status?: string;
-    } | null;
-  };
+  plan?: string;
+  subscription_status?: string;
+  billing_period?: string;
+  executions?: number;
+  included_executions?: number;
+  overage_executions?: number;
+  projected_amount_usd?: number;
 };
 
 type AuditPayload = {
@@ -65,29 +63,32 @@ export default function CommandCenterPage() {
   useEffect(() => {
     let alive = true;
 
+    const safeFetch = (url: string) =>
+      fetch(url, { cache: 'no-store' })
+        .then((r) => r.json().then((json) => ({ ok: r.ok, json })))
+        .catch(() => ({ ok: false, json: { error: 'Network error' } }));
+
     Promise.all([
-      fetch('/api/health', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-      fetch('/api/capacity', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-      fetch('/api/usage', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-      fetch('/api/audit?limit=8', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-    ])
-      .then(([healthRes, capacityRes, usageRes, auditRes]) => {
-        if (!alive) return;
+      safeFetch('/api/health'),
+      safeFetch('/api/capacity'),
+      safeFetch('/api/usage'),
+      safeFetch('/api/audit?limit=8'),
+    ]).then(([healthRes, capacityRes, usageRes, auditRes]) => {
+      if (!alive) return;
 
-        if (!healthRes.ok) throw new Error(healthRes.json.error || 'Failed to load health');
-        if (!capacityRes.ok) throw new Error(capacityRes.json.error || 'Failed to load capacity');
-        if (!usageRes.ok) throw new Error(usageRes.json.error || 'Failed to load usage');
-        if (!auditRes.ok) throw new Error(auditRes.json.error || 'Failed to load audit');
+      if (healthRes.ok) setHealth(healthRes.json);
+      if (capacityRes.ok) setCapacity(capacityRes.json);
+      if (usageRes.ok) setUsage(usageRes.json);
+      if (auditRes.ok) setAudit(auditRes.json);
 
-        setHealth(healthRes.json);
-        setCapacity(capacityRes.json);
-        setUsage(usageRes.json);
-        setAudit(auditRes.json);
-      })
-      .catch((err) => {
-        if (!alive) return;
-        setError(err instanceof Error ? err.message : 'Failed to load command center');
-      });
+      const errors = [
+        !healthRes.ok && 'Health',
+        !capacityRes.ok && 'Capacity',
+        !usageRes.ok && 'Usage',
+        !auditRes.ok && 'Audit',
+      ].filter(Boolean);
+      if (errors.length > 0) setError(`Partial load failure: ${errors.join(', ')}`);
+    });
 
     return () => {
       alive = false;
@@ -183,7 +184,7 @@ export default function CommandCenterPage() {
             </div>
             <div>
               <p className="text-sm text-slate-400">Period</p>
-              <p className="text-2xl font-semibold">{capacity?.period || usage?.summary?.billing_period || '-'}</p>
+              <p className="text-2xl font-semibold">{capacity?.billing_period || usage?.billing_period || '-'}</p>
             </div>
           </div>
         </header>
@@ -253,7 +254,7 @@ export default function CommandCenterPage() {
               </div>
               <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
                 <p className="text-sm text-slate-400">Plan</p>
-                <p className="mt-1 text-2xl font-semibold">{usage?.summary?.subscription?.plan || '-'}</p>
+                <p className="mt-1 text-2xl font-semibold">{usage?.plan || '-'}</p>
               </div>
             </div>
             <div className="mt-4 rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-300">

--- a/app/dashboard/integration/page.tsx
+++ b/app/dashboard/integration/page.tsx
@@ -85,7 +85,7 @@ export default async function IntegrationPage() {
             <p>Core URL: {core.url}</p>
             <p>Status: {core.ok ? core.status || "ok" : core.error || "unreachable"}</p>
             <p>Version: {core.version || "-"}</p>
-            <p>Deterministic: {String((core as any).deterministic ?? "-")}</p>
+            <p>Deterministic: {String("deterministic" in core ? (core as Record<string, unknown>).deterministic : "-")}</p>
           </div>
         </section>
 

--- a/app/dashboard/operations/page.tsx
+++ b/app/dashboard/operations/page.tsx
@@ -37,21 +37,24 @@ export default function OperationsPage() {
 
   useEffect(() => {
     let alive = true;
+    const safeFetch = (url: string) =>
+      fetch(url, { cache: 'no-store' })
+        .then((r) => r.json().then((json) => ({ ok: r.ok, json })))
+        .catch(() => ({ ok: false, json: { error: 'Network error' } }));
+
     Promise.all([
-      fetch('/api/executions?limit=10', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-      fetch('/api/proofs?limit=10', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-    ])
-      .then(([execRes, proofRes]) => {
-        if (!alive) return;
-        if (!execRes.ok) throw new Error(execRes.json.error || 'Failed to load executions');
-        if (!proofRes.ok) throw new Error(proofRes.json.error || 'Failed to load proofs');
-        setExecutions(execRes.json.executions || []);
-        setProofs(proofRes.json.items || []);
-      })
-      .catch((err) => {
-        if (!alive) return;
-        setError(err instanceof Error ? err.message : 'Failed to load operations');
-      });
+      safeFetch('/api/executions?limit=10'),
+      safeFetch('/api/proofs?limit=10'),
+    ]).then(([execRes, proofRes]) => {
+      if (!alive) return;
+      if (execRes.ok) setExecutions(execRes.json.executions || []);
+      if (proofRes.ok) setProofs(proofRes.json.items || []);
+      const errors = [
+        !execRes.ok && 'Executions',
+        !proofRes.ok && 'Proofs',
+      ].filter(Boolean);
+      if (errors.length > 0) setError(`Partial load failure: ${errors.join(', ')}`);
+    });
     return () => {
       alive = false;
     };

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -168,22 +168,27 @@ export default function DashboardPage() {
           auditRes.json(),
         ]);
 
-        if (!agentsRes.ok) throw new Error(agentsJson.error || "Failed to load agents");
-        if (!executionsRes.ok) throw new Error(executionsJson.error || "Failed to load executions");
-        if (!usageRes.ok) throw new Error(usageJson.error || "Failed to load usage");
-        if (!healthRes.ok) throw new Error(healthJson.error || "Failed to load control-plane health");
         if (!alive) return;
 
-        const normalizedAgents = Array.isArray(agentsJson?.items)
-          ? agentsJson.items.map(normalizeAgent).filter((item): item is Agent => item !== null)
-          : [];
-        const summaryPayload = usageJson?.summary ?? usageJson;
-        const normalizedSummary = normalizeUsageSummary(summaryPayload);
+        const warnings: string[] = [];
+        if (!agentsRes.ok) warnings.push("Agents");
+        if (!executionsRes.ok) warnings.push("Executions");
+        if (!usageRes.ok) warnings.push("Usage");
+        if (!healthRes.ok) warnings.push("Health");
 
-        setAgents(normalizedAgents);
-        setExecutions(executionsJson.executions || []);
-        setSummary(normalizedSummary);
-        setHealth(healthJson || null);
+        if (agentsRes.ok) {
+          const normalizedAgents = Array.isArray(agentsJson?.items)
+            ? agentsJson.items.map(normalizeAgent).filter((item): item is Agent => item !== null)
+            : [];
+          setAgents(normalizedAgents);
+        }
+        if (executionsRes.ok) setExecutions(executionsJson.executions || []);
+        if (usageRes.ok) {
+          const summaryPayload = usageJson?.summary ?? usageJson;
+          setSummary(normalizeUsageSummary(summaryPayload));
+        }
+        if (healthRes.ok) setHealth(healthJson || null);
+        if (warnings.length > 0) setError(`Partial: ${warnings.join(", ")} unavailable`);
 
         if (auditRes.ok) {
           setAuditItems(auditJson.items || []);


### PR DESCRIPTION
### Motivation

- Fix command-center UI fields that showed `-` due to payload/type mismatches between the client types and `/api/capacity` and `/api/usage` responses.
- Prevent entire dashboard pages from becoming unusable when one backend endpoint fails by making data loads resilient to partial failures.
- Remove an unsafe `as any` cast in the integration view and replace it with a type-safe presence check.

### Description

- Update `app/dashboard/command-center/page.tsx` to rename `CapacityPayload.period` to `billing_period` and replace the nested `UsagePayload.summary` shape with flat `UsagePayload` fields to match the API response, and update UI fields to read `capacity?.billing_period` and `usage?.plan`.
- Replace all-or-nothing fetch logic with a `safeFetch` helper and partial-apply pattern in `app/dashboard/command-center/page.tsx` so each successful endpoint updates its slice and failures are reported as a consolidated partial error.
- Apply the same resilient loading pattern in `app/dashboard/operations/page.tsx` for `executions` and `proofs`, rendering available data while reporting partial load failures.
- Change `app/dashboard/page.tsx` (dashboard home) to stop throwing on individual fetch failures and instead set only the successfully-loaded slices with a single `Partial: ... unavailable` warning when some endpoints fail.
- Replace the `as any` usage in `app/dashboard/integration/page.tsx` with a safe `in` check and `Record<string, unknown>` access for the `deterministic` field.

### Testing

- Ran `npm run typecheck` which failed with `TS2307` errors because the environment could not resolve `@sentry/nextjs` type declarations, which is unrelated to these page changes.
- No project unit/integration tests were executed in this rollout; existing local CI/`vitest` test suite should be run in CI to validate the changes further.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d87c42fc308326a2442c3db8d2c469)