### PR TITLE
Add multi-model OpenRouter routing with shared memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,6 @@ DEMO_BOOTSTRAP_TOKEN=
 
 # ============ Notifications ============
 RESEND_API_KEY=
+
+# ============ OpenRouter (Multi-Model) ============
+OPENROUTER_API_KEY=

--- a/app/api/agent-chat/route.ts
+++ b/app/api/agent-chat/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireOrgRole } from '../../../lib/authz';
 import { executeToolSafely } from '../../../lib/agent/executor';
-import type { AgentContext } from '../../../lib/agent/context';
+import type { AgentContext, AgentPlan } from '../../../lib/agent/context';
 import { planGoal } from '../../../lib/agent/planner';
 import { DSG_TOOLS } from '../../../lib/agent/tools';
+import { addToolResultToMemory, routeToModel } from '../../../lib/agent/llm-router';
 import { internalErrorMessage, logApiError } from '../../../lib/security/api-error';
 
 function sseData(payload: unknown) {
@@ -19,6 +20,7 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   const message = String(body?.message || '').trim();
   const pageContext = String(body?.pageContext || '').trim();
+  const sessionId = String(body?.sessionId || access.orgId);
   if (!message) {
     return NextResponse.json({ error: 'message is required' }, { status: 400 });
   }
@@ -31,11 +33,42 @@ export async function POST(request: Request) {
     cookieHeader: request.headers.get('cookie') || '',
   };
 
+  const sessionKey = `${access.orgId}:${sessionId}`;
+
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        const plan = planGoal(message, pageContext);
+        let plan: AgentPlan;
+        let reply = '';
+        let modelUsed = 'regex';
+
+        if (process.env.OPENROUTER_API_KEY) {
+          try {
+            const llmResult = await routeToModel(sessionKey, message, pageContext);
+            plan = llmResult.plan;
+            reply = llmResult.reply;
+            modelUsed = llmResult.modelUsed;
+          } catch (error) {
+            logApiError('agent-chat-llm', error, { stage: 'llm-routing' });
+            plan = planGoal(message, pageContext);
+          }
+        } else {
+          plan = planGoal(message, pageContext);
+        }
+
+        if (reply) {
+          controller.enqueue(
+            encoder.encode(
+              sseData({
+                type: 'assistant_reply',
+                reply,
+                model: modelUsed,
+              }),
+            ),
+          );
+        }
+
         controller.enqueue(encoder.encode(sseData({ type: 'plan', steps: plan.steps })));
 
         for (const step of plan.steps) {
@@ -50,6 +83,7 @@ export async function POST(request: Request) {
           try {
             const result = await executeToolSafely(tool, step.params, context);
             controller.enqueue(encoder.encode(sseData({ type: 'step_result', step: step.id, result })));
+            addToolResultToMemory(sessionKey, step.toolId, result);
           } catch (error) {
             logApiError('api/agent-chat', error, { stage: 'tool-execution', step: step.id, toolId: step.toolId });
             controller.enqueue(

--- a/lib/agent/llm-router.ts
+++ b/lib/agent/llm-router.ts
@@ -1,0 +1,263 @@
+import type { AgentPlan, AgentPlanStep } from './context';
+import { DSG_TOOLS } from './tools';
+
+type ModelSpec = {
+  id: string;
+  openRouterId: string;
+  strengths: string[];
+  maxTokens: number;
+};
+
+const FREE_MODELS: ModelSpec[] = [
+  {
+    id: 'qwen-planner',
+    openRouterId: 'qwen/qwen-2.5-7b-instruct:free',
+    strengths: ['planning', 'tool-selection', 'thai'],
+    maxTokens: 2048,
+  },
+  {
+    id: 'deepseek-reasoner',
+    openRouterId: 'deepseek/deepseek-r1-0528:free',
+    strengths: ['reasoning', 'analysis', 'audit', 'proof'],
+    maxTokens: 4096,
+  },
+  {
+    id: 'llama-chat',
+    openRouterId: 'meta-llama/llama-4-scout:free',
+    strengths: ['chat', 'summary', 'explain', 'help'],
+    maxTokens: 2048,
+  },
+  {
+    id: 'qwen-coder',
+    openRouterId: 'qwen/qwen-2.5-coder-7b-instruct:free',
+    strengths: ['code', 'json', 'config', 'technical'],
+    maxTokens: 2048,
+  },
+];
+
+export type MemoryEntry = {
+  role: 'user' | 'assistant' | 'tool_result';
+  content: string;
+  model_id?: string;
+  page_context?: string;
+  timestamp: number;
+};
+
+const memoryStore = new Map<string, MemoryEntry[]>();
+const MAX_MEMORY = 50;
+
+type Intent = 'planning' | 'reasoning' | 'chat' | 'code';
+
+export function getMemory(sessionKey: string): MemoryEntry[] {
+  return memoryStore.get(sessionKey) || [];
+}
+
+export function addMemory(sessionKey: string, entry: MemoryEntry) {
+  const mem = memoryStore.get(sessionKey) || [];
+  mem.push(entry);
+
+  if (mem.length > MAX_MEMORY) {
+    memoryStore.set(sessionKey, mem.slice(-MAX_MEMORY));
+    return;
+  }
+
+  memoryStore.set(sessionKey, mem);
+}
+
+function classifyIntent(message: string): Intent {
+  const lower = message.toLowerCase();
+
+  if (/json|config|policy.*create|schema|sql|code|โค้ด|สคริปต์/.test(lower)) {
+    return 'code';
+  }
+
+  if (/why|ทำไม|วิเคราะห์|analyze|audit|proof|compare|เปรียบเทียบ|อธิบาย|explain/.test(lower)) {
+    return 'reasoning';
+  }
+
+  if (/^(hi|hello|สวัสดี|ช่วย|help|แนะนำ|อะไร|what|how|ยังไง|เล่า|tell)/.test(lower)) {
+    return 'chat';
+  }
+
+  return 'planning';
+}
+
+function selectModel(intent: Intent): ModelSpec {
+  switch (intent) {
+    case 'code':
+      return FREE_MODELS.find((model) => model.id === 'qwen-coder')!;
+    case 'reasoning':
+      return FREE_MODELS.find((model) => model.id === 'deepseek-reasoner')!;
+    case 'chat':
+      return FREE_MODELS.find((model) => model.id === 'llama-chat')!;
+    case 'planning':
+    default:
+      return FREE_MODELS.find((model) => model.id === 'qwen-planner')!;
+  }
+}
+
+function buildSystemPrompt(pageContext?: string): string {
+  const toolList = DSG_TOOLS.map((tool) => `- ${tool.id}: ${tool.description} [${tool.riskLevel}]`).join('\n');
+
+  return `You are DSG Agent — an AI assistant for the DSG Control Plane.
+You help users manage agents, executions, policies, billing, and audit.
+
+Available tools:
+${toolList}
+
+Current page: ${pageContext || 'unknown'}
+
+Respond with a JSON object:
+{
+  "reply": "natural language response to user (Thai or English, match user language)",
+  "plan": {
+    "steps": [
+      { "id": "s1", "toolId": "tool_id_here", "params": {} }
+    ]
+  }
+}
+
+If no tool is needed (just chatting), return empty steps: "steps": []
+Always include "reply" with a helpful message.`;
+}
+
+function buildMessages(
+  sessionKey: string,
+  message: string,
+  pageContext?: string,
+): Array<{ role: string; content: string }> {
+  const memory = getMemory(sessionKey);
+  const messages: Array<{ role: string; content: string }> = [
+    { role: 'system', content: buildSystemPrompt(pageContext) },
+  ];
+
+  const recentMemory = memory.slice(-20);
+  for (const entry of recentMemory) {
+    messages.push({
+      role: entry.role === 'tool_result' ? 'assistant' : entry.role,
+      content: entry.content,
+    });
+  }
+
+  messages.push({ role: 'user', content: message });
+  return messages;
+}
+
+function toPlanSteps(value: unknown): AgentPlanStep[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((step, index) => {
+    const item = step && typeof step === 'object' ? (step as Record<string, unknown>) : {};
+    const params = item.params && typeof item.params === 'object' ? (item.params as Record<string, unknown>) : {};
+
+    return {
+      id: typeof item.id === 'string' && item.id ? item.id : `s${index + 1}`,
+      toolId: typeof item.toolId === 'string' ? item.toolId : '',
+      params,
+    };
+  });
+}
+
+async function callOpenRouter(
+  model: ModelSpec,
+  messages: Array<{ role: string; content: string }>,
+): Promise<{ reply: string; plan: AgentPlan }> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENROUTER_API_KEY not set');
+  }
+
+  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': process.env.APP_URL || 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+      'X-Title': 'DSG Control Plane',
+    },
+    body: JSON.stringify({
+      model: model.openRouterId,
+      messages,
+      max_tokens: model.maxTokens,
+      temperature: 0.3,
+      response_format: { type: 'json_object' },
+    }),
+  });
+
+  if (!response.ok) {
+    const err = await response.text().catch(() => '');
+    throw new Error(`OpenRouter ${model.id} error: ${response.status} ${err}`);
+  }
+
+  const json = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = json.choices?.[0]?.message?.content || '';
+
+  try {
+    const parsed = JSON.parse(content) as {
+      reply?: unknown;
+      plan?: { steps?: unknown };
+    };
+
+    return {
+      reply: String(parsed.reply || ''),
+      plan: {
+        steps: toPlanSteps(parsed.plan?.steps),
+      },
+    };
+  } catch {
+    return { reply: content, plan: { steps: [] } };
+  }
+}
+
+export async function routeToModel(
+  sessionKey: string,
+  message: string,
+  pageContext?: string,
+): Promise<{
+  reply: string;
+  plan: AgentPlan;
+  modelUsed: string;
+  intent: Intent;
+}> {
+  const intent = classifyIntent(message);
+  const model = selectModel(intent);
+  const messages = buildMessages(sessionKey, message, pageContext);
+
+  addMemory(sessionKey, {
+    role: 'user',
+    content: message,
+    page_context: pageContext,
+    timestamp: Date.now(),
+  });
+
+  const result = await callOpenRouter(model, messages);
+
+  addMemory(sessionKey, {
+    role: 'assistant',
+    content: result.reply,
+    model_id: model.id,
+    timestamp: Date.now(),
+  });
+
+  return {
+    ...result,
+    modelUsed: model.id,
+    intent,
+  };
+}
+
+export function addToolResultToMemory(
+  sessionKey: string,
+  toolId: string,
+  result: unknown,
+) {
+  addMemory(sessionKey, {
+    role: 'tool_result',
+    content: `[Tool: ${toolId}] ${JSON.stringify(result).slice(0, 500)}`,
+    timestamp: Date.now(),
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight multi-model router that selects the best free OpenRouter model per intent and allow all models to read/write a single session-scoped memory pool so subsequent turns can reason about prior tool results and replies.

### Description
- Add `lib/agent/llm-router.ts` implementing a free-model registry, intent classifier, session-scoped in-memory `memoryStore`, message builder, `callOpenRouter()` JSON-plan parsing, `routeToModel()` entrypoint, and `addToolResultToMemory()` helper.
- Update `app/api/agent-chat/route.ts` to use `routeToModel()` when `OPENROUTER_API_KEY` is present, emit an `assistant_reply` SSE event with `model` before executing the plan, fall back to the existing `planGoal()` regex planner on errors, and persist tool results into the shared memory using the `orgId:sessionId` session key.
- Add `OPENROUTER_API_KEY` to `.env.example` and keep the existing behavior unchanged when the key is not set; no new dependencies were added.

### Testing
- Ran type checking with `npm run typecheck` and it succeeded.
- Ran unit test `npx vitest run tests/unit/agent/planner.test.ts` and it passed (5 tests).
- The change keeps the existing regex planner as a fallback so runtime behavior remains stable when OpenRouter is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd5d8d10548326a761c3a896e02364)