### PR TITLE
Deprecate/block finance server-store endpoints and add live DB integration tests

### DIFF
--- a/app/api/finance-governance/server-store/approvals/[id]/approve/route.ts
+++ b/app/api/finance-governance/server-store/approvals/[id]/approve/route.ts
@@ -1,27 +1,7 @@
-import { NextResponse } from 'next/server';
-import {
-  applyApprovalAction,
-  getServerWorkflowSnapshot,
-} from '../../../../../../../lib/finance-governance/server-memory-store';
+import { blockedServerStoreResponse } from '../../../../../../../lib/finance-governance/server-store-deprecated';
 
 export const dynamic = 'force-dynamic';
 
-type RouteContext = {
-  params: {
-    id: string;
-  };
-};
-
-export async function POST(_request: Request, context: RouteContext) {
-  const result = applyApprovalAction(context.params.id, 'approve');
-
-  return NextResponse.json(
-    {
-      result,
-      snapshot: getServerWorkflowSnapshot(),
-    },
-    {
-      status: 200,
-    }
-  );
+export async function POST() {
+  return blockedServerStoreResponse();
 }

--- a/app/api/finance-governance/server-store/approvals/[id]/escalate/route.ts
+++ b/app/api/finance-governance/server-store/approvals/[id]/escalate/route.ts
@@ -1,27 +1,7 @@
-import { NextResponse } from 'next/server';
-import {
-  applyApprovalAction,
-  getServerWorkflowSnapshot,
-} from '../../../../../../../lib/finance-governance/server-memory-store';
+import { blockedServerStoreResponse } from '../../../../../../../lib/finance-governance/server-store-deprecated';
 
 export const dynamic = 'force-dynamic';
 
-type RouteContext = {
-  params: {
-    id: string;
-  };
-};
-
-export async function POST(_request: Request, context: RouteContext) {
-  const result = applyApprovalAction(context.params.id, 'escalate');
-
-  return NextResponse.json(
-    {
-      result,
-      snapshot: getServerWorkflowSnapshot(),
-    },
-    {
-      status: 200,
-    }
-  );
+export async function POST() {
+  return blockedServerStoreResponse();
 }

--- a/app/api/finance-governance/server-store/approvals/[id]/reject/route.ts
+++ b/app/api/finance-governance/server-store/approvals/[id]/reject/route.ts
@@ -1,27 +1,7 @@
-import { NextResponse } from 'next/server';
-import {
-  applyApprovalAction,
-  getServerWorkflowSnapshot,
-} from '../../../../../../../lib/finance-governance/server-memory-store';
+import { blockedServerStoreResponse } from '../../../../../../../lib/finance-governance/server-store-deprecated';
 
 export const dynamic = 'force-dynamic';
 
-type RouteContext = {
-  params: {
-    id: string;
-  };
-};
-
-export async function POST(_request: Request, context: RouteContext) {
-  const result = applyApprovalAction(context.params.id, 'reject');
-
-  return NextResponse.json(
-    {
-      result,
-      snapshot: getServerWorkflowSnapshot(),
-    },
-    {
-      status: 200,
-    }
-  );
+export async function POST() {
+  return blockedServerStoreResponse();
 }

--- a/app/api/finance-governance/server-store/reset/route.ts
+++ b/app/api/finance-governance/server-store/reset/route.ts
@@ -1,10 +1,7 @@
-import { NextResponse } from 'next/server';
-import { resetServerWorkflowState } from '../../../../../lib/finance-governance/server-memory-store';
+import { blockedServerStoreResponse } from '../../../../../lib/finance-governance/server-store-deprecated';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST() {
-  return NextResponse.json(resetServerWorkflowState(), {
-    status: 200,
-  });
+  return blockedServerStoreResponse();
 }

--- a/app/api/finance-governance/server-store/state/route.ts
+++ b/app/api/finance-governance/server-store/state/route.ts
@@ -1,10 +1,7 @@
-import { NextResponse } from 'next/server';
-import { getServerWorkflowSnapshot } from '../../../../../lib/finance-governance/server-memory-store';
+import { blockedServerStoreResponse } from '../../../../../lib/finance-governance/server-store-deprecated';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  return NextResponse.json(getServerWorkflowSnapshot(), {
-    status: 200,
-  });
+  return blockedServerStoreResponse();
 }

--- a/app/api/finance-governance/server-store/submit/route.ts
+++ b/app/api/finance-governance/server-store/submit/route.ts
@@ -1,24 +1,7 @@
-import { NextResponse } from 'next/server';
-import {
-  getServerWorkflowSnapshot,
-  submitServerWorkflowItem,
-} from '../../../../../lib/finance-governance/server-memory-store';
+import { blockedServerStoreResponse } from '../../../../../lib/finance-governance/server-store-deprecated';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
-  const body = await request.json().catch(() => null);
-  const caseId = typeof body?.caseId === 'string' && body.caseId.trim().length > 0 ? body.caseId.trim() : 'server-case';
-
-  const result = submitServerWorkflowItem(caseId);
-
-  return NextResponse.json(
-    {
-      result,
-      snapshot: getServerWorkflowSnapshot(),
-    },
-    {
-      status: 200,
-    }
-  );
+export async function POST() {
+  return blockedServerStoreResponse();
 }

--- a/lib/finance-governance/server-store-deprecated.ts
+++ b/lib/finance-governance/server-store-deprecated.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+const MESSAGE = 'finance_governance_server_store_removed_use_scoped_endpoints';
+
+export function blockedServerStoreResponse() {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: MESSAGE,
+      deprecated: true,
+      replacement: '/api/finance-governance/*',
+    },
+    {
+      status: 410,
+      headers: {
+        'X-Deprecated': 'true',
+        'X-Replacement-Endpoint': '/api/finance-governance/*',
+      },
+    }
+  );
+}

