### PR TITLE
Add OpenRouter timeout and in-memory session cleanup

### DIFF
--- a/lib/agent/llm-router.ts
+++ b/lib/agent/llm-router.ts
@@ -43,8 +43,10 @@ export type MemoryEntry = {
   timestamp: number;
 };
 
+// In-memory only (best effort on serverless/warm instances).
 const memoryStore = new Map<string, MemoryEntry[]>();
 const MAX_MEMORY = 50;
+const SESSION_TTL_MS = 30 * 60 * 1000;
 
 type Intent = 'planning' | 'reasoning' | 'chat' | 'code';
 
@@ -62,6 +64,21 @@ export function addMemory(sessionKey: string, entry: MemoryEntry) {
   }
 
   memoryStore.set(sessionKey, mem);
+  cleanupStaleSessions(entry.timestamp);
+}
+
+function cleanupStaleSessions(now: number) {
+  for (const [key, entries] of memoryStore.entries()) {
+    const lastEntry = entries.at(-1);
+    if (!lastEntry) {
+      memoryStore.delete(key);
+      continue;
+    }
+
+    if (now - lastEntry.timestamp > SESSION_TTL_MS) {
+      memoryStore.delete(key);
+    }
+  }
 }
 
 function classifyIntent(message: string): Intent {
@@ -169,22 +186,36 @@ async function callOpenRouter(
     throw new Error('OPENROUTER_API_KEY not set');
   }
 
-  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': process.env.APP_URL || 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
-      'X-Title': 'DSG Control Plane',
-    },
-    body: JSON.stringify({
-      model: model.openRouterId,
-      messages,
-      max_tokens: model.maxTokens,
-      temperature: 0.3,
-      response_format: { type: 'json_object' },
-    }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+
+  let response: Response;
+  try {
+    response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': process.env.APP_URL || 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+        'X-Title': 'DSG Control Plane',
+      },
+      body: JSON.stringify({
+        model: model.openRouterId,
+        messages,
+        max_tokens: model.maxTokens,
+        temperature: 0.3,
+        response_format: { type: 'json_object' },
+      }),
+    });
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error(`OpenRouter ${model.id} timeout after 15000ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   if (!response.ok) {
     const err = await response.text().catch(() => '');


### PR DESCRIPTION
### Motivation
- Prevent long-hanging SSE streams when OpenRouter is slow or unresponsive by timing out external LLM requests. 
- Avoid unbounded growth of the in-process memory store on warm serverless instances by removing stale sessions. 
- Clarify that the current memory store is best-effort in-memory and not durable across serverless invocations.

### Description
- Added a 15s `AbortController` timeout around the OpenRouter `fetch` call in `callOpenRouter()` and surface a clear timeout error (`OpenRouter <model> timeout after 15000ms`) so upstream fallback logic can recover. 
- Introduced `SESSION_TTL_MS = 30 * 60 * 1000` and implemented `cleanupStaleSessions(now)` which is invoked on `addMemory()` to delete sessions whose last entry is older than the TTL. 
- Documented the memory store as in-memory best-effort by adding a clarifying comment above `memoryStore`. 
- Changes are contained to `lib/agent/llm-router.ts` and preserve existing behavior for error handling and JSON parsing fallbacks.

### Testing
- Ran `npm run typecheck` (via `tsc --noEmit -p tsconfig.typecheck.json`) and it completed successfully.
- No additional unit or integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd5f75b0fc83269d3701c3c88fbd81)