### PR TITLE
Add production cutover & marketplace readiness docs, deterministic execution protocol, and Termux/Codex bootstrap scripts

### DIFF
--- a/docs/DETERMINISTIC_EXECUTION_PROTOCOL_10X_2026-04-11.md
+++ b/docs/DETERMINISTIC_EXECUTION_PROTOCOL_10X_2026-04-11.md
@@ -1,0 +1,99 @@
+# Deterministic Execution Protocol (10x Throughput, Same Output)
+
+Date: 2026-04-11
+Objective: เร่งเวลา execution 10x โดยไม่เปลี่ยนผลลัพธ์สุดท้าย
+
+## 1) โครงสร้างงาน (task graph)
+
+T0 Input Lock
+- freeze input snapshot (schema, code, config, test fixtures)
+- produce immutable run-id
+
+T1 Dependency Graph Build
+- parse tasks into DAG
+- classify: independent / dependent / write-conflict domain
+
+T2 Parallel Execute (stateless workers)
+- run independent nodes in parallel
+- isolate write scopes per worker
+
+T3 Deterministic Merge
+- merge outputs by stable ordering key: `(stage, topo_index, task_id)`
+- reject non-deterministic artifacts
+
+T4 Verification Gate
+- deterministic replay check
+- dependency/order validation
+- output hash comparison with expected baseline
+
+## 2) งานที่ทำขนานได้
+
+Parallel set P1 (no shared writes):
+- read-only analysis
+- test generation from fixed fixtures
+- policy/static checks
+- documentation assembly from locked inputs
+
+Parallel set P2 (partitioned writes):
+- per-module codegen/patch in isolated paths
+- per-domain migration drafts in non-overlapping files
+
+Serial-only set S (strict dependency):
+- schema finalization before route binding
+- route binding before integration assertion
+- integration assertion before release decision
+
+## 3) dependency
+
+Hard dependencies:
+1. T0 -> T1 -> T2 -> T3 -> T4
+2. schema tasks -> repository tasks -> API tasks -> dashboard binding -> acceptance tests
+3. acceptance tests -> release gate
+
+No task may skip upstream hard dependency.
+
+## 4) วิธีรวมผลแบบ deterministic
+
+1. Normalize outputs (line endings, sorted keys, fixed locale/timezone)
+2. Sort artifacts with stable comparator `(stage, topo_index, task_id)`
+3. Merge with conflict policy: upstream-wins + explicit conflict log
+4. Compute manifest hash for merged output
+5. Replay merge once; hash must match exactly
+
+If hash mismatch => fail fast, no release.
+
+## 5) ผลลัพธ์สุดท้าย
+
+Expected deterministic final output:
+- same input snapshot => same merged artifacts
+- same dependency order => same test outcomes
+- same release decision for identical evidence
+
+Target speedup method:
+- maximize P1/P2 parallel width
+- keep serial chain minimal and fixed
+- eliminate redundant recomputation via content-hash cache (deterministic key)
+
+## 6) สรุปการตรวจสอบ
+
+Pre-merge checks:
+1. logic unchanged (no algorithmic approximation)
+2. dependency order valid (topological validation pass)
+3. deterministic merge pass (replay hash identical)
+4. correctness pass (tests + migration checks + policy checks)
+
+All 4 checks must pass.
+
+## 7) ความเสี่ยง
+
+1. hidden shared state in tools/scripts
+2. non-deterministic iteration order in runtime/library
+3. wall-clock/timezone leakage into artifacts
+4. parallel write collision in same file/domain
+5. flaky tests interpreted as logic drift
+
+Mitigation:
+- force UTC + fixed locale
+- disable nondeterministic seeds
+- file/domain write locks
+- deterministic retry policy (fixed retry count + backoff schedule)

