### PR TITLE
docs: add DB-to-Supabase alignment audit report

### DIFF
--- a/docs/DB_SUPABASE_ALIGNMENT_2026-04-13.md
+++ b/docs/DB_SUPABASE_ALIGNMENT_2026-04-13.md
@@ -1,0 +1,39 @@
+# DB function/table alignment check (app vs Supabase)
+
+Date: 2026-04-13
+
+## Scope
+- Checked application DB calls in `app/` and `lib/` for `.from('...')` and `.rpc('...')` usage.
+- Cross-checked names against SQL definitions in `supabase/schema.sql` and all files in `supabase/migrations/*.sql`.
+
+## Result summary
+- Total referenced tables/views in app code: **37**
+- Total referenced RPC functions in app code: **1**
+- Missing in Supabase SQL (table/view): **4**
+- Missing in Supabase SQL (RPC): **0**
+
+## Missing DB objects
+1. `agent_execution_requests`
+   - Referenced in:
+     - `app/api/agent-executions/route.ts`
+     - `lib/agent-governance/service.ts`
+2. `agent_execution_steps`
+   - Referenced in:
+     - `lib/agent-governance/service.ts`
+3. `agent_execution_approvals`
+   - Referenced in:
+     - `lib/agent-governance/service.ts`
+4. `user_org_roles`
+   - Referenced in:
+     - `app/api/access/review/route.ts`
+
+## Confirmed aligned RPC
+- `runtime_commit_execution`
+  - Referenced in app code and present in migrations.
+
+## Impact
+- Calls to missing objects will fail at runtime with relation-not-found errors unless those objects already exist in a separate, unmanaged database migration path.
+
+## Recommended next action
+- Add a new migration under `supabase/migrations/` to define the 4 missing relations (or remove code paths that reference them).
+- Optional: add CI guard script that diffs `.from/.rpc` references against migration SQL to prevent future drift.


### PR DESCRIPTION
### Motivation
- Add a short audit that verifies application DB calls (`.from(...)` / `.rpc(...)`) match the Supabase schema/migrations to detect drift and prevent runtime relation-not-found errors.

### Description
- Add `docs/DB_SUPABASE_ALIGNMENT_2026-04-13.md` which documents a scan of `app/` and `lib/` DB references against `supabase/schema.sql` and `supabase/migrations/*`, reports 4 missing relations (`agent_execution_requests`, `agent_execution_steps`, `agent_execution_approvals`, `user_org_roles`) and recommends adding migrations or removing stale references.

### Testing
- Ran the automated repository scan (`python` script) and `rg` checks to extract and cross-check `.from(...)`/`.rpc(...)` usage which completed successfully, and the repository test summary shows the Vitest suite is green (85 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc9465013883269e06db17e1370499)