### PR TITLE
Add onboarding/one-click setup UI, clipboard helpers, and screenshot script

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -36,6 +36,11 @@ type UsageSummary = {
   projected_amount_usd: number;
 };
 
+type OnboardingState = {
+  bootstrap_status?: "pending" | "completed" | "failed";
+  checklist?: { steps?: string[]; next_action?: string };
+};
+
 function normalizeAgent(input: unknown): Agent | null {
   if (!input || typeof input !== "object") return null;
   const row = input as Record<string, unknown>;
@@ -142,6 +147,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>("");
   const [auditError, setAuditError] = useState<string>("");
+  const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -173,12 +179,16 @@ export default function DashboardPage() {
             ok: r.ok,
             json: await r.json(),
           })),
+          fetch("/api/quickstart/onboarding", { cache: "no-store" }).then(async (r) => ({
+            ok: r.ok,
+            json: await r.json(),
+          })),
         ]);
 
         if (!alive) return;
 
         const warnings: string[] = [];
-        const [agentsResult, executionsResult, usageResult, healthResult, auditResult] = results;
+        const [agentsResult, executionsResult, usageResult, healthResult, auditResult, onboardingResult] = results;
 
         if (agentsResult.status === "fulfilled" && agentsResult.value.ok) {
           const normalizedAgents = Array.isArray(agentsResult.value.json?.items)
@@ -241,6 +251,10 @@ export default function DashboardPage() {
           );
         }
 
+        if (onboardingResult.status === "fulfilled" && onboardingResult.value.ok) {
+          setOnboarding(onboardingResult.value.json?.onboarding ?? null);
+        }
+
         if (warnings.length > 0) {
           setError(warnings.join(" | "));
         }
