### PR TITLE
Improve DSG benchmark CLI: placeholder validation, network/error handling, and diagnostics

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -25,6 +25,22 @@ Use the **DSG Benchmark** workflow and provide:
 - optional `execute_path`
 - optional `replay_path_prefix`
 
+For local CLI runs:
+
+```bash
+export BENCHMARK_BASE_URL="https://<your-domain>"
+export BENCHMARK_API_KEY="dsg_live_xxx"
+export BENCHMARK_AGENT_ID="<agent-uuid>"
+export BENCHMARK_EXECUTE_PATH="/api/execute"
+export BENCHMARK_REPLAY_PATH_PREFIX="/api/replay"
+node scripts/benchmark-dsg.mjs
+```
+
+Troubleshooting:
+- Do not leave placeholder values like `<API_KEY ของคุณ>` or `<Agent_ID ของคุณ>`; the script now rejects placeholder-looking values.
+- If execution/replay fails, the script prints per-case status + server error to stderr so you can quickly identify auth/route/runtime issues.
+- If API key/agent mismatch is detected (`Invalid agent_id or API key`), benchmark stops immediately with a curl command you can copy to verify credentials.
+
 ## Output
 
 The workflow produces:
@@ -76,4 +92,3 @@ Follow this exact sequence for production-facing benchmark publishing:
 - Confirm `result.json` values match the run artifact `artifacts/benchmark/benchmark-result.json` from the same workflow run.
 - If Pages returns 404, re-check Pages Source is set to **GitHub Actions** (not branch deploy).
 - If workflow fails on auth, re-check `BENCHMARK_API_KEY` and `BENCHMARK_AGENT_ID` in repository secrets.
-

--- a/scripts/benchmark-dsg.mjs
+++ b/scripts/benchmark-dsg.mjs
@@ -3,6 +3,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+const PLACEHOLDER_HINTS = ["<API_KEY", "<Agent_ID", "<AGENT_ID", "<your", "YOUR_"];
+
 const BASE_URL = mustGetEnv("BENCHMARK_BASE_URL");
 const API_KEY = mustGetEnv("BENCHMARK_API_KEY");
 const AGENT_ID = mustGetEnv("BENCHMARK_AGENT_ID");
@@ -24,6 +26,11 @@ async function main() {
   for (const testCase of cases) {
     const result = await runCase(testCase);
     results.push(result);
+
+    const fatalSetupMessage = getFatalSetupMessage(result);
+    if (fatalSetupMessage) {
+      throw new Error(fatalSetupMessage);
+    }
   }
 
   const summary = buildSummary(results);
@@ -55,6 +62,32 @@ async function main() {
   }
 }
 
+function getFatalSetupMessage(result) {
+  const status = Number(result?.execute_status || 0);
+  const message = String(result?.execute_response?.error || "");
+  const lower = message.toLowerCase();
+
+  if (status === 401 && lower.includes("invalid agent_id or api key")) {
+    return [
+      "Benchmark stopped: invalid BENCHMARK_AGENT_ID or BENCHMARK_API_KEY.",
+      "- Ensure API key belongs to the same agent_id.",
+      "- Reissue a new agent API key and export both values again.",
+      "- Quick check:",
+      `  curl -s -X POST \"${BASE_URL}${EXECUTE_PATH}\" -H \"Content-Type: application/json\" -H \"Authorization: Bearer <API_KEY>\" -d '{\"agent_id\":\"<AGENT_ID>\",\"action\":\"scan\",\"input\":{},\"context\":{}}' | jq .`,
+    ].join("\n");
+  }
+
+  if (status === 401 && lower.includes("missing bearer token")) {
+    return "Benchmark stopped: missing Authorization Bearer token. Check BENCHMARK_API_KEY export.";
+  }
+
+  if (status === 403 && lower.includes("agent is not active")) {
+    return "Benchmark stopped: agent is not active. Activate the agent before running benchmark.";
+  }
+
+  return null;
+}
+
 async function loadCases(filePath) {
   const raw = await fs.readFile(filePath, "utf8");
   const parsed = JSON.parse(raw);
@@ -80,6 +113,18 @@ async function runCase(testCase) {
     body: JSON.stringify(executePayload),
   });
 
