### PR TITLE
Add deploy scripts and Playwright Chromium auto-detect helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
     "test:integration": "vitest run tests/integration",
     "test:failure": "vitest run tests/failure",
     "test:migrations": "vitest run tests/migrations",
-    "test:e2e": "playwright test",
+    "test:e2e": "./scripts/with-playwright-chromium.sh playwright test",
     "test:e2e:install": "playwright install --with-deps chromium",
     "test:e2e:install:shell": "playwright install --only-shell chromium",
-    "test:e2e:live": "playwright test tests/e2e/finance-governance-live-supabase.spec.ts",
-    "test:e2e:staging": "PLAYWRIGHT_BASE_URL=${PLAYWRIGHT_BASE_URL:-https://staging.example.com} playwright test tests/e2e/finance-governance-live-supabase.spec.ts"
+    "test:e2e:live": "./scripts/with-playwright-chromium.sh playwright test tests/e2e/finance-governance-live-supabase.spec.ts",
+    "test:e2e:staging": "./scripts/with-playwright-chromium.sh env PLAYWRIGHT_BASE_URL=${PLAYWRIGHT_BASE_URL:-https://staging.example.com} playwright test tests/e2e/finance-governance-live-supabase.spec.ts",
+    "deploy": "npx vercel deploy --target=preview --yes",
+    "deploy:preview": "npx vercel deploy --target=preview --yes",
+    "deploy:prod": "npx vercel deploy --prod --yes"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",

--- a/scripts/with-playwright-chromium.sh
+++ b/scripts/with-playwright-chromium.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH:-}" ]]; then
+  for candidate in /usr/bin/chromium /usr/bin/google-chrome /usr/bin/google-chrome-stable /usr/bin/chromium-browser; do
+    if [[ -x "$candidate" ]] && "$candidate" --version >/dev/null 2>&1; then
+      export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="$candidate"
+      break
+    fi
+  done
+fi
+
+exec "$@"


### PR DESCRIPTION
### Motivation
- Unblock the release pipeline by adding a minimal `deploy` command and make E2E runs more robust when a system Chromium/Chrome is available. 
- The change is intended to resolve non-logic blockers (missing deploy script and Playwright runtime/Browser executable) so CI can run E2E where environment permits.

### Description
- Added Vercel deploy scripts to `package.json`: `deploy`, `deploy:preview`, and `deploy:prod` (using `npx vercel`).
- Wrapped existing E2E commands in `package.json` to invoke a helper script so the Playwright run can auto-detect a system browser before launching Playwright.
- Added `scripts/with-playwright-chromium.sh`, which respects an existing `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` and otherwise probes common system paths (`/usr/bin/chromium`, `/usr/bin/google-chrome`, `/usr/bin/google-chrome-stable`, `/usr/bin/chromium-browser`) and exports `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` when a usable binary is found, then `exec`s the Playwright command.

### Testing
- `npm run typecheck` succeeded. 
- `npm test` (unit/integration/migration vitest suite) succeeded. 
- `npm run test:e2e` failed because Playwright could not find/download a Chromium executable in this environment (browser runtime missing). 
- `npm run test:e2e:install` failed due to Playwright browser download being blocked by the environment CDN (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69daae7e6c548326b86c1f44e5330cb0)