### PR TITLE
Add runtime contract CI subset checks and align README execution auth contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,21 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Verify runtime contract test files exist
+        run: |
+          test -f tests/integration/api/spine-execute.test.ts
+          test -f tests/integration/api/intent.test.ts
+          test -f tests/integration/api/execute-compat.test.ts
+          test -f tests/unit/security/cors.test.ts
+
+      - name: Runtime contract test subset
+        run: |
+          npm run test -- \
+            tests/integration/api/spine-execute.test.ts \
+            tests/integration/api/intent.test.ts \
+            tests/integration/api/execute-compat.test.ts \
+            tests/unit/security/cors.test.ts
+
       - name: Test
         run: npm run test
 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ Important:
 `/api/execute` currently forwards to `/api/spine/execute`, which enforces runtime access and request validation.
 
 Current execution requirements include:
-- authenticated org-scoped access
 - `Authorization: Bearer <API_KEY>`
 - a valid `agent_id` in the request payload
+- API key + `agent_id` must resolve to an existing agent
+- resolved agent must be in `active` status
 - normal execution rate limiting
 
 ### Authenticated operator routes
@@ -226,7 +227,8 @@ For `POST /api/execute` / `POST /api/spine/execute`, evaluators and integrators 
 
 - `401 Unauthorized` when the Bearer token is missing or empty
 - `400 Bad Request` when required fields such as `agent_id` are missing
-- `403 Forbidden` when the caller does not have the required org-scoped access
+- `401 Unauthorized` when `agent_id` + API key do not resolve to a valid agent
+- `403 Forbidden` when the resolved agent is not in `active` status
 - `429 Too Many Requests` when execution rate limits are exceeded
 
 ### Evaluation guidance


### PR DESCRIPTION
### Motivation
- Ensure critical runtime contract tests are run early and fail fast by adding an explicit subset step to CI.
- Prevent CI surprises by verifying the required runtime test files exist before attempting to run them.
- Align README documentation with the actual runtime auth behavior for execution routes to avoid stale guidance.

### Description
- Add a `Verify runtime contract test files exist` step to `.github/workflows/ci.yml` that checks the presence of the four runtime contract test files using `test -f`.
- Add a `Runtime contract test subset` step to `.github/workflows/ci.yml` that runs a focused subset with `npm run test -- tests/integration/api/spine-execute.test.ts tests/integration/api/intent.test.ts tests/integration/api/execute-compat.test.ts tests/unit/security/cors.test.ts` before the full test suite.
- Update `README.md` runtime route notes to reflect the current auth contract by documenting that `Authorization: Bearer <API_KEY>` plus `agent_id` must resolve to an existing agent and that the resolved agent must be `active`, and adjust the documented `401`/`403` failure modes accordingly.

### Testing
- Verified the existence check with `test -f ...` for all four files which returned OK.
- Ran the focused subset with `npm run test -- tests/integration/api/spine-execute.test.ts tests/integration/api/intent.test.ts tests/integration/api/execute-compat.test.ts tests/unit/security/cors.test.ts` and observed all files and tests pass (4 test files, 17 tests, all passing).
- The CI preserves the original full `npm run test` step after the subset so the full suite still runs in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d945a5502c8326bebc03e78e863f19)