### PR TITLE
Add realtime web search API, agent tool, planner routing and UI for live search

### DIFF
--- a/app/api/realtime-search/route.ts
+++ b/app/api/realtime-search/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../lib/authz';
+import { RuntimeRouteRoles } from '../../../lib/runtime/permissions';
+import { handleApiError } from '../../../lib/security/api-error';
+import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../lib/security/rate-limit';
+
+const SEARCH_RATE_LIMIT = 20;
+const SEARCH_WINDOW_MS = 60_000;
+const MAX_QUERY_LENGTH = 180;
+
+type DuckInstantTopic = {
+  Text?: string;
+  FirstURL?: string;
+};
+
+function normalizeTopics(topics: unknown[]): DuckInstantTopic[] {
+  const out: DuckInstantTopic[] = [];
+  for (const topic of topics) {
+    if (!topic || typeof topic !== 'object') continue;
+    const row = topic as { Text?: unknown; FirstURL?: unknown; Topics?: unknown[] };
+    if (Array.isArray(row.Topics)) {
+      out.push(...normalizeTopics(row.Topics));
+      continue;
+    }
+    if (typeof row.Text === 'string' && typeof row.FirstURL === 'string') {
+      out.push({ Text: row.Text, FirstURL: row.FirstURL });
+    }
+  }
+  return out;
+}
+
+export async function GET(request: Request) {
+  try {
+    const rateLimit = await applyRateLimit({
+      key: getRateLimitKey(request, 'realtime-search'),
+      limit: SEARCH_RATE_LIMIT,
+      windowMs: SEARCH_WINDOW_MS,
+    });
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: buildRateLimitHeaders(rateLimit, SEARCH_RATE_LIMIT) },
+      );
+    }
+
+    const access = await requireOrgRole(RuntimeRouteRoles.monitor);
+    if (!access.ok) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status, headers: buildRateLimitHeaders(rateLimit, SEARCH_RATE_LIMIT) },
+      );
+    }
+
+    const url = new URL(request.url);
+    const q = String(url.searchParams.get('q') || '').trim();
+    if (!q) {
+      return NextResponse.json(
+        { error: 'q is required' },
+        { status: 400, headers: buildRateLimitHeaders(rateLimit, SEARCH_RATE_LIMIT) },
+      );
+    }
+    if (q.length > MAX_QUERY_LENGTH) {
+      return NextResponse.json(
+        { error: `q is too long (max ${MAX_QUERY_LENGTH})` },
+        { status: 400, headers: buildRateLimitHeaders(rateLimit, SEARCH_RATE_LIMIT) },
+      );
+    }
+
+    const remote = await fetch(
+      `https://api.duckduckgo.com/?q=${encodeURIComponent(q)}&format=json&no_redirect=1&no_html=1`,
+      {
+        headers: {
+          accept: 'application/json',
+        },
+        cache: 'no-store',
+      },
+    );
+
+    if (!remote.ok) {
+      return NextResponse.json(
+        { error: `Search provider error (${remote.status})` },
+        { status: 502, headers: buildRateLimitHeaders(rateLimit, SEARCH_RATE_LIMIT) },
+      );
+    }
+
+    const body = (await remote.json().catch(() => ({}))) as {
+      AbstractText?: string;
+      AbstractURL?: string;
+      Heading?: string;
+      RelatedTopics?: unknown[];
+    };
+    const related = normalizeTopics(Array.isArray(body.RelatedTopics) ? body.RelatedTopics : []).slice(0, 5);
+
+    return NextResponse.json(
+      {
+        query: q,
+        provider: 'duckduckgo-instant-answer',
+        heading: body.Heading || '',
+        abstract: body.AbstractText || '',
+        abstract_url: body.AbstractURL || '',
+        results: related.map((item) => ({
+          title: item.Text || '',
+          url: item.FirstURL || '',
+        })),
+      },
+      { headers: buildRateLimitHeaders(rateLimit, SEARCH_RATE_LIMIT) },
+    );
+  } catch (error) {
+    return handleApiError('api/realtime-search', error);
+  }
+}