--- a/docs/MARKETPLACE_GET_STARTED_ACCEPTANCE_CHECKLIST_2026-04-11.md
+++ b/docs/MARKETPLACE_GET_STARTED_ACCEPTANCE_CHECKLIST_2026-04-11.md
@@ -1,0 +1,47 @@
+# Marketplace Get Started Acceptance Checklist
+
+Date: 2026-04-11
+Purpose: ใช้ตรวจสอบว่า onboarding flow สำหรับผู้ใช้ใหม่ “เริ่มได้จริง” ก่อนปล่อย marketplace
+
+## A) First-time user setup
+
+- [ ] สมัคร/ล็อกอินสำเร็จ
+- [ ] สร้าง organization สำเร็จ
+- [ ] เชิญสมาชิกและรับเชิญสำเร็จ
+- [ ] กำหนด role แล้วสิทธิ์ถูกต้องตาม RBAC
+
+## B) First workflow value
+
+- [ ] สร้าง/รับ work item ได้
+- [ ] submit action สำเร็จและบันทึก DB จริง
+- [ ] approve/reject/escalate ทำงานจริงตามสิทธิ์
+- [ ] dashboard สะท้อนสถานะล่าสุดตรงกับ DB
+
+## C) Audit + trust
+
+- [ ] action สำคัญมี audit trail ครบ
+- [ ] query audit แล้วเห็น actor/time/action ชัด
+- [ ] cross-org data access ถูกปิด (isolation ผ่าน)
+
+## D) Entitlement + billing
+
+- [ ] entitlement gate ทำงานจริงตาม plan/seat/quota
+- [ ] quota exceeded ให้ error message ชัดเจน
+- [ ] upgrade path ใช้งานได้จริง
+
+## E) Operability
+
+- [ ] health endpoint ผ่าน
+- [ ] error state สำคัญมี remediation message
+- [ ] runbook incident/recovery ใช้งานได้จริง
+
+## F) Marketplace submission gate
+
+- [ ] Terms / Privacy / Security / Support pages พร้อม
+- [ ] demo script ใช้ production flow เดียวกับลูกค้าจริง
+- [ ] smoke test บัญชีใหม่ผ่านครบทุกข้อ A-E
+
+## Result
+
+- [ ] **GO** (ผ่านครบ)
+- [ ] **NO-GO** (มีข้อไม่ผ่าน)

--- a/docs/MARKETPLACE_TOP_TIER_GAP_AND_GET_STARTED_2026-04-11.md
+++ b/docs/MARKETPLACE_TOP_TIER_GAP_AND_GET_STARTED_2026-04-11.md
@@ -1,0 +1,89 @@
+# Marketplace Top-Tier Benchmark: User Value + Get Started Standard
+
+Date: 2026-04-11
+
+## What top marketplace apps typically guarantee
+
+Top apps in enterprise marketplaces usually give users 4 things immediately:
+
+1. **Time-to-first-value < 15 minutes**
+   - install → connect identity/workspace → run first successful workflow
+2. **Trust-by-default**
+   - RBAC enforced server-side, audit trail queryable, clear data boundaries per org
+3. **Predictable operations**
+   - health/status endpoints, failure states with clear remediation, runbooks
+4. **Commercial readiness**
+   - entitlement + billing gates are real (not hidden toggles), support/legal pages complete
+
+---
+
+## Current repo position vs top-tier standard
+
+### Strong already
+
+- broad product surface (auth, dashboard, APIs, runtime spine)
+- test coverage baseline is strong on unit/integration/migrations
+- existing operational/security docs are present
+
+### Gap to close for top-tier parity
+
+1. workflow/action persistence must be DB-backed end-to-end (no demo source-of-truth)
+2. org/RBAC enforcement must be complete on all critical write/read routes
+3. audit trail must be complete for state transitions (submit/approve/reject/escalate)
+4. billing entitlement must block/allow consistently by plan/quota/seat
+5. launch package must include user-facing onboarding flow + support/legal certainty
+
+---
+
+## User-facing definition of done (what users must receive)
+
+ผู้ใช้ต้องได้สิ่งนี้ตั้งแต่วันแรก:
+
+1. **Start fast**
+   - login/connect แล้วรัน workflow แรกสำเร็จได้ทันที
+2. **See real state**
+   - dashboard สะท้อนสถานะจริงจาก DB ไม่ใช่ mock/session/browser cache
+3. **Safe collaboration**
+   - role ที่ไม่สิทธิ์ต้องทำไม่ได้จริง, org isolation ชัดเจน
+4. **Traceability**
+   - ทุก action สำคัญมี audit evidence ตรวจย้อนหลังได้
+5. **Commercial clarity**
+   - plan/seat/quota behavior ชัด, error message ชัด, อัปเกรดได้จริง
+
+---
+
+## Get Started standard (production)
+
+เป้าหมายคือ flow นี้ต้องผ่านได้ใน environment จริง:
+
+1. Create org / invite member
+2. Assign role
+3. Create or receive task/work item
+4. Submit → Approve/Reject/Escalate
+5. Verify audit log + dashboard state
+6. Hit entitlement boundary and receive expected behavior
+
+**Pass condition:** ผู้ใช้ใหม่ทำ flow จบได้โดยไม่ต้องพึ่ง manual DB fix หรือ feature flag เฉพาะกิจ
+
+---
+
+## Release gate for marketplace submission
+
+ต้องผ่านครบก่อนส่งขึ้น marketplace:
+
+1. Production Cutover acceptance ผ่านครบ
+2. Hardening + Launch acceptance ผ่านครบ
+3. Onboarding/get-started flow ทดสอบบนบัญชีใหม่ผ่าน
+4. Support + terms/privacy/security pages พร้อมใช้งานจริง
+5. Demo script ที่ใช้ขาย = flow production เดียวกับลูกค้า
+
+---
+
+## Immediate execution order (no extra demo phases)
+
+1. ทำ M1 Production Cutover ให้จบทั้งเส้น
+2. ทำ M2 Hardening + Launch ให้จบทั้งเส้น
+3. freeze feature ที่ไม่เกี่ยวกับ launch readiness
+
+นี่คือ baseline เทียบกับแอป top marketplace แบบตรงไปตรงมา: 
+**ชนะที่ความน่าเชื่อถือ + first-value speed + auditability + entitlement correctness**.

