### PR TITLE
test: add spine unit tests for planner, approval, pipeline, and proof/checkpoint hashing

### DIFF
--- a/tests/unit/spine/pipeline-approval.test.ts
+++ b/tests/unit/spine/pipeline-approval.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('issueSpineIntent + executeSpineIntent approval flow', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('issues a new pending intent and reuses it on second call', async () => {
+    const rows: Record<string, any[]> = {
+      runtime_approval_requests: [],
+      agents: [{ id: 'agt_1', org_id: 'org_1', status: 'active', api_key_hash: 'hash1', monthly_limit: 100 }],
+    };
+
+    const from = vi.fn((table: string) => ({
+      select: () => ({
+        eq: function () {
+          return this;
+        },
+        order: function () {
+          return this;
+        },
+        limit: function () {
+          return this;
+        },
+        maybeSingle: async () => {
+          const match = rows[table]?.find(() => true);
+          return { data: match ?? null, error: null };
+        },
+      }),
+      insert: (payload: any) => ({
+        select: () => ({
+          single: async () => {
+            const row = { ...payload, id: 'req_001', status: 'pending', expires_at: new Date(Date.now() + 300_000).toISOString() };
+            rows[table] = rows[table] || [];
+            rows[table].push(row);
+            return { data: row, error: null };
+          },
+        }),
+      }),
+    }));
+
+    vi.doMock('../../../lib/supabase-server', () => ({
+      getSupabaseAdmin: () => ({ from }),
+    }));
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(async () => ({
+        id: 'agt_1', org_id: 'org_1', status: 'active', monthly_limit: 100,
+      })),
+    }));
+
+    const { issueSpineIntent } = await import('../../../lib/spine/engine');
+
+    const payload = {
+      agentId: 'agt_1',
+      action: 'scan',
+      input: {},
+      context: {},
+      canonicalRequest: { action: 'scan', input: {}, context: {} },
+    } as any;
+
+    const first = await issueSpineIntent({ orgId: 'org_1', apiKey: 'key1', payload });
+    expect(first.ok).toBe(true);
+    expect(first.status).toBe(200);
+    expect(first.body).toHaveProperty('request_id');
+
+    const second = await issueSpineIntent({ orgId: 'org_1', apiKey: 'key1', payload });
+    expect(second.ok).toBe(true);
+    expect(second.status).toBe(200);
+    expect(second.body.reused).toBe(true);
+    expect(second.body.request_id).toBe(first.body.request_id);
+  });
+
+  it('returns 409 when intent already consumed', async () => {
+    const from = vi.fn(() => ({
+      select: () => ({
+        eq: function () {
+          return this;
+        },
+        order: function () {
+          return this;
+        },
+        limit: function () {
+          return this;
+        },
+        maybeSingle: async () => ({
+          data: { id: 'req_old', status: 'consumed', expires_at: null },
+          error: null,
+        }),
+      }),
+    }));
+
+    vi.doMock('../../../lib/supabase-server', () => ({
+      getSupabaseAdmin: () => ({ from }),
+    }));
+
+    vi.doMock('../../../lib/agent-auth', () => ({
+      resolveAgentFromApiKey: vi.fn(async () => ({
+        id: 'agt_1', org_id: 'org_1', status: 'active', monthly_limit: 100,
+      })),
+    }));
+
+    const { issueSpineIntent } = await import('../../../lib/spine/engine');
+
+    const payload = {
+      agentId: 'agt_1', action: 'scan', input: {}, context: {},
+      canonicalRequest: { action: 'scan', input: {}, context: {} },
+    } as any;
+
+    const result = await issueSpineIntent({ orgId: 'org_1', apiKey: 'key1', payload });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(409);
+    expect(result.body.error).toContain('already consumed');
+  });
+});

