### PR TITLE
feat(agent-chat): support chatbot-agent setup plan and tool

### DIFF
--- a/app/dashboard/skills/page.tsx
+++ b/app/dashboard/skills/page.tsx
@@ -13,6 +13,7 @@ const TOOLS = [
   ["capacity", "GET /api/capacity", "Read quota and utilization"],
   ["list_agents", "GET /api/agents", "Read org agents and usage"],
   ["create_agent", "POST /api/agents", "Create new agent and one-time API key"],
+  ["create_chatbot_agent", "POST /api/agents", "Create chatbot-ready agent with default monthly limit"],
   ["list_policies", "GET /api/policies", "Read available policies"],
   ["reconcile_effect", "POST /api/effect-callback", "Reconcile effect status"],
   ["auto_setup", "POST /api/setup/auto", "Auto-configure: policy + agent + execution + billing + onboarding"],

--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -10,6 +10,11 @@ function extractEffectId(message: string) {
   return match ? match[0] : '';
 }
 
+function extractQuotedName(message: string) {
+  const match = message.match(/["“”']([^"“”']{2,80})["“”']/);
+  return match ? match[1].trim() : '';
+}
+
 function nextStep(id: number, toolId: string, params: Record<string, unknown>): AgentPlanStep {
   return { id: `s${id}`, toolId, params };
 }
@@ -76,6 +81,19 @@ export function planGoal(message: string): AgentPlan {
           name: 'New Agent',
           policy_id: 'default',
         }),
+      ],
+    };
+  }
+
+  if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
+    return {
+      steps: [
+        nextStep(1, 'list_policies', {}),
+        nextStep(2, 'create_chatbot_agent', {
+          name: extractQuotedName(text) || 'Chatbot Agent',
+          monthly_limit: 50000,
+        }),
+        nextStep(3, 'list_agents', {}),
       ],
     };
   }

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -196,6 +196,27 @@ export const DSG_TOOLS: AgentTool[] = [
       }),
   },
   {
+    id: 'create_chatbot_agent',
+    name: 'Create Chatbot Agent',
+    description: 'Create a chatbot-ready agent with safe defaults for interactive usage.',
+    parameters: {
+      name: { type: 'string', required: false, description: 'Agent name (default: Chatbot Agent)' },
+      policy_id: { type: 'string', required: false, description: 'Policy ID (default policy if omitted)' },
+      monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit (default: 50000)' },
+    },
+    riskLevel: 'write',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, '/api/agents', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: String(params.name || 'Chatbot Agent'),
+          policy_id: params.policy_id ? String(params.policy_id) : undefined,
+          monthly_limit: Number(params.monthly_limit || 50000),
+        }),
+      }),
+  },
+  {
     id: 'list_policies',
     name: 'List Policies',
     description: 'List available policies.',

--- a/tests/unit/agent/planner.test.ts
+++ b/tests/unit/agent/planner.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { planGoal } from '../../../lib/agent/planner';
+
+describe('agent planner chatbot intents', () => {
+  it('creates chatbot agent plan from thai prompt', () => {
+    const plan = planGoal('ช่วยเพิ่มแชทบอทเอเจ้นตามแผนได้');
+    expect(plan.steps.map((step) => step.toolId)).toEqual(['list_policies', 'create_chatbot_agent', 'list_agents']);
+    expect(plan.steps[1]?.params).toMatchObject({ name: 'Chatbot Agent', monthly_limit: 50000 });
+  });
+
+  it('uses quoted name when provided', () => {
+    const plan = planGoal('create chatbot agent "Finance Helper"');
+    expect(plan.steps[1]?.params).toMatchObject({ name: 'Finance Helper' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Operators requested the ability to "เพิ่มแชทบอทเอเจ้นตามแผนได้" via the agent-chat SSE path so a single chat intent can provision a chatbot agent with safe defaults.

### Description
- Add quoted-name extraction helper `extractQuotedName` and chatbot intent branch in `planGoal` to emit the plan `list_policies -> create_chatbot_agent -> list_agents` (defaults to `Chatbot Agent`).
- Introduce a new tool `create_chatbot_agent` in `lib/agent/tools.ts` that posts to `POST /api/agents` with safe defaults (`monthly_limit: 50000`, optional `policy_id`).
- Surface the new tool in the dashboard skills registry at `app/dashboard/skills/page.tsx` so the UI reflects the registry.
- Add unit tests in `tests/unit/agent/planner.test.ts` covering Thai prompt handling and quoted-name extraction.

### Testing
- Ran the unit test for the new planner cases with `npm run test:unit -- tests/unit/agent/planner.test.ts`; the test suite completed and the new tests passed (2 tests).
- Existing unit tests exercised during the run also passed in the invoked test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db33a89b8c8326891a9bbb8dd85916)