### PR TITLE
Apply patch items 5-6 and align repo inventory

### DIFF
--- a/docs/REPO_TRUTH.md
+++ b/docs/REPO_TRUTH.md
@@ -352,10 +352,16 @@ Other key library files/folders:
 - `scripts/check-error-handlers.sh`
 - `scripts/stripe-setup.ts`
 - `scripts/termux-deploy-all-in-one.sh`
+- `scripts/apply-runtime-rpc-fix.sh`
+- `scripts/go-no-go-gate.sh`
+- `scripts/with-playwright-chromium.sh`
+- `scripts/benchmark-dsg.mjs`
+- `scripts/render-benchmark-site.mjs`
 - `apply-billing-checkout-flow.sh`
 - `apply-complete-audit-hotfix.sh`
 - `set-vercel-runtime-env.sh`
 - `set-vercel-stripe-env.sh`
+- `redeploy-vercel-prod.sh`
 
 ### Documentation surface (`docs/`)
 

--- a/next.config.js
+++ b/next.config.js
@@ -33,6 +33,7 @@ function buildScriptSrc() {
 
 const nextConfig = {
   async headers() {
+    // API CORS is intentionally handled at route level via lib/security/cors.ts.
     return [
       {
         source: '/(.*)',
@@ -57,10 +58,6 @@ const nextConfig = {
               "base-uri 'self'",
               "object-src 'none'",
             ].join('; '),
-          },
-          {
-            key: 'X-Api-Cors-Owner',
-            value: 'route-level-lib/security/cors.ts',
           },
         ],
       },

--- a/next.config.js
+++ b/next.config.js
@@ -17,20 +17,6 @@ function unique(values) {
   return Array.from(new Set(values.filter(Boolean)));
 }
 
-function buildAllowedOrigins() {
-  const explicitList = String(process.env.DSG_ALLOWED_ORIGINS || '')
-    .split(',')
-    .map((item) => parseOrigin(item))
-    .filter(Boolean);
-
-  const appOrigin = parseOrigin(process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL);
-  const vercelOrigin = parseOrigin(process.env.VERCEL_PROJECT_PRODUCTION_URL)
-    ? parseOrigin(`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`)
-    : null;
-
-  return unique([...explicitList, appOrigin, vercelOrigin]);
-}
-
 function buildConnectSrc() {
   const coreOrigin = parseOrigin(process.env.DSG_CORE_URL);
 
@@ -45,26 +31,9 @@ function buildScriptSrc() {
   return unique(base).join(' ');
 }
 
-const allowedOrigins = buildAllowedOrigins();
-const primaryCorsOrigin = allowedOrigins[0] || null;
-
-const apiCorsHeaders = primaryCorsOrigin
-  ? [
-      { key: 'Access-Control-Allow-Origin', value: primaryCorsOrigin },
-      { key: 'Access-Control-Allow-Methods', value: 'GET,POST,PUT,PATCH,DELETE,OPTIONS' },
-      {
-        key: 'Access-Control-Allow-Headers',
-        value: 'Authorization,Content-Type,X-Requested-With,Idempotency-Key',
-      },
-      { key: 'Access-Control-Allow-Credentials', value: 'true' },
-      { key: 'Access-Control-Max-Age', value: '600' },
-      { key: 'Vary', value: 'Origin' },
-    ]
-  : [];
-
 const nextConfig = {
   async headers() {
-    const routes = [
+    return [
       {
         source: '/(.*)',
         headers: [
@@ -89,18 +58,13 @@ const nextConfig = {
               "object-src 'none'",
             ].join('; '),
           },
+          {
+            key: 'X-Api-Cors-Owner',
+            value: 'route-level-lib/security/cors.ts',
+          },
         ],
       },
     ];
-
-    if (apiCorsHeaders.length > 0) {
-      routes.push({
-        source: '/api/:path*',
-        headers: apiCorsHeaders,
-      });
-    }
-
-    return routes;
   },
 };
 

--- a/redeploy-vercel-prod.sh
+++ b/redeploy-vercel-prod.sh
@@ -1,20 +1,30 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # ===== CONFIG =====
-DEPLOYMENT_URL="https://tdealer01-crypto-dsg-control-plane-393q95ihl.vercel.app"
-VERCEL_SCOPE="tdealer01-cryptos-projects"
+DEPLOYMENT_URL="${1:-${DEPLOYMENT_URL:-https://tdealer01-crypto-dsg-control-plane-393q95ihl.vercel.app}}"
+VERCEL_SCOPE="${VERCEL_SCOPE:-tdealer01-cryptos-projects}"
 
 AUTH_ARGS=()
 if [ -n "${VERCEL_TOKEN:-}" ]; then
   AUTH_ARGS+=(--token "$VERCEL_TOKEN")
 fi
 
+if [ -z "$DEPLOYMENT_URL" ]; then
+  echo "ERROR: missing deployment URL. Provide it as the first arg or DEPLOYMENT_URL env var." >&2
+  exit 1
+fi
+
 echo "==> checking vercel cli"
 if ! command -v vercel >/dev/null 2>&1; then
-  echo "Vercel CLI not found. Installing..."
-  pkg install -y nodejs
-  npm install -g vercel@latest
+  if command -v pkg >/dev/null 2>&1; then
+    echo "Vercel CLI not found. Installing via Termux pkg..."
+    pkg install -y nodejs
+    npm install -g vercel@latest
+  else
+    echo "Vercel CLI not found. Install with: npm i -g vercel@latest" >&2
+    exit 1
+  fi
 fi
 
 echo "==> vercel version"

--- a/set-vercel-runtime-env.sh
+++ b/set-vercel-runtime-env.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export VERCEL_ORG_ID="team_n189mlAdVHR6cGGiaAwsKzQ0"
-export VERCEL_PROJECT_ID="prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW"
+export VERCEL_ORG_ID="${VERCEL_ORG_ID:-team_n189mlAdVHR6cGGiaAwsKzQ0}"
+export VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW}"
+APP_URL_DEFAULT="${APP_URL_DEFAULT:-https://tdealer01-crypto-dsg-control-plane.vercel.app}"
 
 AUTH_ARGS=()
 if [ -n "${VERCEL_TOKEN:-}" ]; then
@@ -25,6 +26,16 @@ set_env() {
   local value="$2"
   printf '%s' "$value" | vercel env add "$key" production --force "${AUTH_ARGS[@]}"
   echo "✓ $key"
+}
+
+set_env_if_present() {
+  local key="$1"
+  local value="${2:-}"
+  if [ -n "$value" ]; then
+    set_env "$key" "$value"
+  else
+    echo "- skip $key"
+  fi
 }
 
 rm_env() {
@@ -60,6 +71,18 @@ SERVICE_KEY="$(get_val "dsgone_SUPABASE_SECRET_KEY")"
 PUBLISHABLE_KEY="$(get_val "NEXT_PUBLIC_dsgone_SUPABASE_PUBLISHABLE_KEY")"
 AUTONOMA_CLIENT="$(get_val "AUTONOMA_CLIENT_ID")"
 AUTONOMA_SECRET="$(get_val "AUTONOMA_SECRET_ID")"
+CURRENT_APP_URL="$(get_val "APP_URL")"
+CURRENT_NEXT_PUBLIC_APP_URL="$(get_val "NEXT_PUBLIC_APP_URL")"
+CURRENT_ALLOWED_ORIGINS="$(get_val "DSG_ALLOWED_ORIGINS")"
+CURRENT_INTERNAL_SERVICE_TOKEN="$(get_val "INTERNAL_SERVICE_TOKEN")"
+CURRENT_UPSTASH_URL="$(get_val "UPSTASH_REDIS_REST_URL")"
+CURRENT_UPSTASH_TOKEN="$(get_val "UPSTASH_REDIS_REST_TOKEN")"
+
+APP_URL_VALUE="${APP_URL:-${CURRENT_APP_URL:-${CURRENT_NEXT_PUBLIC_APP_URL:-$APP_URL_DEFAULT}}}"
+ALLOWED_ORIGINS_VALUE="${DSG_ALLOWED_ORIGINS:-${CURRENT_ALLOWED_ORIGINS:-$APP_URL_VALUE}}"
+INTERNAL_SERVICE_TOKEN_VALUE="${INTERNAL_SERVICE_TOKEN:-${CURRENT_INTERNAL_SERVICE_TOKEN:-}}"
+UPSTASH_URL_VALUE="${UPSTASH_REDIS_REST_URL:-${CURRENT_UPSTASH_URL:-}}"
+UPSTASH_TOKEN_VALUE="${UPSTASH_REDIS_REST_TOKEN:-${CURRENT_UPSTASH_TOKEN:-}}"
 
 echo "==> setting corrected env var names..."
 [ -n "$ANON_KEY" ] && set_env "NEXT_PUBLIC_SUPABASE_ANON_KEY" "$ANON_KEY"
@@ -68,14 +91,18 @@ echo "==> setting corrected env var names..."
 [ -n "$AUTONOMA_CLIENT" ] && set_env "WORKOS_CLIENT_ID" "$AUTONOMA_CLIENT"
 [ -n "$AUTONOMA_SECRET" ] && set_env "WORKOS_API_KEY" "$AUTONOMA_SECRET"
 
-echo "==> setting defaults..."
-set_env "NEXT_PUBLIC_APP_URL" "https://tdealer01-crypto-dsg-control-plane.vercel.app"
-set_env "APP_URL" "https://tdealer01-crypto-dsg-control-plane.vercel.app"
-set_env "DSG_DEFAULT_POLICY_ID" "policy_default"
-set_env "OVERAGE_RATE_USD" "0.001"
-set_env "ACCESS_MODE" "strict"
-set_env "ACCESS_POLICY" "strict"
-set_env "ENABLE_DEMO_BOOTSTRAP" "false"
+echo "==> setting defaults and runtime-aligned vars..."
+set_env "NEXT_PUBLIC_APP_URL" "$APP_URL_VALUE"
+set_env "APP_URL" "$APP_URL_VALUE"
+set_env "DSG_ALLOWED_ORIGINS" "$ALLOWED_ORIGINS_VALUE"
+set_env "DSG_DEFAULT_POLICY_ID" "${DSG_DEFAULT_POLICY_ID:-policy_default}"
+set_env "OVERAGE_RATE_USD" "${OVERAGE_RATE_USD:-0.001}"
+set_env "ACCESS_MODE" "${ACCESS_MODE:-strict}"
+set_env "ACCESS_POLICY" "${ACCESS_POLICY:-strict}"
+set_env "ENABLE_DEMO_BOOTSTRAP" "${ENABLE_DEMO_BOOTSTRAP:-false}"
+set_env_if_present "INTERNAL_SERVICE_TOKEN" "$INTERNAL_SERVICE_TOKEN_VALUE"
+set_env_if_present "UPSTASH_REDIS_REST_URL" "$UPSTASH_URL_VALUE"
+set_env_if_present "UPSTASH_REDIS_REST_TOKEN" "$UPSTASH_TOKEN_VALUE"
 
 echo "==> removing wrong/legacy vars..."
 rm_env "dsgone_SUPABASE_ANON_KEY"
@@ -94,8 +121,10 @@ vercel env ls production "${AUTH_ARGS[@]}"
 echo
 echo "DONE! Remaining vars to set manually (if still missing):"
 echo "  - NEXT_PUBLIC_SUPABASE_URL"
-echo "  - DSG_CORE_URL"
-echo "  - DSG_CORE_API_KEY"
+echo "  - DSG_CORE_URL (only when DSG_CORE_MODE=remote)"
+echo "  - DSG_CORE_API_KEY (only when DSG_CORE_MODE=remote)"
 echo "  - STRIPE_SECRET_KEY"
 echo "  - STRIPE_WEBHOOK_SECRET"
+echo "  - INTERNAL_SERVICE_TOKEN"
+echo "  - UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN (recommended for serverless rate limiting)"
 echo "  - RESEND_API_KEY (optional)"

--- a/set-vercel-stripe-env.sh
+++ b/set-vercel-stripe-env.sh
@@ -1,9 +1,9 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # ========= CONFIG =========
-export VERCEL_ORG_ID="team_n189mlAdVHR6cGGiaAwsKzQ0"
-export VERCEL_PROJECT_ID="prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW"
+export VERCEL_ORG_ID="${VERCEL_ORG_ID:-team_n189mlAdVHR6cGGiaAwsKzQ0}"
+export VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW}"
 
 # ถ้ามี token ให้ใส่ก่อนรัน:
 # export VERCEL_TOKEN="your_vercel_token"
@@ -13,23 +13,20 @@ if [ -n "${VERCEL_TOKEN:-}" ]; then
 fi
 
 # ========= STRIPE PROD ENV =========
-STRIPE_PRODUCT_ID="prod_UBEqTBITqc9uG9"
+STRIPE_PRODUCT_ID="${STRIPE_PRODUCT_ID:-prod_UBEqTBITqc9uG9}"
 
-STRIPE_PRICE_PRO_MONTHLY="price_1TCsZBKCAFwxVQo9hhfjuC9j"
-STRIPE_PRICE_PRO_YEARLY="price_1TE50jKCAFwxVQo9QhmIQVqP"
+STRIPE_PRICE_PRO_MONTHLY="${STRIPE_PRICE_PRO_MONTHLY:-price_1TCsZBKCAFwxVQo9hhfjuC9j}"
+STRIPE_PRICE_PRO_YEARLY="${STRIPE_PRICE_PRO_YEARLY:-price_1TE50jKCAFwxVQo9QhmIQVqP}"
 
-STRIPE_PRICE_BUSINESS_MONTHLY="price_1TCsZXKCAFwxVQo9sbBSzPWQ"
-STRIPE_PRICE_BUSINESS_YEARLY="price_1TE51LKCAFwxVQo9vrWiywkR"
+STRIPE_PRICE_BUSINESS_MONTHLY="${STRIPE_PRICE_BUSINESS_MONTHLY:-price_1TCsZXKCAFwxVQo9sbBSzPWQ}"
+STRIPE_PRICE_BUSINESS_YEARLY="${STRIPE_PRICE_BUSINESS_YEARLY:-price_1TE51LKCAFwxVQo9vrWiywkR}"
 
-STRIPE_PRICE_ENTERPRISE_MONTHLY="price_1TE51tKCAFwxVQo9Lfdlj5ok"
-STRIPE_PRICE_ENTERPRISE_YEARLY="price_1TE528KCAFwxVQo9pcDbQ5Hx"
+STRIPE_PRICE_ENTERPRISE_MONTHLY="${STRIPE_PRICE_ENTERPRISE_MONTHLY:-price_1TE51tKCAFwxVQo9Lfdlj5ok}"
+STRIPE_PRICE_ENTERPRISE_YEARLY="${STRIPE_PRICE_ENTERPRISE_YEARLY:-price_1TE528KCAFwxVQo9pcDbQ5Hx}"
 
 # alias เผื่อโค้ดเก่ายังใช้ชื่อเดิม
-STRIPE_PRICE_PRO="$STRIPE_PRICE_PRO_MONTHLY"
-STRIPE_PRICE_BUSINESS="$STRIPE_PRICE_BUSINESS_MONTHLY"
-
-# optional: ถ้าจะตั้งด้วยก็ปลด # ออก
-# NEXT_PUBLIC_APP_URL="https://tdealer01-crypto-dsg-control-plane.vercel.app"
+STRIPE_PRICE_PRO="${STRIPE_PRICE_PRO:-$STRIPE_PRICE_PRO_MONTHLY}"
+STRIPE_PRICE_BUSINESS="${STRIPE_PRICE_BUSINESS:-$STRIPE_PRICE_BUSINESS_MONTHLY}"
 
 set_env() {
   local name="$1"
@@ -39,12 +36,34 @@ set_env() {
   echo "OK: $name"
 }
 
+require_non_empty() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "$value" ]]; then
+    echo "ERROR: missing required value for $name" >&2
+    exit 1
+  fi
+}
+
 echo "==> checking vercel cli"
 if ! command -v vercel >/dev/null 2>&1; then
