### PR TITLE
feat(ui): add live finance governance pages wired to api skeleton

### DIFF
--- a/app/finance-governance/live/approvals/page.tsx
+++ b/app/finance-governance/live/approvals/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type ApprovalsResponse = {
+  approvals: Array<{
+    id: string;
+    vendor: string;
+    amount: string;
+    status: string;
+    risk: string;
+  }>;
+};
+
+export default function FinanceGovernanceLiveApprovalsPage() {
+  const [data, setData] = useState<ApprovalsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError('');
+
+        const response = await fetch('/api/finance-governance/approvals', {
+          cache: 'no-store',
+        });
+        const json = (await response.json()) as ApprovalsResponse;
+
+        if (!response.ok) {
+          throw new Error('Failed to load approvals');
+        }
+
+        if (active) {
+          setData(json);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load approvals');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Live approval queue</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Pending finance approvals</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page loads approval items from the finance-governance approvals API and renders basic loading, error, and empty states.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-white/5 p-7 text-slate-200">Loading approvals...</div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-10 rounded-[1.75rem] border border-red-500/30 bg-red-500/10 p-7 text-red-200">{error}</div>
+      ) : null}
+
+      {!loading && !error && data?.approvals.length === 0 ? (
+        <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-white/5 p-7 text-slate-200">No approvals waiting right now.</div>
+      ) : null}
+
+      {!loading && !error && data && data.approvals.length > 0 ? (
+        <div className="mt-10 overflow-x-auto rounded-[1.75rem] border border-white/10 bg-white/5">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-white/5 text-slate-300">
+              <tr>
+                <th className="px-5 py-4 font-semibold">Approval ID</th>
+                <th className="px-5 py-4 font-semibold">Vendor</th>
+                <th className="px-5 py-4 font-semibold">Amount</th>
+                <th className="px-5 py-4 font-semibold">Status</th>
+                <th className="px-5 py-4 font-semibold">Risk / note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.approvals.map((item) => (
+                <tr key={item.id} className="border-t border-white/10 align-top">
+                  <td className="px-5 py-4 font-semibold text-white">{item.id}</td>
+                  <td className="px-5 py-4 text-slate-200">{item.vendor}</td>
+                  <td className="px-5 py-4 text-slate-200">{item.amount}</td>
+                  <td className="px-5 py-4 text-emerald-100">{item.status}</td>
+                  <td className="px-5 py-4 text-slate-300">{item.risk}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/app/finance-governance/live/cases/[id]/page.tsx
+++ b/app/finance-governance/live/cases/[id]/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type CaseDetailResponse = {
+  case: {
+    id: string;
+    status: string;
+    exportStatus: string;
+    transaction: {
+      vendor: string;
+      amount: string;
+      currency: string;
+      workflow: string;
+    };
+    timeline: string[];
+  };
+};
+
+type PageProps = {
+  params: {
+    id: string;
+  };
+};
+
+export default function FinanceGovernanceLiveCaseDetailPage({ params }: PageProps) {
+  const [data, setData] = useState<CaseDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError('');
+
+        const response = await fetch(`/api/finance-governance/cases/${params.id}`, {
+          cache: 'no-store',
+        });
+        const json = (await response.json()) as CaseDetailResponse;
+
+        if (!response.ok) {
+          throw new Error('Failed to load case detail');
+        }
+
+        if (active) {
+          setData(json);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load case detail');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [params.id]);
+
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-violet-200">Live case detail</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Case {params.id}</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page loads case detail from the finance-governance case API and renders loading, error, and data states for one governed case.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-white/5 p-7 text-slate-200">Loading case detail...</div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-10 rounded-[1.75rem] border border-red-500/30 bg-red-500/10 p-7 text-red-200">{error}</div>
+      ) : null}
+
+      {!loading && !error && data ? (
+        <div className="mt-10 grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+          <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <h2 className="text-2xl font-semibold">Transaction summary</h2>
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+                <p className="text-sm text-slate-400">Vendor</p>
+                <p className="mt-2 text-xl font-semibold text-white">{data.case.transaction.vendor}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+                <p className="text-sm text-slate-400">Amount</p>
+                <p className="mt-2 text-xl font-semibold text-white">
+                  {data.case.transaction.currency} {data.case.transaction.amount}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+                <p className="text-sm text-slate-400">Status</p>
+                <p className="mt-2 text-xl font-semibold text-emerald-100">{data.case.status}</p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+                <p className="text-sm text-slate-400">Evidence export</p>
+                <p className="mt-2 text-xl font-semibold text-emerald-100">{data.case.exportStatus}</p>
+              </div>
+            </div>
+            <div className="mt-6 rounded-2xl border border-white/10 bg-slate-950/40 p-5">
+              <p className="text-sm text-slate-400">Workflow</p>
+              <p className="mt-2 text-base text-slate-100">{data.case.transaction.workflow}</p>
+            </div>
+          </section>
+
+          <section className="rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+            <h2 className="text-2xl font-semibold">Case timeline</h2>
+            <div className="mt-6 grid gap-4">
+              {data.case.timeline.length === 0 ? (
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-slate-200">No timeline events yet.</div>
+              ) : (
+                data.case.timeline.map((item, index) => (
+                  <div key={`${item}-${index}`} className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300/20 font-semibold text-cyan-100">
+                      {index + 1}
+                    </div>
+                    <p className="text-sm text-slate-100">{item}</p>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/app/finance-governance/live/onboarding/page.tsx
+++ b/app/finance-governance/live/onboarding/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type OnboardingResponse = {
+  steps: Array<{
+    id: string;
+    label: string;
+    status: 'todo' | 'in_progress' | 'done';
+  }>;
+};
+
+export default function FinanceGovernanceLiveOnboardingPage() {
+  const [data, setData] = useState<OnboardingResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError('');
+
+        const response = await fetch('/api/finance-governance/onboarding', {
+          cache: 'no-store',
+        });
+        const json = (await response.json()) as OnboardingResponse;
+
+        if (!response.ok) {
+          throw new Error('Failed to load onboarding steps');
+        }
+
+        if (active) {
+          setData(json);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load onboarding steps');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Live onboarding</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance workflow onboarding</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page loads onboarding steps from the finance-governance onboarding API and shows basic loading, error, and empty states.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="mt-10 rounded-[1.5rem] border border-white/10 bg-white/5 p-6 text-slate-200">Loading onboarding steps...</div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-10 rounded-[1.5rem] border border-red-500/30 bg-red-500/10 p-6 text-red-200">{error}</div>
+      ) : null}
+
+      {!loading && !error && data?.steps.length === 0 ? (
+        <div className="mt-10 rounded-[1.5rem] border border-white/10 bg-white/5 p-6 text-slate-200">No onboarding steps found.</div>
+      ) : null}
+
+      {!loading && !error && data && data.steps.length > 0 ? (
+        <div className="mt-10 grid gap-4">
+          {data.steps.map((step, index) => (
+            <section key={step.id} className="flex items-center gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-300/20 font-semibold text-emerald-100">
+                {index + 1}
+              </div>
+              <div>
+                <p className="text-base text-slate-100">{step.label}</p>
+                <p className="mt-1 text-sm text-slate-400">Status: {step.status}</p>
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/app/finance-governance/live/page.tsx
+++ b/app/finance-governance/live/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+type WorkspaceSummaryResponse = {
+  workspace: {
+    workspace: string;
+    counts: {
+      pendingApprovals: number;
+      openExceptions: number;
+      readyExports: number;
+    };
+    quickLinks: Array<{
+      href: string;
+      label: string;
+    }>;
+  };
+};
+
+export default function FinanceGovernanceLiveWorkspacePage() {
+  const [data, setData] = useState<WorkspaceSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError('');
+
+        const response = await fetch('/api/finance-governance/workspace/summary', {
+          cache: 'no-store',
+        });
+        const json = (await response.json()) as WorkspaceSummaryResponse;
+
+        if (!response.ok) {
+          throw new Error('Failed to load workspace summary');
+        }
+
+        if (active) {
+          setData(json);
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Failed to load workspace summary');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto min-h-screen max-w-7xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Live workspace</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance governance live workspace</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page loads workspace data from the finance-governance API skeleton instead of relying on hardcoded UI state.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-white/5 p-7 text-slate-200">Loading workspace data...</div>
+      ) : null}
+
+      {error ? (
+        <div className="mt-10 rounded-[1.75rem] border border-red-500/30 bg-red-500/10 p-7 text-red-200">{error}</div>
+      ) : null}
+
+      {!loading && !error && data ? (
+        <>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <p className="text-sm text-slate-400">Pending approvals</p>
+              <p className="mt-3 text-4xl font-bold text-white">{data.workspace.counts.pendingApprovals}</p>
+            </section>
+            <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <p className="text-sm text-slate-400">Open exceptions</p>
+              <p className="mt-3 text-4xl font-bold text-white">{data.workspace.counts.openExceptions}</p>
+            </section>
+            <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <p className="text-sm text-slate-400">Ready exports</p>
+              <p className="mt-3 text-4xl font-bold text-white">{data.workspace.counts.readyExports}</p>
+            </section>
+          </div>
+
+          <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+            <h2 className="text-2xl font-semibold">Quick links</h2>
+            <div className="mt-5 flex flex-wrap gap-4">
+              <Link href="/finance-governance/live/onboarding" className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
+                Live onboarding
+              </Link>
+              <Link href="/finance-governance/live/approvals" className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
+                Live approvals
+              </Link>
+              <Link href="/finance-governance/live/cases/sample-case" className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
+                Live case detail
+              </Link>
+            </div>
+            <div className="mt-5 flex flex-wrap gap-4 text-sm text-slate-300">
+              {data.workspace.quickLinks.map((link) => (
+                <span key={link.href} className="rounded-xl border border-white/10 bg-slate-950/40 px-4 py-2">
+                  API contract source: {link.label}
+                </span>
+              ))}
+            </div>
+          </div>
+        </>
+      ) : null}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Add live finance-governance UI pages that fetch data from the new API skeleton routes instead of using hardcoded page data.

### Added
- `app/finance-governance/live/page.tsx`
- `app/finance-governance/live/onboarding/page.tsx`
- `app/finance-governance/live/approvals/page.tsx`
- `app/finance-governance/live/cases/[id]/page.tsx`

## Why

Phase 5 added shared mock data contracts and finance-governance API skeleton routes. This PR wires a new set of UI pages to those routes so the repository now has end-to-end live surfaces for workspace summary, onboarding, approvals, and case detail.

## Impact

- no changes to existing runtime governance endpoints
- adds live client-side pages that consume finance-governance API routes
- adds loading, error, and empty states to the demo workflow surfaces
