### PR TITLE
feat(api): add finance governance workflow action routes and tests

### DIFF
--- a/app/api/finance-governance/approvals/[id]/approve/route.ts
+++ b/app/api/finance-governance/approvals/[id]/approve/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { buildApprovalActionResult } from '../../../../../../../lib/finance-governance/actions';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  return NextResponse.json(buildApprovalActionResult('approve', context.params.id), {
+    status: 200,
+  });
+}

--- a/app/api/finance-governance/approvals/[id]/escalate/route.ts
+++ b/app/api/finance-governance/approvals/[id]/escalate/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { buildApprovalActionResult } from '../../../../../../../lib/finance-governance/actions';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  return NextResponse.json(buildApprovalActionResult('escalate', context.params.id), {
+    status: 200,
+  });
+}

--- a/app/api/finance-governance/approvals/[id]/reject/route.ts
+++ b/app/api/finance-governance/approvals/[id]/reject/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { buildApprovalActionResult } from '../../../../../../../lib/finance-governance/actions';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  return NextResponse.json(buildApprovalActionResult('reject', context.params.id), {
+    status: 200,
+  });
+}

--- a/app/api/finance-governance/submit/route.ts
+++ b/app/api/finance-governance/submit/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { buildSubmitResult } from '../../../../lib/finance-governance/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const caseId = typeof body?.caseId === 'string' && body.caseId.trim().length > 0 ? body.caseId.trim() : 'sample-case';
+
+  return NextResponse.json(buildSubmitResult(caseId), {
+    status: 200,
+  });
+}

--- a/lib/finance-governance/actions.ts
+++ b/lib/finance-governance/actions.ts
@@ -1,0 +1,45 @@
+export type FinanceGovernanceActionName = 'submit' | 'approve' | 'reject' | 'escalate';
+
+export type FinanceGovernanceActionResult = {
+  ok: true;
+  action: FinanceGovernanceActionName;
+  message: string;
+  nextStatus: string;
+  caseId?: string;
+  approvalId?: string;
+};
+
+export function buildSubmitResult(caseId: string): FinanceGovernanceActionResult {
+  return {
+    ok: true,
+    action: 'submit',
+    message: 'Finance workflow item submitted',
+    nextStatus: 'pending',
+    caseId,
+  };
+}
+
+export function buildApprovalActionResult(
+  action: Extract<FinanceGovernanceActionName, 'approve' | 'reject' | 'escalate'>,
+  approvalId: string
+): FinanceGovernanceActionResult {
+  const nextStatusMap = {
+    approve: 'approved',
+    reject: 'rejected',
+    escalate: 'escalated',
+  } as const;
+
+  const messageMap = {
+    approve: 'Approval marked as approved',
+    reject: 'Approval marked as rejected',
+    escalate: 'Approval escalated for further review',
+  } as const;
+
+  return {
+    ok: true,
+    action,
+    message: messageMap[action],
+    nextStatus: nextStatusMap[action],
+    approvalId,
+  };
+}

--- a/tests/integration/api/finance-governance-actions.test.ts
+++ b/tests/integration/api/finance-governance-actions.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('finance governance action routes', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('submits a finance workflow item', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/submit/route');
+
+    const request = new Request('http://localhost/api/finance-governance/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ caseId: 'case-001' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.action).toBe('submit');
+    expect(body.caseId).toBe('case-001');
+    expect(body.nextStatus).toBe('pending');
+  });
+
+  it('approves an approval item', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/approvals/[id]/approve/route');
+
+    const request = new Request('http://localhost/api/finance-governance/approvals/APR-1001/approve', {
+      method: 'POST',
+    });
+
+    const response = await POST(request, { params: { id: 'APR-1001' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.action).toBe('approve');
+    expect(body.approvalId).toBe('APR-1001');
+    expect(body.nextStatus).toBe('approved');
+  });
+
+  it('rejects an approval item', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/approvals/[id]/reject/route');
+
+    const request = new Request('http://localhost/api/finance-governance/approvals/APR-1002/reject', {
+      method: 'POST',
+    });
+
+    const response = await POST(request, { params: { id: 'APR-1002' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.action).toBe('reject');
+    expect(body.approvalId).toBe('APR-1002');
+    expect(body.nextStatus).toBe('rejected');
+  });
+
+  it('escalates an approval item', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/approvals/[id]/escalate/route');
+
+    const request = new Request('http://localhost/api/finance-governance/approvals/APR-1003/escalate', {
+      method: 'POST',
+    });
+
+    const response = await POST(request, { params: { id: 'APR-1003' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.action).toBe('escalate');
+    expect(body.approvalId).toBe('APR-1003');
+    expect(body.nextStatus).toBe('escalated');
+  });
+});


### PR DESCRIPTION
## Summary

Add workflow action routes for the finance-governance surfaces so the app can move beyond read-only mock views.

### Added
- `lib/finance-governance/actions.ts`
- `app/api/finance-governance/submit/route.ts`
- `app/api/finance-governance/approvals/[id]/approve/route.ts`
- `app/api/finance-governance/approvals/[id]/reject/route.ts`
- `app/api/finance-governance/approvals/[id]/escalate/route.ts`
- `tests/integration/api/finance-governance-actions.test.ts`

## Why

Previous phases added product surfaces, trust pages, API skeleton routes, and live UI pages. This PR adds action endpoints and tests so submit, approve, reject, and escalate operations now have concrete route contracts.

## Impact

- no changes to existing runtime governance endpoints
- adds finance-governance workflow action APIs
- adds integration tests for submit and approval-action response behavior
