### PR TITLE
docs(product): add finance governance landing and pricing copy packs

### DIFF
--- a/docs/product/FINANCE_GOVERNANCE_LANDING_COPY_PACK.md
+++ b/docs/product/FINANCE_GOVERNANCE_LANDING_COPY_PACK.md
@@ -1,0 +1,118 @@
+# Finance Governance Landing Copy Pack
+
+Updated: 2026-04-11
+Owner: Product / GTM / Design
+Status: Ready for implementation on landing and marketing surfaces
+
+## Purpose
+
+Use this copy pack to reposition DSG from a generic control-plane story into a finance governance product for enterprise buyers.
+
+## Hero
+
+Eyebrow:
+Finance Governance Control Plane
+
+Headline:
+Control financial approvals with policy, proof, and audit-ready evidence.
+
+Subhead:
+DSG helps finance, compliance, and audit teams govern how transactions and supporting documents are submitted, reviewed, approved, escalated, and exported for audit without replacing the ERP.
+
+Primary CTA:
+Start Trial
+
+Secondary CTA:
+Book Enterprise Pilot
+
+## Trust strip
+
+- Maker-checker enforcement
+- Policy-based approval routing
+- Exportable audit evidence
+- Org-scoped access control
+- Audit timeline per case
+
+## Problem section
+
+Title:
+Why teams outgrow spreadsheet and email approvals
+
+Body:
+Most finance workflows are still governed across disconnected tools. Approval decisions happen in email threads, evidence lives in shared drives, and audit teams have to reconstruct what happened after the fact.
+
+Pain cards:
+1. Policies exist, but they are not enforced at runtime.
+2. Audit evidence is scattered.
+3. Exceptions are hard to trace.
+
+## Solution section
+
+Title:
+A governance layer for finance workflows
+
+Body:
+DSG sits between your team and your existing systems to enforce approval policy, maker-checker rules, and evidence-backed decisions. Your ERP stays the financial system of record. DSG becomes the governance system of record for approvals, exceptions, and audit exports.
+
+Feature pillars:
+- Policy-enforced routing
+- Maker-checker controls
+- Case-level audit trail
+- Exportable evidence bundles
+
+## Use cases section
+
+Title:
+Start with one workflow. Expand from there.
+
+Use cases:
+- Invoice approval governance
+- Payment release approval
+- Expense exception review
+- Vendor onboarding approval
+- Manual journal entry review
+
+## Buyer section
+
+Title:
+Built for finance, compliance, and audit teams
+
+Bullets:
+- Finance managers who need approvals out of inboxes
+- Controllers who need stronger policy enforcement
+- Compliance leads who need separation of duties
+- Auditors who need evidence without manual reconstruction
+- Governance teams who need visibility into exceptions and overrides
+
+## Why now section
+
+Title:
+Why teams buy this now
+
+Reasons:
+- Approval volume increases as organizations scale
+- Policy complexity increases faster than manual processes can support
+- Internal and external audit pressure keeps growing
+- Teams want faster operations without losing control
+
+## Final CTA section
+
+Headline:
+Start with one governed workflow and prove the value fast.
+
+Body:
+Launch a pilot for invoice or payment approval governance, bring the right approvers into the workflow, and generate evidence your audit team can actually use.
+
+Primary CTA:
+Start Trial
+
+Secondary CTA:
+Talk to Sales
+
+## Copy rules
+
+- Do not lead with generic infrastructure language
+- Do not describe the product as a chatbot
+- Do not sell it as an ERP replacement
+- Use buyer language: approvals, policy, audit, exceptions, evidence, controls
+- Keep the message anchored to one workflow first, then expansion later