--- a/docs/ONE_DAY_14_TEAM_FEASIBILITY_2026-04-11.md
+++ b/docs/ONE_DAY_14_TEAM_FEASIBILITY_2026-04-11.md
@@ -1,0 +1,56 @@
+# Feasibility: 14 Teams in Parallel, 1 Day
+
+Date: 2026-04-11
+
+## Short answer
+
+- **จบทั้งหมดใน 1 วัน: ไม่ได้** (ถ้ารวม production-ready + validation + hardening ครบ)
+- **จบ milestone ย่อยใน 1 วัน: ได้** (ถ้า scope เป็น M1 foundation + integration checkpoint)
+
+## Why full completion in 1 day is unrealistic
+
+1. มีงาน dependency ต่อกัน (schema → write path → read model → acceptance)
+2. ต้องมี integration + regression รอบรวม ไม่ใช่แยกทีมแล้วจบเลย
+3. migration/policy/entitlement ต้อง verify ข้ามเส้นทางสำคัญ
+4. quality gate ต้องการหลักฐานมากกว่าการ “โค้ดเสร็จ”
+
+## What can be done in 1 day with 14 teams (aggressive but valid)
+
+### Team split (14 lanes)
+
+1. Schema/migration core
+2. Workflow state transitions
+3. Audit event model
+4. Repository write path
+5. Repository read path
+6. API action routes (submit/approve/reject/escalate)
+7. API read endpoints
+8. RBAC/org policy enforcement
+9. Billing entitlement checks
+10. Dashboard wiring
+11. Error contracts + response normalization
+12. Test harness (unit/integration/migration)
+13. Smoke scripts + runbook evidence
+14. Reviewer lane (continuous integration review)
+
+### Expected output by end of day
+
+- PR stack สำหรับ M1 foundation ครบเกือบทั้งเส้น
+- integration branch ที่รัน test หลักได้
+- blocker list ชัดเจนสำหรับ Day 2
+
+## One-day acceptance target (realistic)
+
+ภายใน 1 วัน ควรตั้งเป้าแค่นี้:
+
+1. M1 implementation coverage >= 70%
+2. critical path compile/test ผ่านใน integration environment
+3. no new demo-only regressions
+4. open risks ถูกระบุ owner + next action ครบ
+
+## Recommended commitment
+
+- Day 1: Build + integrate + stabilize M1 foundation
+- Day 2: Close gaps + full validation + Go/No-Go for M1 complete
+
+ถ้าฝืนปิดทุกอย่างในวันเดียว ความเสี่ยงคือได้ “เสร็จปลอม” และย้อนแก้หนักในวันถัดไป.

