### PR TITLE
Improve quickstart runtime error messaging for missing migrations

### DIFF
--- a/app/quickstart/page.tsx
+++ b/app/quickstart/page.tsx
@@ -90,7 +90,11 @@ export default function QuickstartPage() {
       const json = await response.json();
 
       if (!response.ok) {
-        throw new Error(json?.error || 'Failed to run sample execution');
+        const rawError = String(json?.error || 'Failed to run sample execution');
+        const message = rawError === 'Internal server error'
+          ? 'Internal server error: quickstart backend setup is incomplete. Check runtime migrations/logs.'
+          : rawError;
+        throw new Error(message);
       }
 
       setExecute(json as ExecuteResponse);

--- a/lib/spine/engine.ts
+++ b/lib/spine/engine.ts
@@ -22,6 +22,26 @@ function mapRpcError(error: unknown) {
   const message = rpcErrorMessage(error).toLowerCase();
   const hasAny = (...patterns: string[]) => patterns.some((pattern) => message.includes(pattern));
 
+  if (
+    hasAny(
+      'runtime_commit_execution',
+      'function public.runtime_commit_execution',
+      'could not find the function public.runtime_commit_execution'
+    )
+  ) {
+    return {
+      status: 500,
+      body: { error: 'Runtime commit RPC is missing. Apply latest Supabase migrations.' },
+    };
+  }
+
+  if (hasAny('runtime_approval_requests', 'relation "runtime_approval_requests" does not exist')) {
+    return {
+      status: 500,
+      body: { error: 'Runtime spine tables are missing. Apply latest Supabase migrations.' },
+    };
+  }
+
   if (hasAny('agent_quota_exceeded', 'agent quota exceeded')) {
     return { status: 429, body: { error: 'Agent monthly quota exceeded' } };
   }


### PR DESCRIPTION
### Motivation
- Quickstart sometimes surfaces a generic `Internal server error` when runtime Supabase migrations or RPCs are not applied, which makes operator troubleshooting difficult. 
- Provide more actionable error messages both in the spine engine and the quickstart UI so operators know to apply migrations or check runtime logs.

### Description
- Add RPC error mapping in `lib/spine/engine.ts` to detect missing `runtime_commit_execution` and missing `runtime_approval_requests` and return 500 responses with actionable messages recommending applying the latest Supabase migrations. 
- Update `app/quickstart/page.tsx` to translate a backend `Internal server error` into a setup-focused message directing operators to check runtime migrations/logs when running the quickstart execution.

### Testing
- Ran `npm run test:unit -- tests/unit/spine/pipeline-approval.test.ts` and the unit tests covering the `issueSpineIntent`/approval flow passed. 
- No automated failures observed for the exercised unit test(s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc722c762c832699b7cdb373be279c)