@@ -284,6 +298,19 @@ export default function DashboardPage() {
       ? "checking"
       : "ok";
 
+  const onboardingProgress = useMemo(() => {
+    const hasAgent = agents.length > 0;
+    const hasExecution = executions.length > 0;
+    const bootstrapped = onboarding?.bootstrap_status === "completed";
+    const completed = [hasAgent, hasExecution, bootstrapped].filter(Boolean).length;
+    const total = 3;
+    return {
+      percent: Math.round((completed / total) * 100),
+      completed,
+      total,
+    };
+  }, [agents.length, executions.length, onboarding?.bootstrap_status]);
+
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
       <div className="mx-auto max-w-7xl px-6 py-10">
@@ -307,6 +334,26 @@ export default function DashboardPage() {
         </div>
 
         {error ? <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-red-200">{error}</div> : null}
+
+        <section className="mt-6 rounded-2xl border border-emerald-400/30 bg-emerald-400/10 p-6">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-emerald-200">Onboarding progress</p>
+              <p className="text-sm text-emerald-100/90">
+                {onboardingProgress.completed}/{onboardingProgress.total} completed
+              </p>
+            </div>
+            <Link href="/quickstart" className="rounded-xl border border-emerald-200/40 px-4 py-2 text-sm font-semibold text-emerald-100">
+              Continue quickstart
+            </Link>
+          </div>
+          <div className="mt-4 h-2 w-full rounded-full bg-slate-800">
+            <div
+              className="h-2 rounded-full bg-emerald-300 transition-all"
+              style={{ width: `${onboardingProgress.percent}%` }}
+            />
+          </div>
+        </section>
 
         {!loading && !error && agents.length === 0 && executions.length === 0 ? (
           <div className="mt-6 rounded-2xl border border-emerald-400/30 bg-emerald-400/10 p-6">

--- a/app/dashboard/skills/page.tsx
+++ b/app/dashboard/skills/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 const TOOLS = [
   ["readiness", "GET /api/core/monitor", "Read readiness, health, entropy, alerts, billing"],
@@ -33,9 +34,11 @@ type SetupResult = {
 };
 
 export default function SkillsPage() {
+  const router = useRouter();
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<SetupResult | null>(null);
   const [error, setError] = useState("");
+  const [copyStatus, setCopyStatus] = useState("");
   const [query, setQuery] = useState("bitcoin regulation latest");
   const [searchResult, setSearchResult] = useState<Record<string, unknown> | null>(null);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -55,11 +58,25 @@ export default function SkillsPage() {
         setError(json.error || `Setup failed (${res.status})`);
       } else {
         setResult(json);
+        if (json?.ok) {
+          setTimeout(() => router.push("/dashboard"), 1200);
+        }
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
     } finally {
       setRunning(false);
+    }
+  }
+
+  async function copyApiKey(value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyStatus("Copied API key");
+      setTimeout(() => setCopyStatus(""), 1800);
+    } catch {
+      setCopyStatus("Copy failed");
+      setTimeout(() => setCopyStatus(""), 1800);
     }
   }
 
@@ -142,6 +159,14 @@ export default function SkillsPage() {
                   <code className="mt-2 block break-all rounded bg-slate-950 p-3 text-xs text-emerald-300">
                     {result.api_key}
                   </code>
+                  <button
+                    onClick={() => void copyApiKey(result.api_key)}
+                    className="mt-3 rounded-lg border border-amber-200/40 px-3 py-2 text-xs font-semibold text-amber-100"
+                  >
+                    Copy to clipboard
+                  </button>
+                  {copyStatus ? <p className="mt-2 text-xs text-amber-100">{copyStatus}</p> : null}
+                  {result.ok ? <p className="mt-2 text-xs text-emerald-200">Setup complete. Redirecting to dashboard...</p> : null}
                 </div>
               )}
 

--- a/app/quickstart/page.tsx
+++ b/app/quickstart/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type AgentResponse = {
   agent_id: string;
@@ -36,12 +37,17 @@ type ExecuteResponse = {
 };
 
 export default function QuickstartPage() {
+  const router = useRouter();
   const [agent, setAgent] = useState<AgentResponse | null>(null);
   const [agentError, setAgentError] = useState('');
   const [execute, setExecute] = useState<ExecuteResponse | null>(null);
   const [executeError, setExecuteError] = useState('');
   const [isCreatingAgent, setIsCreatingAgent] = useState(false);
   const [isExecuting, setIsExecuting] = useState(false);
+  const [isAutoSetupRunning, setIsAutoSetupRunning] = useState(false);
+  const [autoSetupSteps, setAutoSetupSteps] = useState<string[]>([]);
+  const [autoSetupExecutionId, setAutoSetupExecutionId] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState('');
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
   const [isEmptyOrg, setIsEmptyOrg] = useState(false);
 
@@ -72,6 +78,57 @@ export default function QuickstartPage() {
       setAgentError(error instanceof Error ? error.message : 'Failed to create starter agent');
     } finally {
       setIsCreatingAgent(false);
+    }
+  }
+
+  async function runOneClickSetup() {
+    try {
+      setIsAutoSetupRunning(true);
+      setAgentError('');
+      setExecuteError('');
+      setAutoSetupSteps([]);
+      setAutoSetupExecutionId(null);
+
+      const setupResponse = await fetch('/api/setup/auto', { method: 'POST', cache: 'no-store' });
+      const setupJson = await setupResponse.json();
+      if (!setupResponse.ok) {
+        throw new Error(String(setupJson?.error || 'Auto setup failed'));
+      }
+
+      setAutoSetupSteps(Array.isArray(setupJson?.steps) ? setupJson.steps : []);
+      setAutoSetupExecutionId(typeof setupJson?.execution_id === 'string' ? setupJson.execution_id : null);
+
+      if (typeof setupJson?.api_key === 'string' && setupJson.api_key.length > 0) {
+        setAgent({
+          agent_id: typeof setupJson.agent_id === 'string' ? setupJson.agent_id : 'auto-setup-agent',
+          name: 'Auto-Setup Agent',
+          policy_id: 'policy_default',
+          status: 'active',
+          monthly_limit: 10000,
+          api_key: setupJson.api_key,
+          api_key_preview: `${setupJson.api_key.slice(0, 12)}...`,
+          created: true,
+        });
+      }
+
+      setTimeout(() => {
+        router.push('/dashboard');
+      }, 1200);
+    } catch (error) {
+      setAgentError(error instanceof Error ? error.message : 'Auto setup failed');
+    } finally {
+      setIsAutoSetupRunning(false);
+    }
+  }
+
+  async function copyApiKey(value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyStatus('Copied API key');
+      setTimeout(() => setCopyStatus(''), 1800);
+    } catch {
+      setCopyStatus('Copy failed');
+      setTimeout(() => setCopyStatus(''), 1800);
     }
   }
 
@@ -150,6 +207,30 @@ export default function QuickstartPage() {
         </section>
 
         <section className="rounded-[1.5rem] border border-white/10 bg-slate-900/70 p-6">
+          <p className="text-lg font-semibold">One-click setup</p>
+          <p className="mt-2 text-sm text-slate-300">
+            Run full setup (policy + agent + verification execution + onboarding + billing) and continue to dashboard automatically.
+          </p>
+          <button
+            onClick={() => void runOneClickSetup()}
+            disabled={isAutoSetupRunning}
+            className="mt-4 rounded-xl bg-emerald-300 px-4 py-3 font-semibold text-slate-950"
+          >
+            {isAutoSetupRunning ? 'Starting...' : 'Start One-Click Setup'}
+          </button>
+          {autoSetupExecutionId ? (
+            <p className="mt-3 text-sm text-emerald-200">Setup complete. Execution: {autoSetupExecutionId}. Redirecting to dashboard...</p>
+          ) : null}
+          {autoSetupSteps.length > 0 ? (
+            <ul className="mt-3 space-y-1 text-xs text-slate-300">
+              {autoSetupSteps.map((step) => (
+                <li key={step}>• {step}</li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+
+        <section className="rounded-[1.5rem] border border-white/10 bg-slate-900/70 p-6">
           <p className="text-lg font-semibold">Create first agent</p>
           <button
             onClick={() => void createStarterAgent()}
@@ -173,6 +254,13 @@ export default function QuickstartPage() {
                 <div className="mt-3 rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-3 text-emerald-100">
                   <p className="font-semibold">Copy API Key</p>
                   <code className="mt-1 block break-all text-xs">{agent.api_key}</code>
+                  <button
+                    onClick={() => void copyApiKey(agent.api_key)}
+                    className="mt-3 rounded-lg border border-emerald-200/40 px-3 py-2 text-xs font-semibold text-emerald-100"
+                  >
+                    Copy to clipboard
+                  </button>
+                  {copyStatus ? <p className="mt-2 text-xs">{copyStatus}</p> : null}
                 </div>
               ) : null}
             </div>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:failure": "vitest run tests/failure",
     "test:migrations": "vitest run tests/migrations",
     "test:e2e": "./scripts/with-playwright-chromium.sh playwright test",
+    "screenshot": "./scripts/with-playwright-chromium.sh node scripts/capture-screenshot.mjs",
     "test:e2e:install": "playwright install --with-deps chromium",
     "test:e2e:install:shell": "playwright install --only-shell chromium",
     "test:e2e:live": "./scripts/with-playwright-chromium.sh playwright test tests/e2e/finance-governance-live-supabase.spec.ts",

--- a/scripts/capture-screenshot.mjs
+++ b/scripts/capture-screenshot.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { chromium } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const targetUrl = process.argv[2] || 'http://127.0.0.1:3000';
+const outputPath = process.argv[3] || 'artifacts/screenshot.png';
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch({
+      headless: true,
+      ...(executablePath ? { executablePath } : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Executable doesn't exist")) {
+      throw error;
+    }
+
+    console.warn('Chromium executable missing. Installing Playwright headless shell...');
+    try {
+      execSync('npx playwright install --only-shell chromium', { stdio: 'inherit' });
+    } catch (installError) {
+      throw new Error(
+        `Unable to install Chromium automatically. Set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to a local browser binary or allow access to Playwright CDN. Root cause: ${
+          installError instanceof Error ? installError.message : String(installError)
+        }`,
+      );
+    }
+
+    return chromium.launch({
+      headless: true,
+      ...(executablePath ? { executablePath } : {}),
+    });
+  }
+}
+
+const browser = await launchBrowser();
+
+try {
+  await mkdir(dirname(outputPath), { recursive: true });
+  const page = await browser.newPage();
+  await page.goto(targetUrl, { waitUntil: 'networkidle', timeout: 60_000 });
+  await page.screenshot({ path: outputPath, fullPage: true });
+  console.log(`Saved screenshot: ${outputPath}`);
+} finally {
+  await browser.close();
+}

--- a/tests/unit/spine/pipeline-approval.test.ts
+++ b/tests/unit/spine/pipeline-approval.test.ts
@@ -67,6 +67,9 @@ describe('issueSpineIntent + executeSpineIntent approval flow', () => {
     const second = await issueSpineIntent({ orgId: 'org_1', apiKey: 'key1', payload });
     expect(second.ok).toBe(true);
     expect(second.status).toBe(200);
+    if (!('reused' in second.body) || !('request_id' in second.body) || !('request_id' in first.body)) {
+      throw new Error('Expected pending intent payload in response body');
+    }
     expect(second.body.reused).toBe(true);
     expect(second.body.request_id).toBe(first.body.request_id);
   });


### PR DESCRIPTION
### Motivation
- Surface onboarding state and progress on the dashboard and provide a one-click setup path to simplify getting started.
- Make generated API keys easier to copy from the UI and automatically redirect to the dashboard after successful auto-setup.
- Provide a helper script for capturing headless screenshots in CI/automation.

### Description
- Added `OnboardingState` and `onboarding` state to `app/dashboard/page.tsx`, fetches `/api/quickstart/onboarding`, and renders an onboarding progress card with progress bar and a `Continue quickstart` link.
- Implemented onboarding-related progress calculation in the dashboard using `onboarding.bootstrap_status`, `agents`, and `executions` to compute a percent complete object.
- Extended quickstart and skills pages to support one-click auto-setup by calling `POST /api/setup/auto`, showing setup steps and execution id, setting the created agent from the response, and redirecting to `/dashboard` after success using `useRouter`.
- Added clipboard helper `copyApiKey` and `copyStatus` feedback UI to `app/dashboard/skills/page.tsx` and `app/quickstart/page.tsx` to allow copying API keys to the clipboard with transient status messages.
- Added a new npm script `screenshot` to `package.json` and a new script `scripts/capture-screenshot.mjs` that launches Playwright Chromium (installing Playwright shell on demand) and saves a full-page screenshot.
- Tightened a unit test in `tests/unit/spine/pipeline-approval.test.ts` to assert expected fields in the pending intent response body.

### Testing
- Ran unit tests with `vitest run` which included updated `tests/unit/spine/pipeline-approval.test.ts` and all unit tests passed.
- Verified the new `screenshot` helper by running `node scripts/capture-screenshot.mjs http://127.0.0.1:3000 artifacts/screenshot.png` in a local environment and it completed successfully when Chromium was available or was installed automatically.
- Exercised the quickstart/skills flows manually to confirm `POST /api/setup/auto` handling, clipboard copy behavior, and redirect to `/dashboard` after successful setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcc75441008326ba084a9db05dd4a4)