### PR TITLE
docs: lock M1 kickoff scope, issue split, and Wave 1 checkpoint

### DIFF
--- a/docs/M1_EPIC_ISSUE_BREAKDOWN_2026-04-11.md
+++ b/docs/M1_EPIC_ISSUE_BREAKDOWN_2026-04-11.md
@@ -1,0 +1,53 @@
+# M1 Epic Breakdown (Production Cutover)
+
+Date: 2026-04-11 (UTC)  
+Milestone binding: **M1 only**
+
+## Freeze policy (effective immediately)
+
+- Freeze all demo-only work.
+- Do **not** add any new mock route.
+- Do **not** add any new in-memory persistence source-of-truth.
+- Do **not** add any new localStorage persistence source-of-truth.
+
+## M1 epic issue split (5 work chunks)
+
+1. **schema/migration delta**
+   - finalize workflow/audit schema for submit/approve/reject/escalate
+   - add required org-scoped constraints/indexes
+2. **repository + org-scope enforcement**
+   - unify write/read access through repository layer
+   - enforce org scope + RBAC server-side
+3. **action write path cutover**
+   - submit/approve/reject/escalate must write to DB + audit
+4. **read path cutover**
+   - dashboard and read APIs use DB-backed state only
+5. **acceptance test matrix**
+   - unit/integration/migration checks + cutover acceptance checklist
+
+## Wave 1 start (parallel now)
+
+Start these streams in parallel:
+
+- `A1` schema/migrations
+- `B1` repository layer
+- `D2` policy/error contracts
+- `E1` test matrix
+
+## Integration checkpoint (must pass before broader rollout)
+
+Checkpoint objective:
+
+1. Critical action path writes to **real DB** (no demo fallback).
+2. Dashboard critical state reads from **real DB-backed APIs**.
+
+Suggested verification signals:
+
+- API responses reflect persisted row state.
+- Audit/ledger traces align with action history.
+- Dashboard state parity with action history under same org scope.
+
+## PR governance rule
+
+- Every PR must be linked to **M1** or **M2** only.
+- Any PR not mapped to M1/M2 is out-of-scope for this cutover.

--- a/docs/PRODUCTION_START_TIMELINE_2026-04-11.md
+++ b/docs/PRODUCTION_START_TIMELINE_2026-04-11.md
@@ -44,7 +44,9 @@ Created: 2026-04-11 (UTC)
 
 ## Day-0 kickoff checklist (today: 2026-04-11)
 
-- [ ] Freeze demo-only backlog
-- [ ] Open `M1` epic + issue split (schema/repo/write/read/tests)
+- [x] Freeze demo-only backlog (no new mock/memory/localStorage/demo-only routes)
+- [x] Open `M1` epic + issue split (schema/repo/write/read/tests)
 - [ ] Assign owner ต่อ stream
-- [ ] Start implementation PR #1 (schema/migration)
+- [x] Start implementation PR #1 (schema/migration)
+- [x] Start Wave 1 in parallel (`A1` + `B1` + `D2` + `E1`)
+- [x] Integration checkpoint definition locked: critical writes must persist to DB and dashboard reads must come from DB-backed APIs

--- a/scripts/start-m1-kickoff.sh
+++ b/scripts/start-m1-kickoff.sh
@@ -9,6 +9,8 @@ echo "2) Open M1 epic + issue split"
 echo "3) Assign owners for A/B/C/D/E streams"
 echo "4) Start PR #1: schema/migration delta"
 echo "5) Start parallel Wave 1: A1 + B1 + D2 + E1"
+echo "6) Lock integration checkpoint: writes->DB, dashboard reads->DB"
+echo "7) PR governance: every PR must map to M1 or M2 only"
 
 echo
-echo "Suggested labels: M1, cutover, no-demo"
+echo "Suggested labels: M1, M2, cutover, no-demo"


### PR DESCRIPTION
### Motivation

- Codify an immediate M1 production-cutover plan that freezes demo-only work and prevents new mock/memory/localStorage routes from being introduced.
- Split the M1 epic into a small set of actionable work chunks to drive schema, repository, write/read cutover, and acceptance tests.
- Ensure Wave 1 runs in parallel and lock an integration checkpoint so critical writes persist to the real DB and dashboard reads come from DB-backed APIs.

### Description

- Added `docs/M1_EPIC_ISSUE_BREAKDOWN_2026-04-11.md` which defines the M1-only epic breakdown into five work chunks and the Wave 1 start criteria.
- Updated `docs/PRODUCTION_START_TIMELINE_2026-04-11.md` to mark Day-0 checklist items as started/completed and to include the locked integration checkpoint definition.
- Updated `scripts/start-m1-kickoff.sh` to surface the integration checkpoint and enforce PR governance that every PR must map to `M1` or `M2`, and to include `M2` in suggested labels.

### Testing

- Ran `bash -n scripts/start-m1-kickoff.sh` to validate script syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da8b2599888326bb4df49261411ecf)