### PR TITLE
Add one-click quickstart integration pack generation

### DIFF
--- a/app/api/quickstart/agent/route.ts
+++ b/app/api/quickstart/agent/route.ts
@@ -1,22 +1,11 @@
-import { createHash, randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
-import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
 import { requireActiveProfile } from '../../../../lib/auth/require-active-profile';
-import { resolveQuickstartPolicyId } from '../../../../lib/supabase/resolve-policy';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
+import { ensureStarterAgent, StarterAgentError } from '../../../../lib/quickstart/starter-agent';
 
-const TRIAL_EXECUTION_LIMIT = 1000;
 const QUICKSTART_AGENT_RATE_LIMIT = 10;
 const QUICKSTART_AGENT_RATE_WINDOW_MS = 60 * 1000;
-
-function buildApiKey() {
-  return `dsg_live_${randomUUID().replace(/-/g, '')}`;
-}
-
-function buildPreview(apiKey: string) {
-  return `${apiKey.slice(0, 12)}...`;
-}
 
 export async function POST(request: Request) {
   const rateLimit = await applyRateLimit({
@@ -36,101 +25,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: access.error }, { status: access.status, headers });
     }
 
-    const admin = getSupabaseAdmin();
-
-    const { data: existingAgent, error: existingAgentError } = await admin
-      .from('agents')
-      .select('id, name, policy_id, status, monthly_limit')
-      .eq('org_id', access.orgId)
-      .order('created_at', { ascending: true })
-      .limit(1)
-      .maybeSingle();
-
-    if (existingAgentError) {
-      logApiError('api/quickstart/agent', existingAgentError, { stage: 'existing-agent-query' });
-      return NextResponse.json({ error: internalErrorMessage() }, { status: 500, headers });
-    }
-
-    const apiKey = buildApiKey();
-    const apiKeyHash = createHash('sha256').update(apiKey).digest('hex');
-
-    if (existingAgent) {
-      if (existingAgent.status === 'disabled') {
-        return NextResponse.json(
-          { error: 'Starter agent is disabled. Create a new one.' },
-          { status: 400, headers }
-        );
-      }
-
-      const { error: rotateError } = await admin
-        .from('agents')
-        .update({ api_key_hash: apiKeyHash, updated_at: new Date().toISOString() })
-        .eq('id', existingAgent.id)
-        .eq('org_id', access.orgId);
-
-      if (rotateError) {
-        logApiError('api/quickstart/agent', rotateError, { stage: 'rotate-api-key', agentId: existingAgent.id });
-        return NextResponse.json({ error: internalErrorMessage() }, { status: 500, headers });
-      }
-
-      return NextResponse.json({
-        agent_id: existingAgent.id,
-        name: existingAgent.name,
-        policy_id: existingAgent.policy_id,
-        status: existingAgent.status,
-        monthly_limit: existingAgent.monthly_limit,
-        api_key: apiKey,
-        api_key_preview: buildPreview(apiKey),
-        created: false,
-      }, { headers });
-    }
-
-    const resolvedPolicyId = await resolveQuickstartPolicyId(access.orgId);
-    if (!resolvedPolicyId) {
-      return NextResponse.json(
-        { error: 'No policy available. Create a policy before creating an agent.' },
-        { status: 400, headers }
-      );
-    }
-
-    const agentId = `agt_${randomUUID().replace(/-/g, '')}`;
-    const now = new Date().toISOString();
-
-    const { data: inserted, error: insertError } = await admin
-      .from('agents')
-      .insert({
-        id: agentId,
-        org_id: access.orgId,
-        name: 'Starter Agent',
-        policy_id: resolvedPolicyId,
-        status: 'active',
-        monthly_limit: TRIAL_EXECUTION_LIMIT,
-        api_key_hash: apiKeyHash,
-        created_at: now,
-        updated_at: now,
-      })
-      .select('id, name, policy_id, status, monthly_limit')
-      .single();
-
-    if (insertError || !inserted) {
-      logApiError('api/quickstart/agent', insertError, { stage: 'insert-agent' });
-      return NextResponse.json(
-        { error: internalErrorMessage() },
-        { status: 500, headers }
-      );
-    }
-
-    return NextResponse.json({
-      agent_id: inserted.id,
-      name: inserted.name,
-      policy_id: inserted.policy_id,
-      status: inserted.status,
-      monthly_limit: inserted.monthly_limit,
-      api_key: apiKey,
-      api_key_preview: buildPreview(apiKey),
-      created: true,
-    }, { headers });
+    const starterAgent = await ensureStarterAgent(access.orgId);
+    return NextResponse.json(starterAgent, { headers });
   } catch (error) {
+    if (error instanceof StarterAgentError) {
+      if (error.code === 'starter-agent-disabled' || error.code === 'policy-missing') {
+        return NextResponse.json({ error: error.message }, { status: 400, headers });
+      }
+    }
+
     logApiError('api/quickstart/agent', error, { stage: 'unhandled' });
     return NextResponse.json(
       { error: internalErrorMessage() },

--- a/app/api/quickstart/integration-pack/route.ts
+++ b/app/api/quickstart/integration-pack/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { requireActiveProfile } from '../../../../lib/auth/require-active-profile';
+import { ensureStarterAgent, StarterAgentError } from '../../../../lib/quickstart/starter-agent';
+import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
+import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
+
+const QUICKSTART_INTEGRATION_PACK_RATE_LIMIT = 10;
+const QUICKSTART_INTEGRATION_PACK_WINDOW_MS = 60 * 1000;
+
+function buildExecuteCurl(baseUrl: string, agentId: string, apiKey: string) {
+  return `curl -sS -X POST "${baseUrl}/api/execute" \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer ${apiKey}" \\
+  -d '{
+    "agent_id": "${agentId}",
+    "action": "approve-invoice",
+    "input": { "invoice_id": "INV-001", "amount": 50000 },
+    "context": { "risk_score": 0.30, "source": "erp" }
+  }'`;
+}
+
+function buildNodeSnippet(baseUrl: string, agentId: string, apiKey: string) {
+  return `export async function executeWithDSG(input, context = {}) {
+  const response = await fetch("${baseUrl}/api/execute", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer ${apiKey}",
+    },
+    body: JSON.stringify({
+      agent_id: "${agentId}",
+      action: "approve-invoice",
+      input,
+      context,
+    }),
+  });
+
+  const result = await response.json();
+  if (!response.ok) throw new Error(result?.error || "DSG execution failed");
+
+  if (result.decision === "BLOCK") {
+    throw new Error(\`Blocked by DSG policy: \${result.reason}\`);
+  }
+
+  return result;
+}`;
+}
+
+export async function POST(request: Request) {
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, 'quickstart-integration-pack'),
+    limit: QUICKSTART_INTEGRATION_PACK_RATE_LIMIT,
+    windowMs: QUICKSTART_INTEGRATION_PACK_WINDOW_MS,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, QUICKSTART_INTEGRATION_PACK_RATE_LIMIT);
+  if (!rateLimit.allowed) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429, headers });
+  }
+
+  try {
+    const access = await requireActiveProfile();
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status, headers });
+    }
+
+    const starterAgent = await ensureStarterAgent(access.orgId);
+    const baseUrl = new URL(request.url).origin;
+
+    return NextResponse.json({
+      mode: 'server-to-server',
+      auto_provisioned: true,
+      org_id: access.orgId,
+      agent: starterAgent,
+      env: {
+        DSG_BASE_URL: baseUrl,
+        DSG_AGENT_ID: starterAgent.agent_id,
+        DSG_API_KEY: starterAgent.api_key,
+      },
+      smoke_test: {
+        health_check: `curl -sS "${baseUrl}/api/health"`,
+        execute: buildExecuteCurl(baseUrl, starterAgent.agent_id, starterAgent.api_key),
+      },
+      sdk: {
+        language: 'typescript',
+        function_name: 'executeWithDSG',
+        snippet: buildNodeSnippet(baseUrl, starterAgent.agent_id, starterAgent.api_key),
+      },
+      next_step: 'Store DSG_API_KEY in backend secrets, call /api/execute before side effects, and trigger /api/effect-callback after completion.',
+    }, { headers });
+  } catch (error) {
+    if (error instanceof StarterAgentError) {
+      if (error.code === 'starter-agent-disabled' || error.code === 'policy-missing') {
+        return NextResponse.json({ error: error.message }, { status: 400, headers });
+      }
+    }
+
+    logApiError('api/quickstart/integration-pack', error, { stage: 'unhandled' });
+    return NextResponse.json({ error: internalErrorMessage() }, { status: 500, headers });
+  }
+}

