### PR TITLE
feat(api): add finance governance server memory store demo

### DIFF
--- a/app/api/finance-governance/server-store/approvals/[id]/approve/route.ts
+++ b/app/api/finance-governance/server-store/approvals/[id]/approve/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import {
+  applyApprovalAction,
+  getServerWorkflowSnapshot,
+} from '../../../../../../../lib/finance-governance/server-memory-store';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  const result = applyApprovalAction(context.params.id, 'approve');
+
+  return NextResponse.json(
+    {
+      result,
+      snapshot: getServerWorkflowSnapshot(),
+    },
+    {
+      status: 200,
+    }
+  );
+}

--- a/app/api/finance-governance/server-store/approvals/[id]/escalate/route.ts
+++ b/app/api/finance-governance/server-store/approvals/[id]/escalate/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import {
+  applyApprovalAction,
+  getServerWorkflowSnapshot,
+} from '../../../../../../../lib/finance-governance/server-memory-store';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  const result = applyApprovalAction(context.params.id, 'escalate');
+
+  return NextResponse.json(
+    {
+      result,
+      snapshot: getServerWorkflowSnapshot(),
+    },
+    {
+      status: 200,
+    }
+  );
+}

--- a/app/api/finance-governance/server-store/approvals/[id]/reject/route.ts
+++ b/app/api/finance-governance/server-store/approvals/[id]/reject/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import {
+  applyApprovalAction,
+  getServerWorkflowSnapshot,
+} from '../../../../../../../lib/finance-governance/server-memory-store';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function POST(_request: Request, context: RouteContext) {
+  const result = applyApprovalAction(context.params.id, 'reject');
+
+  return NextResponse.json(
+    {
+      result,
+      snapshot: getServerWorkflowSnapshot(),
+    },
+    {
+      status: 200,
+    }
+  );
+}

--- a/app/api/finance-governance/server-store/reset/route.ts
+++ b/app/api/finance-governance/server-store/reset/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { resetServerWorkflowState } from '../../../../../lib/finance-governance/server-memory-store';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  return NextResponse.json(resetServerWorkflowState(), {
+    status: 200,
+  });
+}

--- a/app/api/finance-governance/server-store/state/route.ts
+++ b/app/api/finance-governance/server-store/state/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getServerWorkflowSnapshot } from '../../../../../lib/finance-governance/server-memory-store';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(getServerWorkflowSnapshot(), {
+    status: 200,
+  });
+}

--- a/app/api/finance-governance/server-store/submit/route.ts
+++ b/app/api/finance-governance/server-store/submit/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import {
+  getServerWorkflowSnapshot,
+  submitServerWorkflowItem,
+} from '../../../../../lib/finance-governance/server-memory-store';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const caseId = typeof body?.caseId === 'string' && body.caseId.trim().length > 0 ? body.caseId.trim() : 'server-case';
+
+  const result = submitServerWorkflowItem(caseId);
+
+  return NextResponse.json(
+    {
+      result,
+      snapshot: getServerWorkflowSnapshot(),
+    },
+    {
+      status: 200,
+    }
+  );
+}

