### PR TITLE
Add initial OpenAPI spec and SDK scaffold for DSG client integration

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,268 @@
+openapi: 3.1.0
+info:
+  title: DSG Control Plane API
+  version: 0.1.0
+  description: |
+    Initial OpenAPI surface for customer integration paths in DSG Control Plane.
+servers:
+  - url: https://tdealer01-crypto-dsg-control-plane.vercel.app
+paths:
+  /api/execute:
+    post:
+      summary: Execute an action via spine engine
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecuteRequest'
+      responses:
+        '200':
+          description: Execution result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecuteResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /api/mcp/call:
+    post:
+      summary: Call tools over MCP intent + execute flow
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                agent_id:
+                  type: string
+                action:
+                  type: string
+                  default: mcp-call
+                tool_name:
+                  type: string
+                payload:
+                  type: object
+                  additionalProperties: true
+              required: [agent_id]
+      responses:
+        '200':
+          description: MCP dispatch decision
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runtime:
+                    type: object
+                    additionalProperties: true
+                  dispatch:
+                    type: object
+                    properties:
+                      tool_name:
+                        type: string
+                      dispatched:
+                        type: boolean
+                      bypass_prevented:
+                        type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+  /api/executors/dispatch:
+    post:
+      summary: Dispatch action to registered executor implementation
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecutorDispatchRequest'
+      responses:
+        '200':
+          description: Executor dispatch accepted/completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutorDispatchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/effect-callback:
+    post:
+      summary: Reconcile asynchronous effect callback
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EffectCallbackRequest'
+      responses:
+        '200':
+          description: Callback reconciled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectCallbackResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Effect id not found
+  /api/adapter-plan:
+    get:
+      summary: Read-side adapter path discovery
+      responses:
+        '200':
+          description: Adapter plan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  timestamp:
+                    type: string
+                    format: date-time
+                  target_url:
+                    type: string
+                  inferred_profile:
+                    type: string
+                  inference_reason:
+                    type: string
+                  read_plan:
+                    type: object
+                    additionalProperties: true
+                  note:
+                    type: string
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sb-access-token
+  responses:
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: Authentication required or invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    TooManyRequests:
+      description: Rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ExecuteRequest:
+      type: object
+      properties:
+        agent_id:
+          type: string
+        action:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+        context:
+          type: object
+          additionalProperties: true
+      required: [agent_id, action]
+    ExecuteResponse:
+      type: object
+      properties:
+        decision:
+          type: string
+          enum: [ALLOW, BLOCK, REVIEW]
+        execution_id:
+          type: string
+        reason:
+          type: string
+      required: [decision]
+      additionalProperties: true
+    ExecutorDispatchRequest:
+      type: object
+      properties:
+        agent_id:
+          type: string
+        action:
+          type: string
+        effect_id:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+      required: [agent_id, action]
+    ExecutorDispatchResponse:
+      type: object
+      properties:
+        effect_id:
+          type: string
+        dispatched:
+          type: boolean
+        provider:
+          type: string
+        status:
+          type: string
+        callbackMode:
+          type: string
+          enum: [sync, webhook]
+      required: [effect_id, dispatched, provider, status, callbackMode]
+      additionalProperties: true
+    EffectCallbackRequest:
+      type: object
+      properties:
+        effect_id:
+          type: string
+        status:
+          type: string
+          enum: [succeeded, failed]
+        payload:
+          type: object
+          additionalProperties: true
+      required: [effect_id, status]
+    EffectCallbackResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        idempotent:
+          type: boolean
+      required: [ok]
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+      required: [error]

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,29 @@
+# @dsg/sdk (workspace draft)
+
+Lightweight TypeScript client for DSG Control Plane integrations.
+
+## Usage
+
+```ts
+import { DSGClient } from '@dsg/sdk';
+
+const dsg = new DSGClient({
+  baseUrl: 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+  apiKey: process.env.DSG_API_KEY!,
+  agentId: process.env.DSG_AGENT_ID!,
+});
+
+const result = await dsg.execute('approve_invoice', {
+  invoice_id: 'INV-001',
+  amount: 50_000,
+});
+
+if (result.decision === 'ALLOW') {
+  await dsg.callback(result.execution_id, 'succeeded');
+}
+```
+
+## Notes
+
+- `execute` maps to `POST /api/execute`.
+- `callback` maps to `POST /api/effect-callback` and requires org-auth cookie in production.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@dsg/sdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lightweight DSG Control Plane client SDK",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts"
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,101 @@
+export type DSGDecision = 'ALLOW' | 'BLOCK' | 'REVIEW';
+
+export type DSGExecuteInput = Record<string, unknown>;
+
+export interface DSGExecuteResponse {
+  decision: DSGDecision;
+  execution_id: string;
+  reason?: string;
+  [key: string]: unknown;
+}
+
+export type DSGEffectStatus = 'succeeded' | 'failed';
+
+export interface DSGCallbackResponse {
+  ok: boolean;
+  idempotent?: boolean;
+}
+
+export interface DSGClientOptions {
+  baseUrl: string;
+  apiKey: string;
+  agentId: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class DSGClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly agentId: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: DSGClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.apiKey = options.apiKey;
+    this.agentId = options.agentId;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async execute(
+    action: string,
+    input: DSGExecuteInput,
+    context?: Record<string, unknown>,
+  ): Promise<DSGExecuteResponse> {
+    const response = await this.fetchImpl(`${this.baseUrl}/api/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        agent_id: this.agentId,
+        action,
+        input,
+        context: context ?? {},
+      }),
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response, 'execute failed');
+    }
+
+    return (await response.json()) as DSGExecuteResponse;
+  }
+
+  async callback(
+    effectId: string,
+    status: DSGEffectStatus,
+    payload?: Record<string, unknown>,
+    cookie?: string,
+  ): Promise<DSGCallbackResponse> {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+
+    if (cookie) {
+      headers.Cookie = cookie;
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}/api/effect-callback`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        effect_id: effectId,
+        status,
+        payload: payload ?? {},
+      }),
+    });
+
+    if (!response.ok) {
+      throw await this.readError(response, 'callback failed');
+    }
+
+    return (await response.json()) as DSGCallbackResponse;
+  }
+
+  private async readError(response: Response, fallback: string): Promise<Error> {
+    const text = await response.text().catch(() => '');
+    const message = text ? `${fallback}: ${text}` : fallback;
+    return new Error(`${message} (status ${response.status})`);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable API contract so external integrators can discover and generate clients automatically. 
- Reduce boilerplate for server-to-server integrations by shipping a lightweight official SDK scaffold. 
- Create an additive, source-aligned starting point for future self-service integrations (webhook registration, executor registry, SDK publishing).

### Description
- Add `openapi.yaml` (OpenAPI 3.1) that documents the five main integration surfaces: `POST /api/execute`, `POST /api/mcp/call`, `POST /api/executors/dispatch`, `POST /api/effect-callback`, and `GET /api/adapter-plan`. 
- Add a workspace package scaffold at `packages/sdk` including `package.json`, `README.md`, and `src/index.ts` implementing a `DSGClient` with typed `execute(...)` and `callback(...)` methods. 
- `DSGClient.execute` issues `POST /api/execute` with Bearer API key auth and `DSGClient.callback` posts to `POST /api/effect-callback` and accepts an optional `cookie` parameter because production callbacks require org-auth session cookies. 
- All changes are additive documentation / client scaffolding and do not change existing runtime logic.

### Testing
- Ran unit tests for CORS and surrounding units with Vitest via `npm run test:unit -- tests/unit/security/cors.test.ts`, which completed successfully. 
- Ran `npm run typecheck`, which failed due to pre-existing type errors in unrelated tests (`tests/unit/spine/pipeline-approval.test.ts`). 
- Attempted a YAML parse check for `openapi.yaml` but the environment is missing the `yaml` Node package so automated parsing was not performed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcc86c3f808326a61a82843dfa4a45)