--- a/tests/unit/spine/pipeline-block.test.ts
+++ b/tests/unit/spine/pipeline-block.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateGate, detectOscillation } from '../../../lib/runtime/gate';
+import { registry } from '../../../lib/spine/plugin';
+import type { DSGPlugin } from '../../../lib/spine/plugin';
+import type { PluginInput, PluginOutput } from '../../../lib/spine/types';
+
+describe('evaluateGate — decision boundaries', () => {
+  it('BLOCK when riskScore >= 0.8', () => {
+    expect(evaluateGate({ riskScore: 0.8 }).decision).toBe('BLOCK');
+    expect(evaluateGate({ riskScore: 0.95 }).decision).toBe('BLOCK');
+    expect(evaluateGate({ riskScore: 1.0 }).decision).toBe('BLOCK');
+  });
+
+  it('STABILIZE when riskScore >= 0.4 but < 0.8', () => {
+    expect(evaluateGate({ riskScore: 0.4 }).decision).toBe('STABILIZE');
+    expect(evaluateGate({ riskScore: 0.79 }).decision).toBe('STABILIZE');
+  });
+
+  it('ALLOW when riskScore < 0.4 and no oscillation', () => {
+    expect(evaluateGate({ riskScore: 0.1 }).decision).toBe('ALLOW');
+    expect(evaluateGate({ riskScore: 0.39 }).decision).toBe('ALLOW');
+  });
+
+  it('STABILIZE on oscillation even with low riskScore', () => {
+    const result = evaluateGate({
+      riskScore: 0.1,
+      recentRiskScores: [0.1, 0.6, 0.15, 0.55],
+    });
+    expect(result.decision).toBe('STABILIZE');
+    expect(result.reason).toContain('oscillation');
+  });
+
+  it('no oscillation when window too small', () => {
+    expect(detectOscillation([0.1, 0.9])).toBe(false);
+    expect(detectOscillation([])).toBe(false);
+  });
+
+  it('oscillation when spread >= 0.35 in last 4 scores', () => {
+    expect(detectOscillation([0.1, 0.5, 0.1, 0.5])).toBe(true);
+  });
+
+  it('no oscillation when spread < 0.35', () => {
+    expect(detectOscillation([0.1, 0.2, 0.15, 0.25])).toBe(false);
+  });
+});
+
+describe('runPipeline — gate BLOCK short-circuits arbiters', () => {
+  it('returns BLOCK from gate and skips arbiters', async () => {
+    const blockGate: DSGPlugin = {
+      id: 'test-block-gate',
+      name: 'Test Block Gate',
+      kind: 'gate',
+      verification: { verified: true, solver: null, properties: [] },
+      health: async () => ({ ok: true }),
+      evaluate: async (): Promise<PluginOutput> => ({
+        decision: 'BLOCK',
+        reason: 'test:HIGH_RISK',
+        policy_version: 'test-v1',
+        latency_ms: 1,
+        proof: { proof_hash: 'block-proof', proof_version: 'v1', theorem_set_id: null, solver: null },
+        metrics: {},
+      }),
+    };
+
+    const arbiterCalled = { called: false };
+    const testArbiter: DSGPlugin = {
+      id: 'test-arbiter',
+      name: 'Test Arbiter',
+      kind: 'arbiter',
+      verification: { verified: true, solver: null, properties: [] },
+      health: async () => ({ ok: true }),
+      evaluate: async (): Promise<PluginOutput> => {
+        arbiterCalled.called = true;
+        return {
+          decision: 'ALLOW', reason: 'ok', policy_version: 'v1', latency_ms: 0,
+          proof: { proof_hash: null, proof_version: null, theorem_set_id: null, solver: null },
+          metrics: {},
+        };
+      },
+    };
+
+    registry.registerIfAbsent(blockGate);
+    registry.registerIfAbsent(testArbiter);
+
+    const originalEnv = process.env.DSG_SPINE_GATE_PLUGIN;
+    process.env.DSG_SPINE_GATE_PLUGIN = 'test-block-gate';
+
+    try {
+      const input: PluginInput = {
+        org_id: 'org_1',
+        agent_id: 'agt_1',
+        action: 'dangerous-action',
+        payload: {},
+        truth_state: null,
+        approval: null,
+        spine: { request_id: 'req_1', received_at: new Date().toISOString(), billing_period: '2026-04' },
+      };
+
+      const { runPipeline } = await import('../../../lib/spine/pipeline');
+      const result = await runPipeline(input);
+
+      expect(result.final_decision).toBe('BLOCK');
+      expect(result.final_reason).toBe('test:HIGH_RISK');
+      expect(result.stages).toHaveLength(1);
+      expect(result.stages[0].plugin_id).toBe('test-block-gate');
+      expect(result.proof.proof_hash).toBe('block-proof');
+      expect(arbiterCalled.called).toBe(false);
+    } finally {
+      if (originalEnv === undefined) delete process.env.DSG_SPINE_GATE_PLUGIN;
+      else process.env.DSG_SPINE_GATE_PLUGIN = originalEnv;
+    }
+  });
+
+  it('ALLOW from gate lets arbiter escalate to STABILIZE', async () => {
+    const allowGate: DSGPlugin = {
+      id: 'test-allow-gate',
+      name: 'Test Allow Gate',
+      kind: 'gate',
+      verification: { verified: true, solver: null, properties: [] },
+      health: async () => ({ ok: true }),
+      evaluate: async (): Promise<PluginOutput> => ({
+        decision: 'ALLOW', reason: 'gate:OK', policy_version: 'v1', latency_ms: 1,
+        proof: { proof_hash: null, proof_version: null, theorem_set_id: null, solver: null },
+        metrics: {},
+      }),
+    };
+
+    const stabilizeArbiter: DSGPlugin = {
+      id: 'test-stabilize-arbiter',
+      name: 'Test Stabilize Arbiter',
+      kind: 'arbiter',
+      verification: { verified: true, solver: null, properties: [] },
+      health: async () => ({ ok: true }),
+      evaluate: async (): Promise<PluginOutput> => ({
+        decision: 'STABILIZE', reason: 'arbiter:OSCILLATION', policy_version: 'v1', latency_ms: 2,
+        proof: { proof_hash: 'stab-proof', proof_version: 'v1', theorem_set_id: null, solver: null },
+        metrics: {},
+      }),
+    };
+
+    registry.registerIfAbsent(allowGate);
+    registry.registerIfAbsent(stabilizeArbiter);
+
+    const originalEnv = process.env.DSG_SPINE_GATE_PLUGIN;
+    process.env.DSG_SPINE_GATE_PLUGIN = 'test-allow-gate';
+
+    try {
+      const { runPipeline } = await import('../../../lib/spine/pipeline');
+      const result = await runPipeline({
+        org_id: 'org_1', agent_id: 'agt_1', action: 'scan', payload: {},
+        truth_state: null, approval: null,
+        spine: { request_id: 'req_2', received_at: new Date().toISOString(), billing_period: '2026-04' },
+      });
+
+      expect(result.final_decision).toBe('STABILIZE');
+      expect(result.authoritative_plugin_id).toBe('test-stabilize-arbiter');
+      expect(result.stages.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      if (originalEnv === undefined) delete process.env.DSG_SPINE_GATE_PLUGIN;
+      else process.env.DSG_SPINE_GATE_PLUGIN = originalEnv;
+    }
+  });
+});

--- a/tests/unit/spine/planner-execute.test.ts
+++ b/tests/unit/spine/planner-execute.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { planGoal } from '../../../lib/agent/planner';
+import { normalizeSpinePayload } from '../../../lib/spine/request';
+
+describe('planGoal — keyword → tool mapping', () => {
+  it('plans readiness check for "check status"', () => {
+    const plan = planGoal('check status');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0].toolId).toBe('readiness');
+  });
+
+  it('plans readiness + execute for "run agt_hermes_01"', () => {
+    const plan = planGoal('run agt_hermes_01');
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0].toolId).toBe('readiness');
+    expect(plan.steps[1].toolId).toBe('execute_action');
+    expect(plan.steps[1].params.agent_id).toBe('agt_hermes_01');
+  });
+
+  it('plans audit + recovery for "audit lineage agt_test_01"', () => {
+    const plan = planGoal('audit lineage agt_test_01');
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0].toolId).toBe('audit_summary');
+    expect(plan.steps[1].toolId).toBe('recovery_validate');
+    expect(plan.steps[0].params.agent_id).toBe('agt_test_01');
+  });
+
+  it('plans checkpoint for "บันทึก agt_prod_01"', () => {
+    const plan = planGoal('บันทึก agt_prod_01');
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0].toolId).toBe('recovery_validate');
+    expect(plan.steps[1].toolId).toBe('checkpoint');
+  });
+
+  it('plans capacity for "check โควต้า"', () => {
+    const plan = planGoal('check โควต้า');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0].toolId).toBe('capacity');
+  });
+
+  it('plans list_policies for "show policy"', () => {
+    const plan = planGoal('show policy');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0].toolId).toBe('list_policies');
+  });
+
+  it('plans reconcile_effect with failed status', () => {
+    const plan = planGoal('reconcile eff_abc123 failed');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0].toolId).toBe('reconcile_effect');
+    expect(plan.steps[0].params.effect_id).toBe('eff_abc123');
+    expect(plan.steps[0].params.status).toBe('failed');
+  });
+
+  it('plans create_agent for "สร้างเอเจนต์"', () => {
+    const plan = planGoal('สร้างเอเจนต์');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0].toolId).toBe('create_agent');
+    expect(plan.steps[0].params.name).toBe('New Agent');
+  });
+
+  it('defaults to readiness + list_agents for unknown message', () => {
+    const plan = planGoal('hello world');
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0].toolId).toBe('readiness');
+    expect(plan.steps[1].toolId).toBe('list_agents');
+  });
+
+  it('step IDs are sequential', () => {
+    const plan = planGoal('execute something');
+    expect(plan.steps.map((s) => s.id)).toEqual(['s1', 's2']);
+  });
+});
+
+describe('normalizeSpinePayload — flat and nested formats', () => {
+  it('normalizes flat payload', () => {
+    const result = normalizeSpinePayload({
+      agent_id: 'agt_1',
+      action: 'scan',
+      input: { prompt: 'hello' },
+      context: { source: 'test' },
+    });
+
+    expect(result.agentId).toBe('agt_1');
+    expect(result.action).toBe('scan');
+    expect(result.input).toEqual({ prompt: 'hello' });
+    expect(result.context).toEqual({ source: 'test' });
+    expect(result.canonicalRequest).toEqual({
+      action: 'scan',
+      input: { prompt: 'hello' },
+      context: { source: 'test' },
+    });
+  });
+
+  it('normalizes nested intent envelope', () => {
+    const result = normalizeSpinePayload({
+      agent_id: 'agt_2',
+      intent: {
+        action: 'trade',
+        input: { amount: 100 },
+        context: { market: 'BTC' },
+      },
+    });
+
+    expect(result.agentId).toBe('agt_2');
+    expect(result.action).toBe('trade');
+    expect(result.input).toEqual({ amount: 100 });
+  });
+
+  it('defaults action to "scan" when missing', () => {
+    const result = normalizeSpinePayload({ agent_id: 'agt_3', input: {} });
+    expect(result.action).toBe('scan');
+  });
+
+  it('returns empty agentId for null body', () => {
+    const result = normalizeSpinePayload(null);
+    expect(result.agentId).toBe('');
+  });
+
+  it('strips non-canonical values', () => {
+    const result = normalizeSpinePayload({
+      agent_id: 'agt_4',
+      action: 'test',
+      input: { valid: 'yes', fn: undefined },
+      context: {},
+    });
+    expect(result.input).toEqual({ valid: 'yes' });
+  });
+});

