### PR TITLE
docs: reconcile test baseline to 2026-04-17 evidence (185 tests / 62 files)

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -16,16 +16,16 @@ Reason:
 These files already contain the verified topology, route truth, deployment steps, migration order, and smoke-check guidance.
 
 ### Decision 002
-Status: accepted
-Type: conflict handling
+Status: superseded
+Type: conflict handling (historical)
 
-Test-status disagreement between `README.md` and `docs/REPO_TRUTH.md` must be treated as an open conflict.
+Test-status disagreement between `README.md` and `docs/REPO_TRUTH.md` was treated as an unresolved mismatch before fresh evidence was committed.
 
-Observed values:
+Observed values at that time:
 - README: `185 tests passed, 3 skipped`
 - REPO_TRUTH snapshot: `85 tests`, `41 test files`, `0 failures`
 
-Rule:
+Historical rule:
 Do not normalize or rewrite this into one number until revalidated.
 
 ### Decision 003
@@ -54,3 +54,23 @@ Before any repo modification:
 2. classify fact / inference / next step
 3. stop on conflict
 4. patch only after source review
+
+### Decision 006
+Status: accepted
+Type: test-baseline reconciliation
+
+The April 17, 2026 committed artifact set resolves the earlier 85-vs-185 conflict in favor of **185** as the current authoritative Vitest baseline.
+
+Current baseline:
+- `62 test files passed, 1 skipped, 0 failed`
+- `185 tests passed, 3 skipped, 0 failed`
+
+Authoritative evidence:
+- `qa-logs/npm-test-2026-04-17.log`
+- `qa-logs/npm-test.log`
+- `qa-logs/test-summary.md`
+- `docs/STATUS_SNAPSHOT_2026-04-17.md`
+
+Interpretation rule:
+- Keep April 11 documents for historical traceability.
+- Treat April 17 committed evidence as current truth until superseded by a newer committed run.

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -48,17 +48,21 @@ Minimum deployment truth includes:
 - authenticated operator checks must include runtime/control-plane surfaces
 - live E2E against Supabase/staging is part of the intended validation path
 
-## Known unresolved conflict
+## Test baseline resolution (April 17, 2026)
 
-### Test-count conflict
+The earlier 85-vs-185 mismatch is now resolved in favor of the latest committed evidence set.
 
-Two real files disagree:
+- Historical snapshot (valid for April 11, 2026): `85 tests`, `41 test files`, `0 failures`
+- Current authoritative baseline (committed April 17, 2026): `185 tests passed, 3 skipped, 0 failed` and `62 test files passed, 1 skipped, 0 failed`
 
-- `README.md` latest update (April 14, 2026): `185 tests passed, 3 skipped`
-- `docs/REPO_TRUTH.md` production-ready snapshot (April 11, 2026): `85 tests`, `41 test files`, `0 failures`
+Authoritative evidence files:
 
-This conflict must remain explicit until revalidated from CI or a fresh test run.
-Do not collapse these numbers into a single truth without verification.
+- `qa-logs/npm-test-2026-04-17.log`
+- `qa-logs/npm-test.log`
+- `qa-logs/test-summary.md`
+- `docs/STATUS_SNAPSHOT_2026-04-17.md`
+
+Working rule: preserve older snapshots as historical context, but treat the April 17, 2026 artifact set as the current repo baseline until superseded by a newer committed run.
 
 ## Working rule for future sessions
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@
 
 ---
 
-## Latest Update (April 14, 2026)
+## Latest Update (April 17, 2026)
 
-- Synced README repo-truth with the current codebase structure (runtime control plane + finance governance surfaces now present in `app/` and `lib/`).
-- Re-validated the full automated test suite.
+- Synced README repo-truth to the committed April 17, 2026 evidence refresh.
+- Re-validated the full automated test suite and aligned this README with the authoritative artifact set (`qa-logs/npm-test-2026-04-17.log`, `qa-logs/npm-test.log`, `qa-logs/test-summary.md`, `docs/STATUS_SNAPSHOT_2026-04-17.md`).
 
 ### Test Results (latest run)
 
@@ -124,7 +124,7 @@ A product can have a public AI-readable narrative for positioning, while still k
 - **Public proof narrative** for external evaluation
 - **Verified runtime evidence** for authenticated, org-scoped review
 
-### Current repository snapshot (April 14, 2026)
+### Current repository snapshot (April 17, 2026)
 - App Router pages are available across 19 top-level product surfaces (for example: `app/`, `dashboard/`, `finance-governance/`, `playground/`, `security/`, `support/`).
 - API layer currently exposes 40 route groups under `app/api/*` (including control-plane flows such as `execute`, `spine`, `intent`, `runtime-recovery`, `finance-governance`, `agent-execute`, and `integrations`).
 - The automated Vitest suite is green on this branch; Playwright E2E still depends on external browser download availability in the execution environment.

