### PR TITLE
Fix Playwright E2E type errors in finance-governance-workflow.spec.ts

### DIFF
--- a/tests/e2e/finance-governance-workflow.spec.ts
+++ b/tests/e2e/finance-governance-workflow.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Route } from '@playwright/test';
 
 type Approval = {
   id: string;
@@ -37,7 +37,7 @@ test.describe('finance governance workflow e2e', () => {
 
     await page.route('**/api/finance-governance/**', async (route) => {
       const request = route.request();
-      const orgId = request.headerValue('x-org-id') ?? 'org-demo-live';
+      const orgId = (await request.headerValue('x-org-id')) ?? 'org-demo-live';
       const state = orgStore.get(orgId) ?? createOrgState();
       orgStore.set(orgId, state);
 
@@ -103,9 +103,9 @@ test.describe('finance governance workflow e2e', () => {
   test('org isolation keeps workflow state separate between org headers', async ({ browser }) => {
     const orgStore = new Map<string, OrgState>();
 
-    const handler = async (route: Parameters<Parameters<typeof test>[1]>[0]['route'][0]) => {
+    const handler = async (route: Route) => {
       const request = route.request();
-      const orgId = request.headerValue('x-org-id') ?? 'org-demo-live';
+      const orgId = (await request.headerValue('x-org-id')) ?? 'org-demo-live';
       const state = orgStore.get(orgId) ?? createOrgState();
       orgStore.set(orgId, state);
       const url = new URL(request.url());


### PR DESCRIPTION
### Motivation
- Resolve TypeScript type-check failures in the Playwright E2E test caused by incorrect use of `request.headerValue` and an overly complex handler typing so the test suite can typecheck cleanly.

### Description
- Updated `tests/e2e/finance-governance-workflow.spec.ts` to import Playwright's `Route` type and use it for the shared handler signature.
- Await `request.headerValue('x-org-id')` before applying the fallback so `orgId` is always a `string` rather than `Promise<string> | string`.

### Testing
- Ran `npm run typecheck` which passed, and executed `npm run test:e2e:live` and `npm run test:e2e:staging` where the targeted spec executed but was skipped by live-environment gating (no failures from the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69daab94b8f88326a9bde78b2ac2f5cd)