### PR TITLE
Fix Next.js 15 params typing for finance-governance dynamic routes/pages

### DIFF
--- a/app/api/finance-governance/approvals/[id]/approve/route.ts
+++ b/app/api/finance-governance/approvals/[id]/approve/route.ts
@@ -6,12 +6,13 @@ export const dynamic = 'force-dynamic';
 
 const repository = new FinanceGovernanceRepository();
 
-type RouteContext = { params: { id: string } };
+type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
-    const result = await repository.applyAction(orgId, context.params.id, 'approve');
+    const { id } = await context.params;
+    const result = await repository.applyAction(orgId, id, 'approve');
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_error';

--- a/app/api/finance-governance/approvals/[id]/escalate/route.ts
+++ b/app/api/finance-governance/approvals/[id]/escalate/route.ts
@@ -6,12 +6,13 @@ export const dynamic = 'force-dynamic';
 
 const repository = new FinanceGovernanceRepository();
 
-type RouteContext = { params: { id: string } };
+type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
-    const result = await repository.applyAction(orgId, context.params.id, 'escalate');
+    const { id } = await context.params;
+    const result = await repository.applyAction(orgId, id, 'escalate');
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_error';

--- a/app/api/finance-governance/approvals/[id]/reject/route.ts
+++ b/app/api/finance-governance/approvals/[id]/reject/route.ts
@@ -6,12 +6,13 @@ export const dynamic = 'force-dynamic';
 
 const repository = new FinanceGovernanceRepository();
 
-type RouteContext = { params: { id: string } };
+type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
-    const result = await repository.applyAction(orgId, context.params.id, 'reject');
+    const { id } = await context.params;
+    const result = await repository.applyAction(orgId, id, 'reject');
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_error';

--- a/app/api/finance-governance/cases/[id]/route.ts
+++ b/app/api/finance-governance/cases/[id]/route.ts
@@ -6,12 +6,13 @@ export const dynamic = 'force-dynamic';
 
 const repository = new FinanceGovernanceRepository();
 
-type RouteContext = { params: { id: string } };
+type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
-    const detail = await repository.getCaseDetail(orgId, context.params.id);
+    const { id } = await context.params;
+    const detail = await repository.getCaseDetail(orgId, id);
     return NextResponse.json({ case: detail });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_error';

