### PR TITLE
docs(product): add finance governance schema delta and implementation backlog

### DIFF
--- a/docs/product/FINANCE_GOVERNANCE_IMPLEMENTATION_BACKLOG.md
+++ b/docs/product/FINANCE_GOVERNANCE_IMPLEMENTATION_BACKLOG.md
@@ -1,0 +1,200 @@
+# Finance Governance Implementation Backlog
+
+Updated: 2026-04-11
+Owner: Product / Engineering
+Status: Build backlog
+
+---
+
+## Goal
+
+Translate the finance governance PRD into buildable work packages for product, backend, frontend, and go-to-market execution.
+
+---
+
+## Milestone 1 — Domain foundation
+
+### Epic 1.1: Add finance workflow schema
+- Add `transactions`
+- Add `transaction_documents`
+- Add `approval_requests`
+- Add `approval_steps`
+- Add `approval_decisions`
+- Add `exceptions`
+- Add `evidence_bundles`
+- Add `export_jobs`
+- Add `reconciliation_runs`
+
+### Done when
+- Schema reviewed
+- Migration drafted
+- Types regenerated
+- Basic migration tests added
+
+---
+
+## Milestone 2 — Policy-driven workflow
+
+### Epic 2.1: Submission flow
+- Create transaction submission API
+- Validate required finance fields
+- Validate required documents
+- Add duplicate reference detection
+- Add replay-protection design
+
+### Epic 2.2: Approval orchestration
+- Create approval request on submission
+- Build approval step generation from policy rules
+- Enforce maker-checker
+- Enforce threshold routing
+- Enforce required reasons for reject / override
+
+### Done when
+- Sample transaction can move from submit to approval state
+- Self-approval is blocked
+- Policy route is visible in logs or UI
+
+---
+
+## Milestone 3 — Operator UX
+
+### Epic 3.1: Approval queue
+- Build pending approvals list
+- Add filtering by age, status, vendor, policy
+- Add approve / reject / escalate actions
+- Add permission-denied states
+
+### Epic 3.2: Case detail page
+- Show transaction summary
+- Show attached documents
+- Show policy snapshot
+- Show approval chain
+- Show timeline and exception panel
+
+### Epic 3.3: Admin and onboarding
+- Add finance-governance onboarding template
+- Add role assignment UI
+- Add policy-builder entry point
+
+### Done when
+- A pilot user can onboard, submit, review, and resolve a case without manual DB intervention
+
+---
+
+## Milestone 4 — Audit and evidence
+
+### Epic 4.1: Event completeness
+- Define event taxonomy
+- Ensure each decision is logged with actor, timestamp, reason, and state transition
+- Add export logging
+
+### Epic 4.2: Evidence bundles
+- Build bundle manifest generation
+- Add bundle export job runner
+- Add CSV / JSON / PDF export design
+- Add integrity hash generation
+
+### Epic 4.3: Audit view
+- Build audit screen with filters
+- Add export actions
+- Add empty / loading / error states
+
+### Done when
+- An auditor can open a case and export an evidence bundle from the product UI
+
+---
+
+## Milestone 5 — GTM and trust surface
+
+### Epic 5.1: Pricing and packaging
+- Rewrite pricing page for finance governance packaging
+- Align plan descriptions to Starter / Growth / Enterprise governance value
+- Clarify enterprise pilot path
+
+### Epic 5.2: Marketing surface
+- Rewrite landing headline and subhead
+- Add audit-ready trust strip
+- Add buyer-focused use-case copy
+
+### Epic 5.3: Trust surface
+- Publish Terms / Privacy / Security pages
+- Add support and contact flow
+- Add enterprise trust summary
+
+### Done when
+- A buyer can understand the product, pricing, and trust posture from the web app alone
+
+---
+
+## Milestone 6 — Enterprise readiness
+
+### Epic 6.1: SSO / SCIM alignment
+- Map finance roles to current org role substrate
+- Document admin provisioning path
+- Test group-to-role mapping strategy
+
+### Epic 6.2: Tenant safety
+- Review org scoping across new routes
+- Add cross-org access tests
+- Add export authorization tests
+
+### Epic 6.3: Operational readiness
+- Add dashboards / alerts for approval backlog and exceptions
+- Add support runbook for pilot customers
+
+### Done when
+- The product can support one enterprise design partner without manual ad hoc handling for every approval case
+
+---
+
+## Priority order
+
+### P0
+- Schema delta
+- Submission API
+- Approval orchestration
+- Approval queue
+- Case detail page
+- Audit timeline
+- Evidence export
+
+### P1
+- Landing and pricing rewrite
+- Terms / Privacy / Security pages
+- Admin role UX
+- Exception dashboard
+
+### P2
+- Reconciliation engine
+- External auditor portal
+- Advanced SoD modeling
+- Dedicated deployment options
+
+---
+
+## Marketplace release rule
+
+Do not call the product marketplace-ready until all of the following are true:
+
+- One finance workflow is fully usable end-to-end
+- Billing works for self-serve or pilot conversion
+- Policy-driven approvals are visible and enforceable
+- Evidence export works from UI
+- Trust pages exist
+- Permission-denied, error, and empty states are designed and implemented
+
+---
+
+## Current truth
+
+### Already strong
+- Control-plane foundation
+- Org/auth/billing substrate
+- Runtime contract coverage
+- Governance-oriented product narrative
+
+### Still missing before real market readiness
+- Finance-specific workflow layer
+- Approval UX completion
+- Exportable evidence bundle implementation
+- Pricing/landing rewrite aligned to finance governance buyers

