### PR TITLE
Preserve quota args when retrying runtime_commit_execution fallback

### DIFF
--- a/lib/runtime/commit-rpc.ts
+++ b/lib/runtime/commit-rpc.ts
@@ -32,8 +32,9 @@ function isRpcSignatureMismatch(message: string) {
 }
 
 function toLegacyArgs(args: RuntimeCommitRpcArgs) {
-  const { p_agent_monthly_limit: _agentLimit, p_org_plan_limit: _orgLimit, ...legacy } = args;
-  return legacy;
+  // Preserve quota parameters so schema-cache fallback cannot silently bypass
+  // agent/org billing guardrails by reverting them to SQL defaults.
+  return { ...args };
 }
 
 export async function invokeRuntimeCommitRpc(client: RpcClient, args: RuntimeCommitRpcArgs) {

--- a/tests/unit/runtime/commit-rpc.test.ts
+++ b/tests/unit/runtime/commit-rpc.test.ts
@@ -1,0 +1,37 @@
+import { invokeRuntimeCommitRpc, type RuntimeCommitRpcArgs } from '../../../lib/runtime/commit-rpc';
+
+describe('invokeRuntimeCommitRpc', () => {
+  const baseArgs: RuntimeCommitRpcArgs = {
+    p_org_id: 'org_1',
+    p_agent_id: 'agent_1',
+    p_request_id: 'req_1',
+    p_decision: 'allow',
+    p_reason: 'ok',
+    p_canonical_hash: 'hash_1',
+    p_canonical_json: { ok: true },
+    p_agent_monthly_limit: 100,
+    p_org_plan_limit: 1000,
+  };
+
+  it('preserves quota args in fallback retry payload', async () => {
+    const rpc = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          message: 'Could not find the function public.runtime_commit_execution in the schema cache',
+        },
+      })
+      .mockResolvedValueOnce({ data: { ok: true }, error: null });
+
+    const result = await invokeRuntimeCommitRpc({ rpc }, baseArgs);
+
+    expect(result.error).toBeNull();
+    expect(result.mode).toBe('legacy');
+    expect(rpc).toHaveBeenNthCalledWith(1, 'runtime_commit_execution', baseArgs);
+    expect(rpc).toHaveBeenNthCalledWith(2, 'runtime_commit_execution', expect.objectContaining({
+      p_agent_monthly_limit: 100,
+      p_org_plan_limit: 1000,
+    }));
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent a high-severity regression where the schema-cache fallback path stripped `p_agent_monthly_limit` and `p_org_plan_limit`, causing quota checks to be bypassed when PostgREST signature drift occurred.

### Description

- Change `toLegacyArgs` in `lib/runtime/commit-rpc.ts` to preserve all incoming args (including `p_agent_monthly_limit` and `p_org_plan_limit`) and add an inline comment explaining the safety rationale.
- Keep the existing `invokeRuntimeCommitRpc` retry flow but route the fallback call through the updated `toLegacyArgs` so retries do not revert quota fields to SQL defaults.
- Add a focused unit test `tests/unit/runtime/commit-rpc.test.ts` that simulates a schema-cache signature mismatch on the first RPC call and asserts the fallback call still includes both quota arguments.

### Testing

- Ran the focused unit test with `npm run test:unit -- tests/unit/runtime/commit-rpc.test.ts` and the test passed.
- Ran the unit test suite with `npm run test:unit` and the suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcb85ac21c83268dbf7af1040b2560)