### PR TITLE
Redesign audit evidence dashboard to premium log layout

### DIFF
--- a/app/dashboard/audit/page.tsx
+++ b/app/dashboard/audit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type AuditEvent = {
   id?: number;
@@ -30,13 +30,22 @@ type DeterminismResult = {
   error: string | null;
 };
 
+const BADGE_BASE =
+  "rounded-full border px-2 py-1 text-[10px] font-semibold tracking-[0.12em] uppercase";
+
 function formatDate(value?: string | null) {
   if (!value) return "-";
   try {
-    return new Date(value).toLocaleString();
+    return new Date(value).toISOString();
   } catch {
     return value;
   }
+}
+
+function shortenHash(value?: string | null) {
+  if (!value) return "-";
+  if (value.length < 16) return value;
+  return `${value.slice(0, 8)}...${value.slice(-6)}`;
 }
 
 export default function AuditPage() {
@@ -75,122 +84,97 @@ export default function AuditPage() {
     };
   }, []);
 
-  const freezeCount = determinism.filter(
-    (item) => item.ok && item.data?.gate_action === "FREEZE"
-  ).length;
+  const freezeCount = determinism.filter((item) => item.ok && item.data?.gate_action === "FREEZE").length;
+  const nondeterministicCount = determinism.filter((item) => item.ok && !item.data?.deterministic).length;
+  const ledgerHealth = useMemo(() => {
+    if (!determinism.length) return "--";
+    const healthy = Math.max(0, determinism.length - nondeterministicCount);
+    return `${((healthy / determinism.length) * 100).toFixed(3)}%`;
+  }, [determinism.length, nondeterministicCount]);
 
   return (
-    <main className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto max-w-7xl px-6 py-10">
+    <main className="min-h-screen bg-[#0d0e11] text-[#f7f6f9]">
+      <div className="border-b border-[#47484b]/25 bg-[#121316] px-6 py-6">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <p className="text-sm uppercase tracking-[0.2em] text-slate-400">DSG</p>
-            <h1 className="mt-2 text-3xl font-semibold">Audit Layer</h1>
-            <p className="mt-2 text-slate-400">
-              Region-aware audit events, determinism checks, entropy, and freeze recommendations from DSG core.
-            </p>
+            <p className="font-mono text-[10px] text-[#ababae]">SYSTEM_NOMINAL // IMMUTABLE_LEDGER_ACTIVE</p>
+            <h1 className="mt-2 font-mono text-2xl font-bold tracking-tight text-[#81ecff]">AUDIT_EVIDENCE_LOG</h1>
           </div>
-
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href="/dashboard/audit/matrix"
-              className="rounded-xl border border-slate-700 px-4 py-3 font-semibold text-slate-200"
-            >
-              Matrix
+          <div className="flex flex-wrap items-center gap-3">
+            <Link href="/dashboard/audit/matrix" className="border border-[#81ecff]/25 bg-[#00e3fd]/10 px-3 py-2 text-xs font-semibold text-[#81ecff]">
+              MATRIX
             </Link>
-            <Link
-              href="/dashboard"
-              className="rounded-xl border border-slate-700 px-4 py-3 font-semibold text-slate-200"
-            >
-              Dashboard
+            <Link href="/dashboard" className="border border-[#757578]/30 bg-[#181a1d] px-3 py-2 text-xs font-semibold text-[#f7f6f9]">
+              DASHBOARD
             </Link>
           </div>
         </div>
 
-        {error ? (
-          <div className="mt-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-amber-200">{error}</div>
-        ) : null}
+        {error ? <div className="mt-4 border border-[#ff716c]/40 bg-[#9f0519]/20 p-3 text-xs text-[#ffa8a3]">{error}</div> : null}
 
-        <div className="mt-8 grid gap-6 md:grid-cols-3">
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
-            <p className="text-sm text-slate-400">Audit events</p>
-            <p className="mt-3 text-3xl font-semibold">{loading ? "..." : items.length}</p>
+        <div className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-4">
+          <div className="border-l-4 border-[#81ecff] bg-[#1e2023] p-4">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[#ababae]">ledger_health</p>
+            <p className="mt-2 font-mono text-2xl text-[#81ecff]">{loading ? "..." : ledgerHealth}</p>
           </div>
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
-            <p className="text-sm text-slate-400">Determinism checks</p>
-            <p className="mt-3 text-3xl font-semibold">{loading ? "..." : determinism.length}</p>
+          <div className="border-l-4 border-[#00fe66] bg-[#1e2023] p-4">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[#ababae]">audit_events</p>
+            <p className="mt-2 font-mono text-2xl text-[#00fe66]">{loading ? "..." : items.length}</p>
           </div>
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
-            <p className="text-sm text-slate-400">Recommended freeze</p>
-            <p className="mt-3 text-3xl font-semibold">{loading ? "..." : freezeCount}</p>
+          <div className="border-l-4 border-[#ff6e85] bg-[#1e2023] p-4">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[#ababae]">open_audits</p>
+            <p className="mt-2 font-mono text-2xl text-[#ff6e85]">{loading ? "..." : nondeterministicCount}</p>
+          </div>
+          <div className="border-l-4 border-[#00d4ec] bg-[#1e2023] p-4">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[#ababae]">freeze_recommended</p>
+            <p className="mt-2 font-mono text-2xl text-[#00d4ec]">{loading ? "..." : freezeCount}</p>
           </div>
         </div>
+      </div>
 
-        <div className="mt-8 grid gap-6 lg:grid-cols-2">
-          <section className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Recent Audit Events</h2>
-              <span className="text-sm text-slate-400">{loading ? "Loading..." : `${items.length} rows`}</span>
-            </div>
-            <div className="mt-4 space-y-3">
-              {items.length === 0 && !loading ? (
-                <div className="rounded-xl border border-slate-800 p-4 text-slate-400">No audit events found.</div>
+      <div className="p-6">
+        <div className="overflow-auto border border-[#47484b]/30 bg-[#1e2023]">
+          <table className="min-w-[860px] w-full border-collapse text-left">
+            <thead className="bg-black/40">
+              <tr className="border-b border-[#47484b]/50 text-[10px] uppercase tracking-[0.18em] text-[#ababae]">
+                <th className="px-4 py-3">Timestamp</th>
+                <th className="px-4 py-3">Trace Hash</th>
+                <th className="px-4 py-3">Policy Version</th>
+                <th className="px-4 py-3">Cryptographic Proof</th>
+                <th className="px-4 py-3 text-center">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#47484b]/25 font-mono text-xs">
+              {!loading && items.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-6 text-center text-[#ababae]">
+                    No audit events found.
+                  </td>
+                </tr>
               ) : null}
-              {items.map((item, index) => (
-                <div key={`${item.sequence}-${item.region_id}-${index}`} className="rounded-xl border border-slate-800 p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <p className="font-semibold">Sequence {item.sequence}</p>
-                      <p className="mt-1 text-sm text-slate-400">{item.region_id}</p>
-                    </div>
-                    <span className="rounded-full border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-300">{item.gate_result}</span>
-                  </div>
-                  <div className="mt-3 grid gap-2 text-sm text-slate-300">
-                    <p>Epoch: {item.epoch}</p>
-                    <p>State hash: {item.state_hash}</p>
-                    <p>Entropy: {item.entropy}</p>
-                    <p>Z3 proof hash: {item.z3_proof_hash || "-"}</p>
-                    <p>Created: {formatDate(item.created_at)}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Determinism Results</h2>
-              <span className="text-sm text-slate-400">{loading ? "Loading..." : `${determinism.length} checks`}</span>
-            </div>
-            <div className="mt-4 space-y-3">
-              {determinism.length === 0 && !loading ? (
-                <div className="rounded-xl border border-slate-800 p-4 text-slate-400">No determinism checks found.</div>
-              ) : null}
-              {determinism.map((item) => (
-                <div key={item.sequence} className="rounded-xl border border-slate-800 p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <p className="font-semibold">Sequence {item.sequence}</p>
-                      <p className="mt-1 text-sm text-slate-400">{item.ok ? "Computed by DSG core" : "Core returned warning"}</p>
-                    </div>
-                    <span className="rounded-full border border-slate-700 px-3 py-1 text-xs uppercase tracking-wide text-slate-300">
-                      {item.ok ? item.data?.gate_action : "ERROR"}
-                    </span>
-                  </div>
-                  {item.ok && item.data ? (
-                    <div className="mt-3 grid gap-2 text-sm text-slate-300">
-                      <p>Deterministic: {item.data.deterministic ? "yes" : "no"}</p>
-                      <p>Regions: {item.data.region_count}</p>
-                      <p>Unique hashes: {item.data.unique_state_hashes}</p>
-                      <p>Max entropy: {item.data.max_entropy}</p>
-                    </div>
-                  ) : (
-                    <p className="mt-3 text-sm text-amber-200">{item.error || "Unknown audit warning"}</p>
-                  )}
-                </div>
-              ))}
-            </div>
-          </section>
+              {items.map((item, index) => {
+                const result = determinism.find((entry) => entry.sequence === item.sequence);
+                const deterministic = result?.ok ? result.data?.deterministic : false;
+                return (
+                  <tr key={`${item.sequence}-${item.region_id}-${index}`} className="hover:bg-[#81ecff]/5">
+                    <td className="px-4 py-3 text-[#f7f6f9]/85">{formatDate(item.created_at)}</td>
+                    <td className="px-4 py-3 font-bold text-[#81ecff]">{shortenHash(item.state_hash)}</td>
+                    <td className="px-4 py-3 text-[#f7f6f9]">{item.epoch}</td>
+                    <td className="max-w-[320px] truncate px-4 py-3 text-[10px] text-[#ababae]">{item.z3_proof_hash || item.signature || "-"}</td>
+                    <td className="px-4 py-3 text-center">
+                      <span
+                        className={`${BADGE_BASE} ${
+                          deterministic ? "border-[#00fe66]/40 bg-[#00fe66]/15 text-[#00fe66]" : "border-[#ff6e85]/40 bg-[#ff6e85]/15 text-[#ff909e]"
+                        }`}
+                      >
+                        {deterministic ? "VERIFIED" : item.gate_result}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
         </div>
       </div>
     </main>


### PR DESCRIPTION
### Motivation
- Update the audit view to a premium "evidence log" visual style for denser, operator-friendly ledger scanning aligned with the provided mock.
- Surface operational signals (ledger health, event count, open audits, freeze recommendations) to aid quick triage.
- Improve readability of cryptographic proofs and trace hashes for a compact table-ledger presentation.

### Description
- Reworked the audit page implementation in `app/dashboard/audit/page.tsx` to a dark, dense table layout while preserving live data loading from `/api/audit?limit=20` and existing data shapes.
- Added small helpers and UI primitives including `shortenHash`, `BADGE_BASE`, and switched timestamp formatting to ISO for consistent display.
- Computed operational metrics (`ledgerHealth`, `nondeterministicCount`, `freezeCount`) with `useMemo` and surfaced them as KPI cards, and added deterministic vs non-deterministic status badges with proof/hash truncation and fallback (`z3_proof_hash || signature || "-"`).
- Numerous presentational/styling changes to make the table and header match the premium mock while keeping loading/error handling intact.

### Testing
- Ran `npm run typecheck` and the TypeScript typecheck completed successfully. 
- Ran `npm run test:unit` and unit tests passed (`20` test files, `51` tests executed, `51` passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8d1c28f14832698764b2b10713e17)