### PR TITLE
Update enterprise-proof E2E test to match revised walkthrough text and remove obsolete click

### DIFF
--- a/tests/e2e/enterprise-proof.spec.ts
+++ b/tests/e2e/enterprise-proof.spec.ts
@@ -4,9 +4,8 @@ test('enterprise walkthrough shows all checkpoints', async ({ page }) => {
   await page.goto('/enterprise-proof/start');
 
   await expect(page.getByTestId('enterprise-proof-start')).toBeVisible();
-  await expect(page.getByTestId('walkthrough-steps')).toContainText('Product value and landing positioning');
+  await expect(page.getByTestId('walkthrough-steps')).toContainText('Public proof narrative introduces the product and route boundary');
 
-  await page.getByRole('button', { name: 'Bootstrap Demo Runtime Evidence' }).click();
   await expect(page.getByTestId('demo-context')).toBeVisible();
 
   await page.getByTestId('open-executive-report').click();


### PR DESCRIPTION
### Motivation
- Sync the Playwright E2E test with recent UI/content changes by updating the expected walkthrough wording and removing an obsolete button click.

### Description
- In `tests/e2e/enterprise-proof.spec.ts` updated the expected text in the `toContainText` assertion from `Product value and landing positioning` to `Public proof narrative introduces the product and route boundary`.
- Removed the now-unnecessary `getByRole('button', { name: 'Bootstrap Demo Runtime Evidence' }).click()` call from the test.

### Testing
- Ran the Playwright E2E test `tests/e2e/enterprise-proof.spec.ts` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69daa474dc6083268f010e6816405876)