--- a/docs/product/FINANCE_GOVERNANCE_SCHEMA_DELTA.md
+++ b/docs/product/FINANCE_GOVERNANCE_SCHEMA_DELTA.md
@@ -1,0 +1,237 @@
+# Finance Governance Schema Delta
+
+Updated: 2026-04-11
+Owner: Product / Architecture / Backend
+Status: Implementation-ready schema outline
+
+---
+
+## Purpose
+
+This document defines the minimum finance-governance domain objects required on top of the current DSG control-plane schema.
+
+The current repository already contains strong enterprise foundations for:
+- organizations
+- users
+- policies
+- audit logs
+- executions
+- usage and billing
+- SSO / SCIM / onboarding
+
+What is still missing for a sellable finance governance workflow is the domain layer for financial items, approval state, exceptions, evidence packaging, and export jobs.
+
+---
+
+## Design rule
+
+The customer's ERP or accounting system remains the financial system of record.
+
+DSG becomes the governance system of record for:
+- approval state
+- policy routing state
+- exception state
+- evidence packaging
+- export history
+
+---
+
+## New tables
+
+### 1. transactions
+
+Purpose: store governed financial items submitted for approval.
+
+Suggested fields:
+- `id`
+- `org_id`
+- `external_reference`
+- `transaction_type`
+- `amount`
+- `currency`
+- `vendor_name`
+- `cost_center`
+- `submitter_user_id`
+- `status`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+Constraints:
+- unique `(org_id, external_reference)`
+- status enum: `submitted`, `in_review`, `approved`, `rejected`, `escalated`, `exception`, `exported`, `archived`
+
+### 2. transaction_documents
+
+Purpose: store document attachments and integrity data.
+
+Suggested fields:
+- `id`
+- `transaction_id`
+- `storage_key`
+- `document_type`
+- `checksum`
+- `uploaded_by`
+- `uploaded_at`
+- `metadata`
+
+### 3. approval_requests
+
+Purpose: represent the approval process instance for one transaction.
+
+Suggested fields:
+- `id`
+- `org_id`
+- `transaction_id`
+- `policy_id`
+- `current_step`
+- `status`
+- `submitted_at`
+- `updated_at`
+
+Constraints:
+- status enum: `pending`, `approved`, `rejected`, `escalated`, `exception`, `canceled`, `completed`
+
+### 4. approval_steps
+
+Purpose: define each routed approval stage.
+
+Suggested fields:
+- `id`
+- `approval_request_id`
+- `step_order`
+- `required_role`
+- `assigned_user_id`
+- `rule_snapshot`
+- `status`
+- `due_at`
+- `acted_at`
+- `created_at`
+- `updated_at`
+
+Constraints:
+- unique `(approval_request_id, step_order)`
+- status enum: `pending`, `approved`, `rejected`, `skipped`, `escalated`, `expired`
+
+### 5. approval_decisions
+
+Purpose: capture every decision taken within an approval step.
+
+Suggested fields:
+- `id`
+- `approval_step_id`
+- `actor_user_id`
+- `decision`
+- `reason`
+- `decided_at`
+- `metadata`
+
+Constraints:
+- decision enum: `approved`, `rejected`, `escalated`, `requested_changes`, `overridden`
+
+### 6. exceptions
+
+Purpose: capture workflow exceptions that need review or waiver.
+
+Suggested fields:
+- `id`
+- `approval_request_id`
+- `exception_type`
+- `severity`
+- `opened_by`
+- `resolution_status`
+- `details`
+- `opened_at`
+- `resolved_at`
+
+Constraints:
+- severity enum: `low`, `medium`, `high`, `critical`
+- resolution enum: `open`, `under_review`, `resolved`, `waived`
+
+### 7. reconciliation_runs
+
+Purpose: track comparison runs between governance state and source system state.
+
+Suggested fields:
+- `id`
+- `org_id`
+- `run_type`
+- `source_system`
+- `result_status`
+- `summary`
+- `created_by`
+- `created_at`
+- `completed_at`
+
+Constraints:
+- result status enum: `pending`, `completed`, `failed`, `partial`
+
+### 8. evidence_bundles
+
+Purpose: package a case or time-bounded scope into an exportable evidence object.
+
+Suggested fields:
+- `id`
+- `org_id`
+- `scope_type`
+- `scope_id`
+- `manifest_json`
+- `integrity_hash`
+- `generated_by`
+- `generated_at`
+
+### 9. export_jobs
+
+Purpose: manage export processing and history.
+
+Suggested fields:
+- `id`
+- `org_id`
+- `bundle_id`
+- `format`
+- `status`
+- `created_by`
+- `output_location`
+- `created_at`
+- `completed_at`
+
+Constraints:
+- format enum: `csv`, `pdf`, `json`
+- status enum: `queued`, `running`, `completed`, `failed`, `expired`
+
+---
+
+## Recommended indexes
+
+- `transactions(org_id, created_at desc)`
+- `transactions(org_id, status)`
+- `approval_requests(org_id, status)`
+- `approval_requests(transaction_id)`
+- `approval_steps(approval_request_id, step_order)`
+- `approval_steps(assigned_user_id, status)`
+- `exceptions(approval_request_id, resolution_status)`
+- `reconciliation_runs(org_id, created_at desc)`
+- `evidence_bundles(org_id, scope_type, scope_id)`
+- `export_jobs(org_id, status)`
+
+---
+
+## Permission and workflow notes
+
+- Makers must not approve their own requests
+- Approval routing must honor policy thresholds and SoD rules
+- Export actions must be auditable
+- Re-opening a case must add a new event instead of mutating history silently
+- Duplicate or replayed submissions should be caught before approval requests are created
+
+---
+
+## Delivery order
+
+1. Add `transactions` and `transaction_documents`
+2. Add `approval_requests`, `approval_steps`, `approval_decisions`
+3. Add `exceptions`
+4. Add `evidence_bundles` and `export_jobs`
+5. Add `reconciliation_runs`
+
+This sequence gives the team a clean path from core workflow to exportability.


### PR DESCRIPTION
## Summary

This PR continues the finance-governance productization work by adding implementation-facing artifacts on top of the previously merged PRD and day-1 execution plan.

### Added
- `docs/product/FINANCE_GOVERNANCE_SCHEMA_DELTA.md`
  - defines the minimum domain model required for a sellable finance-governance workflow
  - covers transactions, documents, approval requests, approval steps, decisions, exceptions, reconciliation, evidence bundles, and export jobs
  - defines delivery order and workflow rules

- `docs/product/FINANCE_GOVERNANCE_IMPLEMENTATION_BACKLOG.md`
  - converts the PRD into milestones, epics, priorities, and done conditions
  - breaks the work into domain foundation, policy-driven workflow, operator UX, audit/evidence, GTM surface, and enterprise readiness

## Why

The previous product PR established the strategic direction.
This PR adds the implementation layer needed for engineering and product teams to start building the finance-governance workflow instead of treating the repository as a generic control-plane foundation.

## Impact

- no runtime code changes
- adds build-ready product and architecture planning artifacts
- reduces ambiguity for schema design and milestone planning

## Next recommended step

Use this PR to start:
1. schema migration drafting
2. approval queue and case-detail UI work
3. finance-governance landing/pricing rewrite
