### PR TITLE
Call cleanupStaleSessions before MAX_MEMORY early return and add unit test

### DIFF
--- a/lib/agent/llm-router.ts
+++ b/lib/agent/llm-router.ts
@@ -58,13 +58,14 @@ export function addMemory(sessionKey: string, entry: MemoryEntry) {
   const mem = memoryStore.get(sessionKey) || [];
   mem.push(entry);
 
+  cleanupStaleSessions(entry.timestamp);
+
   if (mem.length > MAX_MEMORY) {
     memoryStore.set(sessionKey, mem.slice(-MAX_MEMORY));
     return;
   }
 
   memoryStore.set(sessionKey, mem);
-  cleanupStaleSessions(entry.timestamp);
 }
 
 function cleanupStaleSessions(now: number) {

--- a/tests/unit/agent/llm-router.test.ts
+++ b/tests/unit/agent/llm-router.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { addMemory, getMemory } from '../../../lib/agent/llm-router';
+
+describe('llm-router memory cleanup', () => {
+  it('cleans stale sessions even when active session exceeds MAX_MEMORY', () => {
+    const base = Date.now();
+    const staleSession = `stale-${base}`;
+    const activeSession = `active-${base}`;
+
+    addMemory(staleSession, {
+      role: 'user',
+      content: 'old',
+      timestamp: base - (31 * 60 * 1000),
+    });
+
+    for (let i = 0; i < 51; i += 1) {
+      addMemory(activeSession, {
+        role: 'user',
+        content: `msg-${i}`,
+        timestamp: base + i,
+      });
+    }
+
+    expect(getMemory(staleSession)).toHaveLength(0);
+    expect(getMemory(activeSession)).toHaveLength(50);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure stale sessions in the in-memory `memoryStore` are cleaned even when an active session triggers the `MAX_MEMORY` trim path in `addMemory`.

### Description
- Move the `cleanupStaleSessions` invocation earlier in `addMemory` so it always runs before the early return caused by exceeding `MAX_MEMORY`.
- Preserve the existing logic that trims and sets the active session to the last `MAX_MEMORY` entries when needed.
- Add a new unit test file `tests/unit/agent/llm-router.test.ts` that asserts stale sessions are removed and active sessions are capped at `MAX_MEMORY`.

### Testing
- Added a Vitest unit test `tests/unit/agent/llm-router.test.ts` exercising `addMemory` and `getMemory` to validate cleanup and capping behavior.
- Ran the unit test and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd60ccbfb483269ef8e9b36311ab1d)