### PR TITLE
Add public benchmark site generation and GitHub Pages workflow

### DIFF
--- a/.github/workflows/benchmark-pages.yml
+++ b/.github/workflows/benchmark-pages.yml
@@ -1,0 +1,88 @@
+name: DSG Benchmark Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Public or staging base URL"
+        required: true
+        type: string
+      execute_path:
+        description: "Execution endpoint path"
+        required: false
+        default: "/api/execute"
+        type: string
+      replay_path_prefix:
+        description: "Replay endpoint prefix"
+        required: false
+        default: "/api/replay"
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: benchmark-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BENCHMARK_BASE_URL: ${{ inputs.base_url }}
+      BENCHMARK_EXECUTE_PATH: ${{ inputs.execute_path }}
+      BENCHMARK_REPLAY_PATH_PREFIX: ${{ inputs.replay_path_prefix }}
+      BENCHMARK_API_KEY: ${{ secrets.BENCHMARK_API_KEY }}
+      BENCHMARK_AGENT_ID: ${{ secrets.BENCHMARK_AGENT_ID }}
+      BENCHMARK_ACTION: scan
+      BENCHMARK_CASES_FILE: benchmarks/cases/gate-cases.json
+      BENCHMARK_OUT_DIR: artifacts/benchmark
+      BENCHMARK_SITE_INPUT: artifacts/benchmark/benchmark-result.json
+      BENCHMARK_SITE_DIR: site
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run benchmark
+        run: npm run benchmark
+
+      - name: Render benchmark site
+        run: npm run benchmark:site
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-benchmark-artifacts
+          path: artifacts/benchmark
+
+      - name: Publish summary to step summary
+        run: cat artifacts/benchmark/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -497,3 +497,31 @@ then DSG ONE is built in that direction.
 ## Keywords
 
 `#EnterpriseAI` `#AIRuntime` `#Auditability` `#VerifiedRuntime` `#Governance` `#ZeroTrust` `#Operators` `#ControlPlane` `#MissionVisibility` `#ExecutionEvidence`
+
+## DSG Public Benchmark
+
+[![DSG Benchmark](https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/actions/workflows/benchmark.yml/badge.svg)](https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/actions/workflows/benchmark.yml)
+[![DSG Benchmark Pages](https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/actions/workflows/benchmark-pages.yml/badge.svg)](https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/actions/workflows/benchmark-pages.yml)
+
+This repository includes a governed runtime benchmark for DSG execution flow.
+
+It validates:
+- gate decision accuracy
+- replay completeness
+- ledger match rate
+- proof presence
+- false allow rate
+- latency
+
+Live report:
+- Public benchmark report: `https://tdealer01-crypto.github.io/tdealer01-crypto-dsg-control-plane/benchmark/`
+- Latest benchmark JSON: `https://tdealer01-crypto.github.io/tdealer01-crypto-dsg-control-plane/benchmark/result.json`
+
+GitHub configuration requirements:
+- Pages source: `GitHub Actions`
+- Required secrets: `BENCHMARK_API_KEY`, `BENCHMARK_AGENT_ID`
+
+Usage:
+- Run benchmark only: use workflow **DSG Benchmark**
+- Run benchmark + publish Pages: use workflow **DSG Benchmark Pages** with `base_url` and optional `execute_path` / `replay_path_prefix`
+

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -39,3 +39,18 @@ It should be interpreted together with:
 - replay proof
 - org-wide proof surfaces
 - enterprise runtime reports
+
+## Public benchmark site
+
+A GitHub Pages deployment workflow is available through:
+
+- `.github/workflows/benchmark-pages.yml`
+
+It:
+1. runs the benchmark
+2. renders a static public report
+3. publishes the report to GitHub Pages
+
+Public outputs:
+- `/benchmark/`
+- `/benchmark/result.json`

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "deploy:preview": "npx vercel deploy --target=preview --yes",
     "deploy:prod": "npx vercel deploy --prod --yes",
     "go:no-go": "./scripts/go-no-go-gate.sh",
-    "benchmark": "node scripts/benchmark-dsg.mjs"
+    "benchmark": "node scripts/benchmark-dsg.mjs",
+    "benchmark:site": "node scripts/render-benchmark-site.mjs",
+    "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",