--- a/docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md
+++ b/docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md
@@ -1,7 +1,11 @@
+> [!WARNING]
+> **Historical snapshot (superseded).** The Vitest numbers in this file (`85 tests`, `41 test files`) are historical for April 11-13, 2026 only.
+> Current authoritative baseline: `62 test files passed, 1 skipped, 0 failed` and `185 tests passed, 3 skipped, 0 failed`, evidenced by `qa-logs/npm-test-2026-04-17.log`, `qa-logs/npm-test.log`, `qa-logs/test-summary.md`, and `docs/STATUS_SNAPSHOT_2026-04-17.md`.
+
 # รายการไฟล์ Production-Ready ของ `tdealer01-crypto-dsg-control-plane`
 
 เอกสารนี้บันทึกรายการไฟล์ production-ready ครบระบบตามข้อมูลที่ผู้ใช้ยืนยันว่าเทสผ่านแล้ว
-(Vitest: **85 tests**, **41 test files**, **0 failures**)
+(Historical Vitest snapshot: **85 tests**, **41 test files**, **0 failures**)
 
 อัปเดตล่าสุด: **2026-04-13 (UTC)** จากข้อมูลยืนยันรอบล่าสุดของผู้ใช้
 
@@ -350,7 +354,7 @@ ollama launch claude --model glm-5.1:cloud
 - **Database** (14 migrations + schema)
 - **Security** (rate-limit, safe-log, error handling)
 
-Vitest ผ่านครบ **85/85 tests** ใน 41 test files โดย E2E fail เฉพาะเรื่อง Playwright browser download (403) ไม่ใช่ bug ของโค้ด
+[Historical snapshot] Vitest ผ่านครบ **85/85 tests** ใน 41 test files โดย E2E fail เฉพาะเรื่อง Playwright browser download (403) ไม่ใช่ bug ของโค้ด
 
 ---
 

--- a/docs/REMAINING_TASKS_2026-04-11.md
+++ b/docs/REMAINING_TASKS_2026-04-11.md
@@ -34,5 +34,6 @@
 
 ## Summary
 
-- Application code quality is strong based on provided results (85/85 Vitest passed).
+- Historical note (April 11 context): application code quality was strong based on then-current results (85/85 Vitest passed).
+- Current baseline has been superseded by the April 17, 2026 committed evidence set (185 passed, 3 skipped; 62 files passed, 1 skipped).
 - Main remaining risk is **environment/infrastructure readiness** (especially E2E runtime and deployment operations), not core feature completeness.

--- a/docs/REPO_TRUTH.md
+++ b/docs/REPO_TRUTH.md
@@ -100,9 +100,25 @@ Suggested recovery flow:
 3. If PR 216 exists remotely, merge/cherry-pick by commit SHA, not PR number label.
 4. If PR 216 does not exist, continue from the latest merged baseline (`#220`) and re-open the missing changes as a new PR.
 
-## Production-ready inventory snapshot (April 11, 2026)
+## Current test baseline (April 17, 2026)
 
-This snapshot records the current production-ready file coverage and latest validated test status in `tdealer01-crypto-dsg-control-plane`.
+This section is the active baseline for test-status truth in this repository.
+
+- Test files: **62 passed, 1 skipped, 0 failed**
+- Tests: **185 passed, 3 skipped, 0 failed**
+
+Evidence pointers:
+- `qa-logs/npm-test-2026-04-17.log`
+- `qa-logs/npm-test.log`
+- `qa-logs/test-summary.md`
+- `docs/STATUS_SNAPSHOT_2026-04-17.md`
+
+Historical context:
+- The April 11 snapshot below remains preserved for timeline/history purposes only.
+
+## Historical production-ready inventory snapshot (April 11, 2026)
+
+This historical snapshot records production-ready file coverage and validated test status as of April 11, 2026 in `tdealer01-crypto-dsg-control-plane`.
 
 ### Test status snapshot
 
@@ -114,7 +130,7 @@ This snapshot records the current production-ready file coverage and latest vali
 | Migrations | 5 | 0 | Passed |
 | E2E (Playwright) | 0 | 1 | Browser install/download issue (environment), not an application logic regression |
 
-Vitest aggregate status: **85 tests**, **41 test files**, **0 failures**.
+Vitest aggregate status at that historical point: **85 tests**, **41 test files**, **0 failures**.
 
 ### Root config and entry surface
 
@@ -374,7 +390,7 @@ Other key library files/folders:
 
 For operator handoff in Thai, the production-ready inventory snapshot above has been validated as equivalent to the Thai checklist shared on April 12, 2026, including:
 
