### PR TITLE
Fix request-access integration test timeout by mocking Supabase server client

### DIFF
--- a/tests/integration/api/request-access.test.ts
+++ b/tests/integration/api/request-access.test.ts
@@ -29,6 +29,11 @@ describe('/api/access/request', () => {
     });
 
     vi.doMock('../../../lib/supabase-server', () => ({ getSupabaseAdmin: vi.fn(() => ({ from })) }));
+    vi.doMock('../../../lib/supabase/server', () => ({
+      createClient: vi.fn(async () => ({
+        auth: { getUser: vi.fn(async () => ({ data: null, error: null })) },
+      })),
+    }));
     vi.doMock('../../../lib/auth/sign-in-events', () => ({ logSignInEvent: vi.fn(async () => {}) }));
 
     const { POST } = await import('../../../app/api/access/request/route');


### PR DESCRIPTION
### Motivation
- The integration test for `/api/access/request` hung due to an unmocked `lib/supabase/server` `createClient()` call (which triggers Next.js `cookies()` in the Vitest environment), causing a 5000ms timeout rather than a thrown error.

### Description
- Add a test-only mock `vi.doMock('../../../lib/supabase/server', ...)` in `tests/integration/api/request-access.test.ts` to stub `createClient().auth.getUser()` and return `{ data: null, error: null }`, keeping production code unchanged.

### Testing
- Ran `npm run test -- tests/integration/api/request-access.test.ts` which completed successfully with `1 file, 1 test` passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d888c81ab08326a48b0014d55d267a)