--- a/app/finance-governance/live/server-store/page.tsx
+++ b/app/finance-governance/live/server-store/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type ApprovalItem = {
+  id: string;
+  vendor: string;
+  amount: string;
+  status: string;
+  risk: string;
+};
+
+type SnapshotResponse = {
+  workspace: {
+    workspace: string;
+    counts: {
+      pendingApprovals: number;
+      openExceptions: number;
+      readyExports: number;
+    };
+  };
+  approvals: ApprovalItem[];
+  lastAction: {
+    action: string;
+    message: string;
+    nextStatus: string;
+    caseId?: string;
+    approvalId?: string;
+  } | null;
+};
+
+type ActionEnvelope = {
+  result: {
+    action: string;
+    message: string;
+    nextStatus: string;
+    caseId?: string;
+    approvalId?: string;
+  };
+  snapshot: SnapshotResponse;
+};
+
+export default function FinanceGovernanceServerStorePage() {
+  const [data, setData] = useState<SnapshotResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  const refresh = useCallback(async (soft = false) => {
+    try {
+      if (soft) {
+        setRefreshing(true);
+      } else {
+        setLoading(true);
+      }
+      setError('');
+      const response = await fetch('/api/finance-governance/server-store/state', { cache: 'no-store' });
+      const json = (await response.json()) as SnapshotResponse;
+
+      if (!response.ok) {
+        throw new Error('Failed to load server-store snapshot');
+      }
+
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load server-store snapshot');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh(false);
+  }, [refresh]);
+
+  async function runSubmit() {
+    try {
+      setBusyKey('submit');
+      setError('');
+      const response = await fetch('/api/finance-governance/server-store/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ caseId: 'server-case-001' }),
+      });
+      const json = (await response.json()) as ActionEnvelope;
+
+      if (!response.ok) {
+        throw new Error('Failed to submit into server store');
+      }
+
+      setData(json.snapshot);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit into server store');
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function runAction(approvalId: string, action: 'approve' | 'reject' | 'escalate') {
+    try {
+      setBusyKey(`${approvalId}:${action}`);
+      setError('');
+      const response = await fetch(`/api/finance-governance/server-store/approvals/${approvalId}/${action}`, {
+        method: 'POST',
+      });
+      const json = (await response.json()) as ActionEnvelope;
+
+      if (!response.ok) {
+        throw new Error(`Failed to ${action} approval in server store`);
+      }
+
+      setData(json.snapshot);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to ${action} approval in server store`);
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function reset() {
+    try {
+      setBusyKey('reset');
+      setError('');
+      const response = await fetch('/api/finance-governance/server-store/reset', {
+        method: 'POST',
+      });
+      const json = (await response.json()) as SnapshotResponse;
+
+      if (!response.ok) {
+        throw new Error('Failed to reset server store');
+      }
+
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset server store');
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen max-w-7xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Server-side state demo</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Backend memory workflow loop</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          This page reads and mutates workflow state stored on the server process. It is faster to validate than a full database integration, but it is not durable persistence across process restarts.
+        </p>
+      </div>
+
+      <div className="mt-8 flex flex-wrap gap-4">
+        <button type="button" onClick={() => void runSubmit()} disabled={busyKey !== null} className="rounded-2xl bg-emerald-400 px-6 py-3 font-semibold text-slate-950 disabled:opacity-70">
+          {busyKey === 'submit' ? 'Submitting...' : 'Submit to server store'}
+        </button>
+        <button type="button" onClick={() => void refresh(true)} disabled={busyKey !== null || refreshing} className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 font-semibold text-white disabled:opacity-70">
+          {refreshing ? 'Refreshing...' : 'Refresh snapshot'}
+        </button>
+        <button type="button" onClick={() => void reset()} disabled={busyKey !== null} className="rounded-2xl border border-red-400/30 bg-red-500/10 px-6 py-3 font-semibold text-red-100 disabled:opacity-70">
+          {busyKey === 'reset' ? 'Resetting...' : 'Reset server store'}
+        </button>
+      </div>
+
+      {error ? <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-red-200">{error}</div> : null}
+
+      {loading ? <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-white/5 p-7 text-slate-200">Loading server-store snapshot...</div> : null}
+
+      {!loading && data ? (
+        <>
+          <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-6">
+            <p className="text-sm text-slate-400">Workspace</p>
+            <p className="mt-2 text-2xl font-semibold text-white">{data.workspace.workspace}</p>
+            {data.lastAction ? (
+              <div className="mt-4 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-4 text-emerald-100">
+                Last action: {data.lastAction.action} — {data.lastAction.message}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-6 grid gap-6 md:grid-cols-3">
+            <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <p className="text-sm text-slate-400">Pending approvals</p>
+              <p className="mt-3 text-4xl font-bold text-white">{data.workspace.counts.pendingApprovals}</p>
+            </section>
+            <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <p className="text-sm text-slate-400">Open exceptions</p>
+              <p className="mt-3 text-4xl font-bold text-white">{data.workspace.counts.openExceptions}</p>
+            </section>
+            <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+              <p className="text-sm text-slate-400">Ready exports</p>
+              <p className="mt-3 text-4xl font-bold text-white">{data.workspace.counts.readyExports}</p>
+            </section>
+          </div>
+
+          <div className="mt-10 overflow-x-auto rounded-[1.75rem] border border-white/10 bg-white/5">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-white/5 text-slate-300">
+                <tr>
+                  <th className="px-5 py-4 font-semibold">Approval ID</th>
+                  <th className="px-5 py-4 font-semibold">Vendor</th>
+                  <th className="px-5 py-4 font-semibold">Amount</th>
+                  <th className="px-5 py-4 font-semibold">Status</th>
+                  <th className="px-5 py-4 font-semibold">Risk / note</th>
+                  <th className="px-5 py-4 font-semibold">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.approvals.map((item) => (
+                  <tr key={item.id} className="border-t border-white/10 align-top">
+                    <td className="px-5 py-4 font-semibold text-white">{item.id}</td>
+                    <td className="px-5 py-4 text-slate-200">{item.vendor}</td>
+                    <td className="px-5 py-4 text-slate-200">{item.amount}</td>
+                    <td className="px-5 py-4 text-emerald-100">{item.status}</td>
+                    <td className="px-5 py-4 text-slate-300">{item.risk}</td>
+                    <td className="px-5 py-4">
+                      <div className="flex flex-wrap gap-2">
+                        <button type="button" onClick={() => void runAction(item.id, 'approve')} disabled={busyKey !== null} className="rounded-xl bg-emerald-400 px-3 py-2 font-semibold text-slate-950 disabled:opacity-70">
+                          {busyKey === `${item.id}:approve` ? 'Approving...' : 'Approve'}
+                        </button>
+                        <button type="button" onClick={() => void runAction(item.id, 'reject')} disabled={busyKey !== null} className="rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 font-semibold text-red-100 disabled:opacity-70">
+                          {busyKey === `${item.id}:reject` ? 'Rejecting...' : 'Reject'}
+                        </button>
+                        <button type="button" onClick={() => void runAction(item.id, 'escalate')} disabled={busyKey !== null} className="rounded-xl border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 font-semibold text-cyan-100 disabled:opacity-70">
+                          {busyKey === `${item.id}:escalate` ? 'Escalating...' : 'Escalate'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+    </main>
+  );
+}

--- a/lib/finance-governance/server-memory-store.ts
+++ b/lib/finance-governance/server-memory-store.ts
@@ -1,0 +1,110 @@
+import {
+  type FinanceGovernanceApprovalItem,
+  getApprovalItems,
+  getWorkspaceSummary,
+} from './mock-data';
+import {
+  buildApprovalActionResult,
+  buildSubmitResult,
+  type FinanceGovernanceActionResult,
+} from './actions';
+
+type ServerWorkflowState = {
+  workspaceName: string;
+  approvals: FinanceGovernanceApprovalItem[];
+  submittedCount: number;
+  lastAction: FinanceGovernanceActionResult | null;
+};
+
+type ServerWorkflowSnapshot = {
+  workspace: {
+    workspace: string;
+    counts: {
+      pendingApprovals: number;
+      openExceptions: number;
+      readyExports: number;
+    };
+  };
+  approvals: FinanceGovernanceApprovalItem[];
+  lastAction: FinanceGovernanceActionResult | null;
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __financeGovernanceServerWorkflowState: ServerWorkflowState | undefined;
+}
+
+function createDefaultState(): ServerWorkflowState {
+  const summary = getWorkspaceSummary();
+
+  return {
+    workspaceName: summary.workspace,
+    approvals: getApprovalItems(),
+    submittedCount: 0,
+    lastAction: null,
+  };
+}
+
+function getStore(): ServerWorkflowState {
+  if (!globalThis.__financeGovernanceServerWorkflowState) {
+    globalThis.__financeGovernanceServerWorkflowState = createDefaultState();
+  }
+
+  return globalThis.__financeGovernanceServerWorkflowState;
+}
+
+function computeCounts(approvals: FinanceGovernanceApprovalItem[], submittedCount: number) {
+  return {
+    pendingApprovals: approvals.filter((item) => !['approved', 'rejected'].includes(item.status.toLowerCase())).length,
+    openExceptions: approvals.filter((item) => item.status.toLowerCase().includes('exception')).length,
+    readyExports: submittedCount,
+  };
+}
+
+export function getServerWorkflowSnapshot(): ServerWorkflowSnapshot {
+  const store = getStore();
+
+  return {
+    workspace: {
+      workspace: store.workspaceName,
+      counts: computeCounts(store.approvals, store.submittedCount),
+    },
+    approvals: store.approvals,
+    lastAction: store.lastAction,
+  };
+}
+
+export function resetServerWorkflowState(): ServerWorkflowSnapshot {
+  globalThis.__financeGovernanceServerWorkflowState = createDefaultState();
+  return getServerWorkflowSnapshot();
+}
+
+export function submitServerWorkflowItem(caseId: string): FinanceGovernanceActionResult {
+  const store = getStore();
+  const result = buildSubmitResult(caseId);
+
+  store.submittedCount += 1;
+  store.lastAction = result;
+
+  return result;
+}
+
+export function applyApprovalAction(
+  approvalId: string,
+  action: 'approve' | 'reject' | 'escalate'
+): FinanceGovernanceActionResult {
+  const store = getStore();
+  const result = buildApprovalActionResult(action, approvalId);
+
+  store.approvals = store.approvals.map((item) =>
+    item.id === approvalId
+      ? {
+          ...item,
+          status: result.nextStatus,
+        }
+      : item
+  );
+  store.lastAction = result;
+
+  return result;
+}

--- a/tests/integration/api/finance-governance-server-store.test.ts
+++ b/tests/integration/api/finance-governance-server-store.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('finance governance server store routes', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns server store snapshot', async () => {
+    const { GET } = await import('../../../app/api/finance-governance/server-store/state/route');
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.workspace.workspace).toBe('Finance Governance Workspace');
+    expect(Array.isArray(body.approvals)).toBe(true);
+  });
+
+  it('submits into server store and returns updated snapshot', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/server-store/submit/route');
+
+    const request = new Request('http://localhost/api/finance-governance/server-store/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ caseId: 'server-case-001' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.result.action).toBe('submit');
+    expect(body.snapshot.workspace.counts.readyExports).toBeGreaterThanOrEqual(1);
+  });
+
+  it('applies approve action in server store', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/approve/route');
+
+    const request = new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1001/approve', {
+      method: 'POST',
+    });
+
+    const response = await POST(request, { params: { id: 'APR-1001' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.result.action).toBe('approve');
+    expect(body.snapshot.approvals.find((item: { id: string }) => item.id === 'APR-1001')?.status).toBe('approved');
+  });
+
+  it('applies reject action in server store', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/reject/route');
+
+    const request = new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1002/reject', {
+      method: 'POST',
+    });
+
+    const response = await POST(request, { params: { id: 'APR-1002' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.result.action).toBe('reject');
+    expect(body.snapshot.approvals.find((item: { id: string }) => item.id === 'APR-1002')?.status).toBe('rejected');
+  });
+
+  it('applies escalate action in server store', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/escalate/route');
+
+    const request = new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1003/escalate', {
+      method: 'POST',
+    });
+
+    const response = await POST(request, { params: { id: 'APR-1003' } });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.result.action).toBe('escalate');
+    expect(body.snapshot.approvals.find((item: { id: string }) => item.id === 'APR-1003')?.status).toBe('escalated');
+  });
+
+  it('resets server store state', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/server-store/reset/route');
+
+    const request = new Request('http://localhost/api/finance-governance/server-store/reset', {
+      method: 'POST',
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.workspace.workspace).toBe('Finance Governance Workspace');
+    expect(body.workspace.counts.readyExports).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add a server-side workflow state demo for finance-governance surfaces using process memory.

### Added
- `lib/finance-governance/server-memory-store.ts`
- `app/api/finance-governance/server-store/state/route.ts`
- `app/api/finance-governance/server-store/reset/route.ts`
- `app/api/finance-governance/server-store/submit/route.ts`
- `app/api/finance-governance/server-store/approvals/[id]/approve/route.ts`
- `app/api/finance-governance/server-store/approvals/[id]/reject/route.ts`
- `app/api/finance-governance/server-store/approvals/[id]/escalate/route.ts`
- `app/finance-governance/live/server-store/page.tsx`
- `tests/integration/api/finance-governance-server-store.test.ts`

## Why

Previous phases added browser-persistent demos. This PR moves the loop to backend process memory so the repo now has a server-side state demo without pretending it is durable database persistence.

## Impact

- no changes to existing runtime governance endpoints
- adds backend-memory state loop for finance-governance workflows
- adds tests for snapshot, submit, approve, reject, escalate, and reset behavior
