### PR TITLE
CI: add `permissions.contents: read` and rename Test step to Full test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -56,7 +59,7 @@ jobs:
             tests/integration/api/execute-compat.test.ts \
             tests/unit/security/cors.test.ts
 
-      - name: Test
+      - name: Full test suite
         run: npm run test
 
       - name: Build


### PR DESCRIPTION
### Motivation
- Ensure the CI workflow matches the expectations from the runtime contract changes (PR #243) so the targeted runtime contract subset can run with the required repository read permission and to make the test steps' intent clearer.

### Description
- Updated `.github/workflows/ci.yml` to add a top-level `permissions: contents: read` entry and renamed the `Test` step to `Full test suite` while keeping the existing `Runtime contract test subset` step unchanged.

### Testing
- Ran the runtime contract subset with `npm run test -- tests/integration/api/spine-execute.test.ts tests/integration/api/intent.test.ts tests/integration/api/execute-compat.test.ts tests/unit/security/cors.test.ts` and the targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9476d14508326b0b659fe5b9fb2b1)