### PR TITLE
docs(skill): fix Step 6 execute curl auth and response schema example

### DIFF
--- a/.agents/skills/dashboard-auto-setup-ui/SKILL.md
+++ b/.agents/skills/dashboard-auto-setup-ui/SKILL.md
@@ -156,14 +156,36 @@ Env Check:
 
 ถ้าต้องการ execute ผ่าน API ตรง (ไม่ผ่าน UI):
 
+> **หมายเหตุ:** `/api/execute` ต้องการ auth 2 ชั้น:
+> 1. **Session cookie** — ได้จาก login ผ่าน browser (Supabase auth)
+> 2. **Bearer API key** — ได้จาก Step 2 หรือ Step 4
+>
+> วิธีง่ายที่สุด: ใช้ **Command Center** ใน Step 5 แทน curl
+> ถ้าต้องใช้ curl จริง ให้ copy session cookie จาก browser DevTools (Application → Cookies)
+
 ```bash
 curl -X POST https://tdealer01-crypto-dsg-control-plane.vercel.app/api/execute \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <API_KEY_FROM_STEP_2_OR_4>" \
+  -H "Cookie: sb-access-token=<SESSION_TOKEN>; sb-refresh-token=<REFRESH_TOKEN>" \
   -d '{
     "agent_id": "<AGENT_ID>",
     "action": "test-action",
-    "payload": {
+    "context": { "risk_score": 0.3 },
+    "input": { "amount": 100, "asset": "BTC" }
+  }'
+```
+
+หรือใช้ `intent` wrapper:
+```bash
+curl -X POST https://tdealer01-crypto-dsg-control-plane.vercel.app/api/execute \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <API_KEY_FROM_STEP_2_OR_4>" \
+  -H "Cookie: sb-access-token=<SESSION_TOKEN>; sb-refresh-token=<REFRESH_TOKEN>" \
+  -d '{
+    "agent_id": "<AGENT_ID>",
+    "intent": {
+      "action": "test-action",
       "context": { "risk_score": 0.3 },
       "input": { "amount": 100, "asset": "BTC" }
     }
@@ -185,10 +207,17 @@ POST /api/execute
 ### Expected Response
 ```json
 {
-  "execution_id": "exec_...",
+  "request_id": "exec_...",
   "decision": "ALLOW",
   "reason": "Risk score 0.30 below stabilize threshold 0.40",
-  "latency_ms": 42
+  "latency_ms": 42,
+  "policy_version": "v1",
+  "replayed": false,
+  "ledger_sequence": 1,
+  "truth_sequence": 1,
+  "proof": { ... },
+  "authoritative_plugin_id": "internal-risk-gate",
+  "pipeline_trace": [ ... ]
 }
 ```
 


### PR DESCRIPTION
### Motivation

- Document that `/api/execute` requires dual auth (Supabase session cookie + Bearer API key) so curl examples match runtime auth behavior. 
- Ensure example payload shape matches `normalizeSpinePayload()` (it reads top-level or `intent.*`, not `payload.*`).
- Correct expected response fields to reflect actual runtime return value (`request_id` plus additional metadata).

### Description

- Updated `.agents/skills/dashboard-auto-setup-ui/SKILL.md` Step 6 to add a note about dual auth and recommend using the Command Center as an easier alternative. 
- Added `Cookie:` header to the `curl` example and moved `context`/`input` out of `payload` to top-level, and added an alternative `intent` wrapper example. 
- Replaced `execution_id` with `request_id` in the Expected Response and expanded the example to include `policy_version`, `replayed`, `ledger_sequence`, `truth_sequence`, `proof`, `authoritative_plugin_id`, and `pipeline_trace` to match the runtime response. 
- Only the documentation file `.agents/skills/dashboard-auto-setup-ui/SKILL.md` was modified.

### Testing

- Ran `grep -n 'execution_id' .agents/skills/dashboard-auto-setup-ui/SKILL.md` and `grep -n '"payload"' .agents/skills/dashboard-auto-setup-ui/SKILL.md` to verify the outdated keys/payload nesting are removed, and the checks passed. 
- Verified presence of the cookie header with `grep -n 'Cookie:' .agents/skills/dashboard-auto-setup-ui/SKILL.md` and presence of `request_id` with `grep -n 'request_id' .agents/skills/dashboard-auto-setup-ui/SKILL.md`, both succeeded. 
- Ran `npm run lint` and `npm run typecheck` and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8ae1c3a208326886ace218974c5a5)