### PR TITLE
Add PROJECT_TRUTH.md and DECISION_LOG.md from verified repository files

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,0 +1,56 @@
+# DECISION_LOG
+
+## 2026-04-17
+
+### Decision 001
+Status: accepted
+Type: source-of-truth structure
+
+`PROJECT_TRUTH.md` should act as a control document, not the deepest canonical source.
+Canonical project docs remain:
+
+- `docs/REPO_TRUTH.md`
+- `docs/RUNBOOK_DEPLOY.md`
+
+Reason:
+These files already contain the verified topology, route truth, deployment steps, migration order, and smoke-check guidance.
+
+### Decision 002
+Status: accepted
+Type: conflict handling
+
+Test-status disagreement between `README.md` and `docs/REPO_TRUTH.md` must be treated as an open conflict.
+
+Observed values:
+- README: `185 tests passed, 3 skipped`
+- REPO_TRUTH snapshot: `85 tests`, `41 test files`, `0 failures`
+
+Rule:
+Do not normalize or rewrite this into one number until revalidated.
+
+### Decision 003
+Status: accepted
+Type: operational interpretation
+
+For repo-wide analysis and release checks, use this route interpretation:
+
+- `/api/health` = public baseline probe
+- `/api/execute` = stable execution compatibility entry
+- `/api/intent` and `/api/spine/execute` = current spine execution layer
+- `/api/usage`, `/api/executions`, `/api/audit`, `/api/policies`, `/api/capacity`, `/api/agent-chat` = authenticated operator surfaces
+
+### Decision 004
+Status: accepted
+Type: release risk framing
+
+Current practical deployment risk should be treated primarily as configuration drift and deployment/runtime alignment risk until disproven, not as missing runtime-spine inventory.
+
+### Decision 005
+Status: accepted
+Type: workflow guard
+
+Before any repo modification:
+1. read the real target file
+2. classify fact / inference / next step
+3. stop on conflict
+4. patch only after source review

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -1,0 +1,70 @@
+# PROJECT_TRUTH
+
+Last reviewed: 2026-04-17
+Mode: dry-run
+Status: derived from real repository files only
+
+## Canonical sources
+
+This file is a thin control document. The canonical project documents are:
+
+1. `docs/REPO_TRUTH.md`
+2. `docs/RUNBOOK_DEPLOY.md`
+
+When information in this file conflicts with those source files, stop and resolve the conflict before making repo changes.
+
+## Project identity
+
+The repository currently presents itself as:
+
+- Product name in `README.md`: `DSG ONE`
+- Product role: enterprise AI runtime control plane
+- Package name in `package.json`: `dsg-platform`
+
+## Operational truth
+
+Use these interpretations unless a newer verified source overrides them:
+
+- Public baseline probe: `GET /api/health`
+- Stable execution compatibility entry: `POST /api/execute`
+- Current spine-oriented execution layer: `POST /api/intent`, `POST /api/spine/execute`
+- Operator-facing routes are authenticated/org-scoped and should not be treated as anonymous probes:
+  - `GET /api/usage`
+  - `GET /api/executions`
+  - `GET /api/audit`
+  - `GET, POST /api/policies`
+  - `GET /api/capacity`
+  - `POST /api/agent-chat`
+
+## Deployment truth
+
+Deployment and production-readiness checks must be grounded in `docs/RUNBOOK_DEPLOY.md`.
+
+Minimum deployment truth includes:
+
+- required env vars must be validated before release
+- Supabase migrations must be applied in order
+- smoke checks must include `/api/health`
+- authenticated operator checks must include runtime/control-plane surfaces
+- live E2E against Supabase/staging is part of the intended validation path
+
+## Known unresolved conflict
+
+### Test-count conflict
+
+Two real files disagree:
+
+- `README.md` latest update (April 14, 2026): `185 tests passed, 3 skipped`
+- `docs/REPO_TRUTH.md` production-ready snapshot (April 11, 2026): `85 tests`, `41 test files`, `0 failures`
+
+This conflict must remain explicit until revalidated from CI or a fresh test run.
+Do not collapse these numbers into a single truth without verification.
+
+## Working rule for future sessions
+
+Before patching, deploying, or updating docs:
+
+1. Read the real file first
+2. Classify statements as fact vs inference
+3. If a new statement conflicts with this file or canonical sources, stop and log the conflict
+4. Prefer newer, directly validated evidence over older documentation snapshots


### PR DESCRIPTION
## Summary
- add `PROJECT_TRUTH.md` as a thin control document
- add `DECISION_LOG.md` to record accepted repository decisions derived from real files
- keep the current README vs REPO_TRUTH test-count mismatch explicit instead of normalizing it

## Sources used
- `docs/REPO_TRUTH.md`
- `docs/RUNBOOK_DEPLOY.md`
- `README.md`
- `package.json`

## Notes
- This PR is based on real file reads only
- No existing files were modified
- The known test-count conflict is intentionally preserved as an unresolved conflict pending revalidation
