### PR TITLE
docs: synchronize README with current repo truth and test status

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,20 @@
 
 ---
 
-## Latest Update (April 8, 2026)
+## Latest Update (April 14, 2026)
 
-- Hardened `/auth/continue` rate-limit key generation to avoid runtime/test instability when `request.nextUrl` is unavailable by falling back to `new URL(request.url).pathname`.
-- Re-ran validation checks after the update.
+- Synced README repo-truth with the current codebase structure (runtime control plane + finance governance surfaces now present in `app/` and `lib/`).
+- Re-validated the full automated test suite.
 
 ### Test Results (latest run)
 
 ```bash
-npm run test       # PASS (45 files, 100 tests)
-npm run typecheck  # PASS
-npm run lint       # PASS
+npm run test  # PASS (62 files passed, 1 skipped; 185 tests passed, 3 skipped)
 ```
+
+Notes:
+- The skipped file is `tests/integration/api/finance-governance-live-db.test.ts` (live DB integration guard).
+- E2E Playwright depends on browser availability in environment setup.
 
 ---
 
@@ -120,6 +122,11 @@ A product can have a public AI-readable narrative for positioning, while still k
 ### Enterprise proof surfaces
 - **Public proof narrative** for external evaluation
 - **Verified runtime evidence** for authenticated, org-scoped review
+
+### Current repository snapshot (April 14, 2026)
+- App Router pages are available across 19 top-level product surfaces (for example: `app/`, `dashboard/`, `finance-governance/`, `playground/`, `security/`, `support/`).
+- API layer currently exposes 40 route groups under `app/api/*` (including control-plane flows such as `execute`, `spine`, `intent`, `runtime-recovery`, `finance-governance`, `agent-execute`, and `integrations`).
+- The automated Vitest suite is green on this branch; Playwright E2E still depends on external browser download availability in the execution environment.
 
 ---
 
@@ -524,4 +531,3 @@ GitHub configuration requirements:
 Usage:
 - Run benchmark only: use workflow **DSG Benchmark**
 - Run benchmark + publish Pages: use workflow **DSG Benchmark Pages** with `base_url` and optional `execute_path` / `replay_path_prefix`
-


### PR DESCRIPTION
### Motivation
- Align the repository README with the actual code layout and recent test results so documentation matches runtime code structure.
- Record and surface the current automated test outcomes and note environmental limitations for Playwright E2E runs.

### Description
- Updated `README.md` "Latest Update" block to April 14, 2026 and replaced the outdated test summary with the current Vitest results.
- Added a new `Current repository snapshot (April 14, 2026)` section that enumerates App Router top-level surfaces and the `app/api/*` route-group footprint.
- Clarified that no runtime code was changed and added a note about Playwright E2E browser-download/environment limitations.

### Testing
- Ran `npm run test` (Vitest) and it passed: 62 files passed, 1 skipped; 185 tests passed, 3 skipped.
- Ran `npm run typecheck` (`tsc --noEmit -p tsconfig.typecheck.json`) and it passed.
- Attempted `npm run test:e2e` which failed in this environment because the Playwright Chromium executable is not present and cannot be downloaded.
- Attempted `npm run test:e2e:install` which failed during browser download due to a CDN/proxy `403 Domain forbidden` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de81d9188c8326831b91a98601b484)