--- a/tests/integration/api/finance-governance-live-db.test.ts
+++ b/tests/integration/api/finance-governance-live-db.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+
+const hasSupabaseEnv = Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY);
+const describeLive = hasSupabaseEnv ? describe : describe.skip;
+
+async function cleanupOrg(orgId: string) {
+  const supabase = getSupabaseAdmin() as any;
+  await supabase.from('finance_workflow_action_events').delete().eq('org_id', orgId);
+  await supabase.from('finance_workflow_approvals').delete().eq('org_id', orgId);
+  await supabase.from('finance_workflow_cases').delete().eq('org_id', orgId);
+}
+
+describeLive('finance governance API + repository + supabase (live)', () => {
+  const orgA = `it-live-org-a-${Date.now()}`;
+  const orgB = `it-live-org-b-${Date.now()}`;
+
+  beforeEach(async () => {
+    await cleanupOrg(orgA);
+    await cleanupOrg(orgB);
+  });
+
+  it('keeps org data isolated: org A submit does not leak to org B', async () => {
+    const { POST: submit } = await import('../../../app/api/finance-governance/submit/route');
+    const { GET: workspaceSummary } = await import('../../../app/api/finance-governance/workspace/summary/route');
+
+    const submitResponse = await submit(
+      new Request('http://localhost/api/finance-governance/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-org-id': orgA },
+        body: JSON.stringify({ caseId: 'sample-case' }),
+      })
+    );
+
+    expect(submitResponse.status).toBe(200);
+
+    const orgAResponse = await workspaceSummary(new Request('http://localhost/api/finance-governance/workspace/summary', { headers: { 'x-org-id': orgA } }));
+    const orgABody = await orgAResponse.json();
+
+    const orgBResponse = await workspaceSummary(new Request('http://localhost/api/finance-governance/workspace/summary', { headers: { 'x-org-id': orgB } }));
+    const orgBBody = await orgBResponse.json();
+
+    expect(orgAResponse.status).toBe(200);
+    expect(orgABody.workspace.counts.readyExports).toBe(1);
+    expect(orgBResponse.status).toBe(200);
+    expect(orgBBody.workspace.counts.readyExports).toBe(0);
+  });
+
+  it('writes audit trail timeline for submit → approve flow', async () => {
+    const { POST: submit } = await import('../../../app/api/finance-governance/submit/route');
+    const { POST: approve } = await import('../../../app/api/finance-governance/approvals/[id]/approve/route');
+    const { GET: caseDetail } = await import('../../../app/api/finance-governance/cases/[id]/route');
+
+    const submitResponse = await submit(
+      new Request('http://localhost/api/finance-governance/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-org-id': orgA },
+        body: JSON.stringify({ caseId: 'sample-case' }),
+      })
+    );
+    expect(submitResponse.status).toBe(200);
+
+    const approveResponse = await approve(new Request('http://localhost/api/finance-governance/approvals/APR-1001/approve', { method: 'POST', headers: { 'x-org-id': orgA } }), {
+      params: { id: 'APR-1001' },
+    });
+    expect(approveResponse.status).toBe(200);
+
+    const caseResponse = await caseDetail(new Request('http://localhost/api/finance-governance/cases/sample-case', { headers: { 'x-org-id': orgA } }), {
+      params: { id: 'sample-case' },
+    });
+    const caseBody = await caseResponse.json();
+
+    expect(caseResponse.status).toBe(200);
+    expect(caseBody.case.timeline.some((entry: string) => entry.startsWith('submit:'))).toBe(true);
+    expect(caseBody.case.timeline.some((entry: string) => entry.startsWith('approve:'))).toBe(true);
+  });
+});

