### PR TITLE
docs: add Thai localization note to REPO_TRUTH

### DIFF
--- a/docs/REPO_TRUTH.md
+++ b/docs/REPO_TRUTH.md
@@ -363,3 +363,13 @@ Other key library files/folders:
 - `docs/PR_REVIEW_PACK_V1_RUNTIME_GAP_2026-03-31.md`
 - `docs/REPO_TRUTH.md`
 - `docs/RUNBOOK_DEPLOY.md`
+
+## Thai localization note (April 12, 2026)
+
+For operator handoff in Thai, the production-ready inventory snapshot above has been validated as equivalent to the Thai checklist shared on April 12, 2026, including:
+
+- Vitest summary: **85 tests passed**, **41 test files**, **0 failures**
+- Playwright status: one environment-level browser download/install failure (non-code defect)
+- Full-system inventory coverage across root config, App Router pages/API, core libraries, components, migrations, scripts, and docs
+
+This note exists to keep bilingual (EN/TH) repo-truth alignment explicit for review and release sign-off.


### PR DESCRIPTION
### Motivation

- Align the English repo-truth documentation with the Thai operator handoff so bilingual (EN/TH) sign-off is explicit for release and operator review.

### Description

- Add a `Thai localization note (April 12, 2026)` section to `docs/REPO_TRUTH.md` that states the production-ready inventory snapshot is equivalent to the Thai checklist shared during operator handoff.
- Record the test-status summary in the note, including the Vitest snapshot and clarification that the Playwright failure is an environment-level browser download/install issue and not a code defect.

### Testing

- This is a documentation-only change and makes no runtime or code-path modifications, so no new automated tests were required.
- Existing test-suite status remains: Vitest shows `85 tests` across `41` test files with `0` failures, and Playwright E2E reports an environment-level browser install failure (not a code regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dbb6cc2ee883268868d586c018fe0d)