### PR TITLE
feat(product): add finance governance public pages and workflow skeleton

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+
+const contactOptions = [
+  {
+    title: 'Enterprise pilot',
+    text: 'For organizations evaluating invoice or payment approval governance with security and rollout review.',
+  },
+  {
+    title: 'Pricing and packaging',
+    text: 'For questions about Starter, Growth, Enterprise, pilot setup, or billing-backed feature gates.',
+  },
+  {
+    title: 'Support and rollout',
+    text: 'For onboarding planning, workflow rollout sequencing, and product support for approval operations.',
+  },
+];
+
+export default function ContactPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Contact</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Talk to sales or plan a pilot</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          Use this surface for enterprise pilot conversations, rollout planning, and product questions while the broader finance-governance application continues moving toward full marketplace readiness.
+        </p>
+      </div>
+
+      <div className="mt-12 grid gap-6 md:grid-cols-3">
+        {contactOptions.map((option) => (
+          <section key={option.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <h2 className="text-2xl font-semibold">{option.title}</h2>
+            <p className="mt-4 leading-7 text-slate-200">{option.text}</p>
+          </section>
+        ))}
+      </div>
+
+      <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+        <p className="text-sm text-slate-300">Suggested next actions</p>
+        <div className="mt-4 flex flex-wrap gap-4">
+          <Link href="/finance-governance" className="rounded-2xl bg-emerald-400 px-6 py-3 text-base font-semibold text-slate-950">
+            View product page
+          </Link>
+          <Link href="/finance-governance/pricing" className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
+            View pricing
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/finance-governance/app/approvals/page.tsx
+++ b/app/finance-governance/app/approvals/page.tsx
@@ -1,0 +1,62 @@
+const approvals = [
+  {
+    id: 'APR-1001',
+    vendor: 'Northwind Supply',
+    amount: 'US$14,250',
+    status: 'Needs approver',
+    risk: 'Threshold exceeded',
+  },
+  {
+    id: 'APR-1002',
+    vendor: 'Contoso Services',
+    amount: 'US$2,480',
+    status: 'Exception open',
+    risk: 'Missing document',
+  },
+  {
+    id: 'APR-1003',
+    vendor: 'Blue Ocean Partners',
+    amount: 'US$31,900',
+    status: 'Compliance review',
+    risk: 'High-risk vendor',
+  },
+];
+
+export default function FinanceGovernanceApprovalsPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Approval queue</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Pending finance approvals</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This queue is the skeleton for role-aware approvals, filtering, and action handling across governed finance workflows.
+        </p>
+      </div>
+
+      <div className="mt-10 overflow-x-auto rounded-[1.75rem] border border-white/10 bg-white/5">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-white/5 text-slate-300">
+            <tr>
+              <th className="px-5 py-4 font-semibold">Approval ID</th>
+              <th className="px-5 py-4 font-semibold">Vendor</th>
+              <th className="px-5 py-4 font-semibold">Amount</th>
+              <th className="px-5 py-4 font-semibold">Status</th>
+              <th className="px-5 py-4 font-semibold">Risk / note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {approvals.map((item) => (
+              <tr key={item.id} className="border-t border-white/10 align-top">
+                <td className="px-5 py-4 font-semibold text-white">{item.id}</td>
+                <td className="px-5 py-4 text-slate-200">{item.vendor}</td>
+                <td className="px-5 py-4 text-slate-200">{item.amount}</td>
+                <td className="px-5 py-4 text-emerald-100">{item.status}</td>
+                <td className="px-5 py-4 text-slate-300">{item.risk}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/app/finance-governance/app/cases/[id]/page.tsx
+++ b/app/finance-governance/app/cases/[id]/page.tsx
@@ -1,0 +1,54 @@
+type CaseDetailPageProps = {
+  params: {
+    id: string;
+  };
+};
+
+const timeline = [
+  'Submission created by finance maker',
+  'Policy route resolved for threshold-based approval',
+  'Exception opened for missing supporting document',
+  'Compliance review requested',
+  'Evidence bundle marked ready for export',
+];
+
+export default function FinanceGovernanceCaseDetailPage({ params }: CaseDetailPageProps) {
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
+      <div className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+        <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+          <p className="text-sm uppercase tracking-[0.3em] text-violet-200">Case detail</p>
+          <h1 className="mt-4 text-4xl font-bold md:text-5xl">Case {params.id}</h1>
+          <p className="mt-6 text-lg leading-8 text-slate-300">
+            This page is the skeleton for transaction summary, policy snapshot, approval chain, and decision context within one governed case.
+          </p>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+              <p className="text-sm text-slate-400">Status</p>
+              <p className="mt-2 text-xl font-semibold text-emerald-100">Compliance review</p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+              <p className="text-sm text-slate-400">Evidence export</p>
+              <p className="mt-2 text-xl font-semibold text-emerald-100">Ready</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+          <h2 className="text-2xl font-semibold">Case timeline</h2>
+          <div className="mt-6 grid gap-4">
+            {timeline.map((item, index) => (
+              <div key={item} className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300/20 font-semibold text-cyan-100">
+                  {index + 1}
+                </div>
+                <p className="text-sm text-slate-100">{item}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/finance-governance/app/onboarding/page.tsx
+++ b/app/finance-governance/app/onboarding/page.tsx
@@ -1,0 +1,32 @@
+const steps = [
+  'Create or confirm the workspace',
+  'Invite finance, approver, audit, and admin roles',
+  'Select invoice or payment approval template',
+  'Publish the first policy version',
+  'Submit the first governed item',
+];
+
+export default function FinanceGovernanceOnboardingPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Onboarding</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance workflow onboarding template</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page is the skeleton for the first-run setup flow that turns a new organization into a configured finance-governance workspace.
+        </p>
+      </div>
+
+      <div className="mt-10 grid gap-4">
+        {steps.map((step, index) => (
+          <section key={step} className="flex items-center gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
+            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-300/20 font-semibold text-emerald-100">
+              {index + 1}
+            </div>
+            <p className="text-base text-slate-100">{step}</p>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/finance-governance/app/page.tsx
+++ b/app/finance-governance/app/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+
+const quickLinks = [
+  { href: '/finance-governance/app/onboarding', label: 'Onboarding template' },
+  { href: '/finance-governance/app/approvals', label: 'Approval queue' },
+  { href: '/finance-governance/app/cases/sample-case', label: 'Sample case detail' },
+];
+
+const cards = [
+  {
+    title: 'Pending approvals',
+    value: '12',
+    text: 'Items waiting for reviewer action in the current workspace.',
+  },
+  {
+    title: 'Open exceptions',
+    value: '3',
+    text: 'Cases that require exception review, waiver, or follow-up.',
+  },
+  {
+    title: 'Ready exports',
+    value: '5',
+    text: 'Evidence bundles available for internal or external review.',
+  },
+];
+
+export default function FinanceGovernanceAppHomePage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-7xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Workspace</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance governance workspace</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This is the in-app starting point for onboarding, approval operations, case review, and audit export flows.
+        </p>
+      </div>
+
+      <div className="mt-10 grid gap-6 md:grid-cols-3">
+        {cards.map((card) => (
+          <section key={card.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <p className="text-sm text-slate-400">{card.title}</p>
+            <p className="mt-3 text-4xl font-bold text-white">{card.value}</p>
+            <p className="mt-4 leading-7 text-slate-200">{card.text}</p>
+          </section>
+        ))}
+      </div>
+
+      <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+        <h2 className="text-2xl font-semibold">Quick links</h2>
+        <div className="mt-5 flex flex-wrap gap-4">
+          {quickLinks.map((link) => (
+            <Link key={link.href} href={link.href} className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/finance-governance/page.tsx
+++ b/app/finance-governance/page.tsx
@@ -1,0 +1,186 @@
+import Link from 'next/link';
+
+const trustItems = [
+  'Maker-checker enforcement',
+  'Policy-based approval routing',
+  'Exportable audit evidence',
+  'Org-scoped access control',
+  'Audit timeline per case',
+];
+
+const painCards = [
+  {
+    title: 'Policies exist, but they are not enforced at runtime',
+    text: 'Thresholds, role rules, and separation-of-duties controls are often documented but easy to bypass when approvals happen across email, chat, and spreadsheets.',
+  },
+  {
+    title: 'Audit evidence is scattered',
+    text: 'When someone asks who approved a transaction, why they approved it, and what evidence they used, teams end up stitching together screenshots, attachments, and chat history manually.',
+  },
+  {
+    title: 'Exceptions are hard to trace',
+    text: 'Overrides, missing documents, escalations, and re-opened cases are often tracked informally, which makes audit readiness and operational confidence worse over time.',
+  },
+];
+
+const pillars = [
+  {
+    title: 'Policy-enforced routing',
+    text: 'Define thresholds, role rules, and workflow paths so approvals follow the right route automatically.',
+  },
+  {
+    title: 'Maker-checker controls',
+    text: 'Block self-approval and reduce the risk of unauthorized or weakly reviewed decisions.',
+  },
+  {
+    title: 'Case-level audit trail',
+    text: 'Track every submission, review, approval, escalation, override, and export with actor, role, timestamp, and reason.',
+  },
+  {
+    title: 'Exportable evidence bundles',
+    text: 'Package transactions, policy context, approval decisions, and document references into a usable export for internal or external review.',
+  },
+];
+
+const useCases = [
+  'Invoice approval governance',
+  'Payment release approval',
+  'Expense exception review',
+  'Vendor onboarding approval',
+  'Manual journal entry review',
+];
+
+const buyerBullets = [
+  'Finance managers who need approvals out of inboxes',
+  'Controllers who need stronger policy enforcement',
+  'Compliance leads who need separation of duties',
+  'Auditors who need evidence without manual reconstruction',
+  'Governance teams who need visibility into exceptions and overrides',
+];
+
+export default function FinanceGovernancePage() {
+  return (
+    <main className="min-h-screen bg-hero-radial text-white">
+      <section className="mx-auto max-w-7xl px-6 pb-16 pt-20">
+        <div className="max-w-4xl">
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-sm font-medium text-emerald-200 shadow-glow">
+            Finance Governance Control Plane
+          </div>
+          <h1 className="mt-8 text-5xl font-bold leading-tight md:text-7xl">
+            Control financial approvals with policy, proof, and audit-ready evidence.
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-100">
+            DSG helps finance, compliance, and audit teams govern how transactions and supporting documents are submitted, reviewed, approved, escalated, and exported for audit without replacing the ERP.
+          </p>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link href="/login" className="rounded-2xl bg-emerald-400 px-6 py-4 text-base font-semibold text-slate-950 transition hover:scale-[1.01]">
+              Start Trial
+            </Link>
+            <Link href="/finance-governance/pricing" className="rounded-2xl border border-white/30 bg-white/10 px-6 py-4 text-base font-semibold text-white transition hover:border-emerald-300/70 hover:bg-emerald-300/15">
+              View Pricing
+            </Link>
+            <Link href="/docs" className="rounded-2xl border border-white/25 bg-slate-900/30 px-6 py-4 text-base font-semibold text-slate-100 transition hover:border-white/40 hover:text-white">
+              Read Docs
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-12 flex flex-wrap gap-3 text-sm">
+          {trustItems.map((item) => (
+            <div key={item} className="rounded-full border border-cyan-200/35 bg-cyan-300/10 px-4 py-2 font-medium text-cyan-100">
+              {item}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-8">
+        <div className="mb-8 max-w-3xl">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Why teams buy</p>
+          <h2 className="mt-3 text-3xl font-bold md:text-4xl">Why teams outgrow spreadsheet and email approvals</h2>
+          <p className="mt-4 text-slate-300">
+            Most finance workflows are still governed across disconnected tools. Approval decisions happen in email threads, evidence lives in shared drives, and audit teams have to reconstruct what happened after the fact.
+          </p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {painCards.map((card) => (
+            <div key={card.title} className="rounded-[1.75rem] border border-white/20 bg-slate-900/75 p-7 backdrop-blur-sm">
+              <p className="text-lg font-semibold text-white">{card.title}</p>
+              <p className="mt-3 leading-7 text-slate-100">{card.text}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-16">
+        <div className="mb-8 max-w-3xl">
+          <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Solution</p>
+          <h2 className="mt-3 text-3xl font-bold md:text-4xl">A governance layer for finance workflows</h2>
+          <p className="mt-4 text-slate-300">
+            DSG sits between your team and your existing systems to enforce approval policy, maker-checker rules, and evidence-backed decisions. Your ERP stays the financial system of record. DSG becomes the governance system of record for approvals, exceptions, and audit exports.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {pillars.map((pillar) => (
+            <div key={pillar.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <div className="inline-flex rounded-2xl bg-emerald-300/20 px-3 py-2 text-sm font-semibold text-emerald-100">
+                {pillar.title}
+              </div>
+              <p className="mt-5 leading-7 text-slate-100">{pillar.text}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-10">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-[2rem] border border-white/10 bg-slate-900/70 p-8">
+            <p className="text-xs uppercase tracking-[0.3em] text-violet-200">Use cases</p>
+            <h3 className="mt-3 text-2xl font-bold">Start with one workflow. Expand from there.</h3>
+            <div className="mt-6 grid gap-3">
+              {useCases.map((item) => (
+                <div key={item} className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-100">
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-[2rem] border border-white/10 bg-slate-900/70 p-8">
+            <p className="text-xs uppercase tracking-[0.3em] text-cyan-200">Built for</p>
+            <h3 className="mt-3 text-2xl font-bold">Finance, compliance, and audit teams</h3>
+            <ul className="mt-6 space-y-3 text-sm leading-7 text-slate-200">
+              {buyerBullets.map((item) => (
+                <li key={item}>• {item}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 pb-20 pt-8">
+        <div className="rounded-[2rem] border border-emerald-400/20 bg-gradient-to-r from-emerald-400/15 via-cyan-400/10 to-transparent p-8 md:p-10">
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Pilot motion</p>
+              <h2 className="mt-3 text-3xl font-bold md:text-4xl">Start with one governed workflow and prove the value fast.</h2>
+              <p className="mt-4 max-w-2xl text-slate-300">
+                Launch a pilot for invoice or payment approval governance, bring the right approvers into the workflow, and generate evidence your audit team can actually use.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-4">
+              <Link href="/login" className="inline-flex items-center justify-center rounded-2xl bg-white px-6 py-4 text-base font-semibold text-slate-950">
+                Start Trial
+              </Link>
+              <Link href="/finance-governance/pricing" className="inline-flex items-center justify-center rounded-2xl border border-white/30 bg-white/10 px-6 py-4 text-base font-semibold text-white">
+                View Pricing
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/finance-governance/pricing/page.tsx
+++ b/app/finance-governance/pricing/page.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+type BillingInterval = 'monthly' | 'yearly';
+type PaidPlanKey = 'pro' | 'business' | 'enterprise';
+
+type PlanCard = {
+  key: 'trial' | PaidPlanKey;
+  name: string;
+  monthlyPrice: string;
+  yearlyPrice: string;
+  subtitle: string;
+  trial: string;
+  features: string[];
+  cta: string;
+  highlighted?: boolean;
+};
+
+const plans: PlanCard[] = [
+  {
+    key: 'trial',
+    name: 'Starter',
+    monthlyPrice: 'Free',
+    yearlyPrice: 'Free',
+    subtitle: 'Best for first finance workflow evaluation and stakeholder review',
+    trial: 'No card required',
+    features: [
+      '1 finance workflow workspace',
+      'Baseline approval queue',
+      'Policy setup for one workflow',
+      'Audit timeline visibility',
+    ],
+    cta: 'Start Starter Trial',
+  },
+  {
+    key: 'pro',
+    name: 'Growth',
+    monthlyPrice: 'US$99/mo',
+    yearlyPrice: 'US$990/yr',
+    subtitle: 'Best for finance teams moving from spreadsheets and email into governed approvals',
+    trial: '14-day free trial',
+    features: [
+      'Multi-step approval routing',
+      'Maker-checker enforcement',
+      'Exception handling',
+      'Approval dashboards',
+    ],
+    cta: 'Start Growth',
+    highlighted: true,
+  },
+  {
+    key: 'business',
+    name: 'Enterprise',
+    monthlyPrice: 'US$299/mo',
+    yearlyPrice: 'US$2,990/yr',
+    subtitle: 'Best for audit-heavy deployments, identity integration, and governance-first rollout support',
+    trial: '30-day pilot',
+    features: [
+      'SSO and SCIM readiness',
+      'Advanced segregation-of-duties support',
+      'Evidence bundle export',
+      'Governance onboarding support',
+    ],
+    cta: 'Start Enterprise Pilot',
+  },
+  {
+    key: 'enterprise',
+    name: 'Custom',
+    monthlyPrice: 'Contact us',
+    yearlyPrice: 'Contact us',
+    subtitle: 'Best for complex entities, dedicated rollout planning, and custom retention requirements',
+    trial: 'Custom commercial plan',
+    features: [
+      'Custom workflow volume',
+      'Private rollout support',
+      'Trust and security review path',
+      'Deployment planning with support',
+    ],
+    cta: 'Talk to Sales',
+  },
+];
+
+function isPaidPlanKey(planKey: PlanCard['key']): planKey is PaidPlanKey {
+  return planKey === 'pro' || planKey === 'business' || planKey === 'enterprise';
+}
+
+export default function FinanceGovernancePricingPage() {
+  const [interval, setInterval] = useState<BillingInterval>('monthly');
+  const [loadingPlan, setLoadingPlan] = useState<PaidPlanKey | null>(null);
+  const [error, setError] = useState('');
+
+  async function startCheckout(plan: PaidPlanKey) {
+    try {
+      setLoadingPlan(plan);
+      setError('');
+
+      const response = await fetch('/api/billing/checkout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          plan,
+          interval,
+        }),
+      });
+
+      const json = await response.json();
+
+      if (!response.ok || !json?.url) {
+        throw new Error(json?.error || 'Failed to start checkout');
+      }
+
+      window.location.href = json.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start checkout');
+    } finally {
+      setLoadingPlan(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen px-6 py-16 text-white">
+      <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="inline-flex rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-sm font-medium text-emerald-200">
+            Pricing built for policy-enforced finance workflows
+          </div>
+          <h1 className="mt-8 text-4xl font-bold md:text-6xl">Choose the plan that matches your finance governance workflow.</h1>
+          <p className="mt-6 text-lg leading-8 text-slate-300">
+            DSG pricing is built for finance, compliance, and audit teams that need maker-checker controls, policy-enforced approvals, and exportable evidence for every decision.
+          </p>
+
+          <div className="mt-8 inline-flex rounded-2xl border border-white/10 bg-white/5 p-1">
+            <button
+              type="button"
+              onClick={() => setInterval('monthly')}
+              className={[
+                'rounded-xl px-5 py-3 text-sm font-semibold transition',
+                interval === 'monthly' ? 'bg-emerald-400 text-slate-950' : 'text-slate-300',
+              ].join(' ')}
+            >
+              Monthly
+            </button>
+            <button
+              type="button"
+              onClick={() => setInterval('yearly')}
+              className={[
+                'rounded-xl px-5 py-3 text-sm font-semibold transition',
+                interval === 'yearly' ? 'bg-emerald-400 text-slate-950' : 'text-slate-300',
+              ].join(' ')}
+            >
+              Yearly
+            </button>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mx-auto mt-8 max-w-3xl rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-14 grid gap-6 lg:grid-cols-4">
+          {plans.map((plan) => {
+            const price = interval === 'monthly' ? plan.monthlyPrice : plan.yearlyPrice;
+
+            return (
+              <div
+                key={plan.name}
+                className={[
+                  'rounded-[1.75rem] border p-6 backdrop-blur-sm',
+                  plan.highlighted
+                    ? 'border-emerald-400/50 bg-emerald-400/10 shadow-glow'
+                    : 'border-white/10 bg-white/5',
+                ].join(' ')}
+              >
+                <div className="mb-6">
+                  {plan.highlighted ? (
+                    <div className="mb-4 inline-flex rounded-full bg-emerald-400 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-950">
+                      Most popular
+                    </div>
+                  ) : null}
+                  <h2 className="text-2xl font-bold">{plan.name}</h2>
+                  <p className="mt-3 text-4xl font-semibold">{price}</p>
+                  <p className="mt-3 text-sm text-emerald-200">{plan.trial}</p>
+                  <p className="mt-3 text-sm leading-6 text-slate-400">{plan.subtitle}</p>
+                </div>
+
+                <ul className="space-y-3 text-sm text-slate-200">
+                  {plan.features.map((feature) => (
+                    <li key={feature} className="rounded-xl border border-white/10 bg-slate-950/40 px-4 py-3">
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+
+                {plan.key === 'trial' ? (
+                  <Link href="/login" aria-label="Start starter trial" className="mt-8 inline-flex w-full items-center justify-center rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center font-semibold text-white">
+                    {plan.cta}
+                  </Link>
+                ) : plan.key === 'enterprise' ? (
+                  <Link href="/contact" className="mt-8 inline-flex w-full items-center justify-center rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center font-semibold text-white">
+                    {plan.cta}
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (isPaidPlanKey(plan.key)) {
+                        void startCheckout(plan.key);
+                      }
+                    }}
+                    disabled={loadingPlan !== null}
+                    className={[
+                      'mt-8 inline-flex w-full items-center justify-center rounded-2xl px-4 py-3 text-center font-semibold transition',
+                      plan.highlighted
+                        ? 'bg-emerald-400 text-slate-950'
+                        : 'border border-white/10 bg-white/5 text-white',
+                      loadingPlan !== null ? 'opacity-70' : '',
+                    ].join(' ')}
+                  >
+                    {loadingPlan === plan.key ? 'Redirecting...' : plan.cta}
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-12 grid gap-6 lg:grid-cols-[1fr_0.9fr]">
+          <div className="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
+            <p className="text-lg font-semibold text-white">Why these plans map to real finance teams</p>
+            <ul className="mt-4 space-y-3 text-sm leading-7 text-slate-300">
+              <li>• Starter lowers friction for teams validating one approval workflow with real stakeholders.</li>
+              <li>• Growth supports production finance operations that need multi-step approvals and exception handling.</li>
+              <li>• Enterprise gives room for audit-heavy rollouts, governance onboarding, and identity integration.</li>
+              <li>• Packaging is tied to governance maturity, not vague AI usage language.</li>
+            </ul>
+          </div>
+          <div className="rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-6">
+            <p className="text-lg font-semibold text-white">Billing notes</p>
+            <ul className="mt-4 space-y-3 text-sm leading-7 text-slate-300">
+              <li>• Starter can be used to validate one governed workflow before broader rollout.</li>
+              <li>• Growth starts with a 14-day self-serve trial for teams ready to operationalize approvals.</li>
+              <li>• Enterprise starts with a 30-day pilot for buyer validation, security review, and rollout planning.</li>
+              <li>• Checkout and subscription management are backed by Stripe Billing and Stripe Customer Portal.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,41 @@
+const sections = [
+  {
+    title: 'What this page covers',
+    text: 'This page summarizes how DSG handles product data, workspace scope, approval records, and exportable evidence within the finance-governance product surface.',
+  },
+  {
+    title: 'Product data scope',
+    text: 'Organizations use DSG to manage approval workflows, policy context, exceptions, audit records, and evidence exports. The customer ERP or accounting system remains the financial system of record.',
+  },
+  {
+    title: 'Workspace scoping',
+    text: 'Product actions, approvals, exports, and billing-backed entitlements should remain scoped to the authenticated organization workspace.',
+  },
+  {
+    title: 'Operational note',
+    text: 'This page is an implementation placeholder for marketplace and trust-surface readiness. It should be replaced or expanded with final legal language before broad commercial rollout.',
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Privacy</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Privacy overview</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page establishes a buyer-facing privacy surface so the product reads like a real enterprise application rather than a prototype. Final legal review is still required before production rollout.
+        </p>
+      </div>
+
+      <div className="mt-12 grid gap-6">
+        {sections.map((section) => (
+          <section key={section.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <h2 className="text-2xl font-semibold">{section.title}</h2>
+            <p className="mt-4 leading-7 text-slate-200">{section.text}</p>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -1,0 +1,56 @@
+const sections = [
+  {
+    title: 'Access control',
+    points: [
+      'Org-scoped access boundaries',
+      'Role-based access control',
+      'Maker-checker workflow enforcement',
+      'Permission-aware export access',
+    ],
+  },
+  {
+    title: 'Governance and auditability',
+    points: [
+      'Case-level audit timeline',
+      'Policy-aware approval decisions',
+      'Exception visibility and escalation tracking',
+      'Exportable evidence bundles for review and audit workflows',
+    ],
+  },
+  {
+    title: 'Operational controls',
+    points: [
+      'Authenticated billing and admin surfaces',
+      'Preview-before-production deployment flow',
+      'Monitoring for auth, billing, approval, and export failures',
+      'Workspace-scoped feature and entitlement handling',
+    ],
+  },
+];
+
+export default function SecurityPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Security overview</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Security and governance posture</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          DSG Finance Governance Control Plane is designed to help organizations govern approvals, policy routing, evidence packaging, and billing-backed workspace access without making public surfaces the system of record.
+        </p>
+      </div>
+
+      <div className="mt-12 grid gap-6">
+        {sections.map((section) => (
+          <section key={section.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <h2 className="text-2xl font-semibold">{section.title}</h2>
+            <ul className="mt-5 space-y-3 text-sm leading-7 text-slate-200">
+              {section.points.map((point) => (
+                <li key={point}>• {point}</li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,41 @@
+const sections = [
+  {
+    title: 'Commercial use',
+    text: 'DSG Finance Governance Control Plane is intended for organizational use, controlled workflow operations, policy enforcement, and audit-related export flows.',
+  },
+  {
+    title: 'Workspace responsibility',
+    text: 'Organizations are responsible for configuring roles, policies, approver assignments, and the accuracy of submitted workflow data within their workspace.',
+  },
+  {
+    title: 'Billing and access',
+    text: 'Paid product access, pilot terms, and feature entitlements should be governed by the applicable billing plan, order terms, and workspace authorization model.',
+  },
+  {
+    title: 'Rollout note',
+    text: 'This page is a product-facing trust placeholder and must be replaced or expanded with final legal terms before broad commercial release.',
+  },
+];
+
+export default function TermsPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-violet-200">Terms</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Terms of service overview</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page gives the product a buyer-visible legal surface while implementation and GTM work continue. Final terms still require legal review before general availability.
+        </p>
+      </div>
+
+      <div className="mt-12 grid gap-6">
+        {sections.map((section) => (
+          <section key={section.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <h2 className="text-2xl font-semibold">{section.title}</h2>
+            <p className="mt-4 leading-7 text-slate-200">{section.text}</p>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Add concrete product-facing pages for finance governance marketplace readiness.

### Added public pages
- `app/finance-governance/page.tsx`
- `app/finance-governance/pricing/page.tsx`
- `app/security/page.tsx`
- `app/privacy/page.tsx`
- `app/terms/page.tsx`
- `app/contact/page.tsx`

### Added workflow skeleton pages
- `app/finance-governance/app/page.tsx`
- `app/finance-governance/app/onboarding/page.tsx`
- `app/finance-governance/app/approvals/page.tsx`
- `app/finance-governance/app/cases/[id]/page.tsx`

## Why

Previous phases established product direction, schema plans, launch readiness, and buyer-facing copy. This PR moves the repository forward with actual routes for public trust surfaces and in-app workflow skeletons.

## Impact

- no backend contract changes
- adds real product surfaces for review, demo, and iteration
- improves marketplace readiness by adding trust pages and workflow entry points