-  echo "Vercel CLI not found. Installing..."
-  pkg install -y nodejs
-  npm install -g vercel@latest
+  if command -v pkg >/dev/null 2>&1; then
+    echo "Vercel CLI not found. Installing via Termux pkg..."
+    pkg install -y nodejs
+    npm install -g vercel@latest
+  else
+    echo "Vercel CLI not found. Install with: npm i -g vercel@latest" >&2
+    exit 1
+  fi
 fi
+
+require_non_empty "STRIPE_PRODUCT_ID" "$STRIPE_PRODUCT_ID"
+require_non_empty "STRIPE_PRICE_PRO_MONTHLY" "$STRIPE_PRICE_PRO_MONTHLY"
+require_non_empty "STRIPE_PRICE_PRO_YEARLY" "$STRIPE_PRICE_PRO_YEARLY"
+require_non_empty "STRIPE_PRICE_BUSINESS_MONTHLY" "$STRIPE_PRICE_BUSINESS_MONTHLY"
+require_non_empty "STRIPE_PRICE_BUSINESS_YEARLY" "$STRIPE_PRICE_BUSINESS_YEARLY"
+require_non_empty "STRIPE_PRICE_ENTERPRISE_MONTHLY" "$STRIPE_PRICE_ENTERPRISE_MONTHLY"
+require_non_empty "STRIPE_PRICE_ENTERPRISE_YEARLY" "$STRIPE_PRICE_ENTERPRISE_YEARLY"
 
 echo "==> version"
 vercel --version "${AUTH_ARGS[@]}" || true