--- a/docs/ORCHESTRATION_PLAN_M1_M2_2026-04-11.md
+++ b/docs/ORCHESTRATION_PLAN_M1_M2_2026-04-11.md
@@ -1,0 +1,90 @@
+# Orchestrator Execution Plan (Speed + Correctness)
+
+Date: 2026-04-11
+Scope: M1 Production Cutover + M2 Hardening/Launch
+
+## 1) แผนแบ่งงาน (Planner)
+
+### Stream A — Data Foundation (upstream)
+- A1: Schema delta + migrations for workflow state + audit completeness
+- A2: Constraint/index hardening + rollback verification
+
+### Stream B — Backend Enforcement
+- B1: Repository abstraction for write/read paths
+- B2: Org scoping + RBAC enforcement at API boundary
+- B3: Action endpoints (`submit/approve/reject/escalate`) persist to DB
+
+### Stream C — Read Model + UI Wiring
+- C1: Read endpoints consume DB-only source-of-truth
+- C2: Dashboard pages sync to DB-backed read model
+
+### Stream D — Commercial + Governance
+- D1: Billing entitlement checks by plan/seat/quota
+- D2: Policy validation + permission denial paths + error contracts
+
+### Stream E — Quality + Release
+- E1: Test matrix (unit/integration/migration/smoke)
+- E2: Marketplace get-started acceptance checklist execution
+- E3: Launch package (terms/privacy/security/support/demo script)
+
+## 2) งานที่รันขนานได้ (Parallel lanes)
+
+### Wave 1 (ทันที, ไม่รอกัน)
+- A1, B1, D2, E1 รันพร้อมกัน
+
+### Wave 2 (หลัง A1 พร้อม)
+- A2 + B2 + B3 รันขนาน
+
+### Wave 3 (หลัง B3 พร้อม)
+- C1 + audit verification + entitlement integration (D1) รันขนาน
+
+### Wave 4 (หลัง C1 พร้อม)
+- C2 + E2 + E3 รันขนาน
+
+## 3) บทบาทเอเจนต์และเอาต์พุต
+
+### Planner
+- ส่ง: dependency graph + wave schedule + owner map
+- ไม่แน่ใจ: hidden coupling ระหว่าง API กับ dashboard caching
+- ส่งต่อ: Builder/Reviewer
+
+### Researcher
+- ส่ง: policy/RBAC edge-case list, entitlement failure modes, migration risk list
+- ไม่แน่ใจ: production traffic pattern ที่กระทบ index design
+- ส่งต่อ: Builder (schema + policy), Reviewer
+
+### Builder
+- ส่ง: implementation PRs ตามลำดับ A→B→C→D
+- ไม่แน่ใจ: legacy demo route impact
+- ส่งต่อ: Reviewer (compat + regression)
+
+### Reviewer
+- ส่ง: completeness/correctness/consistency report + no-demo regression verdict
+- ไม่แน่ใจ: missing negative tests per endpoint
+- ส่งต่อ: Planner สำหรับ replanning รอบย่อย
+
+## 4) ผลลัพธ์รวมที่ต้องได้
+
+1. DB-backed state machine สำหรับ submit/approve/reject/escalate
+2. Org/RBAC enforcement ครบทุก critical route
+3. Dashboard/read model อ้างอิง DB state จริง
+4. Entitlement gate ใช้งานจริงตาม plan/quota/seat
+5. ผ่าน acceptance checklist พร้อม GO/NO-GO ชัดเจน
+
+## 5) จุดเสี่ยง/ข้อจำกัด
+
+- migration order conflict กับข้อมูลเดิม
+- route บางจุดยังผูกกับ demo assumptions
+- E2E browser infra ยังไม่เสถียรในบาง environment
+- entitlement edge cases อาจโผล่หลังเปิดใช้จริง
+
+## 6) ข้อเสนอแนะเพื่อเร่งรอบถัดไป
+
+1. ตรึง rule: PR ต้องติด `M1` หรือ `M2` เท่านั้น
+2. freeze งานที่ไม่ช่วย launch readiness จนหลัง 2026-04-24
+3. ใช้ daily triage 2 รอบ (midday + EOD) เพื่อลด blocker latency
+4. merge เฉพาะ output ที่ Reviewer validate แล้ว
+
+## 7) Start signal
+
+เริ่มทำ production ตอนนี้ทันที โดยเปิด Wave 1 พร้อมกันทั้งหมด.

