### PR TITLE
Add /support page and harden dashboard APIs against missing Supabase tables

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -5,6 +5,7 @@ import { getSupabaseAdmin } from '../../../lib/supabase-server';
 import { requireActiveProfile } from '../../../lib/auth/require-active-profile';
 import { resolvePolicyId } from '../../../lib/supabase/resolve-policy';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../lib/security/rate-limit';
+import { isMissingRelationError } from '../../../lib/supabase/is-missing-relation';
 
 export const dynamic = 'force-dynamic';
 
@@ -85,13 +86,15 @@ export async function GET(request: Request) {
         .eq('billing_period', now)
         .in('agent_id', agentIds);
 
-      if (usageError) {
+      if (usageError && !isMissingRelationError(usageError)) {
         logServerError(usageError, 'agents-get-usage');
         return serverErrorResponse({ headers });
       }
 
-      for (const row of usageRows || []) {
-        usageByAgent.set(String(row.agent_id), Number(row.executions || 0));
+      if (!usageError) {
+        for (const row of usageRows || []) {
+          usageByAgent.set(String(row.agent_id), Number(row.executions || 0));
+        }
       }
     }
 

--- a/app/api/executions/route.ts
+++ b/app/api/executions/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "../../../lib/supabase/server";
 import { getDSGCoreLedger, getDSGCoreMetrics } from "../../../lib/dsg-core";
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from "../../../lib/security/rate-limit";
 import { logServerError, serverErrorResponse } from "../../../lib/security/error-response";
+import { isMissingRelationError } from "../../../lib/supabase/is-missing-relation";
 
 export const dynamic = "force-dynamic";
 const EXECUTIONS_RATE_LIMIT = 60;
@@ -67,7 +68,7 @@ export async function GET(request: Request) {
       getDSGCoreMetrics(),
     ]);
 
-    if (error) {
+    if (error && !isMissingRelationError(error)) {
       logServerError(error, "executions-get");
       return serverErrorResponse();
     }
@@ -85,6 +86,9 @@ export async function GET(request: Request) {
         metrics: metricsData,
         error: !coreLedger.ok ? coreLedger.error : metricsError,
       },
+      warnings: error && isMissingRelationError(error)
+        ? ["executions table not found; returning empty list"]
+        : [],
     });
   } catch (error) {
     logServerError(error, "executions-get");

--- a/app/api/usage/route.ts
+++ b/app/api/usage/route.ts
@@ -4,6 +4,7 @@ import { requireOrgRole } from '../../../lib/authz';
 import { getOverageRateUsd, INCLUDED_EXECUTIONS } from '../../../lib/billing/overage-config';
 import { RuntimeRouteRoles } from '../../../lib/runtime/permissions';
 import { internalErrorMessage, logApiError } from '../../../lib/security/api-error';
+import { isMissingRelationError } from '../../../lib/supabase/is-missing-relation';
 
 export const dynamic = 'force-dynamic';
 
@@ -49,10 +50,7 @@ export async function GET() {
       .limit(1)
       .maybeSingle();
 
-    if (
-      subscriptionError &&
-      !/relation .* does not exist/i.test(subscriptionError.message)
-    ) {
+    if (subscriptionError && !isMissingRelationError(subscriptionError)) {
       logApiError('api/usage', subscriptionError, { stage: 'subscription-query' });
       return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }
@@ -67,7 +65,7 @@ export async function GET() {
       .eq('org_id', access.orgId)
       .eq('billing_period', billingPeriodKey);
 
-    if (usageError) {
+    if (usageError && !isMissingRelationError(usageError)) {
       logApiError('api/usage', usageError, { stage: 'usage-counter-query' });
       return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
     }

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+
+const supportChannels = [
+  {
+    title: 'Email support',
+    detail: 'support@dsg.one',
+    description:
+      'Best for production incidents, account access issues, and policy decision anomalies that require investigation.',
+  },
+  {
+    title: 'Response target',
+    detail: 'Within 1 business day',
+    description:
+      'Pilot and paid workspaces receive triage updates on every open incident until closure.',
+  },
+  {
+    title: 'Escalation path',
+    detail: 'Subject: ESCALATION',
+    description:
+      'For severe impact (blocked operations, incorrect enforcement, or billing disruption), include workspace ID and execution ID.',
+  },
+];
+
+export default function SupportPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
+      <div className="max-w-3xl">
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Support</p>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">Operational support for DSG Control Plane</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          Use this page as the customer-facing support surface for pilot and production environments.
+          Contact the team for incident handling, rollout assistance, and billing-related requests.
+        </p>
+      </div>
+
+      <div className="mt-12 grid gap-6 md:grid-cols-3">
+        {supportChannels.map((channel) => (
+          <section key={channel.title} className="rounded-[1.75rem] border border-white/10 bg-white/5 p-7">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">{channel.title}</p>
+            <h2 className="mt-3 text-2xl font-semibold">{channel.detail}</h2>
+            <p className="mt-4 leading-7 text-slate-200">{channel.description}</p>
+          </section>
+        ))}
+      </div>
+
+      <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+        <h3 className="text-xl font-semibold">What to include in a support request</h3>
+        <ul className="mt-4 list-disc space-y-2 pl-6 text-slate-200">
+          <li>Workspace name and organization ID</li>
+          <li>Affected endpoint or dashboard path (for example: /dashboard, /api/usage)</li>
+          <li>Execution ID or timestamp range in UTC</li>
+          <li>Impact severity (degraded, blocked, or data discrepancy)</li>
+        </ul>
+        <div className="mt-6 flex flex-wrap gap-4">
+          <Link href="/docs" className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
+            Read operator docs
+          </Link>
+          <Link href="/dashboard" className="rounded-2xl bg-emerald-400 px-6 py-3 text-base font-semibold text-slate-950">
+            Open dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/GlobalNav.tsx
+++ b/components/GlobalNav.tsx
@@ -8,6 +8,7 @@ const PUBLIC_NAV = [
   { href: '/', label: 'Home' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/docs', label: 'Docs' },
+  { href: '/support', label: 'Support' },
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/app-shell', label: 'App Shell' },
 ];

--- a/lib/supabase/is-missing-relation.ts
+++ b/lib/supabase/is-missing-relation.ts
@@ -1,0 +1,17 @@
+type ErrorLike = {
+  message?: string | null;
+  code?: string | null;
+};
+
+export function isMissingRelationError(error: unknown) {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as ErrorLike;
+  const message = String(candidate.message || '');
+  const code = String(candidate.code || '');
+
+  return (
+    code === '42P01' ||
+    /relation .* does not exist/i.test(message) ||
+    /could not find the table/i.test(message)
+  );
+}


### PR DESCRIPTION
### Motivation
- The dashboard surface was showing a red `Internal server error` banner in partially migrated or pilot environments when optional Supabase relations (billing/usage/executions) were missing, which undermines customer trust. 
- A simple, customer-facing `/support` page was requested so users have a clear contact path while the backend is hardened.

### Description
- Added a production-facing support page at `app/support/page.tsx` with support email (`support@dsg.one`), response target, escalation path, and a checklist for support requests. 
- Exposed `Support` in the public navigation by updating `components/GlobalNav.tsx`. 
- Introduced `lib/supabase/is-missing-relation.ts` to detect Supabase relation/table-missing errors robustly. 
- Hardened dashboard-backed APIs to degrade gracefully instead of returning 500s: updated `app/api/usage/route.ts` to ignore missing `billing_subscriptions`/`usage_counters`, `app/api/agents/route.ts` to continue with `usage_this_month = 0` when `usage_counters` is absent, and `app/api/executions/route.ts` to return an empty list plus `warnings` metadata when the `executions` relation is missing. 

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran integration UI/API tests with `npm run test -- tests/integration/api tests/integration/ui` and the suite completed with all runnable checks passing (Test Files: 28 passed, 1 skipped; Tests: 65 passed, 3 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db5eefa26c832687eec4518ecfad43)