### PR TITLE
docs: add remaining tasks checklist for production readiness

### DIFF
--- a/docs/REMAINING_TASKS_2026-04-11.md
+++ b/docs/REMAINING_TASKS_2026-04-11.md
@@ -1,0 +1,38 @@
+# Remaining Tasks (as of 2026-04-11)
+
+## Immediate blockers
+
+1. **Fix E2E pipeline environment**
+   - Resolve Playwright browser install/download failure (HTTP 403 in CI/runtime environment).
+   - Add deterministic setup for browsers (pinned versions + mirror/cache strategy).
+
+## Before production launch
+
+2. **Run full E2E suite after Playwright fix**
+   - Re-run end-to-end flows for auth, dashboard, billing checkout, and core API journeys.
+
+3. **Deployment validation in staging**
+   - Apply latest migrations to a staging database.
+   - Validate API health checks, auth redirects, RBAC, and runtime execution paths.
+
+4. **Secrets and runtime configuration hardening**
+   - Verify all required environment variables are present for Vercel/Supabase/Stripe/Resend.
+   - Rotate any temporary or shared credentials used during setup.
+
+5. **Operational readiness checks**
+   - Confirm logging, alerting, and incident runbooks are usable by on-call operators.
+   - Execute smoke tests from runbook after deployment.
+
+## Recommended quality gates
+
+6. **CI quality gate policy**
+   - Keep Vitest (unit/integration/migration/negative) as required.
+   - Make E2E required once Playwright environment issue is fixed.
+
+7. **Release checklist formalization**
+   - Add a single release checklist covering schema migration order, rollback plan, and post-deploy verification.
+
+## Summary
+
+- Application code quality is strong based on provided results (85/85 Vitest passed).
+- Main remaining risk is **environment/infrastructure readiness** (especially E2E runtime and deployment operations), not core feature completeness.


### PR DESCRIPTION
### Motivation
- Capture and communicate the remaining operational and environment tasks required before production launch because unit/integration tests are green but E2E and deployment readiness remain outstanding.

### Description
- Add `docs/REMAINING_TASKS_2026-04-11.md` containing a concise checklist covering the immediate Playwright browser-install blocker (HTTP 403), re-running full E2E flows, staging migration and validation, secrets/runtime hardening, operational readiness checks, and CI quality gate / release checklist recommendations.

### Testing
- Documentation-only change with no runtime code modifications, and the repository’s test status shows `Vitest: 85 tests across 41 files, 0 failures`, while E2E currently fails due to a Playwright browser download environment issue (not a code bug).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da9fbf91408326bebcdd11148c32ec)