--- a/docs/PRODUCTION_CUTOVER_2_ROUNDS_2026-04-11.md
+++ b/docs/PRODUCTION_CUTOVER_2_ROUNDS_2026-04-11.md
@@ -1,0 +1,146 @@
+# Production Cutover in 2 Rounds (Marketplace + Enterprise Ready)
+
+Date: 2026-04-11
+Owner: Control Plane Team
+
+## Executive decision (ตรงๆ)
+
+- **ได้**: ทำให้พร้อม Marketplace/Enterprise ได้ โดยล็อกงานเหลือ **2 รอบจริง** เท่านั้น
+- **ไม่ได้**: ถ้ายังเพิ่ม mock/memory/localStorage/demo-route ใหม่ จะวนไม่จบ
+
+---
+
+## Stop list (มีผลทันที)
+
+ห้ามเพิ่มงานใหม่ประเภทต่อไปนี้:
+
+1. mock route ใหม่
+2. server-memory store ใหม่
+3. localStorage persistence ใหม่
+4. demo-only workflow/action/page ใหม่
+
+เกณฑ์รับงานใหม่มีข้อเดียว: **ชิ้นนี้อยู่ถึง production หรือไม่**
+
+---
+
+## Round 1 — Production Cutover (ใหญ่สุด, ต้องทำก่อน)
+
+เป้าหมาย: ตัดจาก demo persistence ไปเป็น DB-backed production flow ทั้งเส้น
+
+### R1.1 Data + schema hardening
+
+- finalize schema/workflow tables ให้รองรับ submit/approve/reject/escalate
+- เพิ่ม index/constraints ที่จำเป็นกับ org-scoped workloads
+- migration ต้อง idempotent และ rollback-aware
+
+**Primary paths**
+- `supabase/schema.sql`
+- `supabase/migrations/*`
+
+### R1.2 Repository layer + org scope
+
+- ทุก write/read ผ่าน repository layer เดียว
+- enforce org scoping + RBAC ที่ server side ทุก endpoint
+- ตัด logic ที่พึ่ง browser state เป็น source-of-truth
+
+**Primary paths**
+- `lib/auth/*`
+- `lib/runtime/*`
+- `lib/spine/*`
+- `lib/gate/*`
+
+### R1.3 Action routes write DB จริง
+
+- submit / approve / reject / escalate ต้องเขียน DB + audit trail
+- response payload ต้องสะท้อน persisted state จริง
+- ห้าม fallback ไป memory/local demo stores
+
+**Primary paths**
+- `app/api/execute/*`
+- `app/api/executions/*`
+- `app/api/policies/*`
+- `app/api/audit/*`
+- `app/api/ledger/*`
+
+### R1.4 Read routes read DB จริง
+
+- dashboard/read pages ดึงจาก DB-backed API เท่านั้น
+- normalize pagination/filtering ตาม org + permission
+
+**Primary paths**
+- `app/dashboard/**`
+- `app/api/*` (read endpoints)
+
+### R1.5 Cutover acceptance (Go/No-Go)
+
+ต้องผ่านครบ:
+
+1. ไม่มี endpoint production ที่ใช้ mock/memory/localStorage เป็น source-of-truth
+2. submit/approve/reject/escalate เขียน DB จริง + trace ใน audit
+3. dashboard หลักอ่านสถานะล่าสุดจาก DB ตรงกันกับ action history
+4. Vitest ผ่าน และ migration test ผ่าน
+
+---
+
+## Round 2 — Hardening + Launch
+
+เป้าหมาย: จาก “ใช้ได้” ไป “ปล่อยขายได้”
+
+### R2.1 Security + policy validation
+
+- permission checks ครบทุก route (deny-by-default)
+- error states มาตรฐาน (authz, quota, policy, upstream failure)
+- audit export/replay ตรวจสอบได้
+
+### R2.2 Billing/entitlement production mode
+
+- entitlement gate ผูก billing plan/seat/quota จริง
+- ปิดช่องใช้ฟรีที่ bypass policy
+
+### R2.3 Operational readiness
+
+- deploy checks: staging/prod parity
+- smoke test runbook ชัดเจน
+- rollback/runbook/incident flow ครบ
+
+### R2.4 Marketplace/Enterprise readiness
+
+- terms/privacy/security/support pages ครบและเชื่อมจริง
+- listing/demo script ใช้ flow production (ไม่ใช่ demo fork)
+
+### R2.5 Launch acceptance (Go/No-Go)
+
+ต้องผ่านครบ:
+
+1. policy + permission enforcement ผ่าน test/spot-check
+2. billing entitlement ทำงานจริงในเส้นทางสำคัญ
+3. smoke test production checklist ผ่าน
+4. docs operator/runbook/recovery อัปเดตล่าสุด
+
+---
+
+## Delivery model (ไม่แตกเป็น 10 เฟส)
+
+- ใช้ 2 milestone เท่านั้น
+  - `M1: Production Cutover`
+  - `M2: Hardening + Launch`
+- ทุก PR ต้องติด label ใด label หนึ่งเท่านั้น: `M1` หรือ `M2`
+- PR ที่เป็น demo-only ให้ reject ทันที
+
+---
+
+## Immediate next step (เริ่มตอนนี้)
+
+ให้เริ่มจาก **M1 / R1.1 + R1.2** ก่อนทันที และแตก task ตามไฟล์จริงใน repo:
+
+1. schema/migration delta
+2. repository + org-scope enforcement
+3. action write path cutover
+4. read path cutover
+5. acceptance test matrix
+
+เอกสารนี้ตั้งใจใช้เป็น baseline ตัดสินว่า “งานไหนอยู่ถึง production” และกันงานหลอกซ้ำ.
+
+See also: `docs/MARKETPLACE_TOP_TIER_GAP_AND_GET_STARTED_2026-04-11.md` for top-tier benchmark and user get-started standard.
+
+Timeline locked in `docs/PRODUCTION_START_TIMELINE_2026-04-11.md`.