-- Vitest summary: **85 tests passed**, **41 test files**, **0 failures**
+- Historical Vitest summary (April 11 snapshot): **85 tests passed**, **41 test files**, **0 failures**
 - Playwright status: one environment-level browser download/install failure (non-code defect)
 - Full-system inventory coverage across root config, App Router pages/API, core libraries, components, migrations, scripts, and docs
 
@@ -393,5 +409,5 @@ Recommended triage order:
 
 Operational interpretation for this repository:
 
-- The current control-plane inventory and Vitest baseline remain valid (85/85 tests passing, Playwright browser install issue is environment-related).
+- The April 11 control-plane inventory remains historically valid for that date; current test baseline is the April 17 committed result (185 passed, 3 skipped; 62 files passed, 1 skipped).
 - A `286/294` merge indicator should be handled as release-process metadata drift until a concrete failing required check is identified.

--- a/docs/STATUS_SNAPSHOT_2026-04-11.md
+++ b/docs/STATUS_SNAPSHOT_2026-04-11.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> **Historical snapshot (superseded).** This file records status as of April 11-12, 2026.
+> For the current authoritative baseline, see `docs/STATUS_SNAPSHOT_2026-04-17.md` and the April 17 evidence set in `qa-logs/`.
+
 # Status Snapshot (2026-04-12)
 
 ## Direct answer
@@ -19,5 +23,5 @@
 
 ## Evidence note (refreshed)
 
-- Vitest ล่าสุด: **85 tests / 41 files / 0 failures**
+- Vitest ณ ช่วงเวลาของ snapshot นี้ (historical): **85 tests / 41 files / 0 failures**
 - E2E issue ที่พบเป็น browser install ใน environment ไม่ใช่ defect ของ product logic


### PR DESCRIPTION
### Motivation

- Resolve the repository-wide 85-vs-185 test-count mismatch by making the committed April 17, 2026 artifact set the current authoritative baseline while preserving April 11 snapshots as historical context. 
- Ensure public-facing docs and control documents consistently point to the April 17 evidence files and no longer present the 85/41 snapshot as the current truth.

### Description

- Updated `README.md` to reflect `Latest Update (April 17, 2026)`, include the April 17 evidence pointers, and keep the `185 tests / 62 files` wording as the current baseline. 
- Replaced the unresolved conflict block in `PROJECT_TRUTH.md` with a resolved `Test baseline resolution (April 17, 2026)` section that preserves the April 11 snapshot as historical and points to authoritative evidence files (`qa-logs/npm-test-2026-04-17.log`, `qa-logs/npm-test.log`, `qa-logs/test-summary.md`, `docs/STATUS_SNAPSHOT_2026-04-17.md`).
- Updated `DECISION_LOG.md` to mark the prior conflict decision as historical/superseded and added a new Decision (Decision 006) that records the reconciliation and declares the April 17 committed artifact set authoritative (62 files passed / 185 tests passed, with skips detailed).
- Modified `docs/REPO_TRUTH.md` to add a `Current test baseline (April 17, 2026)` section, relabel the April 11 inventory as a historical snapshot, and convert references that implied 85/85 was current into historical wording.
- Added clear historical/superseded banners and pointers in `docs/STATUS_SNAPSHOT_2026-04-11.md` and `docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md` while preserving the original snapshot content.
- Updated `docs/REMAINING_TASKS_2026-04-11.md` to make the 85/85 statement explicitly historical and reference the April 17 baseline.
- Limited scope to documentation only; no runtime code, migrations, or deployment scripts were changed.

### Testing

- Ran automated repository searches for stale strings (`85 tests`, `41 test files`, `85/85`, `Latest Update (April 14, 2026)`, `Known unresolved conflict`, `open conflict`, `pending revalidation`) and confirmed updated files no longer present the 85 baseline as current truth.
- Verified the edited files list and diffs to ensure only intended doc changes were introduced (files changed: `README.md`, `PROJECT_TRUTH.md`, `DECISION_LOG.md`, `docs/REPO_TRUTH.md`, `docs/STATUS_SNAPSHOT_2026-04-11.md`, `docs/PRODUCTION_READY_FILE_LIST_2026-04-11.md`, `docs/REMAINING_TASKS_2026-04-11.md`).
- Confirmed the repository now points to the authoritative April 17 evidence set (`qa-logs/npm-test-2026-04-17.log`, `qa-logs/npm-test.log`, `qa-logs/test-summary.md`, `docs/STATUS_SNAPSHOT_2026-04-17.md`) as the current baseline; automated searches returned no remaining files claiming the 85 baseline as current.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2533207c08326898c831650adfda4)