### PR TITLE
Improve dashboard resilience and align payload types

### DIFF
--- a/app/dashboard/command-center/page.tsx
+++ b/app/dashboard/command-center/page.tsx
@@ -14,17 +14,27 @@ type HealthPayload = {
 };
 
 type CapacityPayload = {
+  ok?: boolean;
+  plan_key?: string;
+  billing_interval?: string;
+  subscription_status?: string;
+  billing_period?: string;
   executions: number;
+  included_executions?: number;
   remaining_executions: number;
   utilization: number;
+  overage_executions?: number;
   projected_amount_usd: number;
-  billing_period: string;
 };
 
 type UsagePayload = {
   plan?: string;
   subscription_status?: string;
   billing_period?: string;
+  executions?: number;
+  included_executions?: number;
+  overage_executions?: number;
+  projected_amount_usd?: number;
 };
 
 type AuditPayload = {

--- a/app/dashboard/integration/page.tsx
+++ b/app/dashboard/integration/page.tsx
@@ -28,6 +28,7 @@ function EntryCard({
 
 export default async function IntegrationPage() {
   const core = await getDSGCoreHealth();
+  const coreTyped = core as typeof core & { deterministic?: boolean };
 
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
@@ -85,7 +86,7 @@ export default async function IntegrationPage() {
             <p>Core URL: {core.url}</p>
             <p>Status: {core.ok ? core.status || "ok" : core.error || "unreachable"}</p>
             <p>Version: {core.version || "-"}</p>
-            <p>Deterministic: {String((core as any).deterministic ?? "-")}</p>
+            <p>Deterministic: {String(coreTyped.deterministic ?? "-")}</p>
           </div>
         </section>
 

--- a/app/dashboard/operations/page.tsx
+++ b/app/dashboard/operations/page.tsx
@@ -37,21 +37,30 @@ export default function OperationsPage() {
 
   useEffect(() => {
     let alive = true;
-    Promise.all([
-      fetch('/api/executions?limit=10', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-      fetch('/api/proofs?limit=10', { cache: 'no-store' }).then((r) => r.json().then((json) => ({ ok: r.ok, json }))),
-    ])
-      .then(([execRes, proofRes]) => {
-        if (!alive) return;
-        if (!execRes.ok) throw new Error(execRes.json.error || 'Failed to load executions');
-        if (!proofRes.ok) throw new Error(proofRes.json.error || 'Failed to load proofs');
-        setExecutions(execRes.json.executions || []);
-        setProofs(proofRes.json.items || []);
-      })
-      .catch((err) => {
-        if (!alive) return;
-        setError(err instanceof Error ? err.message : 'Failed to load operations');
-      });
+    Promise.allSettled([
+      fetch('/api/executions?limit=10', { cache: 'no-store' }).then((r) => r.json()),
+      fetch('/api/proofs?limit=10', { cache: 'no-store' }).then((r) => r.json()),
+    ]).then(([execRes, proofRes]) => {
+      if (!alive) return;
+
+      const warnings: string[] = [];
+
+      if (execRes.status === 'fulfilled' && !execRes.value.error) {
+        setExecutions(execRes.value.executions || []);
+      } else {
+        warnings.push(`Executions: ${execRes.status === 'fulfilled' ? execRes.value.error : String(execRes.reason)}`);
+      }
+
+      if (proofRes.status === 'fulfilled' && !proofRes.value.error) {
+        setProofs(proofRes.value.items || []);
+      } else {
+        warnings.push(`Proofs: ${proofRes.status === 'fulfilled' ? proofRes.value.error : String(proofRes.reason)}`);
+      }
+
+      if (warnings.length > 0) {
+        setError(warnings.join(' | '));
+      }
+    });
     return () => {
       alive = false;
     };

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -168,22 +168,38 @@ export default function DashboardPage() {
           auditRes.json(),
         ]);
 
-        if (!agentsRes.ok) throw new Error(agentsJson.error || "Failed to load agents");
-        if (!executionsRes.ok) throw new Error(executionsJson.error || "Failed to load executions");
-        if (!usageRes.ok) throw new Error(usageJson.error || "Failed to load usage");
-        if (!healthRes.ok) throw new Error(healthJson.error || "Failed to load control-plane health");
         if (!alive) return;
 
-        const normalizedAgents = Array.isArray(agentsJson?.items)
-          ? agentsJson.items.map(normalizeAgent).filter((item): item is Agent => item !== null)
-          : [];
-        const summaryPayload = usageJson?.summary ?? usageJson;
-        const normalizedSummary = normalizeUsageSummary(summaryPayload);
+        const warnings: string[] = [];
 
-        setAgents(normalizedAgents);
-        setExecutions(executionsJson.executions || []);
-        setSummary(normalizedSummary);
-        setHealth(healthJson || null);
+        if (agentsRes.ok) {
+          const normalizedAgents = Array.isArray(agentsJson?.items)
+            ? agentsJson.items.map(normalizeAgent).filter((item): item is Agent => item !== null)
+            : [];
+          setAgents(normalizedAgents);
+        } else {
+          warnings.push(agentsJson.error || "Failed to load agents");
+        }
+
+        if (executionsRes.ok) {
+          setExecutions(executionsJson.executions || []);
+        } else {
+          warnings.push(executionsJson.error || "Failed to load executions");
+        }
+
+        if (usageRes.ok) {
+          const summaryPayload = usageJson?.summary ?? usageJson;
+          const normalizedSummary = normalizeUsageSummary(summaryPayload);
+          setSummary(normalizedSummary);
+        } else {
+          warnings.push(usageJson.error || "Failed to load usage");
+        }
+
+        if (healthRes.ok) {
+          setHealth(healthJson || null);
+        } else {
+          warnings.push(healthJson.error || "Failed to load health");
+        }
 
         if (auditRes.ok) {
           setAuditItems(auditJson.items || []);
@@ -193,6 +209,10 @@ export default function DashboardPage() {
           setAuditItems([]);
           setDeterminism([]);
           setAuditError(auditJson.error || "Failed to load audit data");
+        }
+
+        if (warnings.length > 0) {
+          setError(warnings.join(" | "));
         }
       } catch (err) {
         if (!alive) return;


### PR DESCRIPTION
### Motivation
- UI pages were brittle because frontend types expected nested fields while API routes return flat fields, causing undefined displays.
- Several dashboard pages used all-or-nothing fetch patterns so a single endpoint failure would take down the whole page.
- The integration page used `as any` to access `deterministic`, producing type-unsafe code.

### Description
- Aligned command-center payload types to the actual API shape by extending `CapacityPayload` and `UsagePayload` with billing and quota fields (`billing_period`, `plan_key`, `included_executions`, `overage_executions`, `projected_amount_usd`, etc.).
- Converted the operations page fetch logic to partial-failure handling via `Promise.allSettled`, displaying successfully loaded data while collecting per-endpoint warnings.
- Changed the main dashboard loader to avoid throwing on individual API failures and instead set partial state for agents/executions/usage/health while aggregating warnings into `setError`.
- Removed `as any` in the integration page by introducing a typed extension (`coreTyped`) and safely reading `deterministic`.

### Testing
- Ran `npm run typecheck` and the TypeScript checks passed.
- Ran `npm run lint` and ESLint passed with no errors.
- Ran `npm test` and all tests completed successfully (test suite passed).
- Ran `npm run build` and the production build completed successfully (build succeeded with unrelated dependency warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8839e24e883269173a20f6a6a9bfa)