### PR TITLE
Apply patch items 1-4 from PROJECT_TRUTH audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 APP_URL=http://localhost:3000
 
+# Comma-separated cross-origin allowlist for API access
+DSG_ALLOWED_ORIGINS=
+
 # ============ Supabase ============
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
@@ -30,6 +33,13 @@ ACCESS_POLICY=strict
 APPROVAL_REQUIRED_DOMAINS=
 APPROVED_APPROVAL_DOMAINS=
 APPROVED_AUTO_JOIN_DOMAINS=
+
+# ============ Internal Services ============
+INTERNAL_SERVICE_TOKEN=
+
+# ============ Rate Limiting (recommended for serverless) ============
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
 
 # ============ SSO / Identity ============
 WORKOS_API_KEY=

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -1,8 +1,8 @@
 # PROJECT_TRUTH
 
 Last reviewed: 2026-04-17
-Mode: dry-run
-Status: derived from real repository files only
+Mode: active
+Status: merged into main; derived from real repository files only
 
 ## Canonical sources
 

--- a/app/api/executions/route.ts
+++ b/app/api/executions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient } from "../../../lib/supabase/server";
 import { getDSGCoreLedger, getDSGCoreMetrics } from "../../../lib/dsg-core";
+import { requireRuntimeAccess } from '../../../lib/authz-runtime';
+import { getSupabaseAdmin } from "../../../lib/supabase-server";
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from "../../../lib/security/rate-limit";
 import { logServerError, serverErrorResponse } from "../../../lib/security/error-response";
 
@@ -23,26 +24,12 @@ export async function GET(request: Request) {
       );
     }
 
-    const supabase = await createClient();
-
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
-
-    if (userError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const access = await requireRuntimeAccess(request, 'executions_read');
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
     }
 
-    const { data: profile, error: profileError } = await supabase
-      .from("users")
-      .select("org_id, is_active")
-      .eq("auth_user_id", user.id)
-      .maybeSingle();
-
-    if (profileError || !profile?.org_id || !profile.is_active) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const supabase = getSupabaseAdmin();
 
     const url = new URL(request.url);
     const limit = Math.min(Number(url.searchParams.get("limit") || "10"), 50);
@@ -60,7 +47,7 @@ export async function GET(request: Request) {
           reason,
           created_at
         `)
-        .eq("org_id", profile.org_id)
+        .eq("org_id", access.orgId)
         .order("created_at", { ascending: false })
         .limit(limit),
       getDSGCoreLedger(limit),

--- a/app/api/intent/route.ts
+++ b/app/api/intent/route.ts
@@ -3,9 +3,13 @@ import { resolveAgentFromApiKey } from '../../../lib/agent-auth';
 import { issueSpineIntent } from '../../../lib/spine/engine';
 import { normalizeSpinePayload } from '../../../lib/spine/request';
 import { buildCorsHeaders, buildPreflightResponse } from '../../../lib/security/cors';
+import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../lib/security/rate-limit';
 import { handleApiError } from '../../../lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
+
+const INTENT_RATE_LIMIT = 60;
+const INTENT_RATE_WINDOW_MS = 60 * 1000;
 
 function jsonWithHeaders(
   request: Request,
@@ -32,24 +36,44 @@ export async function OPTIONS(request: Request) {
 }
 
 export async function POST(request: Request) {
+  let responseHeaders: Headers | undefined;
+
   try {
+    const rateLimit = await applyRateLimit({
+      key: getRateLimitKey(request, 'spine-intent'),
+      limit: INTENT_RATE_LIMIT,
+      windowMs: INTENT_RATE_WINDOW_MS,
+    });
+
+    responseHeaders = buildCorsHeaders(
+      request,
+      buildRateLimitHeaders(rateLimit, INTENT_RATE_LIMIT)
+    );
+
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: responseHeaders }
+      );
+    }
+
     const apiKey = extractBearerToken(request);
     if (!apiKey) {
-      return jsonWithHeaders(request, { error: 'Missing Bearer token' }, 401);
+      return jsonWithHeaders(request, { error: 'Missing Bearer token' }, 401, responseHeaders);
     }
 
     const payload = normalizeSpinePayload(await request.json().catch(() => null));
     if (!payload.agentId) {
-      return jsonWithHeaders(request, { error: 'agent_id is required' }, 400);
+      return jsonWithHeaders(request, { error: 'agent_id is required' }, 400, responseHeaders);
     }
 
     const agent = await resolveAgentFromApiKey(payload.agentId, apiKey);
     if (!agent) {
-      return jsonWithHeaders(request, { error: 'Invalid agent_id or API key' }, 401);
+      return jsonWithHeaders(request, { error: 'Invalid agent_id or API key' }, 401, responseHeaders);
     }
 
     if (agent.status !== 'active') {
-      return jsonWithHeaders(request, { error: 'Agent is not active' }, 403);
+      return jsonWithHeaders(request, { error: 'Agent is not active' }, 403, responseHeaders);
     }
 
     const result = await issueSpineIntent({
@@ -60,11 +84,11 @@ export async function POST(request: Request) {
 
     return NextResponse.json(result.body, {
       status: result.status,
-      headers: buildCorsHeaders(request),
+      headers: responseHeaders,
     });
   } catch (error) {
     return handleApiError('api/intent', error, {
-      headers: buildCorsHeaders(request),
+      headers: responseHeaders ?? buildCorsHeaders(request),
     });
   }
 }

--- a/lib/runtime/permissions.ts
+++ b/lib/runtime/permissions.ts
@@ -8,6 +8,7 @@ export const RuntimeRouteRoles: Record<string, RuntimeRole[]> = {
   checkpoint: ['runtime_auditor', 'org_admin'],
   runtime_summary: ['runtime_auditor', 'reviewer', 'org_admin'],
   monitor: ['operator', 'org_admin', 'runtime_auditor'],
+  executions_read: ['operator', 'org_admin', 'runtime_auditor'],
   usage_read: ['billing_admin', 'org_admin'],
   policies_read: ['reviewer', 'org_admin', 'runtime_auditor'],
   policies_write: ['org_admin', 'reviewer'],


### PR DESCRIPTION
## Summary
- update `PROJECT_TRUTH.md` metadata to reflect active main-branch status
- expand `.env.example` to include runtime CORS, internal-service, and Upstash rate-limit vars used by the codebase
- align `app/api/executions` with the shared runtime access model via `requireRuntimeAccess()`
- add route-level rate limiting to `app/api/intent` using the same 60 req/min pattern as spine execution

## Files changed
- `PROJECT_TRUTH.md`
- `.env.example`
- `lib/runtime/permissions.ts`
- `app/api/executions/route.ts`
- `app/api/intent/route.ts`

## Notes
- based on real file reads only
- does not modify test-count docs because `README.md` and `docs/REPO_TRUTH.md` still conflict on test totals
- does not yet change CORS ownership or deploy scripts; those remain for a later patch set
