### PR TITLE
Add access request review API, UI actions, script fix, and integration tests

### DIFF
--- a/app/api/access/review/route.ts
+++ b/app/api/access/review/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgPermission } from '../../../../lib/auth/require-org-permission';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { handleApiError } from '../../../../lib/security/api-error';
+
+function normalizeEmail(value: unknown) {
+  return String(value || '').trim().toLowerCase();
+}
+
+async function parseBody(request: NextRequest) {
+  const contentType = request.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return (await request.json()) as Record<string, unknown>;
+  }
+
+  const form = await request.formData();
+  return {
+    request_id: form.get('request_id'),
+    action: form.get('action'),
+    role: form.get('role'),
+    note: form.get('note'),
+  } as Record<string, unknown>;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const access = await requireOrgPermission('org.manage_access');
+    if ('status' in access) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
+    const body = await parseBody(request);
+    const requestId = String(body.request_id || '').trim();
+    const action = String(body.action || '').trim().toLowerCase();
+    const role = String(body.role || 'operator').trim().toLowerCase();
+    const note = String(body.note || '').trim() || null;
+
+    if (!requestId) {
+      return NextResponse.json({ error: 'request_id is required' }, { status: 400 });
+    }
+    if (action !== 'approve' && action !== 'reject') {
+      return NextResponse.json({ error: 'action must be approve or reject' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+    const { data: reqRow, error: reqErr } = await admin
+      .from('access_requests')
+      .select('id, email, org_id, status')
+      .eq('id', requestId)
+      .maybeSingle();
+
+    if (reqErr || !reqRow?.id) {
+      return NextResponse.json({ error: 'request not found' }, { status: 404 });
+    }
+    if (reqRow.status !== 'pending') {
+      return NextResponse.json({ error: 'request already reviewed' }, { status: 409 });
+    }
+    if (reqRow.org_id && reqRow.org_id !== access.orgId) {
+      return NextResponse.json({ error: 'cross-org review is not allowed' }, { status: 403 });
+    }
+
+    const nextStatus = action === 'approve' ? 'approved' : 'rejected';
+    const { error: updateErr } = await admin
+      .from('access_requests')
+      .update({
+        status: nextStatus,
+        org_id: access.orgId,
+        reviewed_by_user_id: access.userId,
+        review_note: note,
+      })
+      .eq('id', requestId);
+    if (updateErr) throw updateErr;
+
+    if (action === 'approve') {
+      const email = normalizeEmail(reqRow.email);
+      const { data: targetUser } = await admin
+        .from('users')
+        .select('id')
+        .eq('email', email)
+        .maybeSingle();
+
+      if (targetUser?.id) {
+        await admin
+          .from('users')
+          .update({ org_id: access.orgId, role, is_active: true })
+          .eq('id', targetUser.id);
+
+        await admin
+          .from('user_org_roles')
+          .upsert({ org_id: access.orgId, user_id: targetUser.id, role }, { onConflict: 'org_id,user_id,role', ignoreDuplicates: true });
+
+        const runtimeRole = role === 'owner' || role === 'admin' ? 'org_admin' : role === 'viewer' ? 'reviewer' : role;
+        await admin
+          .from('runtime_roles')
+          .upsert({ org_id: access.orgId, user_id: targetUser.id, role: runtimeRole }, { onConflict: 'org_id,user_id,role', ignoreDuplicates: true });
+      }
+    }
+
+    await admin.from('sign_in_events').insert({
+      email: normalizeEmail(reqRow.email),
+      org_id: access.orgId,
+      auth_user_id: access.authUserId,
+      event_type: 'request_access_reviewed',
+      source: 'access-review',
+      success: true,
+      metadata: { request_id: requestId, action, role, reviewed_by_user_id: access.userId },
+    });
+
+    const acceptsHtml = (request.headers.get('accept') || '').includes('text/html');
+    if (acceptsHtml) {
+      return NextResponse.redirect(new URL('/dashboard/settings/access', request.url), { status: 302 });
+    }
+
+    return NextResponse.json({ ok: true, status: nextStatus });
+  } catch (error) {
+    return handleApiError('api/access/review', error);
+  }
+}

--- a/app/dashboard/settings/access/page.tsx
+++ b/app/dashboard/settings/access/page.tsx
@@ -63,16 +63,31 @@ export default async function DashboardAccessSettingsPage() {
           <table className="w-full text-left text-sm">
             <thead className="text-slate-400">
               <tr>
-                <th className="pb-2">Email</th><th className="pb-2">Domain</th><th className="pb-2">Workspace</th><th className="pb-2">Created</th><th className="pb-2">Status</th>
+                <th className="pb-2">Email</th><th className="pb-2">Domain</th><th className="pb-2">Workspace</th><th className="pb-2">Created</th><th className="pb-2">Status</th><th className="pb-2">Action</th>
               </tr>
             </thead>
             <tbody>
               {requests.map((item) => (
                 <tr key={item.id} className="border-t border-slate-800">
                   <td className="py-2">{item.email}</td><td>{item.email_domain}</td><td>{item.workspace_name || '-'}</td><td>{new Date(item.created_at).toLocaleString()}</td><td>{item.status}</td>
+                  <td>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <form action="/api/access/review" method="post" className="inline-flex items-center gap-2">
+                        <input type="hidden" name="request_id" value={item.id} />
+                        <input type="hidden" name="action" value="approve" />
+                        <input type="hidden" name="role" value="operator" />
+                        <button className="rounded-lg bg-emerald-500 px-3 py-1 text-xs font-semibold text-slate-950">Approve</button>
+                      </form>
+                      <form action="/api/access/review" method="post" className="inline-flex items-center gap-2">
+                        <input type="hidden" name="request_id" value={item.id} />
+                        <input type="hidden" name="action" value="reject" />
+                        <button className="rounded-lg border border-rose-500 px-3 py-1 text-xs font-semibold text-rose-300">Reject</button>
+                      </form>
+                    </div>
+                  </td>
                 </tr>
               ))}
-              {requests.length === 0 ? <tr><td colSpan={5} className="py-3 text-slate-400">No pending requests.</td></tr> : null}
+              {requests.length === 0 ? <tr><td colSpan={6} className="py-3 text-slate-400">No pending requests.</td></tr> : null}
             </tbody>
           </table>
         </div>

--- a/scripts/go-no-go-gate.sh
+++ b/scripts/go-no-go-gate.sh
@@ -14,7 +14,7 @@ check_endpoint() {
   local url="${BASE_URL%/}${path}"
   local code
   code=$(curl -sS -o /tmp/go-no-go-response.json -w "%{http_code}" --max-time 20 "$url" || echo "000")
-  if [[ "$code" =~ ^2|3 ]]; then
+  if [[ "$code" =~ ^(2|3)[0-9][0-9]$ ]]; then
     echo "✅ ${path} -> HTTP ${code}"
   else
     echo "❌ ${path} -> HTTP ${code}"
@@ -47,7 +47,7 @@ else
   failures=$((failures + 1))
 fi
 
-if rg -n '/api/finance-governance/server-store/' app lib; then
+if rg -n '/api/finance-governance/server-store/' app lib tests; then
   echo "❌ Legacy server-store caller(s) found"
   failures=$((failures + 1))
 else

--- a/tests/integration/api/access-review.test.ts
+++ b/tests/integration/api/access-review.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('/api/access/review', () => {
+  beforeEach(() => vi.resetModules());
+
+  it('returns 403 when reviewer lacks org.manage_access', async () => {
+    vi.doMock('../../../lib/auth/require-org-permission', () => ({
+      requireOrgPermission: vi.fn(async () => ({ ok: false, status: 403, error: 'Insufficient permission' })),
+    }));
+    vi.doMock('../../../lib/supabase-server', () => ({ getSupabaseAdmin: vi.fn(() => ({ from: vi.fn() })) }));
+
+    const { POST } = await import('../../../app/api/access/review/route');
+    const req = new Request('http://localhost/api/access/review', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ request_id: 'req_1', action: 'approve' }),
+    });
+
+    const res = await POST(req as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('approves pending access request and activates matching user', async () => {
+    vi.doMock('../../../lib/auth/require-org-permission', () => ({
+      requireOrgPermission: vi.fn(async () => ({
+        ok: true,
+        orgId: 'org_1',
+        userId: 'reviewer_1',
+        authUserId: 'auth_reviewer_1',
+        email: 'admin@acme.com',
+        role: 'admin',
+      })),
+    }));
+
+    const updateRequestEq = vi.fn(async () => ({ data: null, error: null }));
+    const updateUserEq = vi.fn(async () => ({ data: null, error: null }));
+    const upsertUserRole = vi.fn(async () => ({ data: null, error: null }));
+    const upsertRuntimeRole = vi.fn(async () => ({ data: null, error: null }));
+    const insertSignIn = vi.fn(async () => ({ data: null, error: null }));
+
+    const from = vi.fn((table: string) => {
+      if (table === 'access_requests') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: { id: 'req_1', email: 'user@acme.com', org_id: 'org_1', status: 'pending' }, error: null })),
+            })),
+          })),
+          update: vi.fn(() => ({ eq: updateRequestEq })),
+        };
+      }
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: { id: 'user_1' }, error: null })),
+            })),
+          })),
+          update: vi.fn(() => ({ eq: updateUserEq })),
+        };
+      }
+      if (table === 'user_org_roles') return { upsert: upsertUserRole };
+      if (table === 'runtime_roles') return { upsert: upsertRuntimeRole };
+      if (table === 'sign_in_events') return { insert: insertSignIn };
+      return {};
+    });
+
+    vi.doMock('../../../lib/supabase-server', () => ({ getSupabaseAdmin: vi.fn(() => ({ from })) }));
+
+    const { POST } = await import('../../../app/api/access/review/route');
+    const req = new Request('http://localhost/api/access/review', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ request_id: 'req_1', action: 'approve', role: 'operator' }),
+    });
+
+    const res = await POST(req as never);
+    expect(res.status).toBe(200);
+    expect(updateRequestEq).toHaveBeenCalledOnce();
+    expect(updateUserEq).toHaveBeenCalledOnce();
+    expect(upsertUserRole).toHaveBeenCalledOnce();
+    expect(upsertRuntimeRole).toHaveBeenCalledOnce();
+    expect(insertSignIn).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a server endpoint to let organization reviewers approve or reject access requests and materialize approved users into the org with appropriate roles.
- Expose quick approve/reject actions in the access settings UI so reviewers can act on pending requests from the dashboard.
- Harden the go/no-go gate script to correctly match HTTP 2xx/3xx responses and include the `tests` directory in legacy caller scans.

### Description
- Implemented a new `POST /api/access/review` handler at `app/api/access/review/route.ts` that validates reviewer permissions via `requireOrgPermission`, validates inputs, updates `access_requests` status, assigns `org_id` and `reviewed_by_user_id`, activates and assigns an existing `users` record when approving, upserts `user_org_roles` and `runtime_roles`, logs a `sign_in_events` entry, and returns JSON or redirects for HTML accept headers.
- Updated `app/dashboard/settings/access/page.tsx` to add an "Action" column with inline forms for `approve` and `reject` posting to the new endpoint and adjusted table column spans accordingly.
- Fixed `scripts/go-no-go-gate.sh` to use a stricter regex for 2xx/3xx HTTP detection and to search the `tests` directory when scanning for legacy `/api/finance-governance/server-store/` callers.
- Added integration tests at `tests/integration/api/access-review.test.ts` that mock dependencies and cover permission rejection and the approve workflow.

### Testing
- Ran the new `vitest` integration tests in `tests/integration/api/access-review.test.ts`, and both tests passed.
- No other automated tests were changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db25120f5083268f4c09a86c3cbd9a)