--- a/tests/integration/api/finance-governance-server-store.test.ts
+++ b/tests/integration/api/finance-governance-server-store.test.ts
@@ -1,139 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+const EXPECTED_ERROR = 'finance_governance_server_store_removed_use_scoped_endpoints';
 
 describe('finance governance server store routes', () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
-  it('returns server store snapshot', async () => {
+  it('blocks server store snapshot endpoint with deprecation metadata', async () => {
     const { GET } = await import('../../../app/api/finance-governance/server-store/state/route');
 
     const response = await GET();
     const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body.workspace.workspace).toBe('Finance Governance Workspace');
-    expect(Array.isArray(body.approvals)).toBe(true);
+    expect(response.status).toBe(410);
+    expect(body.error).toBe(EXPECTED_ERROR);
+    expect(body.deprecated).toBe(true);
+    expect(response.headers.get('x-deprecated')).toBe('true');
   });
 
-  it('submits into server store and returns updated snapshot', async () => {
+  it('blocks submit endpoint', async () => {
     const { POST } = await import('../../../app/api/finance-governance/server-store/submit/route');
-
-    const request = new Request('http://localhost/api/finance-governance/server-store/submit', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ caseId: 'server-case-001' }),
-    });
-
-    const response = await POST(request);
+    const response = await POST();
     const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body.result.action).toBe('submit');
-    expect(body.snapshot.workspace.counts.readyExports).toBeGreaterThanOrEqual(1);
+    expect(response.status).toBe(410);
+    expect(body.error).toBe(EXPECTED_ERROR);
   });
 
