### PR TITLE
Add runtime_commit_execution RPC shim with legacy fallback and recovery tooling

### DIFF
--- a/app/api/demo/bootstrap/route.ts
+++ b/app/api/demo/bootstrap/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { canonicalHash, canonicalJson } from '../../../../lib/runtime/canonical';
 import { buildCheckpointHash } from '../../../../lib/runtime/checkpoint';
+import { invokeRuntimeCommitRpc } from '../../../../lib/runtime/commit-rpc';
 import { getOverageRateUsd } from '../../../../lib/billing/overage-config';
 import { handleApiError } from '../../../../lib/security/api-error';
 
@@ -58,7 +59,7 @@ export async function POST(request: Request) {
       expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
     });
 
-    const { data: commit, error: commitError } = await supabase.rpc('runtime_commit_execution', {
+    const { data: commit, error: commitError } = await invokeRuntimeCommitRpc(supabase, {
       p_org_id: orgId,
       p_agent_id: agentId,
       p_request_id: approvalId,

--- a/app/api/setup/auto/route.ts
+++ b/app/api/setup/auto/route.ts
@@ -5,6 +5,7 @@ import { getOverageRateUsd, INCLUDED_EXECUTIONS } from '../../../../lib/billing/
 import { bootstrapOrgStarterState } from '../../../../lib/onboarding/bootstrap';
 import { canonicalHash, canonicalJson } from '../../../../lib/runtime/canonical';
 import { buildCheckpointHash } from '../../../../lib/runtime/checkpoint';
+import { invokeRuntimeCommitRpc } from '../../../../lib/runtime/commit-rpc';
 import { handleApiError } from '../../../../lib/security/api-error';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
@@ -168,7 +169,7 @@ export async function POST(_request: Request) {
         (results.steps as string[]).push(toStepStatus('approval', approvalError));
       }
     } else {
-      const { data: commit, error: commitError } = await admin.rpc('runtime_commit_execution', {
+      const { data: commit, error: commitError, mode: commitMode } = await invokeRuntimeCommitRpc(admin, {
         p_org_id: orgId,
         p_agent_id: agentId,
         p_request_id: approvalId,
@@ -195,7 +196,9 @@ export async function POST(_request: Request) {
         results.execution_id = row?.execution_id;
         results.ledger_id = row?.ledger_id;
         results.truth_state_id = row?.truth_state_id;
-        (results.steps as string[]).push(`rpc_commit: OK (execution=${row?.execution_id})`);
+        (results.steps as string[]).push(
+          `rpc_commit: OK${commitMode === 'legacy' ? ' (legacy-signature)' : ''} (execution=${row?.execution_id})`,
+        );
 
         if (row?.ledger_id && row?.truth_state_id) {
           const cpHash = buildCheckpointHash({

--- a/docs/RUNBOOK_DEPLOY.md
+++ b/docs/RUNBOOK_DEPLOY.md
@@ -162,6 +162,28 @@ Run migrations for the target environment before traffic cutover.
 
 - Validate schema changes via application smoke checks.
 
+### One-command runtime RPC + PostgREST cache recovery
+When `rpc_commit` fails because PostgREST cannot find `public.runtime_commit_execution(...)` in schema cache:
+
+```bash
+SUPABASE_DB_URL='postgres://...' ./scripts/apply-runtime-rpc-fix.sh
+```
+
+This script:
+1. Re-applies `20260402_billing_quota_in_rpc.sql`
+2. Re-applies `20260404_runtime_spine_rpc_hardening.sql`
+3. Sends `NOTIFY pgrst, 'reload schema'`
+4. Verifies `runtime_commit_execution` has the expected argument count (>= 17)
+
+You can also run it via npm script:
+
+```bash
+SUPABASE_DB_URL='postgres://...' npm run ops:runtime-rpc-fix
+```
+
+For Termux auto-install flow, `scripts/termux-deploy-all-in-one.sh` now prompts for `SUPABASE_DB_URL` and runs this fix automatically when provided.
+For CI/non-interactive mode, set `SUPABASE_DB_URL` in environment before running `scripts/termux-deploy-all-in-one.sh` (the script will skip the prompt when `CI=true`).
+
 ### Runtime RPC drift recovery (`runtime_commit_execution`)
 If runtime requests fail with errors indicating missing/invalid runtime commit RPC behavior, recover with a **safe cutover**:
 

--- a/lib/runtime/commit-rpc.ts
+++ b/lib/runtime/commit-rpc.ts
@@ -1,0 +1,51 @@
+type RpcClient = {
+  rpc: (fn: string, args: Record<string, unknown>) => unknown;
+};
+
+export type RuntimeCommitRpcArgs = {
+  p_org_id: string;
+  p_agent_id: string;
+  p_request_id: string;
+  p_decision: string;
+  p_reason: string;
+  p_metadata?: Record<string, unknown>;
+  p_canonical_hash: string;
+  p_canonical_json: Record<string, unknown>;
+  p_latency_ms?: number;
+  p_request_payload?: Record<string, unknown>;
+  p_context_payload?: Record<string, unknown>;
+  p_policy_version?: string | null;
+  p_audit_evidence?: Record<string, unknown>;
+  p_usage_amount_usd?: number;
+  p_created_at?: string;
+  p_agent_monthly_limit?: number;
+  p_org_plan_limit?: number;
+};
+
+function isRpcSignatureMismatch(message: string) {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('runtime_commit_execution') &&
+    normalized.includes('schema cache') &&
+    normalized.includes('function')
+  );
+}
+
+function toLegacyArgs(args: RuntimeCommitRpcArgs) {
+  const { p_agent_monthly_limit: _agentLimit, p_org_plan_limit: _orgLimit, ...legacy } = args;
+  return legacy;
+}
+
+export async function invokeRuntimeCommitRpc(client: RpcClient, args: RuntimeCommitRpcArgs) {
+  const first = await client.rpc('runtime_commit_execution', args) as { data: unknown; error: { message: string } | null };
+  if (!first.error) {
+    return { ...first, mode: 'latest' as const };
+  }
+
+  if (!isRpcSignatureMismatch(first.error.message)) {
+    return { ...first, mode: 'latest' as const };
+  }
+
+  const fallback = await client.rpc('runtime_commit_execution', toLegacyArgs(args)) as { data: unknown; error: { message: string } | null };
+  return { ...fallback, mode: 'legacy' as const };
+}

--- a/lib/spine/engine.ts
+++ b/lib/spine/engine.ts
@@ -3,6 +3,7 @@ import { getOverageRateUsd, INCLUDED_EXECUTIONS } from '../billing/overage-confi
 import { getSupabaseAdmin } from '../supabase-server';
 import { buildApprovalKey } from '../runtime/approval';
 import { canonicalHash, canonicalJson, type CanonicalInput } from '../runtime/canonical';
+import { invokeRuntimeCommitRpc } from '../runtime/commit-rpc';
 import { runPipeline, SpineInfraError } from './pipeline';
 import type { SpineIntentPayload, TruthState } from './types';
 
@@ -339,7 +340,7 @@ export async function executeSpineIntent(params: {
     },
   };
 
-  const { data: commitResult, error: rpcError } = await supabase.rpc('runtime_commit_execution', {
+  const { data: commitResult, error: rpcError } = await invokeRuntimeCommitRpc(supabase, {
     p_org_id: agent.org_id,
     p_agent_id: agent.id,
     p_request_id: approvalRequest.id,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "go:no-go": "./scripts/go-no-go-gate.sh",
     "benchmark": "node scripts/benchmark-dsg.mjs",
     "benchmark:site": "node scripts/render-benchmark-site.mjs",
-    "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs"
+    "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs",
+    "ops:runtime-rpc-fix": "./scripts/apply-runtime-rpc-fix.sh"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",

--- a/scripts/apply-runtime-rpc-fix.sh
+++ b/scripts/apply-runtime-rpc-fix.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB_URL="${SUPABASE_DB_URL:-${1:-}}"
+
+if [[ -z "${DB_URL}" ]]; then
+  echo "ERROR: Missing DB URL."
+  echo "Usage: SUPABASE_DB_URL=postgres://... ./scripts/apply-runtime-rpc-fix.sh"
+  echo "   or: ./scripts/apply-runtime-rpc-fix.sh postgres://..."
+  exit 1
+fi
+
+echo "[1/4] Applying billing quota RPC migration..."
+psql "${DB_URL}" -v ON_ERROR_STOP=1 -f "${ROOT_DIR}/supabase/migrations/20260402_billing_quota_in_rpc.sql"
+
+echo "[2/4] Applying runtime spine RPC hardening migration..."
+psql "${DB_URL}" -v ON_ERROR_STOP=1 -f "${ROOT_DIR}/supabase/migrations/20260404_runtime_spine_rpc_hardening.sql"
+
+echo "[3/4] Reloading PostgREST schema cache..."
+psql "${DB_URL}" -v ON_ERROR_STOP=1 -c "NOTIFY pgrst, 'reload schema';"
+
+echo "[4/4] Verifying runtime_commit_execution signature..."
+ARG_COUNT="$(
+  psql "${DB_URL}" -tA -v ON_ERROR_STOP=1 -c "
+    select coalesce(max(p.pronargs), 0)
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname = 'runtime_commit_execution';
+  " | tr -d '[:space:]'
+)"
+
+if [[ "${ARG_COUNT}" -lt 17 ]]; then
+  echo "ERROR: runtime_commit_execution still has ${ARG_COUNT} args (expected >= 17)."
+  exit 1
+fi
+
+echo "OK: runtime_commit_execution is up to date (args=${ARG_COUNT}) and schema cache reload was requested."

--- a/scripts/termux-deploy-all-in-one.sh
+++ b/scripts/termux-deploy-all-in-one.sh
@@ -64,10 +64,23 @@ set_vercel_env "NEXT_PUBLIC_APP_URL" "$APP_URL"
 set_vercel_env "APP_URL" "$APP_URL"
 set_vercel_env "DSG_CORE_MODE" "internal"
 
-log "Step 2/5: Supabase link + migration push"
+log "Step 2/6: Supabase link + migration push"
 supabase login
 supabase link --project-ref "$SUPABASE_PROJECT_REF"
 supabase db push
+
+if [[ -z "${SUPABASE_DB_URL:-}" && "${CI:-}" != "true" ]]; then
+  read -r -p "SUPABASE_DB_URL สำหรับ reload PostgREST cache (ถ้ายังไม่มีให้กด Enter ข้าม): " SUPABASE_DB_URL
+fi
+
+if [[ -n "${SUPABASE_DB_URL:-}" ]]; then
+  log "Step 3/6: Apply runtime RPC hardening + reload PostgREST schema cache"
+  SUPABASE_DB_URL="${SUPABASE_DB_URL}" ./scripts/apply-runtime-rpc-fix.sh
+else
+  log "Step 3/6: ข้าม runtime RPC fix (ไม่ได้ใส่ SUPABASE_DB_URL)"
+  echo "  สามารถรันทีหลังได้ด้วย:"
+  echo "  SUPABASE_DB_URL='postgres://...' ./scripts/apply-runtime-rpc-fix.sh"
+fi
 
 cat <<'NOTE'
 
@@ -78,10 +91,10 @@ cat <<'NOTE'
    - Redirect URL: https://tdealer01-crypto-dsg-control-plane.vercel.app/auth/confirm
 NOTE
 
-log "Step 3/5: Deploy production บน Vercel"
+log "Step 4/6: Deploy production บน Vercel"
 vercel --prod
 
-log "Step 4/5: Health checks"
+log "Step 5/6: Health checks"
 printf "\n/api/health =>\n"
 curl -sS "${APP_URL}/api/health" | sed 's/^/  /'
 printf "\n\n/api/core/monitor =>\n"


### PR DESCRIPTION
### Motivation

- Provide a robust wrapper for calling `runtime_commit_execution` that automatically falls back to a legacy RPC signature when PostgREST schema cache or signature drift prevents the newer signature from being invoked.
- Reduce production/manual recovery pain by adding an ops script and documentation to re-apply migrations and trigger a PostgREST schema reload when RPC signature drift occurs.

### Description

- Add `lib/runtime/commit-rpc.ts` which exports `invokeRuntimeCommitRpc` that calls `runtime_commit_execution` and falls back to a legacy argument set when a schema/signature mismatch is detected.
- Replace direct `supabase.rpc('runtime_commit_execution', ...)` calls with `invokeRuntimeCommitRpc(...)` in `app/api/demo/bootstrap/route.ts`, `app/api/setup/auto/route.ts`, and `lib/spine/engine.ts`, and surface the chosen `mode` to callers for log/status messages.
- Add an executable ops script `scripts/apply-runtime-rpc-fix.sh` that reapplies the RPC-related migrations, sends `NOTIFY pgrst, 'reload schema'`, and verifies `runtime_commit_execution` argument count, and wire it into the Termux deploy flow in `scripts/termux-deploy-all-in-one.sh` and `package.json` via `ops:runtime-rpc-fix` script.
- Update docs `docs/RUNBOOK_DEPLOY.md` to document the one-command RPC + PostgREST cache recovery step and note the behavior of the new script.

### Testing

- Ran unit tests with `npm run test:unit` (Vitest) and the suite passed.
- Executed `./scripts/apply-runtime-rpc-fix.sh` against a development Postgres instance to verify the migrations apply, the `NOTIFY pgrst` command runs, and the argument-count verification succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc9d19261c83269625bcd75b2d182c)