--- a/app/finance-governance/app/cases/[id]/page.tsx
+++ b/app/finance-governance/app/cases/[id]/page.tsx
@@ -1,7 +1,7 @@
 type CaseDetailPageProps = {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 };
 
 const timeline = [
@@ -12,13 +12,15 @@ const timeline = [
   'Evidence bundle marked ready for export',
 ];
 
-export default function FinanceGovernanceCaseDetailPage({ params }: CaseDetailPageProps) {
+export default async function FinanceGovernanceCaseDetailPage({ params }: CaseDetailPageProps) {
+  const { id } = await params;
+
   return (
     <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
       <div className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
         <section className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
           <p className="text-sm uppercase tracking-[0.3em] text-violet-200">Case detail</p>
-          <h1 className="mt-4 text-4xl font-bold md:text-5xl">Case {params.id}</h1>
+          <h1 className="mt-4 text-4xl font-bold md:text-5xl">Case {id}</h1>
           <p className="mt-6 text-lg leading-8 text-slate-300">
             This page is the skeleton for transaction summary, policy snapshot, approval chain, and decision context within one governed case.
           </p>

--- a/app/finance-governance/live/cases/[id]/page.tsx
+++ b/app/finance-governance/live/cases/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
 import { financeGovernanceFetch } from '../../request';
 
 type CaseDetailResponse = {
@@ -18,13 +19,9 @@ type CaseDetailResponse = {
   };
 };
 
-type PageProps = {
-  params: {
-    id: string;
-  };
-};
-
-export default function FinanceGovernanceLiveCaseDetailPage({ params }: PageProps) {
+export default function FinanceGovernanceLiveCaseDetailPage() {
+  const params = useParams<{ id: string }>();
+  const caseId = params?.id ?? '';
   const [data, setData] = useState<CaseDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -37,7 +34,7 @@ export default function FinanceGovernanceLiveCaseDetailPage({ params }: PageProp
         setLoading(true);
         setError('');
 
-        const response = await financeGovernanceFetch(`/api/finance-governance/cases/${params.id}`, {
+        const response = await financeGovernanceFetch(`/api/finance-governance/cases/${caseId}`, {
           cache: 'no-store',
         });
         const json = (await response.json()) as CaseDetailResponse;
@@ -65,13 +62,13 @@ export default function FinanceGovernanceLiveCaseDetailPage({ params }: PageProp
     return () => {
       active = false;
     };
-  }, [params.id]);
+  }, [caseId]);
 
   return (
     <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
       <div className="max-w-3xl">
         <p className="text-sm uppercase tracking-[0.3em] text-violet-200">Live case detail</p>
-        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Case {params.id}</h1>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Case {caseId}</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
           This page loads case detail from the finance-governance case API and renders loading, error, and data states for one governed case.
         </p>

--- a/tests/integration/api/finance-governance-actions.test.ts
+++ b/tests/integration/api/finance-governance-actions.test.ts
@@ -45,7 +45,7 @@ describe('finance governance action routes', () => {
       headers: { 'x-org-id': 'org-test' },
     });
 
-    const response = await POST(request, { params: { id: 'APR-1001' } });
+    const response = await POST(request, { params: Promise.resolve({ id: 'APR-1001' }) });
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -62,7 +62,7 @@ describe('finance governance action routes', () => {
       headers: { 'x-org-id': 'org-test' },
     });
 
-    const response = await POST(request, { params: { id: 'APR-1002' } });
+    const response = await POST(request, { params: Promise.resolve({ id: 'APR-1002' }) });
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -79,7 +79,7 @@ describe('finance governance action routes', () => {
       headers: { 'x-org-id': 'org-test' },
     });
 
-    const response = await POST(request, { params: { id: 'APR-1003' } });
+    const response = await POST(request, { params: Promise.resolve({ id: 'APR-1003' }) });
     const body = await response.json();
 
     expect(response.status).toBe(200);

--- a/tests/integration/api/finance-governance-api.test.ts
+++ b/tests/integration/api/finance-governance-api.test.ts
@@ -71,9 +71,9 @@ describe('finance governance api routes', () => {
 
     const request = new Request('http://localhost/api/finance-governance/cases/sample-case', { headers: { 'x-org-id': 'org-test' } });
     const response = await GET(request, {
-      params: {
+      params: Promise.resolve({
         id: 'sample-case',
-      },
+      }),
     });
     const body = await response.json();
 

--- a/tests/integration/api/finance-governance-live-db.test.ts
+++ b/tests/integration/api/finance-governance-live-db.test.ts
@@ -61,12 +61,12 @@ describeLive('finance governance API + repository + supabase (live)', () => {
     expect(submitResponse.status).toBe(200);
 
     const approveResponse = await approve(new Request('http://localhost/api/finance-governance/approvals/APR-1001/approve', { method: 'POST', headers: { 'x-org-id': orgA } }), {
-      params: { id: 'APR-1001' },
+      params: Promise.resolve({ id: 'APR-1001' }),
     });
     expect(approveResponse.status).toBe(200);
 
     const caseResponse = await caseDetail(new Request('http://localhost/api/finance-governance/cases/sample-case', { headers: { 'x-org-id': orgA } }), {
-      params: { id: 'sample-case' },
+      params: Promise.resolve({ id: 'sample-case' }),
     });
     const caseBody = await caseResponse.json();
 
@@ -94,9 +94,9 @@ describeLive('finance governance API + repository + supabase (live)', () => {
       ).status
     ).toBe(200);
 
-    expect((await approve(new Request('http://localhost/api/finance-governance/approvals/APR-1001/approve', { method: 'POST', headers: { 'x-org-id': orgA } }), { params: { id: 'APR-1001' } })).status).toBe(200);
-    expect((await reject(new Request('http://localhost/api/finance-governance/approvals/APR-1002/reject', { method: 'POST', headers: { 'x-org-id': orgA } }), { params: { id: 'APR-1002' } })).status).toBe(200);
-    expect((await escalate(new Request('http://localhost/api/finance-governance/approvals/APR-1003/escalate', { method: 'POST', headers: { 'x-org-id': orgA } }), { params: { id: 'APR-1003' } })).status).toBe(200);
+    expect((await approve(new Request('http://localhost/api/finance-governance/approvals/APR-1001/approve', { method: 'POST', headers: { 'x-org-id': orgA } }), { params: Promise.resolve({ id: 'APR-1001' }) })).status).toBe(200);
+    expect((await reject(new Request('http://localhost/api/finance-governance/approvals/APR-1002/reject', { method: 'POST', headers: { 'x-org-id': orgA } }), { params: Promise.resolve({ id: 'APR-1002' }) })).status).toBe(200);
+    expect((await escalate(new Request('http://localhost/api/finance-governance/approvals/APR-1003/escalate', { method: 'POST', headers: { 'x-org-id': orgA } }), { params: Promise.resolve({ id: 'APR-1003' }) })).status).toBe(200);
 
     const { data: events } = await supabase
       .from('finance_workflow_action_events')


### PR DESCRIPTION
### Motivation
- Next.js 15 changed the `params` contract for app-route/page handlers to be Promise-based which caused build/type errors for finance-governance dynamic handlers and pages.  
- The build failed with an invalid route export error until `context.params` usages and page props were updated to the new shape.

### Description
- Updated API route handlers under `app/api/finance-governance/...` to use `type RouteContext = { params: Promise<{ id: string }> }` and `await context.params` before using `id` in repository calls (`approve`, `reject`, `escalate`, `cases/[id]`).
- Converted the server-side page `app/finance-governance/app/cases/[id]/page.tsx` to an `async` component and awaited `params` to read `id` before render.
- Changed the client page `app/finance-governance/live/cases/[id]/page.tsx` to read the route param via `useParams()` and derive `caseId` for fetching, removing reliance on props-based `params`.
- Updated integration tests to pass `params: Promise.resolve({ id })` when invoking dynamic route handlers directly so tests align with the Promise-based `params` typing.

### Testing
- Ran `npm run typecheck` and it completed successfully with no type errors.
- Ran `npx vitest run tests/integration/api/finance-governance-actions.test.ts tests/integration/api/finance-governance-api.test.ts` and both integration test files passed.
- Ran `npm run build` and the Next.js production build completed successfully; remaining OpenTelemetry/Prisma warnings are upstream and do not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db369e2e0c83268d3b75aad3e238c1)