--- a/docs/product/FINANCE_GOVERNANCE_PRICING_COPY_PACK.md
+++ b/docs/product/FINANCE_GOVERNANCE_PRICING_COPY_PACK.md
@@ -1,0 +1,192 @@
+# Finance Governance Pricing Copy Pack
+
+Updated: 2026-04-11
+Owner: Product / GTM / Design
+Status: Ready for implementation in `app/pricing/page.tsx`
+
+---
+
+## Purpose
+
+This document rewrites the pricing surface from a generic control-plane narrative into a finance-governance product narrative.
+
+It is intended to be used directly when updating `app/pricing/page.tsx` and related marketing surfaces.
+
+---
+
+## Top banner copy
+
+### Current direction
+Generic execution-volume and operator-scope wording.
+
+### Replacement
+**Pricing built for policy-enforced finance workflows**
+
+Alternative:
+**Plans designed for audit-ready approval operations**
+
+---
+
+## Hero headline
+
+### Recommended headline
+**Choose the plan that matches your finance governance workflow.**
+
+Alternative options:
+- **Pricing for finance teams that need policy, approvals, and audit evidence**
+- **From first pilot to enterprise governance rollout**
+
+---
+
+## Hero subhead
+
+### Recommended subhead
+DSG pricing is built for finance, compliance, and audit teams that need maker-checker controls, policy-enforced approvals, and exportable evidence for every decision.
+
+### Alternative subhead
+Start with a controlled pilot, then scale to multi-step approval workflows, enterprise access controls, and audit-ready evidence exports.
+
+---
+
+## Plan packaging
+
+### Plan 1
+#### Name
+Starter
+
+#### Price placeholder
+Use current self-serve entry price or trial-first model
+
+#### Subtitle
+Best for first finance workflow evaluation and stakeholder review
+
+#### Trial line
+No card required
+
+#### Features
+- 1 finance workflow workspace
+- baseline approval queue
+- policy setup for one workflow
+- audit timeline visibility
+- CSV export
+
+#### CTA
+Start Starter Trial
+
+---
+
+### Plan 2
+#### Name
+Growth
+
+#### Price placeholder
+Use current mid-tier self-serve subscription
+
+#### Subtitle
+Best for finance teams moving from spreadsheets and email into governed approvals
+
+#### Trial line
+14-day free trial
+
+#### Features
+- multi-step approval routing
+- maker-checker enforcement
+- exception handling
+- approval dashboards
+- Stripe-backed subscription checkout
+
+#### CTA
+Start Growth
+
+#### Highlight label
+Most popular
+
+---
+
+### Plan 3
+#### Name
+Enterprise
+
+#### Price placeholder
+Use current enterprise price or contact-sales motion
+
+#### Subtitle
+Best for audit-heavy deployments, SSO/SCIM, and governance-first rollout support
+
+#### Trial line
+30-day pilot
+
+#### Features
+- SSO / SCIM readiness
+- advanced segregation-of-duties support
+- evidence bundle export
+- governance onboarding
+- rollout support
+
+#### CTA
+Start Enterprise Pilot
+
+---
+
+## Why this pricing works
+
+### Recommended section title
+**Why these plans map to real finance teams**
+
+### Recommended bullets
+- Starter lowers friction for teams validating one approval workflow with real stakeholders.
+- Growth supports production finance operations that need multi-step approvals and exception handling.
+- Enterprise gives room for audit-heavy rollouts, governance onboarding, and identity integration.
+- Packaging is tied to governance maturity, not vague AI usage language.
+
+---
+
+## Billing notes
+
+### Recommended section title
+**Billing notes**
+
+### Recommended bullets
+- Starter can be used to validate one governed workflow before broader rollout.
+- Growth starts with a 14-day self-serve trial for teams ready to operationalize approvals.
+- Enterprise starts with a 30-day pilot for buyer validation, security review, and rollout planning.
+- Checkout and subscription management are backed by Stripe Billing and Stripe Customer Portal.
+- Billing, entitlements, and approval access should stay workspace-scoped and authenticated.
+
+---
+
+## Buyer-facing FAQ copy
+
+### Q: Who is this for?
+Finance managers, approvers, compliance reviewers, auditors, and governance teams that need approval controls and audit-ready evidence.
+
+### Q: Do I need to replace my ERP?
+No. DSG acts as the governance layer for approvals, policy enforcement, and evidence, while your ERP remains the financial system of record.
+
+### Q: What makes Enterprise different?
+Enterprise adds governance onboarding, identity integration, advanced controls, and stronger support for audit-heavy environments.
+
+### Q: Can customers manage billing themselves?
+Yes. Self-serve subscription and billing management should be routed through Stripe Checkout and the Stripe Customer Portal where appropriate.
+
+---
+
+## Copy rules
+
+- Avoid generic phrases like "control-plane usage" on the public pricing page.
+- Talk about finance workflows, approvals, policy enforcement, and auditability.
+- Avoid selling the product as a chatbot or general AI assistant.
+- The page should explain value in buyer language, not internal infrastructure language.
+
+---
+
+## Ready-to-paste condensed version
+
+### Banner
+Pricing built for policy-enforced finance workflows
+
+### Headline
+Choose the plan that matches your finance governance workflow.
+
+### Subhead
+DSG pricing is built for finance, compliance, and audit teams that need maker-checker controls, policy-enforced approvals, and exportable evidence for every decision.


### PR DESCRIPTION
## Summary

Add buyer-facing copy packs for finance governance marketing surfaces.

### Added
- `docs/product/FINANCE_GOVERNANCE_PRICING_COPY_PACK.md`
- `docs/product/FINANCE_GOVERNANCE_LANDING_COPY_PACK.md`

## Why

Previous work defined product direction, schema, backlog, and launch planning. This PR adds implementation-ready copy for pricing and landing pages.

## Impact

- no runtime code changes
- helps design and GTM teams update public-facing product pages
