### PR TITLE
docs: add enterprise/marketplace readiness snapshot (2026-04-11)

### DIFF
--- a/docs/STATUS_SNAPSHOT_2026-04-11.md
+++ b/docs/STATUS_SNAPSHOT_2026-04-11.md
@@ -1,0 +1,25 @@
+# Status Snapshot (2026-04-11)
+
+## Direct answer
+
+- **Enterprise-ready:** ยังไม่ 100% Go-Live ตามเกต เพราะยังมีงานปิด gap ด้าน release governance/security และ evidence sign-off ที่ต้องผ่านครบก่อนเปิด production เต็มรูปแบบ
+- **Marketplace-ready:** ยังไม่ถึงเกณฑ์ top-tier/submit-ready เพราะ checklist onboarding/get-started และ trust/legal/support package ยังไม่ปิดครบ
+
+## Open items before enterprise Go-Live
+
+1. CI lockfile guard และ deterministic install enforcement
+2. Error handling policy enforcement แบบใช้ helper กลางทุก endpoint
+3. Explicit CORS policy (กรณี external client)
+4. Script governance สำหรับ production
+
+## Open items before marketplace submission
+
+1. ปิด checklist A–F ใน Marketplace Get Started Acceptance ให้ครบ
+2. ทำ onboarding flow บัญชีใหม่ให้จบจริงโดยไม่พึ่ง manual DB fix/feature flag เฉพาะกิจ
+3. ทำ Terms/Privacy/Security/Support surface ให้พร้อมใช้งานจริง
+4. ให้ demo script = production flow เดียวกับลูกค้า
+
+## Evidence note
+
+- เอกสาร production-ready file list และผลเทส Vitest 85/85 เป็นฐานที่แข็งแรง
+- แต่เอกสาร launch-gate หลายชุดยังระบุงานค้างสำหรับ go-live/submission


### PR DESCRIPTION
### Motivation
- Capture the current readiness position for enterprise Go‑Live and marketplace submission in a single operational snapshot so outstanding launch gates are explicit (`docs/STATUS_SNAPSHOT_2026-04-11.md`).

### Description
- Add `docs/STATUS_SNAPSHOT_2026-04-11.md` containing a direct answer on enterprise/marketplace readiness and concise lists of open items; this is documentation-only and does not change runtime code.

### Testing
- Automated test summary: `Vitest` passed all tests (85 tests across 41 files, 0 failures); Playwright E2E reported a browser install issue (403) which is an environment artifact and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dab591feb88326a5c46bcbd59cf819)