@@ -63,9 +82,6 @@ set_env "STRIPE_PRICE_ENTERPRISE_YEARLY" "$STRIPE_PRICE_ENTERPRISE_YEARLY"
 
 set_env "STRIPE_PRICE_PRO" "$STRIPE_PRICE_PRO"
 set_env "STRIPE_PRICE_BUSINESS" "$STRIPE_PRICE_BUSINESS"
-
-# ถ้าจะใช้ด้วย ค่อยเปิดบรรทัดนี้
-# set_env "NEXT_PUBLIC_APP_URL" "$NEXT_PUBLIC_APP_URL"
 
 echo
 echo "DONE: production env updated"


### PR DESCRIPTION
## Summary
- remove static API CORS ownership from `next.config.js` and leave API CORS at route level via `lib/security/cors.ts`
- make Vercel runtime, Stripe, and redeploy helper scripts override-friendly while preserving current defaults
- update `docs/REPO_TRUTH.md` inventory to include newly verified scripts present in the repository

## Files changed
- `next.config.js`
- `set-vercel-runtime-env.sh`
- `set-vercel-stripe-env.sh`
- `redeploy-vercel-prod.sh`
- `docs/REPO_TRUTH.md`

## Intentionally not included yet
- `scripts/termux-deploy-all-in-one.sh`
  - skipped for now by request
  - should be handled in a later patch set if Termux flow needs full env-first alignment

## Sources used
- `PROJECT_TRUTH.md`
- `docs/REPO_TRUTH.md`
- `docs/RUNBOOK_DEPLOY.md`
- `lib/security/cors.ts`
- `next.config.js`
- `set-vercel-runtime-env.sh`
- `set-vercel-stripe-env.sh`
- `redeploy-vercel-prod.sh`
- confirmed script files present in `main`

## Notes
- based on real file reads only
- does not modify the unresolved README vs REPO_TRUTH test-count conflict
