### PR TITLE
docs: record Playwright Chromium env note in production-ready file list

### DIFF
--- a/docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md
+++ b/docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md
@@ -339,3 +339,10 @@
 - **Security** (rate-limit, safe-log, error handling)
 
 Vitest ผ่านครบ **85/85 tests** ใน 41 test files โดย E2E fail เฉพาะเรื่อง Playwright browser download (403) ไม่ใช่ bug ของโค้ด
+
+---
+
+## หมายเหตุสภาพแวดล้อม (2026-04-11)
+
+ตรวจสอบตัวแปร `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` แล้วพบว่ายังว่าง (`""`) ใน environment ปัจจุบัน จึงสอดคล้องกับอาการ E2E ที่ติดตั้ง browser ไม่สำเร็จ (403) โดยไม่ใช่ regression จากโค้ดแอปพลิเคชัน.
+


### PR DESCRIPTION
### Motivation
- Add an environment note to the production-ready inventory to document why Playwright E2E failed (browser install 403) and capture that `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` is empty in the current environment.

### Description
- Updated `docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md` to append an environment note dated 2026-04-11 explaining the empty `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` and its relation to the Playwright browser-install 403 issue.

### Testing
- Confirmed the environment check by running `echo "Using Chromium at: $PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"` which printed an empty value indicating the variable is unset. 
- Existing automated test summary remains `Vitest: 85 tests, 41 test files, 0 failures` as documented in the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dab079afc4832691e035ffd1a1464e)