--- a/scripts/render-benchmark-site.mjs
+++ b/scripts/render-benchmark-site.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const INPUT_FILE =
+  process.env.BENCHMARK_SITE_INPUT || "artifacts/benchmark/benchmark-result.json";
+const SITE_DIR = process.env.BENCHMARK_SITE_DIR || "site";
+
+async function main() {
+  const raw = await fs.readFile(INPUT_FILE, "utf8");
+  const result = JSON.parse(raw);
+
+  await fs.mkdir(path.join(SITE_DIR, "benchmark"), { recursive: true });
+
+  const benchmarkIndex = renderBenchmarkPage(result);
+  const rootIndex = renderRootIndex(result);
+
+  await fs.writeFile(
+    path.join(SITE_DIR, "benchmark", "index.html"),
+    benchmarkIndex,
+    "utf8",
+  );
+
+  await fs.writeFile(
+    path.join(SITE_DIR, "benchmark", "result.json"),
+    JSON.stringify(result, null, 2),
+    "utf8",
+  );
+
+  await fs.writeFile(path.join(SITE_DIR, "index.html"), rootIndex, "utf8");
+
+  console.log(`[ok] wrote ${SITE_DIR}/benchmark/index.html`);
+  console.log(`[ok] wrote ${SITE_DIR}/benchmark/result.json`);
+  console.log(`[ok] wrote ${SITE_DIR}/index.html`);
+}
+
+function renderRootIndex(result) {
+  const verdict = result.summary?.pass ? "PASS" : "FAIL";
+  const gateAccuracy = result.summary?.metrics?.gate_accuracy ?? "N/A";
+  const replayCompleteness =
+    result.summary?.metrics?.replay_completeness ?? "N/A";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>DSG Benchmark</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark light" />
+  <style>
+    body {
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+      background: #0b1020;
+      color: #e7ecf5;
+    }
+    .wrap {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 48px 20px 80px;
+    }
+    .card {
+      background: #121a30;
+      border: 1px solid #24304f;
+      border-radius: 16px;
+      padding: 24px;
+      box-shadow: 0 10px 30px rgba(0,0,0,.25);
+    }
+    .eyebrow { color: #8ea3d1; font-size: 14px; margin-bottom: 10px; }
+    h1 { font-size: 36px; margin: 0 0 12px; }
+    p { color: #c3cee5; line-height: 1.6; }
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      margin: 24px 0;
+    }
+    .metric {
+      background: #0d1529;
+      border: 1px solid #24304f;
+      border-radius: 12px;
+      padding: 16px;
+    }
+    .metric-label { color: #8ea3d1; font-size: 13px; }
+    .metric-value { font-size: 28px; font-weight: 700; margin-top: 6px; }
+    .btn {
+      display: inline-block;
+      padding: 12px 16px;
+      background: #1b5cff;
+      color: white;
+      text-decoration: none;
+      border-radius: 10px;
+      font-weight: 600;
+      margin-top: 10px;
+    }
+    .small { color: #8ea3d1; font-size: 13px; margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <div class="eyebrow">DSG Public Benchmark</div>
+      <h1>Governed runtime benchmark</h1>
+      <p>
+        DSG benchmark results measure gate decision accuracy, replay completeness,
+        ledger match, proof presence, and false allow rate for governed runtime execution.
+      </p>
+
+      <div class="metrics">
+        <div class="metric">
+          <div class="metric-label">Verdict</div>
+          <div class="metric-value">${escapeHtml(verdict)}</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Gate Accuracy</div>
+          <div class="metric-value">${escapeHtml(gateAccuracy)}</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Replay Completeness</div>
+          <div class="metric-value">${escapeHtml(replayCompleteness)}</div>
+        </div>
+      </div>
+
+      <a class="btn" href="./benchmark/">Open full benchmark report</a>
+      <div class="small">Generated from the repository benchmark workflow artifacts.</div>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function renderBenchmarkPage(result) {
+  const meta = result.meta ?? {};
+  const summary = result.summary ?? {};
+  const metrics = summary.metrics ?? {};
+  const totals = summary.totals ?? {};
+  const rows = (result.results ?? [])
+    .map(
+      (r) => `<tr>
+  <td>${escapeHtml(r.case_id)}</td>
+  <td>${escapeHtml(r.expected_decision)}</td>
+  <td>${escapeHtml(r.observed_decision)}</td>
+  <td>${r.decision_match ? "yes" : "no"}</td>
+  <td>${r.replay_ok ? "yes" : "no"}</td>
+  <td>${r.ledger_ok === true ? "yes" : "no"}</td>
+  <td>${r.proof_present ? "yes" : "no"}</td>
+  <td>${escapeHtml(String(r.latency_ms))}</td>
+</tr>`,
+    )
+    .join("\n");
+
+  const verdict = summary.pass ? "PASS" : "FAIL";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>DSG Benchmark Report</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark light" />
+  <style>
+    :root {
+      --bg: #0b1020;
+      --panel: #121a30;
+      --panel-2: #0d1529;
+      --border: #24304f;
+      --text: #e7ecf5;
+      --muted: #8ea3d1;
+      --accent: #1b5cff;
+      --good: #1ea672;
+      --bad: #e25555;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    .wrap {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 32px 20px 80px;
+    }
+    h1 { font-size: 38px; margin: 0 0 10px; }
+    h2 { font-size: 22px; margin: 0 0 16px; }
+    p, li { color: #c3cee5; line-height: 1.6; }
+    .muted { color: var(--muted); }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      margin: 20px 0 32px;
+    }
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 18px;
+      box-shadow: 0 10px 30px rgba(0,0,0,.2);
+    }
+    .label { font-size: 13px; color: var(--muted); }
+    .value { font-size: 30px; font-weight: 700; margin-top: 6px; }
+    .section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 22px;
+      margin-top: 20px;
+    }
+    .pill {
+      display: inline-block;
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+      border: 1px solid var(--border);
+      background: ${summary.pass ? "rgba(30,166,114,.15)" : "rgba(226,85,85,.15)"};
+      color: ${summary.pass ? "var(--good)" : "var(--bad)"};
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+      font-size: 14px;
+    }
+    th, td {
+      text-align: left;
+      padding: 12px 10px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    th { color: var(--muted); font-weight: 600; }
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+    pre {
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+      overflow: auto;
+      color: #d7def0;
+    }
+    a { color: #8eb0ff; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="muted">DSG Public Benchmark Report</div>
+    <h1>Governed runtime benchmark</h1>
+    <p>
+      This benchmark validates governed runtime behavior for DSG execution flow,
+      including gate decision accuracy, replay completeness, ledger match, proof presence,
+      false allow rate, and latency.
+    </p>
+    <div class="pill">${escapeHtml(verdict)}</div>
+
+    <div class="grid">
+      <div class="card"><div class="label">Gate Accuracy</div><div class="value">${escapeHtml(metrics.gate_accuracy ?? "N/A")}</div></div>
+      <div class="card"><div class="label">Replay Completeness</div><div class="value">${escapeHtml(metrics.replay_completeness ?? "N/A")}</div></div>
+      <div class="card"><div class="label">Ledger Match Rate</div><div class="value">${escapeHtml(metrics.ledger_match_rate ?? "N/A")}</div></div>
+      <div class="card"><div class="label">Proof Presence Rate</div><div class="value">${escapeHtml(metrics.proof_presence_rate ?? "N/A")}</div></div>
+      <div class="card"><div class="label">False Allow Rate</div><div class="value">${escapeHtml(metrics.false_allow_rate ?? "N/A")}</div></div>
+      <div class="card"><div class="label">Average Latency</div><div class="value">${escapeHtml(String(metrics.avg_latency_ms ?? "N/A"))} ms</div></div>
+    </div>
+
+    <div class="section">
+      <h2>Target</h2>
+      <ul>
+        <li>Generated at: <code>${escapeHtml(meta.generated_at ?? "N/A")}</code></li>
+        <li>Base URL: <code>${escapeHtml(meta.base_url ?? "N/A")}</code></li>
+        <li>Execute path: <code>${escapeHtml(meta.execute_path ?? "N/A")}</code></li>
+        <li>Replay path prefix: <code>${escapeHtml(meta.replay_path_prefix ?? "N/A")}</code></li>
+        <li>Agent ID: <code>${escapeHtml(meta.agent_id ?? "N/A")}</code></li>
+        <li>Total cases: <code>${escapeHtml(String(meta.total_cases ?? "N/A"))}</code></li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>Totals</h2>
+      <pre>${escapeHtml(JSON.stringify(totals, null, 2))}</pre>
+    </div>
+
+    <div class="section">
+      <h2>Case Results</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Case</th>
+            <th>Expected</th>
+            <th>Observed</th>
+            <th>Decision match</th>
+            <th>Replay ok</th>
+            <th>Ledger ok</th>
+            <th>Proof present</th>
+            <th>Latency ms</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>Raw result JSON</h2>
+      <p><a href="./result.json">Download result.json</a></p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a public, static benchmark report generated from the existing `artifacts/benchmark/benchmark-result.json` so results can be published without changing the benchmark core logic.
- Offer a simple, reproducible workflow to run the benchmark, render a static site, and publish it to GitHub Pages for easy public inspection.

### Description

- Add two npm scripts: `benchmark:site` to render the static site and `benchmark:full` to run the benchmark then render the site, while keeping `benchmark-result.json` as the source of truth in `artifacts/benchmark` (changes to `package.json`).
- Add `scripts/render-benchmark-site.mjs` which reads `artifacts/benchmark/benchmark-result.json` and writes `site/index.html`, `site/benchmark/index.html`, and `site/benchmark/result.json` with HTML-escaped fields and a human-friendly report view.
- Add `.github/workflows/benchmark-pages.yml` which runs the benchmark, runs the site renderer, uploads artifacts, and deploys the `site` folder to GitHub Pages via the Actions Pages flow.
- Update docs and README (`docs/BENCHMARKS.md`, `README.md`) with a new "Public benchmark site" section, badges, public report/JSON URLs, required Pages configuration, required secrets (`BENCHMARK_API_KEY`, `BENCHMARK_AGENT_ID`), and usage notes.

### Testing

- Verified static site generation with a synthetic result by running `BENCHMARK_SITE_INPUT=/tmp/bench.json BENCHMARK_SITE_DIR=/tmp/site node scripts/render-benchmark-site.mjs` and confirmed `/tmp/site/index.html`, `/tmp/site/benchmark/index.html`, and `/tmp/site/benchmark/result.json` were created successfully.
- Ran `npm install --package-lock-only --ignore-scripts` and confirmed `package-lock.json` remained in sync (no lockfile diff).
- Confirmed repository files and docs updates pass a local consistency check and do not modify existing benchmark core logic or test scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dbdd1778d48326847860827c90b706)