### PR TITLE
Add Live Control entry to dashboard navigation

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ const NAV = [
   { href: '/dashboard/integration', label: 'Integration' },
   { href: '/dashboard/mission', label: 'Mission' },
   { href: '/dashboard/operations', label: 'Operations' },
+  { href: '/dashboard/live-control', label: 'Live Control' },
   { href: '/dashboard/executions', label: 'Executions' },
   { href: '/dashboard/skills', label: 'Skills' },
   { href: '/dashboard/verification', label: 'Verification' },


### PR DESCRIPTION
### Motivation
- Make the newly merged route `/dashboard/live-control` discoverable from the primary dashboard navigation so users can access it from the main menu.

### Description
- Add `{ href: '/dashboard/live-control', label: 'Live Control' }` to the `NAV` array in `app/dashboard/layout.tsx` so the link appears in the dashboard top nav.

### Testing
- Ran `npm test` (which runs `vitest run`) and all automated tests passed: 100 tests passed across 45 files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8f89b6a00832695b983cd2162c8cf)