--- a/docs/PRODUCTION_START_TIMELINE_2026-04-11.md
+++ b/docs/PRODUCTION_START_TIMELINE_2026-04-11.md
@@ -1,0 +1,50 @@
+# Production Start Timeline (Locked)
+
+Created: 2026-04-11 (UTC)
+
+## Answer (direct)
+
+เริ่ม **ทันที**: kickoff วันนี้ **2026-04-11** โดยนับเป็นวันเริ่ม `M1: Production Cutover`.
+
+## 14-day execution window
+
+### Week 1 (2026-04-11 → 2026-04-17): M1 core cutover
+
+1. Schema + migration delta (submit/approve/reject/escalate persistence)
+2. Repository layer + org/RBAC enforcement
+3. Action routes write DB จริง
+4. Read routes read DB จริง
+
+**Week 1 exit criteria**
+- ไม่มี production endpoint ที่พึ่ง mock/memory/localStorage เป็น source-of-truth
+- action history ตรงกับ dashboard state จาก DB
+
+### Week 2 (2026-04-18 → 2026-04-24): M2 hardening + launch prep
+
+1. Policy + permission validation ครบ
+2. Billing entitlement checks ครบ
+3. Error-state + observability + runbook checks
+4. Marketplace submission package (terms/privacy/security/support + demo script)
+
+**Week 2 exit criteria**
+- ผ่าน marketplace get-started acceptance checklist
+- พร้อม Go/No-Go decision สำหรับ submission
+
+## Daily operating cadence (fixed)
+
+- 10:00 UTC: cutover standup (blockers + risk)
+- 16:00 UTC: integration checkpoint (API/UI parity)
+- 21:00 UTC: release readiness note (GO/NO-GO drift)
+
+## Non-negotiables
+
+1. ห้ามเพิ่ม demo-only scope ใหม่
+2. ทุก PR ต้อง label `M1` หรือ `M2`
+3. งานที่ไม่ช่วย marketplace readiness ให้เลื่อนไปหลัง 2026-04-24
+
+## Day-0 kickoff checklist (today: 2026-04-11)
+
+- [ ] Freeze demo-only backlog
+- [ ] Open `M1` epic + issue split (schema/repo/write/read/tests)
+- [ ] Assign owner ต่อ stream
+- [ ] Start implementation PR #1 (schema/migration)

