### PR TITLE
Add integration/unit tests for spine execute & CORS; update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +20,7 @@ jobs:
     env:
       CI: true
       NEXT_TELEMETRY_DISABLED: 1
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,8 +45,16 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Test
+      - name: Full test suite
         run: npm run test
+
+      - name: Runtime contract test subset
+        run: |
+          npm run test -- \
+            tests/integration/api/spine-execute.test.ts \
+            tests/integration/api/intent.test.ts \
+            tests/integration/api/execute-compat.test.ts \
+            tests/unit/security/cors.test.ts
 
       - name: Build
         run: npm run build

--- a/tests/integration/api/execute-compat.test.ts
+++ b/tests/integration/api/execute-compat.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+describe('/api/execute compatibility route', () => {
+  it('re-exports OPTIONS and POST from spine execute route', async () => {
+    const compatRoute = await import('../../../app/api/execute/route');
+    const spineRoute = await import('../../../app/api/spine/execute/route');
+
+    expect(compatRoute.dynamic).toBe('force-dynamic');
+    expect(compatRoute.OPTIONS).toBe(spineRoute.OPTIONS);
+    expect(compatRoute.POST).toBe(spineRoute.POST);
+  });
+});

--- a/tests/integration/api/spine-execute.test.ts
+++ b/tests/integration/api/spine-execute.test.ts
@@ -1,0 +1,414 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function mockCors() {
+  const buildCorsHeaders = vi.fn(
+    (_request: Request, extraHeaders?: HeadersInit) =>
+      new Headers({
+        'access-control-allow-origin': 'https://app.example.com',
+        ...(extraHeaders instanceof Headers
+          ? Object.fromEntries(extraHeaders.entries())
+          : (extraHeaders as Record<string, string> | undefined) || {}),
+      })
+  );
+
+  const buildPreflightResponse = vi.fn(
+    () =>
+      new Response(null, {
+        status: 204,
+        headers: {
+          'access-control-allow-origin': 'https://app.example.com',
+          'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+        },
+      })
+  );
+
+  vi.doMock('../../../lib/security/cors', () => ({
+    buildCorsHeaders,
+    buildPreflightResponse,
+  }));
+
+  return { buildCorsHeaders, buildPreflightResponse };
+}
+
+function mockRateLimit() {
+  const applyRateLimit = vi.fn(async () => ({
+    allowed: true,
+    resetAt: Date.now() + 60_000,
+  }));
+  const buildRateLimitHeaders = vi.fn(() => ({
+    'x-ratelimit-limit': '60',
+  }));
+  const getRateLimitKey = vi.fn(() => 'spine-execute:test');
+
+  vi.doMock('../../../lib/security/rate-limit', () => ({
+    applyRateLimit,
+    buildRateLimitHeaders,
+    getRateLimitKey,
+  }));
+
+  return { applyRateLimit, buildRateLimitHeaders, getRateLimitKey };
+}
+
+function mockApiError() {
+  const handleApiError = vi.fn(
+    (_route: string, _error: unknown, options?: { headers?: HeadersInit }) =>
+      new Response(JSON.stringify({ error: 'Internal server error' }), {
+        status: 500,
+        headers: options?.headers,
+      })
+  );
+
+  vi.doMock('../../../lib/security/api-error', () => ({
+    handleApiError,
+  }));
+
+  return { handleApiError };
+}
+
+describe('/api/spine/execute', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns preflight response for OPTIONS', async () => {
+    const { buildPreflightResponse } = mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent: vi.fn(),
+      issueSpineIntent: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(),
+    }));
+
+    const { OPTIONS } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://app.example.com' },
+    });
+
+    const res = await OPTIONS(req as never);
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://app.example.com'
+    );
+    expect(buildPreflightResponse).toHaveBeenCalledOnce();
+  });
+
+  it('returns 401 when Bearer token is missing', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent: vi.fn(),
+      issueSpineIntent: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: {},
+        context: {},
+        canonicalRequest: { action: 'scan', input: {}, context: {} },
+      })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ agent_id: 'agt_1' }),
+    });
+
+    const res = await POST(req as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: 'Missing Bearer token' });
+  });
+
+  it('returns 400 when agent_id is missing', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent: vi.fn(),
+      issueSpineIntent: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: '',
+        action: 'scan',
+        input: {},
+        context: {},
+        canonicalRequest: { action: 'scan', input: {}, context: {} },
+      })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer dsg_live_test',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    });
+
+    const res = await POST(req as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: 'agent_id is required' });
+  });
+
+  it('returns 401 when agent_id and api key do not resolve', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    const resolveAgentFromApiKey = vi.fn(async () => null);
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey,
+    }));
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent: vi.fn(),
+      issueSpineIntent: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: {},
+        context: {},
+        canonicalRequest: { action: 'scan', input: {}, context: {} },
+      })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer bad_key',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ agent_id: 'agt_1' }),
+    });
+
+    const res = await POST(req as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: 'Invalid agent_id or API key' });
+    expect(resolveAgentFromApiKey).toHaveBeenCalledWith('agt_1', 'bad_key');
+  });
+
+  it('returns 403 when agent is not active', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(async () => ({
+        id: 'agt_1',
+        org_id: 'org_1',
+        status: 'disabled',
+      })),
+    }));
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent: vi.fn(),
+      issueSpineIntent: vi.fn(),
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: {},
+        context: {},
+        canonicalRequest: { action: 'scan', input: {}, context: {} },
+      })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer dsg_live_test',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ agent_id: 'agt_1' }),
+    });
+
+    const res = await POST(req as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ error: 'Agent is not active' });
+  });
+
+  it('executes successfully with valid agent credentials', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    const resolveAgentFromApiKey = vi.fn(async () => ({
+      id: 'agt_1',
+      org_id: 'org_1',
+      status: 'active',
+    }));
+
+    const executeSpineIntent = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: { request_id: 'req_1', decision: 'ALLOW' },
+    }));
+
+    const issueSpineIntent = vi.fn();
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey,
+    }));
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent,
+      issueSpineIntent,
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: { prompt: 'hello' },
+        context: {},
+        canonicalRequest: {
+          action: 'scan',
+          input: { prompt: 'hello' },
+          context: {},
+        },
+      })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer dsg_live_good',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ agent_id: 'agt_1', input: { prompt: 'hello' } }),
+    });
+
+    const res = await POST(req as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ request_id: 'req_1', decision: 'ALLOW' });
+    expect(resolveAgentFromApiKey).toHaveBeenCalledWith('agt_1', 'dsg_live_good');
+    expect(executeSpineIntent).toHaveBeenCalledWith({
+      orgId: 'org_1',
+      apiKey: 'dsg_live_good',
+      payload: expect.objectContaining({ agentId: 'agt_1', action: 'scan' }),
+    });
+    expect(issueSpineIntent).not.toHaveBeenCalled();
+  });
+
+  it('issues intent and retries execute when no pending runtime intent exists', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(async () => ({
+        id: 'agt_1',
+        org_id: 'org_1',
+        status: 'active',
+      })),
+    }));
+
+    const executeSpineIntent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        body: { error: 'No pending runtime intent for request' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: { request_id: 'req_2', decision: 'ALLOW' },
+      });
+
+    const issueSpineIntent = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: { request_id: 'intent_1' },
+    }));
+
+    vi.doMock('../../../lib/spine/engine', () => ({
+      executeSpineIntent,
+      issueSpineIntent,
+    }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: { prompt: 'retry me' },
+        context: {},
+        canonicalRequest: {
+          action: 'scan',
+          input: { prompt: 'retry me' },
+          context: {},
+        },
+      })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer dsg_live_good',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        agent_id: 'agt_1',
+        input: { prompt: 'retry me' },
+      }),
+    });
+
+    const res = await POST(req as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ request_id: 'req_2', decision: 'ALLOW' });
+    expect(issueSpineIntent).toHaveBeenCalledOnce();
+    expect(executeSpineIntent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/security/cors.test.ts
+++ b/tests/unit/security/cors.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('lib/security/cors', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.DSG_ALLOWED_ORIGINS;
+    delete process.env.APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('builds allowed origins from explicit allowlist and app url', async () => {
+    process.env.DSG_ALLOWED_ORIGINS =
+      'https://app.example.com, https://admin.example.com';
+    process.env.APP_URL = 'https://control.example.com/app';
+
+    const { getAllowedCorsOrigins } = await import('../../../lib/security/cors');
+    const origins = getAllowedCorsOrigins();
+
+    expect(origins).toEqual([
+      'https://app.example.com',
+      'https://admin.example.com',
+      'https://control.example.com',
+    ]);
+  });
+
+  it('resolves an allowed request origin', async () => {
+    process.env.DSG_ALLOWED_ORIGINS = 'https://app.example.com';
+
+    const { resolveAllowedOrigin } = await import('../../../lib/security/cors');
+
+    const req = new Request('http://localhost/api/execute', {
+      headers: {
+        origin: 'https://app.example.com',
+      },
+    });
+
+    expect(resolveAllowedOrigin(req)).toBe('https://app.example.com');
+  });
+
+  it('adds CORS headers only for allowed origins', async () => {
+    process.env.DSG_ALLOWED_ORIGINS = 'https://app.example.com';
+
+    const { buildCorsHeaders } = await import('../../../lib/security/cors');
+
+    const allowedReq = new Request('http://localhost/api/execute', {
+      headers: { origin: 'https://app.example.com' },
+    });
+
+    const disallowedReq = new Request('http://localhost/api/execute', {
+      headers: { origin: 'https://evil.example.com' },
+    });
+
+    const allowedHeaders = buildCorsHeaders(allowedReq);
+    const blockedHeaders = buildCorsHeaders(disallowedReq);
+
+    expect(allowedHeaders.get('Access-Control-Allow-Origin')).toBe(
+      'https://app.example.com'
+    );
+    expect(blockedHeaders.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+
+  it('returns 204 preflight for allowed origin', async () => {
+    process.env.DSG_ALLOWED_ORIGINS = 'https://app.example.com';
+
+    const { buildPreflightResponse } = await import('../../../lib/security/cors');
+
+    const req = new Request('http://localhost/api/execute', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://app.example.com' },
+    });
+
+    const res = buildPreflightResponse(req);
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://app.example.com'
+    );
+  });
+
+  it('returns 403 preflight for disallowed origin', async () => {
+    process.env.DSG_ALLOWED_ORIGINS = 'https://app.example.com';
+
+    const { buildPreflightResponse } = await import('../../../lib/security/cors');
+
+    const req = new Request('http://localhost/api/execute', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://evil.example.com' },
+    });
+
+    const res = buildPreflightResponse(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ error: 'Origin not allowed' });
+  });
+
+  it('returns 204 preflight when origin header is absent', async () => {
+    const { buildPreflightResponse } = await import('../../../lib/security/cors');
+
+    const req = new Request('http://localhost/api/execute', {
+      method: 'OPTIONS',
+    });
+
+    const res = buildPreflightResponse(req);
+
+    expect(res.status).toBe(204);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve coverage around the Spine execute API and CORS behavior by adding focused integration and unit tests to catch regressions in runtime contract and CORS logic. 
- Ensure CI has the right permissions and runs a dedicated subset of runtime contract tests in addition to the full test suite for faster feedback on critical API paths. 
- Verify build, lint, and typechecks remain part of CI to prevent regressions during test additions.

### Description
- Updated `.github/workflows/ci.yml` to add `permissions.contents: read`, keep concurrency settings, rename the Test step label to `Full test suite`, and add a new `Runtime contract test subset` step that runs four targeted tests. 
- Added `tests/integration/api/spine-execute.test.ts` covering `/api/spine/execute` behavior including OPTIONS preflight, auth and agent checks, successful execution, and retry/issue flow when runtime intents are missing. 
- Added `tests/integration/api/execute-compat.test.ts` to validate the `/api/execute` compatibility route re-exports the spine handlers. 
- Added `tests/unit/security/cors.test.ts` to validate allowed origin parsing, header construction, and preflight responses for CORS handling.

### Testing
- CI: ran `npm ci`, `npm install --package-lock-only --ignore-scripts` lockfile verification, `npm run lint`, `npm run typecheck`, `npm run test`, and `npm run build`, all of which completed successfully in CI. 
- Runtime contract subset: executed the four targeted tests via `npm run test -- tests/integration/api/spine-execute.test.ts tests/integration/api/intent.test.ts tests/integration/api/execute-compat.test.ts tests/unit/security/cors.test.ts` and they passed. 
- Local unit/integration tests: ran the new test files under `npm run test` and they succeeded as part of the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d940cead8c832696d1cc09437d9d56)