### PR TITLE
docs: add merge-block triage note for 286/294 status

### DIFF
--- a/docs/REPO_TRUTH.md
+++ b/docs/REPO_TRUTH.md
@@ -373,3 +373,19 @@ For operator handoff in Thai, the production-ready inventory snapshot above has 
 - Full-system inventory coverage across root config, App Router pages/API, core libraries, components, migrations, scripts, and docs
 
 This note exists to keep bilingual (EN/TH) repo-truth alignment explicit for review and release sign-off.
+
+## Merge mismatch note: "286/294 merge ไม่ได้" (April 12, 2026)
+
+If a reviewer sees a merge-progress indicator like **286/294** and cannot merge, treat it as a **branch divergence/incomplete-sync signal**, not a product-readiness failure by default.
+
+Recommended triage order:
+
+1. Ensure local branch is synchronized with the latest protected target branch (`main` or release branch) and re-run CI on the rebased head.
+2. Re-check required status checks in GitHub branch protection (especially required workflow names after any CI workflow rename).
+3. Confirm there are no unresolved "outdated review" or "required conversation resolution" gates.
+4. If all checks are green but merge is still blocked, inspect merge queue / required linear-history settings and retry via the configured merge method.
+
+Operational interpretation for this repository:
+
+- The current control-plane inventory and Vitest baseline remain valid (85/85 tests passing, Playwright browser install issue is environment-related).
+- A `286/294` merge indicator should be handled as release-process metadata drift until a concrete failing required check is identified.


### PR DESCRIPTION
### Motivation

- Provide a short, operational triage guide when a reviewer encounters a merge-progress indicator like "286/294 merge ไม่ได้" so teams treat it as a process/branch-sync issue rather than a code-quality failure. 
- Reduce release friction by giving a reproducible checklist for unlocking merge-blocks and aligning reviewers on next steps.

### Description

- Appended a new section `Merge mismatch note: "286/294 merge ไม่ได้" (April 12, 2026)` to `docs/REPO_TRUTH.md` explaining the event interpretation. 
- Added a concise 4-step triage checklist that references syncing with the protected target branch (`main`), re-checking required status checks, confirming review/conversation resolution gates, and inspecting merge-queue/linear-history settings. 
- Included a repository-specific operational interpretation that reminds readers the existing Vitest baseline remains valid and that Playwright E2E issues are environment-related.

### Testing

- This is a documentation-only change so no code-path tests were required and CI behavior is unaffected by the change. 
- The repository's validated automated test baseline is unchanged: Vitest `85` tests across `41` test files with `0` failures. 
- The Playwright E2E suite still reports an environment-level browser install issue that is not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dbbf433c408326b0c2e70e264d93d4)