### PR TITLE
ci: add dedicated E2E pipeline workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: E2E Pipeline
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CI: true
+      NEXT_TELEMETRY_DISABLED: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit + integration tests
+        run: npm test
+
+      - name: E2E tests
+        run: npm run test:e2e
+
+      - name: Live E2E tests
+        run: npm run test:e2e:live
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY }}


### PR DESCRIPTION
### Motivation
- Playwright browser installation and execution frequently fails in Termux environments, so running E2E on GitHub-hosted Ubuntu runners ensures reliable browser setup and test execution.

### Description
- Add `.github/workflows/e2e.yml` which sets up Node 20, runs `npm ci`, installs Playwright browsers with `npx playwright install --with-deps`, then runs `npm run typecheck`, the test suite, `npm run test:e2e`, and the live E2E job (`npm run test:e2e:live`) wired to Supabase secrets.

### Testing
- Verified the new workflow YAML parses successfully using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/e2e.yml')"` which returned OK.
- Attempted to validate the YAML with a Python snippet but it failed due to the environment missing the `PyYAML` module (not a workflow problem).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dab28561588326a88d4ad00f30e956)