+  if (!executeRes.ok && !executeRes.network_error) {
+    console.error(
+      `[benchmark][${testCase.case_id}] execute failed: status=${executeRes.status} path=${EXECUTE_PATH} error=${extractErrorMessage(executeRes.data)}`,
+    );
+  }
+
+  if (executeRes.network_error) {
+    console.error(
+      `[benchmark][${testCase.case_id}] execute network error: ${executeRes.network_error}`,
+    );
+  }
+
   const executionId = findExecutionId(executeRes.data);
   let replayRes = null;
 
@@ -91,6 +136,12 @@ async function runCase(testCase) {
         headers: authHeaders(),
       },
     );
+
+    if (!replayRes.ok && !replayRes.network_error) {
+      console.error(
+        `[benchmark][${testCase.case_id}] replay failed: status=${replayRes.status} path=${REPLAY_PATH_PREFIX}/${executionId} error=${extractErrorMessage(replayRes.data)}`,
+      );
+    }
   }
 
   const finishedAt = Date.now();
@@ -125,6 +176,7 @@ async function runCase(testCase) {
     latency_ms: latencyMs,
     execute_status: executeRes.status,
     replay_status: replayRes?.status ?? null,
+    network_error: executeRes.network_error || replayRes?.network_error || null,
     request: executePayload,
     execute_response: executeRes.data,
     replay_response: replayRes?.data ?? null,
@@ -225,7 +277,21 @@ ${rows}
 }
 
 async function fetchJson(url, init) {
-  const res = await fetch(url, init);
+  let res;
+  try {
+    res = await fetch(url, init);
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      data: {
+        error: "Network request failed",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      network_error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
   const text = await res.text();
   let data;
   try {
@@ -238,7 +304,13 @@ async function fetchJson(url, init) {
     ok: res.ok,
     status: res.status,
     data,
+    network_error: null,
   };
+}
+
+function extractErrorMessage(data) {
+  if (!data || typeof data !== "object") return "unknown";
+  return data.error || data.message || "unknown";
 }
 
 function authHeaders() {
@@ -303,6 +375,13 @@ function mustGetEnv(name) {
   if (!value) {
     throw new Error(`Missing required environment variable: ${name}`);
   }
+
+  if (PLACEHOLDER_HINTS.some((hint) => value.includes(hint))) {
+    throw new Error(
+      `Environment variable ${name} still has placeholder text. Replace it with a real value before running benchmark.`,
+    );
+  }
+
   return value;
 }
 


### PR DESCRIPTION
### Motivation
- Make the local `benchmark-dsg.mjs` runner more robust and user-friendly by rejecting placeholder env values, surfacing network/auth errors quickly, and providing actionable troubleshooting hints. 
- Update documentation to show a local CLI run example and common troubleshooting steps so users can debug auth/route/runtime issues faster.

### Description
- Add placeholder detection (`PLACEHOLDER_HINTS`) and fail early in `mustGetEnv` when environment variables contain placeholder-like text. 
- Add network error handling in `fetchJson` to return structured error info when `fetch` throws, and propagate a `network_error` field in case results. 
- Log per-case execute/replay failures and network errors with `console.error`, and include `network_error` in returned case results. 
- Add `getFatalSetupMessage` to detect common fatal auth/setup responses (invalid API key/agent, missing bearer token, inactive agent), print a helpful message (including a copyable `curl` check), and stop the run when detected. 
- Add `extractErrorMessage` helper for concise error strings and expand `docs/BENCHMARKS.md` with a local run example and troubleshooting tips.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc6c75c29c8326800e881ea76ed61f)