--- a/app/dashboard/skills/page.tsx
+++ b/app/dashboard/skills/page.tsx
@@ -10,6 +10,7 @@ const TOOLS = [
   ["audit_summary", "GET /api/runtime-summary", "Read runtime truth + latest ledger entries"],
   ["checkpoint", "POST /api/checkpoint", "Create checkpoint hash from truth + ledger"],
   ["recovery_validate", "POST /api/runtime-recovery", "Validate lineage integrity and sequence continuity"],
+  ["realtime_web_search", "GET /api/realtime-search?q=...", "Search live online information in real time"],
   ["capacity", "GET /api/capacity", "Read quota and utilization"],
   ["list_agents", "GET /api/agents", "Read org agents and usage"],
   ["create_agent", "POST /api/agents", "Create new agent and one-time API key"],
@@ -35,6 +36,13 @@ export default function SkillsPage() {
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<SetupResult | null>(null);
   const [error, setError] = useState("");
+  const [query, setQuery] = useState("bitcoin regulation latest");
+  const [searchResult, setSearchResult] = useState<Record<string, unknown> | null>(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState("");
+  const [customToolName, setCustomToolName] = useState("");
+  const [customToolPurpose, setCustomToolPurpose] = useState("");
+  const [customTools, setCustomTools] = useState<Array<{ name: string; purpose: string }>>([]);
 
   async function runAutoSetup() {
     setRunning(true);
@@ -53,6 +61,34 @@ export default function SkillsPage() {
     } finally {
       setRunning(false);
     }
+  }
+
+  async function runRealtimeSearch() {
+    setSearchLoading(true);
+    setSearchError("");
+    setSearchResult(null);
+    try {
+      const res = await fetch(`/api/realtime-search?q=${encodeURIComponent(query)}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) {
+        setSearchError(json.error || `Search failed (${res.status})`);
+        return;
+      }
+      setSearchResult(json);
+    } catch (e) {
+      setSearchError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setSearchLoading(false);
+    }
+  }
+
+  function addCustomTool() {
+    const name = customToolName.trim();
+    const purpose = customToolPurpose.trim();
+    if (!name || !purpose) return;
+    setCustomTools((current) => [...current, { name, purpose }]);
+    setCustomToolName("");
+    setCustomToolPurpose("");
   }
 
   return (
@@ -146,6 +182,76 @@ export default function SkillsPage() {
                 </div>
               )}
             </div>
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900 p-8">
+          <h2 className="text-xl font-semibold">Tool Skills Studio (MCP + CLI Workflow)</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            ออกแบบ tool skills ใหม่สำหรับ workflow งานจริงแบบเรียลไทม์: รับงาน → แตกเป็นขั้นตอน →
+            map ไป MCP/API/CLI → ทดสอบผลลัพธ์
+          </p>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            <input
+              value={customToolName}
+              onChange={(event) => setCustomToolName(event.target.value)}
+              placeholder="ชื่อ tool ใหม่ เช่น sec_news_scan"
+              className="rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm"
+            />
+            <input
+              value={customToolPurpose}
+              onChange={(event) => setCustomToolPurpose(event.target.value)}
+              placeholder="หน้าที่ เช่น สรุปข่าว compliance"
+              className="rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm"
+            />
+            <button
+              onClick={addCustomTool}
+              className="rounded-xl bg-sky-400 px-4 py-3 text-sm font-semibold text-slate-950"
+            >
+              เพิ่มเครื่องมือ
+            </button>
+          </div>
+          {customTools.length > 0 && (
+            <ul className="mt-4 space-y-2 text-sm text-slate-200">
+              {customTools.map((tool, index) => (
+                <li key={`${tool.name}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950 p-3">
+                  <span className="font-mono text-emerald-300">{tool.name}</span> — {tool.purpose}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900 p-8">
+          <h2 className="text-xl font-semibold">Realtime Online Search</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            ค้นหาข้อมูลออนไลน์แบบเรียลไทม์สำหรับงานที่ได้รับ โดยเรียกผ่าน{" "}
+            <code className="rounded bg-slate-800 px-2 py-1 text-emerald-300">GET /api/realtime-search</code>
+          </p>
+          <div className="mt-4 flex flex-col gap-3 md:flex-row">
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="ค้นหาสิ่งที่ต้องการ..."
+              className="w-full rounded-xl border border-slate-700 bg-slate-950 px-4 py-3 text-sm"
+            />
+            <button
+              onClick={() => void runRealtimeSearch()}
+              disabled={searchLoading}
+              className="rounded-xl bg-emerald-400 px-6 py-3 text-sm font-semibold text-slate-950 disabled:opacity-50"
+            >
+              {searchLoading ? "กำลังค้นหา..." : "ค้นหาแบบเรียลไทม์"}
+            </button>
+          </div>
+          {searchError && (
+            <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-red-200">
+              {searchError}
+            </div>
+          )}
+          {searchResult && (
+            <pre className="mt-4 overflow-x-auto rounded-xl border border-slate-800 bg-slate-950 p-4 text-xs text-emerald-200">
+              {JSON.stringify(searchResult, null, 2)}
+            </pre>
           )}
         </section>
 

--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -59,6 +59,12 @@ export function planGoal(message: string): AgentPlan {
     return { steps: [nextStep(1, 'capacity', {})] };
   }
 
+  if (/search|ค้นหา|ออนไลน์|online|เว็บ|web/.test(lower)) {
+    return {
+      steps: [nextStep(1, 'realtime_web_search', { query: text })],
+    };
+  }
+
   if (/policy|นโยบาย/.test(lower)) {
     return { steps: [nextStep(1, 'list_policies', {})] };
   }

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -161,6 +161,22 @@ export const DSG_TOOLS: AgentTool[] = [
       }),
   },
   {
+    id: 'realtime_web_search',
+    name: 'Real-time Web Search',
+    description: 'Search live online information and return quick references.',
+    parameters: {
+      query: { type: 'string', required: true, description: 'Search query' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(
+        context,
+        `/api/realtime-search?q=${encodeURIComponent(String(params.query || ''))}`,
+        { method: 'GET' },
+      ),
+  },
+  {
     id: 'capacity',
     name: 'Check Quota & Capacity',
     description: 'Fetch quota remaining and utilization.',

--- a/tests/unit/agent/planner.test.ts
+++ b/tests/unit/agent/planner.test.ts
@@ -12,4 +12,11 @@ describe('agent planner chatbot intents', () => {
     const plan = planGoal('create chatbot agent "Finance Helper"');
     expect(plan.steps[1]?.params).toMatchObject({ name: 'Finance Helper' });
   });
+
+  it('routes online search prompts to realtime web search tool', () => {
+    const plan = planGoal('ค้นหาข่าว bitcoin online ตอนนี้');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0]?.toolId).toBe('realtime_web_search');
+    expect(plan.steps[0]?.params).toMatchObject({ query: 'ค้นหาข่าว bitcoin online ตอนนี้' });
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide agents with the ability to perform live online searches and return quick reference results for tasks that require up-to-date information.
- Expose a user-facing control in the skills dashboard to exercise and prototype realtime search and custom tools.
- Route natural-language search intents to a dedicated agent tool so planners can include live searches in plans.

### Description
- Add a new API route `GET /api/realtime-search` that proxies DuckDuckGo Instant Answer, normalizes `RelatedTopics`, enforces a `monitor` role via `requireOrgRole`, applies rate limiting (`SEARCH_RATE_LIMIT = 20` per `SEARCH_WINDOW_MS = 60000`), and validates query length (`MAX_QUERY_LENGTH = 180`).
- Implement `normalizeTopics` to flatten and sanitize nested DuckDuckGo related topics and map responses into `{ title, url }` results, and return structured JSON with `provider`, `query`, `heading`, `abstract`, and `results`.
- Register a new agent tool `realtime_web_search` in `lib/agent/tools.ts` that performs `GET /api/realtime-search?q=...` and requires the `monitor` role.
- Update the planner in `lib/agent/planner.ts` to route search-related prompts to the `realtime_web_search` tool by adding a search intent pattern and creating a step with the `query` param.
- Enhance the dashboard skills page `app/dashboard/skills/page.tsx` to list the new `realtime_web_search` tool, add a "Tool Skills Studio" area for creating simple custom tools, and add a "Realtime Online Search" UI with input, search action, error handling, and JSON result preview.
- Add a unit test in `tests/unit/agent/planner.test.ts` that asserts search prompts produce a `realtime_web_search` step and preserve the original query as the `query` parameter.

### Testing
- Ran unit tests with `vitest`; the updated planner tests (including the new realtime search intent test) passed.
- Exercised `GET /api/realtime-search` behavior via unit-level checks (rate limit, param validation, and provider mapping) during development and confirmed expected JSON outputs and HTTP error codes for invalid inputs and provider failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db46394e5883268b6fde83ee6c3e65)