### PR TITLE
Add live Supabase E2E test and staging rerun support

### DIFF
--- a/docs/RUNBOOK_DEPLOY.md
+++ b/docs/RUNBOOK_DEPLOY.md
@@ -234,3 +234,31 @@ If these values are incorrect, `createClient()` / admin client initialization ca
 ## Roll-forward criteria
 - All checks pass without elevated error rate.
 - Core monitor remains stable with `readiness_status: "ready"`.
+
+## 8) Live E2E flow (no mocks) against Supabase, then staging rerun
+Use this flow when validating end-to-end state transitions through the real finance-governance APIs and database.
+
+### Prerequisites
+- Playwright browser installed (`npm run test:e2e:install`).
+- Live Supabase env vars available in shell:
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+- (Optional) Staging deployment credentials for Vercel CLI.
+
+### Step A: Run live E2E locally against real Supabase
+```bash
+npm run test:e2e:live
+```
+This executes `tests/e2e/finance-governance-live-supabase.spec.ts` and verifies UI actions plus Supabase persistence.
+
+### Step B: Deploy to staging
+```bash
+npx vercel deploy --target=preview
+```
+Capture the generated staging URL.
+
+### Step C: Re-run the same live E2E against staging
+```bash
+PLAYWRIGHT_BASE_URL=<staging-url> npm run test:e2e:live
+```
+When `PLAYWRIGHT_BASE_URL` is set, Playwright uses the staging URL and does not start a local dev server.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:migrations": "vitest run tests/migrations",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install --with-deps chromium",
-    "test:e2e:install:shell": "playwright install --only-shell chromium"
+    "test:e2e:install:shell": "playwright install --only-shell chromium",
+    "test:e2e:live": "playwright test tests/e2e/finance-governance-live-supabase.spec.ts",
+    "test:e2e:staging": "PLAYWRIGHT_BASE_URL=${PLAYWRIGHT_BASE_URL:-https://staging.example.com} playwright test tests/e2e/finance-governance-live-supabase.spec.ts"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000';
+const runAgainstExternalBaseUrl = Boolean(process.env.PLAYWRIGHT_BASE_URL);
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -8,16 +10,18 @@ export default defineConfig({
   fullyParallel: false,
   retries: 0,
   use: {
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL,
     trace: 'on-first-retry',
     ...(chromiumExecutablePath ? { launchOptions: { executablePath: chromiumExecutablePath } } : {}),
   },
-  webServer: {
-    command: 'ENABLE_DEMO_BOOTSTRAP=true DEMO_BOOTSTRAP_TOKEN=e2e NEXT_PUBLIC_DEMO_BOOTSTRAP_TOKEN=e2e npm run dev',
-    port: 3000,
-    reuseExistingServer: true,
-    timeout: 120_000,
-  },
+  webServer: runAgainstExternalBaseUrl
+    ? undefined
+    : {
+        command: 'ENABLE_DEMO_BOOTSTRAP=true DEMO_BOOTSTRAP_TOKEN=e2e NEXT_PUBLIC_DEMO_BOOTSTRAP_TOKEN=e2e npm run dev',
+        port: 3000,
+        reuseExistingServer: true,
+        timeout: 120_000,
+      },
   projects: [
     {
       name: 'chromium',

--- a/tests/e2e/finance-governance-live-supabase.spec.ts
+++ b/tests/e2e/finance-governance-live-supabase.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const hasLiveSupabaseEnv = Boolean(supabaseUrl && supabaseServiceRoleKey);
+
+const describeLive = hasLiveSupabaseEnv ? test.describe : test.describe.skip;
+
+describeLive('finance governance live e2e against supabase', () => {
+  function getSupabase() {
+    return createClient(supabaseUrl!, supabaseServiceRoleKey!, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  async function cleanupOrg(orgId: string) {
+    const supabase = getSupabase();
+    await supabase.from('finance_workflow_action_events').delete().eq('org_id', orgId);
+    await supabase.from('finance_workflow_approvals').delete().eq('org_id', orgId);
+    await supabase.from('finance_workflow_cases').delete().eq('org_id', orgId);
+  }
+
+  test('submit -> approve persists to Supabase and updates workflow UI', async ({ page }) => {
+    const orgId = `pw-live-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+    await cleanupOrg(orgId);
+
+    await page.addInitScript((value) => {
+      window.localStorage.setItem('finance-governance-demo-org-id', value);
+    }, orgId);
+
+    await page.goto('/finance-governance/live/workflow');
+
+    await expect(page.getByRole('heading', { name: 'Read, act, and refresh in one workflow surface' })).toBeVisible();
+    await expect(page.locator('tr', { hasText: 'APR-1001' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Submit sample workflow item' }).click();
+    await expect(page.getByText('Submitted for review. Next status: pending.')).toBeVisible();
+
+    const approvalRow = page.locator('tr', { hasText: 'APR-1001' });
+    await approvalRow.getByRole('button', { name: 'Approve' }).click();
+    await expect(page.getByText('Approval completed. Next status: approved.')).toBeVisible();
+    await expect(approvalRow.getByText('approved')).toBeVisible();
+
+    const supabase = getSupabase();
+
+    const { data: events, error: eventsError } = await supabase
+      .from('finance_workflow_action_events')
+      .select('action')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: true });
+
+    expect(eventsError).toBeNull();
+    expect((events ?? []).map((item) => item.action)).toEqual(expect.arrayContaining(['submit', 'approve']));
+
+    const { data: approval, error: approvalError } = await supabase
+      .from('finance_workflow_approvals')
+      .select('status')
+      .eq('org_id', orgId)
+      .eq('id', 'APR-1001')
+      .single();
+
+    expect(approvalError).toBeNull();
+    expect(approval?.status).toBe('approved');
+
+    await cleanupOrg(orgId);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a real end-to-end Playwright test that runs against Supabase (no route mocks) to validate the full submit → approve flow and persisted DB state, and enable re-running the same test against a staging/preview deployment without starting a local dev server.

### Description
- Add a new Playwright spec `tests/e2e/finance-governance-live-supabase.spec.ts` that drives `/finance-governance/live/workflow`, asserts UI transitions, and verifies persistence in `finance_workflow_action_events` and `finance_workflow_approvals` (auto-skips when required env vars are absent). 
- Update `playwright.config.ts` to support `PLAYWRIGHT_BASE_URL` and disable the local `webServer` when an external base URL is provided. 
- Add npm scripts `test:e2e:live` and `test:e2e:staging` to run the live spec locally or against a staging URL respectively. 
- Document the live run → deploy preview → rerun workflow in `docs/RUNBOOK_DEPLOY.md`.

### Testing
- Ran `npx playwright test tests/e2e/enterprise-proof.spec.ts --list` which listed the test successfully. 
- Ran `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=test npx playwright test tests/e2e/finance-governance-live-supabase.spec.ts --list` which listed the new live test successfully. 
- Ran `npm run typecheck` which failed due to pre-existing TypeScript errors in `tests/e2e/finance-governance-workflow.spec.ts` (not introduced by these changes). 
- Attempted `npx vercel deploy --target=preview --yes` which could not complete in this environment due to network/credential limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69daa96ceb048326b4acc1ab5064a5f5)