### PR TITLE
Add persistent dashboard AgentChatWidget and expand agent planner/tools

### DIFF
--- a/app/api/agent-chat/route.ts
+++ b/app/api/agent-chat/route.ts
@@ -18,6 +18,7 @@ export async function POST(request: Request) {
 
   const body = await request.json().catch(() => null);
   const message = String(body?.message || '').trim();
+  const pageContext = String(body?.pageContext || '').trim();
   if (!message) {
     return NextResponse.json({ error: 'message is required' }, { status: 400 });
   }
@@ -34,7 +35,7 @@ export async function POST(request: Request) {
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        const plan = planGoal(message);
+        const plan = planGoal(message, pageContext);
         controller.enqueue(encoder.encode(sseData({ type: 'plan', steps: plan.steps })));
 
         for (const step of plan.steps) {

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import AgentChatWidget from '../../components/AgentChatWidget';
 
 const NAV = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -45,6 +46,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         </div>
       </div>
       {children}
+      <AgentChatWidget />
     </div>
   );
 }

--- a/components/AgentChatWidget.tsx
+++ b/components/AgentChatWidget.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+type ChatLine = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+const STORAGE_KEY = 'dsg_chat_history';
+const MAX_HISTORY = 100;
+
+const PAGE_SUGGESTIONS: Record<string, { label: string; prompt: string }[]> = {
+  '/dashboard': [{ label: 'Check readiness', prompt: 'check readiness' }],
+  '/dashboard/agents': [
+    { label: 'Create agent', prompt: 'create agent' },
+    { label: 'List agents', prompt: 'list agents' },
+  ],
+  '/dashboard/policies': [{ label: 'List policies', prompt: 'list policies' }],
+  '/dashboard/executions': [{ label: 'Check audit', prompt: 'audit lineage' }],
+  '/dashboard/billing': [{ label: 'Check capacity', prompt: 'check capacity' }],
+  '/dashboard/capacity': [{ label: 'Check quota', prompt: 'check capacity' }],
+  '/dashboard/skills': [{ label: 'Run auto-setup', prompt: 'run auto_setup' }],
+  '/dashboard/operations': [{ label: 'Audit lineage', prompt: 'audit lineage' }],
+};
+
+function makeLine(role: ChatLine['role'], content: string): ChatLine {
+  return {
+    id: `${role}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    role,
+    content,
+  };
+}
+
+export default function AgentChatWidget() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [lines, setLines] = useState<ChatLine[]>([
+    makeLine('system', 'DSG Agent พร้อมช่วย — พิมพ์คำสั่งหรือกดปุ่มลัดตามหน้าที่ใช้งาน'),
+  ]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as ChatLine[];
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        setLines(parsed.slice(-MAX_HISTORY));
+      }
+    } catch {
+      // ignore storage read failures
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(lines.slice(-MAX_HISTORY)));
+    } catch {
+      // ignore storage write failures
+    }
+  }, [lines]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [lines]);
+
+  const suggestions = useMemo(() => {
+    return PAGE_SUGGESTIONS[pathname] || PAGE_SUGGESTIONS['/dashboard'] || [];
+  }, [pathname]);
+
+  async function submit(message: string) {
+    if (!message.trim() || busy) return;
+    setBusy(true);
+    setLines((prev) => [...prev, makeLine('user', message)]);
+    setDraft('');
+
+    try {
+      const res = await fetch('/api/agent-chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, pageContext: pathname }),
+      });
+
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error || 'Agent chat failed');
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error('No stream body returned');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        const events = buffer.split('\n\n');
+        buffer = events.pop() || '';
+
+        for (const raw of events) {
+          if (!raw.startsWith('data: ')) continue;
+          const event = JSON.parse(raw.slice(6));
+          if (event.type === 'step_result' || event.type === 'step_error') {
+            setLines((prev) => [...prev, makeLine('assistant', JSON.stringify(event, null, 2))]);
+          }
+        }
+      }
+    } catch (err) {
+      setLines((prev) => [...prev, makeLine('assistant', err instanceof Error ? err.message : 'Agent chat failed')]);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full bg-emerald-500 text-black shadow-lg shadow-emerald-500/30 transition hover:scale-105"
+        aria-label="Open agent chat"
+      >
+        <svg className="mx-auto h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+          />
+        </svg>
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex h-[520px] w-[380px] flex-col rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
+      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-100">DSG Agent</p>
+          <p className="text-[10px] text-slate-400">{pathname}</p>
+        </div>
+        <button onClick={() => setOpen(false)} className="text-slate-400 hover:text-white" aria-label="Close agent chat">
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
+        {lines.map((line) => (
+          <div
+            key={line.id}
+            className={
+              line.role === 'user'
+                ? 'ml-auto max-w-[85%] rounded-xl border border-emerald-500/30 bg-emerald-500/20 px-3 py-2 text-xs text-emerald-100'
+                : line.role === 'system'
+                  ? 'max-w-[90%] rounded-xl border border-indigo-500/20 bg-indigo-500/10 px-3 py-2 text-xs text-indigo-200'
+                  : 'max-w-[90%] rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-200'
+            }
+          >
+            <pre className="whitespace-pre-wrap break-all font-mono">{line.content}</pre>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-1.5 overflow-x-auto border-t border-slate-800 px-4 py-2">
+        {suggestions.map((suggestion) => (
+          <button
+            key={suggestion.prompt}
+            onClick={() => submit(suggestion.prompt)}
+            disabled={busy}
+            className="whitespace-nowrap rounded-lg border border-slate-700 bg-slate-900 px-2.5 py-1 text-[10px] font-medium text-slate-300 hover:border-emerald-400 disabled:opacity-50"
+          >
+            {suggestion.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="border-t border-slate-800 p-3">
+        <div className="flex gap-2">
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                void submit(draft);
+              }
+            }}
+            placeholder="พิมพ์คำสั่ง..."
+            className="flex-1 rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none focus:border-emerald-400"
+          />
+          <button
+            onClick={() => submit(draft)}
+            disabled={busy}
+            className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-black disabled:bg-slate-700 disabled:text-slate-400"
+          >
+            {busy ? '...' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -19,10 +19,33 @@ function nextStep(id: number, toolId: string, params: Record<string, unknown>): 
   return { id: `s${id}`, toolId, params };
 }
 
-export function planGoal(message: string): AgentPlan {
+export function planGoal(message: string, pageContext?: string): AgentPlan {
   const text = message.trim();
   const lower = text.toLowerCase();
   const agentId = extractAgentId(text);
+
+
+  if (/^(ช่วย|help|แนะนำ|suggest)$/i.test(lower)) {
+    switch (pageContext) {
+      case '/dashboard/agents':
+        return { steps: [nextStep(1, 'list_agents', {})] };
+      case '/dashboard/policies':
+        return { steps: [nextStep(1, 'list_policies', {})] };
+      case '/dashboard/billing':
+      case '/dashboard/capacity':
+        return { steps: [nextStep(1, 'capacity', {})] };
+      case '/dashboard/executions':
+      case '/dashboard/operations':
+        return {
+          steps: [
+            nextStep(1, 'audit_summary', { agent_id: agentId }),
+            nextStep(2, 'recovery_validate', { agent_id: agentId }),
+          ],
+        };
+      default:
+        return { steps: [nextStep(1, 'readiness', {})] };
+    }
+  }
 
   if (/readiness|health|status|สถานะ/.test(lower)) {
     return { steps: [nextStep(1, 'readiness', {})] };
@@ -55,6 +78,41 @@ export function planGoal(message: string): AgentPlan {
     };
   }
 
+
+  if (/execution|executions|proof|replay|หลักฐาน/.test(lower)) {
+    const executionId = text.match(/exec_[a-zA-Z0-9_-]+/)?.[0] || '';
+    if (executionId) {
+      return { steps: [nextStep(1, 'get_execution_proof', { execution_id: executionId })] };
+    }
+
+    if (/proof/.test(lower)) {
+      return { steps: [nextStep(1, 'list_proofs', {})] };
+    }
+
+    return { steps: [nextStep(1, 'list_executions', {})] };
+  }
+
+  if (/ledger|บัญชี/.test(lower)) {
+    return { steps: [nextStep(1, 'get_ledger', {})] };
+  }
+
+  if (/usage|billing|ค่าใช้จ่าย|แพลน|plan/.test(lower)) {
+    return {
+      steps: [
+        nextStep(1, 'get_usage', {}),
+        nextStep(2, 'capacity', {}),
+      ],
+    };
+  }
+
+  if (/metric|latency|allow rate|block rate/.test(lower)) {
+    return { steps: [nextStep(1, 'get_metrics', {})] };
+  }
+
+  if (/integration|เชื่อมต่อ/.test(lower)) {
+    return { steps: [nextStep(1, 'get_integration', {})] };
+  }
+
   if (/quota|capacity|โควต้า/.test(lower)) {
     return { steps: [nextStep(1, 'capacity', {})] };
   }
@@ -63,6 +121,11 @@ export function planGoal(message: string): AgentPlan {
     return {
       steps: [nextStep(1, 'realtime_web_search', { query: text })],
     };
+  }
+
+
+  if (/list agents|show agents|agents|เอเจนต์ทั้งหมด/.test(lower)) {
+    return { steps: [nextStep(1, 'list_agents', {})] };
   }
 
   if (/policy|นโยบาย/.test(lower)) {
@@ -89,6 +152,19 @@ export function planGoal(message: string): AgentPlan {
         }),
       ],
     };
+  }
+
+
+  if (/agent detail|รายละเอียดเอเจนต์/.test(lower) && agentId) {
+    return { steps: [nextStep(1, 'get_agent_detail', { agent_id: agentId })] };
+  }
+
+  if (/rotate key|rotate api key/.test(lower) && agentId) {
+    return { steps: [nextStep(1, 'rotate_agent_key', { agent_id: agentId })] };
+  }
+
+  if (/delete agent|disable agent|ลบเอเจนต์/.test(lower) && agentId) {
+    return { steps: [nextStep(1, 'delete_agent', { agent_id: agentId })] };
   }
 
   if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -257,6 +257,167 @@ export const DSG_TOOLS: AgentTool[] = [
         body: JSON.stringify(params),
       }),
   },
+
+  {
+    id: 'list_executions',
+    name: 'List Executions',
+    description: 'List recent executions for this organization.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 10)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/executions?limit=${encodeURIComponent(String(params.limit || 10))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_execution_proof',
+    name: 'Get Execution Proof',
+    description: 'Get replay details and proof context for one execution.',
+    parameters: {
+      execution_id: { type: 'string', required: true, description: 'Execution ID' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/replay/${encodeURIComponent(String(params.execution_id || ''))}`, { method: 'GET' }),
+  },
+  {
+    id: 'list_proofs',
+    name: 'List Proofs',
+    description: 'List recent proof artifacts from audit logs.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 20)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/proofs?limit=${encodeURIComponent(String(params.limit || 20))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_ledger',
+    name: 'Get Ledger',
+    description: 'Get combined ledger and core-ledger snapshot.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 20)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/ledger?limit=${encodeURIComponent(String(params.limit || 20))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_audit',
+    name: 'Get Audit Events',
+    description: 'Get audit events and determinism checks.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 20)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/audit?limit=${encodeURIComponent(String(params.limit || 20))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_usage',
+    name: 'Get Usage',
+    description: 'Get current plan usage and projected overage.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'usage_read',
+    execute: async (_params, context) => callJson(context, '/api/usage', { method: 'GET' }),
+  },
+  {
+    id: 'get_metrics',
+    name: 'Get Metrics',
+    description: 'Get current day control-plane performance metrics.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (_params, context) => callJson(context, '/api/metrics', { method: 'GET' }),
+  },
+  {
+    id: 'get_integration',
+    name: 'Get Integration Status',
+    description: 'Fetch integration status and source-of-truth posture.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (_params, context) => callJson(context, '/api/integration', { method: 'GET' }),
+  },
+  {
+    id: 'get_agent_detail',
+    name: 'Get Agent Detail',
+    description: 'Get details and monthly usage for one agent.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, { method: 'GET' }),
+  },
+  {
+    id: 'update_agent',
+    name: 'Update Agent',
+    description: 'Update agent metadata, status, policy, or monthly limit.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+      name: { type: 'string', required: false, description: 'New name' },
+      status: { type: 'string', required: false, description: 'active or disabled' },
+      policy_id: { type: 'string', required: false, description: 'New policy ID' },
+      monthly_limit: { type: 'number', required: false, description: 'New monthly limit' },
+    },
+    riskLevel: 'write',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          name: params.name,
+          status: params.status,
+          policy_id: params.policy_id,
+          monthly_limit: params.monthly_limit,
+        }),
+      }),
+  },
+  {
+    id: 'rotate_agent_key',
+    name: 'Rotate Agent API Key',
+    description: 'Rotate and return a new one-time API key for an agent.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'critical',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}/rotate-key`, {
+        method: 'POST',
+      }),
+  },
+  {
+    id: 'delete_agent',
+    name: 'Disable Agent',
+    description: 'Disable an agent (soft delete).',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'critical',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, {
+        method: 'DELETE',
+      }),
+  },
+  {
+    id: 'get_enterprise_proof',
+    name: 'Get Enterprise Proof Report',
+    description: 'Fetch public enterprise proof and attestation report.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (_params, context) => callJson(context, '/api/enterprise-proof/report', { method: 'GET' }),
+  },
   {
     id: 'auto_setup',
     name: 'Run Org Auto Setup',

--- a/tests/unit/agent/planner.test.ts
+++ b/tests/unit/agent/planner.test.ts
@@ -19,4 +19,21 @@ describe('agent planner chatbot intents', () => {
     expect(plan.steps[0]?.toolId).toBe('realtime_web_search');
     expect(plan.steps[0]?.params).toMatchObject({ query: 'ค้นหาข่าว bitcoin online ตอนนี้' });
   });
+
+
+  it('uses page context for help prompt', () => {
+    const plan = planGoal('help', '/dashboard/policies');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0]?.toolId).toBe('list_policies');
+  });
+
+  it('routes execution intent to list executions and replay tools', () => {
+    const listPlan = planGoal('show executions');
+    expect(listPlan.steps[0]?.toolId).toBe('list_executions');
+
+    const replayPlan = planGoal('show proof exec_abc123');
+    expect(replayPlan.steps[0]?.toolId).toBe('get_execution_proof');
+    expect(replayPlan.steps[0]?.params).toMatchObject({ execution_id: 'exec_abc123' });
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Provide a persistent, floating agent chat UI across all dashboard pages so chat state and history survive navigation and refresh. 
- Make planner responses smarter by giving the planner page context for tailored quick-actions and help suggestions. 
- Broaden agent capabilities by exposing more existing server API routes as tools so the planner can perform more read/write operations. 

### Description
- Added a new client component `components/AgentChatWidget.tsx` that implements a floating chat widget with SSE streaming to `/api/agent-chat`, page-aware quick actions via `usePathname()`, and localStorage-backed persistence under the key `dsg_chat_history` (capped to last 100 messages). 
- Mounted the widget in `app/dashboard/layout.tsx` so the widget persists across dashboard navigation. 
- Extended the planner API by changing `lib/agent/planner.ts` to `planGoal(message, pageContext?)` and implemented page-context-aware help routing plus new intent patterns for executions/proofs, ledger, usage/metrics/integration, and agent-detail/rotate/delete flows. 
- Updated `app/api/agent-chat/route.ts` to accept `pageContext` from the request body and pass it into `planGoal()`. 
- Expanded `lib/agent/tools.ts` with additional read/write tools that call existing API endpoints (executions, replay/proofs, ledger, audit, usage, metrics, integration, agent detail/update/rotate/delete, enterprise proof), so the planner can select and execute them via the existing `executeToolSafely()` flow. 
- Added unit tests in `tests/unit/agent/planner.test.ts` that cover page-context help behavior and execution/proof routing. 

### Testing
- Ran the planner unit tests and related spine planner tests with `npm run test -- tests/unit/agent/planner.test.ts tests/unit/spine/planner-execute.test.ts`, and both test files passed (20 tests total passed). 
- Ran type checking with `npm run typecheck` and it completed successfully with no type errors. 
- The change relies on existing SSE + `executeToolSafely()` execution flow and does not modify gate/executor logic, so runtime behavior uses existing server-side authorization and gate checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd34a84df08326bb1f6c75efc0bcd0)