--- a/app/quickstart/page.tsx
+++ b/app/quickstart/page.tsx
@@ -36,6 +36,24 @@ type ExecuteResponse = {
   request_id: string;
 };
 
+type IntegrationPack = {
+  env: {
+    DSG_BASE_URL: string;
+    DSG_AGENT_ID: string;
+    DSG_API_KEY: string;
+  };
+  smoke_test: {
+    health_check: string;
+    execute: string;
+  };
+  sdk: {
+    language: string;
+    function_name: string;
+    snippet: string;
+  };
+  next_step: string;
+};
+
 export default function QuickstartPage() {
   const router = useRouter();
   const [agent, setAgent] = useState<AgentResponse | null>(null);
@@ -44,12 +62,14 @@ export default function QuickstartPage() {
   const [executeError, setExecuteError] = useState('');
   const [isCreatingAgent, setIsCreatingAgent] = useState(false);
   const [isExecuting, setIsExecuting] = useState(false);
+  const [isGeneratingPack, setIsGeneratingPack] = useState(false);
   const [isAutoSetupRunning, setIsAutoSetupRunning] = useState(false);
   const [autoSetupSteps, setAutoSetupSteps] = useState<string[]>([]);
   const [autoSetupExecutionId, setAutoSetupExecutionId] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState('');
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
   const [isEmptyOrg, setIsEmptyOrg] = useState(false);
+  const [integrationPack, setIntegrationPack] = useState<IntegrationPack | null>(null);
 
   useEffect(() => {
     void (async () => {
@@ -159,6 +179,36 @@ export default function QuickstartPage() {
       setExecuteError(error instanceof Error ? error.message : 'Failed to run sample execution');
     } finally {
       setIsExecuting(false);
+    }
+  }
+
+  async function generateIntegrationPack() {
+    try {
+      setIsGeneratingPack(true);
+      setAgentError('');
+
+      const response = await fetch('/api/quickstart/integration-pack', { method: 'POST' });
+      const json = await response.json();
+      if (!response.ok) {
+        throw new Error(String(json?.error || 'Failed to generate integration pack'));
+      }
+
+      const pack = json as IntegrationPack;
+      setIntegrationPack(pack);
+      setAgent({
+        agent_id: pack.env.DSG_AGENT_ID,
+        name: 'Starter Agent',
+        policy_id: agent?.policy_id || 'policy_default',
+        status: 'active',
+        monthly_limit: agent?.monthly_limit || 1000,
+        api_key: pack.env.DSG_API_KEY,
+        api_key_preview: `${pack.env.DSG_API_KEY.slice(0, 12)}...`,
+        created: true,
+      });
+    } catch (error) {
+      setAgentError(error instanceof Error ? error.message : 'Failed to generate integration pack');
+    } finally {
+      setIsGeneratingPack(false);
     }
   }
 
@@ -296,6 +346,42 @@ export default function QuickstartPage() {
               <p>Latency: {execute.latency_ms} ms</p>
               <p>Execution ID: {execute.request_id}</p>
               <p>Audit ID: {execute.audit_id || 'n/a'}</p>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="rounded-[1.5rem] border border-emerald-400/30 bg-emerald-500/10 p-6">
+          <p className="text-lg font-semibold">Auto integration pack (recommended)</p>
+          <p className="mt-2 text-sm text-slate-200">
+            Generate backend-ready environment variables, smoke test commands, and a TypeScript helper with one click.
+          </p>
+          <button
+            onClick={() => void generateIntegrationPack()}
+            disabled={isGeneratingPack}
+            className="mt-4 rounded-xl bg-emerald-300 px-4 py-3 font-semibold text-slate-950"
+          >
+            {isGeneratingPack ? 'Generating...' : 'Generate Pack'}
+          </button>
+          {integrationPack ? (
+            <div className="mt-4 space-y-4 text-xs text-emerald-50">
+              <div className="rounded-xl border border-emerald-200/30 bg-slate-950/70 p-4">
+                <p className="text-sm font-semibold">.env for your backend</p>
+                <pre className="mt-2 overflow-auto whitespace-pre-wrap">
+{`DSG_BASE_URL=${integrationPack.env.DSG_BASE_URL}
+DSG_AGENT_ID=${integrationPack.env.DSG_AGENT_ID}
+DSG_API_KEY=${integrationPack.env.DSG_API_KEY}`}
+                </pre>
+              </div>
+              <div className="rounded-xl border border-emerald-200/30 bg-slate-950/70 p-4">
+                <p className="text-sm font-semibold">Smoke test commands</p>
+                <pre className="mt-2 overflow-auto whitespace-pre-wrap">{integrationPack.smoke_test.health_check}</pre>
+                <pre className="mt-3 overflow-auto whitespace-pre-wrap">{integrationPack.smoke_test.execute}</pre>
+              </div>
+              <div className="rounded-xl border border-emerald-200/30 bg-slate-950/70 p-4">
+                <p className="text-sm font-semibold">TypeScript helper ({integrationPack.sdk.function_name})</p>
+                <pre className="mt-2 overflow-auto whitespace-pre-wrap">{integrationPack.sdk.snippet}</pre>
+              </div>
+              <p className="text-sm text-emerald-100">{integrationPack.next_step}</p>
             </div>
           ) : null}
         </section>

--- a/lib/quickstart/starter-agent.ts
+++ b/lib/quickstart/starter-agent.ts
@@ -1,0 +1,120 @@
+import { createHash, randomUUID } from 'crypto';
+import { getSupabaseAdmin } from '../supabase-server';
+import { resolveQuickstartPolicyId } from '../supabase/resolve-policy';
+
+const TRIAL_EXECUTION_LIMIT = 1000;
+
+export type StarterAgentResult = {
+  agent_id: string;
+  name: string;
+  policy_id: string;
+  status: string;
+  monthly_limit: number;
+  api_key: string;
+  api_key_preview: string;
+  created: boolean;
+};
+
+type StarterAgentErrorCode = 'starter-agent-disabled' | 'policy-missing' | 'db-error';
+
+export class StarterAgentError extends Error {
+  constructor(
+    message: string,
+    public readonly code: StarterAgentErrorCode,
+  ) {
+    super(message);
+    this.name = 'StarterAgentError';
+  }
+}
+
+function buildApiKey() {
+  return `dsg_live_${randomUUID().replace(/-/g, '')}`;
+}
+
+function buildPreview(apiKey: string) {
+  return `${apiKey.slice(0, 12)}...`;
+}
+
+export async function ensureStarterAgent(orgId: string): Promise<StarterAgentResult> {
+  const admin = getSupabaseAdmin();
+  const { data: existingAgent, error: existingAgentError } = await admin
+    .from('agents')
+    .select('id, name, policy_id, status, monthly_limit')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (existingAgentError) {
+    throw new StarterAgentError('Failed to load starter agent', 'db-error');
+  }
+
+  const apiKey = buildApiKey();
+  const apiKeyHash = createHash('sha256').update(apiKey).digest('hex');
+
+  if (existingAgent) {
+    if (existingAgent.status === 'disabled') {
+      throw new StarterAgentError('Starter agent is disabled. Create a new one.', 'starter-agent-disabled');
+    }
+
+    const { error: rotateError } = await admin
+      .from('agents')
+      .update({ api_key_hash: apiKeyHash, updated_at: new Date().toISOString() })
+      .eq('id', existingAgent.id)
+      .eq('org_id', orgId);
+
+    if (rotateError) {
+      throw new StarterAgentError('Failed to rotate starter agent key', 'db-error');
+    }
+
+    return {
+      agent_id: existingAgent.id,
+      name: existingAgent.name,
+      policy_id: existingAgent.policy_id,
+      status: existingAgent.status,
+      monthly_limit: existingAgent.monthly_limit,
+      api_key: apiKey,
+      api_key_preview: buildPreview(apiKey),
+      created: false,
+    };
+  }
+
+  const resolvedPolicyId = await resolveQuickstartPolicyId(orgId);
+  if (!resolvedPolicyId) {
+    throw new StarterAgentError('No policy available. Create a policy before creating an agent.', 'policy-missing');
+  }
+
+  const agentId = `agt_${randomUUID().replace(/-/g, '')}`;
+  const now = new Date().toISOString();
+
+  const { data: inserted, error: insertError } = await admin
+    .from('agents')
+    .insert({
+      id: agentId,
+      org_id: orgId,
+      name: 'Starter Agent',
+      policy_id: resolvedPolicyId,
+      status: 'active',
+      monthly_limit: TRIAL_EXECUTION_LIMIT,
+      api_key_hash: apiKeyHash,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id, name, policy_id, status, monthly_limit')
+    .single();
+
+  if (insertError || !inserted) {
+    throw new StarterAgentError('Failed to create starter agent', 'db-error');
+  }
+
+  return {
+    agent_id: inserted.id,
+    name: inserted.name,
+    policy_id: inserted.policy_id,
+    status: inserted.status,
+    monthly_limit: inserted.monthly_limit,
+    api_key: apiKey,
+    api_key_preview: buildPreview(apiKey),
+    created: true,
+  };
+}


### PR DESCRIPTION
### Motivation
- Reduce manual setup for customers by auto-provisioning a starter agent and producing backend-ready integration artifacts for server-to-server integration. 
- Centralize starter-agent provisioning and rotation logic to avoid duplicated DB logic across quickstart endpoints. 

### Description
- Add a shared helper `ensureStarterAgent` in `lib/quickstart/starter-agent.ts` that provisions or rotates a starter agent and returns a standardized `StarterAgentResult` (includes `api_key`, preview, and metadata). 
- Refactor `POST /api/quickstart/agent` (`app/api/quickstart/agent/route.ts`) to use `ensureStarterAgent` and surface clearer error codes for disabled agents or missing policies. 
- Add a new authenticated, rate-limited endpoint `POST /api/quickstart/integration-pack` (`app/api/quickstart/integration-pack/route.ts`) that auto-provisions starter credentials and returns `.env` variables, copy-paste smoke-test `curl` commands, and a TypeScript helper snippet for calling `POST /api/execute`. 
- Extend the `/quickstart` UI (`app/quickstart/page.tsx`) with an “Auto integration pack (recommended)” section and a one-click generator that displays the env values, smoke-test commands, and the TS helper snippet. 

### Testing
- Ran type checking with `npm run typecheck` and it succeeded. 
- Ran unit tests with `npm run test:unit` (Vitest) and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2377319288326b2cacb25e8fba62c)