-  it('applies approve action in server store', async () => {
-    const { POST } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/approve/route');
-
-    const request = new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1001/approve', {
-      method: 'POST',
-    });
-
-    const response = await POST(request, { params: { id: 'APR-1001' } });
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body.result.action).toBe('approve');
-    expect(body.snapshot.approvals.find((item: { id: string }) => item.id === 'APR-1001')?.status).toBe('approved');
-  });
-
-  it('applies reject action in server store', async () => {
-    const { POST } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/reject/route');
-
-    const request = new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1002/reject', {
-      method: 'POST',
-    });
-
-    const response = await POST(request, { params: { id: 'APR-1002' } });
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body.result.action).toBe('reject');
-    expect(body.snapshot.approvals.find((item: { id: string }) => item.id === 'APR-1002')?.status).toBe('rejected');
-  });
-
-  it('applies escalate action in server store', async () => {
-    const { POST } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/escalate/route');
-
-    const request = new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1003/escalate', {
-      method: 'POST',
-    });
-
-    const response = await POST(request, { params: { id: 'APR-1003' } });
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body.result.action).toBe('escalate');
-    expect(body.snapshot.approvals.find((item: { id: string }) => item.id === 'APR-1003')?.status).toBe('escalated');
-  });
-
-  it('resets server store state', async () => {
-    const { POST } = await import('../../../app/api/finance-governance/server-store/reset/route');
-
-    const request = new Request('http://localhost/api/finance-governance/server-store/reset', {
-      method: 'POST',
-    });
-
-    const response = await POST(request);
-    const body = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(body.workspace.workspace).toBe('Finance Governance Workspace');
-    expect(body.workspace.counts.readyExports).toBe(0);
-  });
-
-  it('runs submit → approve → reject → escalate flow and returns synchronized API state', async () => {
-    const { POST: reset } = await import('../../../app/api/finance-governance/server-store/reset/route');
-    const { POST: submit } = await import('../../../app/api/finance-governance/server-store/submit/route');
+  it('blocks approve/reject/escalate/reset endpoints', async () => {
     const { POST: approve } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/approve/route');
     const { POST: reject } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/reject/route');
     const { POST: escalate } = await import('../../../app/api/finance-governance/server-store/approvals/[id]/escalate/route');
-    const { GET: getState } = await import('../../../app/api/finance-governance/server-store/state/route');
+    const { POST: reset } = await import('../../../app/api/finance-governance/server-store/reset/route');
 
-    await reset(new Request('http://localhost/api/finance-governance/server-store/reset', { method: 'POST' }));
-
-    const submitResponse = await submit(
-      new Request('http://localhost/api/finance-governance/server-store/submit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ caseId: 'sequence-case-001' }),
-      })
-    );
-    expect(submitResponse.status).toBe(200);
-
-    const approveResponse = await approve(new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1001/approve', { method: 'POST' }), {
-      params: { id: 'APR-1001' },
-    });
-    expect(approveResponse.status).toBe(200);
-
-    const rejectResponse = await reject(new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1002/reject', { method: 'POST' }), {
-      params: { id: 'APR-1002' },
-    });
-    expect(rejectResponse.status).toBe(200);
-
-    const escalateResponse = await escalate(new Request('http://localhost/api/finance-governance/server-store/approvals/APR-1003/escalate', { method: 'POST' }), {
-      params: { id: 'APR-1003' },
-    });
-    expect(escalateResponse.status).toBe(200);
-
-    const stateResponse = await getState();
-    const stateBody = await stateResponse.json();
-
-    expect(stateResponse.status).toBe(200);
-    expect(stateBody.workspace.counts.readyExports).toBe(1);
-    expect(stateBody.approvals.find((item: { id: string }) => item.id === 'APR-1001')?.status).toBe('approved');
-    expect(stateBody.approvals.find((item: { id: string }) => item.id === 'APR-1002')?.status).toBe('rejected');
-    expect(stateBody.approvals.find((item: { id: string }) => item.id === 'APR-1003')?.status).toBe('escalated');
+    for (const call of [approve, reject, escalate, reset]) {
+      const response = await call();
+      const body = await response.json();
+      expect(response.status).toBe(410);
+      expect(body.error).toBe(EXPECTED_ERROR);
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent use of the in-memory `server-store` endpoints in production because they bypass persistent, audited Supabase state and threaten multitenant correctness.
- Add non-mocked live integration coverage for critical org isolation and audit timeline behavior (API → Repository → Supabase → DB).

### Description
- Replace all `app/api/finance-governance/server-store/*` handlers to return a single `410 Gone` response via a shared helper in `lib/finance-governance/server-store-deprecated.ts` and include deprecation metadata and a replacement hint (`/api/finance-governance/*`).
- Remove runtime behavior from the server-memory endpoints so they are blocked consistently (`state`, `submit`, `reset`, `approvals/*/approve|reject|escalate`).
- Update the server-store integration test to assert the endpoints are blocked and return the deprecation payload.
- Add `tests/integration/api/finance-governance-live-db.test.ts` which runs only when Supabase env vars are present and verifies org A → submit does not leak to org B and that a `submit → approve` flow produces `submit:` and `approve:` entries in the case timeline.

### Testing
- Ran `vitest run tests/integration/api/finance-governance-server-store.test.ts tests/integration/api/finance-governance-live-db.test.ts` and observed the server-store test passed and the live DB test suite was skipped automatically when Supabase env vars were not present.
- Ran `vitest run tests/integration/api/finance-governance-actions.test.ts tests/integration/api/finance-governance-api.test.ts` and observed both test files passed.
- The added live tests are gated by environment (`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`) so they run only in environments with Supabase access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da93279a0c8326bd2db8518c37b02a)