--- a/docs/TERMUX_CODEX_MULTICA_STATUS_AND_PLAN.md
+++ b/docs/TERMUX_CODEX_MULTICA_STATUS_AND_PLAN.md
@@ -1,0 +1,107 @@
+# Termux + Codex + Multica: Status and Planning (Practical Path)
+
+Last updated: 2026-04-11
+
+## Current status
+
+- Recommended architecture is confirmed as:
+  - **Termux host** → `proot-distro` → **Debian guest** → install **Codex CLI** + **Multica CLI/daemon**.
+- A runnable bootstrap script is now available at:
+  - `scripts/termux-proot-codex-multica-setup.sh`
+- Script scope:
+  - prepares Termux packages
+  - installs Debian if missing
+  - installs Codex (npm) and Multica (release tarball) inside Debian
+  - writes baseline `~/.codex/config.toml`
+  - prints next-step login/daemon commands
+
+## Execution plan (talk-through before production rollout)
+
+### Phase 1 — Environment bootstrap (owner: operator)
+
+1. Run from Termux:
+
+```bash
+bash scripts/termux-proot-codex-multica-setup.sh
+```
+
+2. Success criteria:
+   - `codex --version` returns version in Debian
+   - `multica version` returns version in Debian
+
+### Phase 2 — Authentication and runtime wiring
+
+1. In Debian:
+
+```bash
+codex login --device-auth
+multica login --token
+multica daemon start
+multica daemon status
+```
+
+2. If Codex is not detected by daemon:
+
+```bash
+export MULTICA_CODEX_PATH="$(which codex)"
+multica daemon start --foreground
+```
+
+3. Success criteria:
+   - daemon status reports healthy runtime
+   - Codex runtime appears in detected/registered agents
+
+### Phase 3 — Functional smoke test
+
+1. Create test project and run Codex task:
+
+```bash
+mkdir -p ~/work/test-agent
+cd ~/work/test-agent
+git init
+printf 'def add(a,b):\n    return a-b\n' > app.py
+codex
+```
+
+2. Prompt:
+
+```text
+Fix the bug in app.py and add a simple test.
+```
+
+3. Success criteria:
+   - generated patch changes subtraction to addition
+   - basic test added and passes locally
+
+## Risk register and fallback
+
+1. **npm/node too old in Debian image**
+   - fallback: install Codex binary release into `~/.local/bin/codex`
+2. **OAuth callback issues in headless environment**
+   - fallback: `codex login --device-auth` and `multica login --token`
+3. **daemon cannot find codex on PATH**
+   - fallback: set `MULTICA_CODEX_PATH`
+
+## Operational notes
+
+- Keep installs in user space (`~/.local/bin`) to avoid `sudo` assumptions.
+- Re-run script safely: Debian install is skipped if already present.
+- Use `multica daemon start --foreground` when collecting logs for troubleshooting.
+
+## Merge decision (current recommendation)
+
+**Recommendation: ยังไม่ merge ทันที** จนกว่าจะผ่าน "device validation" บนมือถือจริงอย่างน้อย 1 เครื่อง (Android ARM64 + Termux + Debian proot) ตามเกณฑ์ด้านล่าง
+
+### Merge gate (ต้องผ่านก่อน merge)
+
+1. Bootstrap ผ่านครบโดยไม่แก้สคริปต์หน้างาน
+   - `bash scripts/termux-proot-codex-multica-setup.sh`
+2. Auth ผ่านทั้งสองฝั่ง
+   - `codex login --device-auth` สำเร็จ
+   - `multica login --token` สำเร็จ
+3. Runtime พร้อมใช้งาน
+   - `multica daemon status` ต้องเห็น runtime สุขภาพปกติ
+4. End-to-end smoke task สำเร็จ
+   - Codex แก้ bug ตัวอย่าง + เพิ่ม test ได้จริง
+
+ถ้ายังไม่ผ่านครบ 4 ข้อนี้ ให้ถือเป็น **No-Go** และค้างที่สถานะ review/iterate ก่อน

--- a/scripts/start-m1-kickoff.sh
+++ b/scripts/start-m1-kickoff.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Day-0 kickoff helper for M1 Production Cutover.
+
+echo "[M1 Kickoff] date: $(date -u +%F)"
+echo "1) Freeze demo-only scope"
+echo "2) Open M1 epic + issue split"
+echo "3) Assign owners for A/B/C/D/E streams"
+echo "4) Start PR #1: schema/migration delta"
+echo "5) Start parallel Wave 1: A1 + B1 + D2 + E1"
+
+echo
+echo "Suggested labels: M1, cutover, no-demo"