--- a/tests/unit/spine/proof-checkpoint.test.ts
+++ b/tests/unit/spine/proof-checkpoint.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalHash, canonicalJson } from '../../../lib/runtime/canonical';
+import { buildCheckpointHash } from '../../../lib/runtime/checkpoint';
+import { buildApprovalKey } from '../../../lib/runtime/approval';
+
+describe('canonical determinism — proof foundation', () => {
+  it('produces identical hash regardless of key order', () => {
+    const a = canonicalHash({ decision: 'ALLOW', action: 'scan', input: { b: 2, a: 1 } });
+    const b = canonicalHash({ action: 'scan', decision: 'ALLOW', input: { a: 1, b: 2 } });
+    expect(a).toBe(b);
+  });
+
+  it('produces different hash for different values', () => {
+    const allow = canonicalHash({ decision: 'ALLOW' });
+    const block = canonicalHash({ decision: 'BLOCK' });
+    expect(allow).not.toBe(block);
+  });
+
+  it('handles nested arrays deterministically', () => {
+    const a = canonicalJson({ steps: [{ tool: 'readiness' }, { tool: 'execute' }] });
+    const b = canonicalJson({ steps: [{ tool: 'readiness' }, { tool: 'execute' }] });
+    expect(a).toBe(b);
+  });
+
+  it('handles null and primitive values', () => {
+    expect(canonicalHash(null)).toBe(canonicalHash(null));
+    expect(canonicalHash('test')).toBe(canonicalHash('test'));
+    expect(canonicalHash(42)).toBe(canonicalHash(42));
+    expect(canonicalHash(true)).toBe(canonicalHash(true));
+  });
+});
+
+describe('buildCheckpointHash — runtime checkpoint integrity', () => {
+  it('produces deterministic checkpoint hash', () => {
+    const input = {
+      truthCanonicalHash: 'abc123',
+      latestLedgerId: 'ledger_001',
+      latestLedgerSequence: 5,
+      latestTruthSequence: 3,
+    };
+
+    const hash1 = buildCheckpointHash(input);
+    const hash2 = buildCheckpointHash(input);
+    expect(hash1).toBe(hash2);
+    expect(hash1).toHaveLength(64);
+  });
+
+  it('different truth hash produces different checkpoint', () => {
+    const base = {
+      latestLedgerId: 'ledger_001',
+      latestLedgerSequence: 5,
+      latestTruthSequence: 3,
+    };
+
+    const a = buildCheckpointHash({ ...base, truthCanonicalHash: 'hash_a' });
+    const b = buildCheckpointHash({ ...base, truthCanonicalHash: 'hash_b' });
+    expect(a).not.toBe(b);
+  });
+
+  it('different ledger sequence produces different checkpoint', () => {
+    const base = {
+      truthCanonicalHash: 'same',
+      latestLedgerId: 'ledger_001',
+      latestTruthSequence: 3,
+    };
+
+    const a = buildCheckpointHash({ ...base, latestLedgerSequence: 5 });
+    const b = buildCheckpointHash({ ...base, latestLedgerSequence: 6 });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('buildApprovalKey — anti-replay determinism', () => {
+  it('same org+agent+request produces same key', () => {
+    const a = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_1', request: { action: 'scan', input: { x: 1 } } });
+    const b = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_1', request: { action: 'scan', input: { x: 1 } } });
+    expect(a).toBe(b);
+  });
+
+  it('key order in request does not affect approval key', () => {
+    const a = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_1', request: { input: { b: 2, a: 1 }, action: 'scan' } });
+    const b = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_1', request: { action: 'scan', input: { a: 1, b: 2 } } });
+    expect(a).toBe(b);
+  });
+
+  it('different org/agent/request changes key', () => {
+    const base = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_1', request: { action: 'scan' } });
+    const orgChanged = buildApprovalKey({ orgId: 'org_2', agentId: 'agt_1', request: { action: 'scan' } });
+    const agentChanged = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_2', request: { action: 'scan' } });
+    const requestChanged = buildApprovalKey({ orgId: 'org_1', agentId: 'agt_1', request: { action: 'trade' } });
+
+    expect(orgChanged).not.toBe(base);
+    expect(agentChanged).not.toBe(base);
+    expect(requestChanged).not.toBe(base);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add missing unit coverage for the Spine execution surface to validate planner routing, payload normalization, gate/arbiters pipeline behavior, and deterministic proof/checkpoint hashing.
- Ensure DB-dependent approval flows are exercised with realistic mocks to prevent regressions in `issueSpineIntent` behavior.
- Exercise `runPipeline` with actual plugin registry registration to validate short-circuiting and escalation semantics without heavy mocking.

### Description
- Added `tests/unit/spine/planner-execute.test.ts` which covers `planGoal` keyword→tool mapping and `normalizeSpinePayload` canonicalization for flat, nested and null payloads.
- Added `tests/unit/spine/pipeline-approval.test.ts` which mocks `getSupabaseAdmin` and `resolveAgentFromApiKey` to validate `issueSpineIntent` reuse and consumed-intent conflict handling.
- Added `tests/unit/spine/pipeline-block.test.ts` which tests `evaluateGate`/`detectOscillation` thresholds and verifies `runPipeline` behavior using registry-registered test `gate` and `arbiter` plugins.
- Added `tests/unit/spine/proof-checkpoint.test.ts` which asserts deterministic outputs for `canonicalHash`/`canonicalJson`, `buildCheckpointHash`, and `buildApprovalKey` anti-replay properties.

### Testing
- Ran the unit test command `npm run test:unit -- tests/unit/spine tests/unit/agent/planner.test.ts tests/unit/runtime/approval.test.ts tests/unit/runtime/gate.test.ts tests/unit/runtime/canonical.test.ts` and all executed tests passed.
- Vitest summary: `Test Files 27 passed (27)` and `Tests 97 passed (97)`, with the new spine unit tests included and succeeding.
- The approval flow tests use `vi.resetModules()` and `vi.doMock()` to simulate Supabase and agent resolution, and they passed under the mocked conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dbbdc509448326b9fb5f52b8cf804c)