### PR TITLE
feat(api): add finance governance api skeleton and route tests

### DIFF
--- a/app/api/finance-governance/approvals/route.ts
+++ b/app/api/finance-governance/approvals/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getApprovalItems } from '../../../../lib/finance-governance/mock-data';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    approvals: getApprovalItems(),
+  });
+}

--- a/app/api/finance-governance/cases/[id]/route.ts
+++ b/app/api/finance-governance/cases/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { getCaseDetail } from '../../../../../lib/finance-governance/mock-data';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  return NextResponse.json({
+    case: getCaseDetail(context.params.id),
+  });
+}

--- a/app/api/finance-governance/onboarding/route.ts
+++ b/app/api/finance-governance/onboarding/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getOnboardingSteps } from '../../../../lib/finance-governance/mock-data';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    steps: getOnboardingSteps(),
+  });
+}

--- a/app/api/finance-governance/workspace/summary/route.ts
+++ b/app/api/finance-governance/workspace/summary/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getWorkspaceSummary } from '../../../../../lib/finance-governance/mock-data';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    workspace: getWorkspaceSummary(),
+  });
+}

--- a/lib/finance-governance/mock-data.ts
+++ b/lib/finance-governance/mock-data.ts
@@ -1,0 +1,112 @@
+export type FinanceGovernanceWorkspaceSummary = {
+  workspace: string;
+  counts: {
+    pendingApprovals: number;
+    openExceptions: number;
+    readyExports: number;
+  };
+  quickLinks: Array<{
+    href: string;
+    label: string;
+  }>;
+};
+
+export type FinanceGovernanceOnboardingStep = {
+  id: string;
+  label: string;
+  status: 'todo' | 'in_progress' | 'done';
+};
+
+export type FinanceGovernanceApprovalItem = {
+  id: string;
+  vendor: string;
+  amount: string;
+  status: string;
+  risk: string;
+};
+
+export type FinanceGovernanceCaseDetail = {
+  id: string;
+  status: string;
+  exportStatus: string;
+  transaction: {
+    vendor: string;
+    amount: string;
+    currency: string;
+    workflow: string;
+  };
+  timeline: string[];
+};
+
+export function getWorkspaceSummary(): FinanceGovernanceWorkspaceSummary {
+  return {
+    workspace: 'Finance Governance Workspace',
+    counts: {
+      pendingApprovals: 12,
+      openExceptions: 3,
+      readyExports: 5,
+    },
+    quickLinks: [
+      { href: '/finance-governance/app/onboarding', label: 'Onboarding template' },
+      { href: '/finance-governance/app/approvals', label: 'Approval queue' },
+      { href: '/finance-governance/app/cases/sample-case', label: 'Sample case detail' },
+    ],
+  };
+}
+
+export function getOnboardingSteps(): FinanceGovernanceOnboardingStep[] {
+  return [
+    { id: 'workspace', label: 'Create or confirm the workspace', status: 'done' },
+    { id: 'roles', label: 'Invite finance, approver, audit, and admin roles', status: 'in_progress' },
+    { id: 'template', label: 'Select invoice or payment approval template', status: 'todo' },
+    { id: 'policy', label: 'Publish the first policy version', status: 'todo' },
+    { id: 'sample', label: 'Submit the first governed item', status: 'todo' },
+  ];
+}
+
+export function getApprovalItems(): FinanceGovernanceApprovalItem[] {
+  return [
+    {
+      id: 'APR-1001',
+      vendor: 'Northwind Supply',
+      amount: 'US$14,250',
+      status: 'Needs approver',
+      risk: 'Threshold exceeded',
+    },
+    {
+      id: 'APR-1002',
+      vendor: 'Contoso Services',
+      amount: 'US$2,480',
+      status: 'Exception open',
+      risk: 'Missing document',
+    },
+    {
+      id: 'APR-1003',
+      vendor: 'Blue Ocean Partners',
+      amount: 'US$31,900',
+      status: 'Compliance review',
+      risk: 'High-risk vendor',
+    },
+  ];
+}
+
+export function getCaseDetail(id: string): FinanceGovernanceCaseDetail {
+  return {
+    id,
+    status: 'Compliance review',
+    exportStatus: 'Ready',
+    transaction: {
+      vendor: 'Northwind Supply',
+      amount: '14,250',
+      currency: 'USD',
+      workflow: 'Invoice approval governance',
+    },
+    timeline: [
+      'Submission created by finance maker',
+      'Policy route resolved for threshold-based approval',
+      'Exception opened for missing supporting document',
+      'Compliance review requested',
+      'Evidence bundle marked ready for export',
+    ],
+  };
+}

--- a/tests/integration/api/finance-governance-api.test.ts
+++ b/tests/integration/api/finance-governance-api.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('finance governance api routes', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns workspace summary data', async () => {
+    const { GET } = await import('../../../app/api/finance-governance/workspace/summary/route');
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.workspace.counts.pendingApprovals).toBe(12);
+    expect(body.workspace.quickLinks).toHaveLength(3);
+  });
+
+  it('returns onboarding steps', async () => {
+    const { GET } = await import('../../../app/api/finance-governance/onboarding/route');
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.steps).toHaveLength(5);
+    expect(body.steps[0].id).toBe('workspace');
+  });
+
+  it('returns approval queue items', async () => {
+    const { GET } = await import('../../../app/api/finance-governance/approvals/route');
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.approvals).toHaveLength(3);
+    expect(body.approvals[0].id).toBe('APR-1001');
+  });
+
+  it('returns case detail data for requested id', async () => {
+    const { GET } = await import('../../../app/api/finance-governance/cases/[id]/route');
+
+    const request = new Request('http://localhost/api/finance-governance/cases/sample-case');
+    const response = await GET(request, {
+      params: {
+        id: 'sample-case',
+      },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.case.id).toBe('sample-case');
+    expect(body.case.timeline).toHaveLength(5);
+    expect(body.case.transaction.workflow).toBe('Invoice approval governance');
+  });
+});


### PR DESCRIPTION
## Summary

Add backend skeleton routes and tests for the finance governance workflow surfaces.

### Added
- `lib/finance-governance/mock-data.ts`
- `app/api/finance-governance/workspace/summary/route.ts`
- `app/api/finance-governance/onboarding/route.ts`
- `app/api/finance-governance/approvals/route.ts`
- `app/api/finance-governance/cases/[id]/route.ts`
- `tests/integration/api/finance-governance-api.test.ts`

## Why

Previous phases added public pages, trust surfaces, and workflow skeleton pages. This PR gives those surfaces a shared mock data contract and real API endpoints that front-end work can consume while the finance domain is still being implemented.

## Impact

- no changes to existing runtime governance endpoints
- adds new finance-governance API skeleton routes
- adds integration tests for response shapes and route behavior