--- a/scripts/termux-proot-codex-multica-setup.sh
+++ b/scripts/termux-proot-codex-multica-setup.sh
@@ -1,0 +1,105 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# Run this script in Termux (outside proot). It installs Debian via proot-distro,
+# then provisions Codex + Multica inside Debian as a non-root user setup.
+
+log() {
+  printf "\n[%s] %s\n" "$(date '+%H:%M:%S')" "$*"
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || {
+    printf "ERROR: missing command: %s\n" "$cmd" >&2
+    exit 1
+  }
+}
+
+log "Step 1/4: Prepare Termux packages"
+pkg update -y
+pkg upgrade -y
+pkg install -y proot-distro curl
+
+require_cmd proot-distro
+
+log "Step 2/4: Install Debian in proot (skip if already installed)"
+if ! proot-distro list | grep -q '^debian'; then
+  proot-distro install debian
+else
+  log "Debian already present, skipping install"
+fi
+
+log "Step 3/4: Create Debian bootstrap script"
+cat > "$HOME/.termux-debian-codex-multica.sh" <<'DEBIAN_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf "\n[%s] %s\n" "$(date '+%H:%M:%S')" "$*"
+}
+
+log "Debian: install base dependencies"
+apt update
+apt install -y curl ca-certificates git xz-utils tar nodejs npm procps
+
+log "Debian: install Codex CLI via npm"
+npm install -g @openai/codex
+codex --version
+
+log "Debian: configure Codex default settings"
+mkdir -p "$HOME/.codex"
+cat > "$HOME/.codex/config.toml" <<'CONFIG_EOF'
+model = "gpt-5.4"
+approval_policy = "on-request"
+CONFIG_EOF
+
+log "Debian: install Multica CLI to ~/.local/bin"
+mkdir -p "$HOME/.local/bin"
+OS=linux
+ARCH="$(uname -m)"
+
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *)
+    printf "Unsupported architecture: %s\n" "$ARCH" >&2
+    exit 1
+    ;;
+esac
+
+LATEST="$(curl -sI https://github.com/multica-ai/multica/releases/latest | awk -F'/' '/^location:/I{print $NF}' | tr -d '\r\n')"
+
+curl -sL "https://github.com/multica-ai/multica/releases/download/${LATEST}/multica_${OS}_${ARCH}.tar.gz" -o /tmp/multica.tar.gz
+tar -xzf /tmp/multica.tar.gz -C /tmp multica
+mv /tmp/multica "$HOME/.local/bin/multica"
+chmod +x "$HOME/.local/bin/multica"
+rm -f /tmp/multica.tar.gz
+
+grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" || \
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+export PATH="$HOME/.local/bin:$PATH"
+multica version
+
+cat <<'NEXT_STEPS'
+
+Setup complete.
+Next steps (run manually in Debian):
+  1) codex login --device-auth
+  2) multica login --token
+  3) multica daemon start
+  4) multica daemon status
+
+If Codex is not detected:
+  export MULTICA_CODEX_PATH="$(which codex)"
+  multica daemon start --foreground
+NEXT_STEPS
+DEBIAN_EOF
+
+chmod +x "$HOME/.termux-debian-codex-multica.sh"
+
+log "Step 4/4: Execute bootstrap inside Debian"
+proot-distro login debian -- /bin/bash -lc '$HOME/.termux-debian-codex-multica.sh'
+
+log "Done. Enter Debian with: proot-distro login debian"


### PR DESCRIPTION
### Motivation

- Provide a coordinated two-milestone cutover plan (`M1`/`M2`) to migrate demo routes to DB-backed production flows and prevent new demo-only regressions. 
- Standardize orchestration, timeline, and parallel work streams so multiple teams can execute a production cutover in a controlled, auditable way. 
- Capture marketplace readiness and get-started acceptance criteria to meet top-tier app expectations for first-time user value, trust, and operability. 
- Supply a reproducible Termux → proot Debian bootstrap for installing `codex` and `multica` to enable local/mobile device validation and agent testing.

### Description

- Added comprehensive cutover and readiness documentation in `docs/PRODUCTION_CUTOVER_2_ROUNDS_2026-04-11.md`, `docs/PRODUCTION_START_TIMELINE_2026-04-11.md`, and orchestration and stream plans in `docs/ORCHESTRATION_PLAN_M1_M2_2026-04-11.md` to define scope, waves, and non-negotiables. 
- Added operational and acceptance artifacts including `docs/MARKETPLACE_GET_STARTED_ACCEPTANCE_CHECKLIST_2026-04-11.md`, `docs/MARKETPLACE_TOP_TIER_GAP_AND_GET_STARTED_2026-04-11.md`, `docs/ONE_DAY_14_TEAM_FEASIBILITY_2026-04-11.md`, and a deterministic merging protocol in `docs/DETERMINISTIC_EXECUTION_PROTOCOL_10X_2026-04-11.md`. 
- Added device/bootstrap automation scripts `scripts/start-m1-kickoff.sh` (kickoff helper) and `scripts/termux-proot-codex-multica-setup.sh` (Termux → Debian bootstrap that installs `codex` and `multica` and emits next-step instructions), both marked executable. 
- Included operational guidance, risk registers, merge gates, and suggested labels (`M1`, `M2`, `cutover`, `no-demo`) to drive PR/CI discipline and acceptance gates such as migration tests, `Vitest`, and smoke checks defined in the docs.

### Testing

- No automated tests were executed as part of this documentation and script-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da7bc4c0d083269e3ded8d61175c02)