### PR TITLE
Improve Playwright E2E setup with configurable browser path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:failure": "vitest run tests/failure",
-    "test:migrations": "vitest run tests/migrations"
+    "test:migrations": "vitest run tests/migrations",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium",
+    "test:e2e:install:shell": "playwright install --only-shell chromium"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 60_000,
@@ -8,6 +10,7 @@ export default defineConfig({
   use: {
     baseURL: 'http://127.0.0.1:3000',
     trace: 'on-first-retry',
+    ...(chromiumExecutablePath ? { launchOptions: { executablePath: chromiumExecutablePath } } : {}),
   },
   webServer: {
     command: 'ENABLE_DEMO_BOOTSTRAP=true DEMO_BOOTSTRAP_TOKEN=e2e NEXT_PUBLIC_DEMO_BOOTSTRAP_TOKEN=e2e npm run dev',


### PR DESCRIPTION
### Motivation
- E2E runs were blocked by network/proxy restrictions that prevent Playwright from downloading browsers from the CDN, so tests must be runnable when downloads are unavailable.
- Provide explicit npm scripts and a way for CI/runtime to point Playwright at a preinstalled Chromium/Chrome binary to make E2E reliable in restricted environments.

### Description
- Added E2E scripts to `package.json`: `test:e2e`, `test:e2e:install`, and `test:e2e:install:shell` to standardize running tests and browser install flows.
- Updated `playwright.config.ts` to read `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` and pass it as `launchOptions.executablePath` when present, allowing Playwright to use a preinstalled browser binary.
- Small config-only changes; no runtime application logic was modified.

### Testing
- `npm test` (Vitest suite) executed and passed successfully (unit/integration/migration tests ran as expected).
- `npx playwright test --list` succeeded and listed the available E2E specs.
- `npx playwright install chromium` failed in this environment due to CDN/network policy returning HTTP 403, reproducing the original issue.
- `npm run test:e2e` failed here because no browser executable was available in the Playwright cache, demonstrating the need for `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` or preinstalled browser in CI/staging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69daa1b129888326a96588ac799c40b9)