### PR TITLE
Add Thai QA docs and full-system test report; remove hardcoded operator email in setup checklist

### DIFF
--- a/docs/FULL_SYSTEM_TEST_REPORT_2026-04-17_TH.md
+++ b/docs/FULL_SYSTEM_TEST_REPORT_2026-04-17_TH.md
@@ -1,0 +1,69 @@
+# Full System Test Report (Thai)
+
+วันที่รันทดสอบ: 2026-04-17 (UTC)
+ผู้รัน: Codex agent
+
+## 1) Scope ที่รันจริง
+
+รัน test suite ครบทุกหมวดที่มีใน repository ตาม script มาตรฐาน:
+
+- Unit (`npm run test:unit`)
+- Integration (`npm run test:integration`)
+- Failure/Negative (`npm run test:failure`)
+- Migrations (`npm run test:migrations`)
+- E2E (`npm run test:e2e`)
+- E2E browser install (`npm run test:e2e:install`)
+
+---
+
+## 2) ผลลัพธ์สรุป
+
+| Category | Result | รายละเอียด |
+|---|---|---|
+| Unit | PASS | 29 files, 109 tests ผ่านทั้งหมด |
+| Integration | PASS (with skips) | 28 files ผ่าน, 1 file skipped, 65 tests ผ่าน, 3 tests skipped |
+| Failure (negative) | PASS | 1 file, 4 tests ผ่าน |
+| Migrations | PASS | 4 files, 7 tests ผ่าน |
+| E2E (Playwright) | FAIL (environment) | ไม่สามารถ launch browser ได้ เพราะไม่มี executable |
+| E2E browser install | FAIL (environment) | ดาวน์โหลด Chromium ไม่สำเร็จ (HTTP 403: `Domain forbidden`) |
+
+---
+
+## 3) สรุปตามเกณฑ์ pass/fail ที่กำหนด
+
+- ยัง **ไม่สามารถสรุป pass/fail เชิง full-flow UI จริงทั้งหมด** ได้ เนื่องจาก E2E browser ใน environment นี้ใช้งานไม่ได้
+- Fail ของ E2E ที่พบเป็น **environment/tooling issue** ไม่ใช่ assertion fail ของ business logic
+
+---
+
+## 4) Error หลักที่พบ
+
+### 4.1 Playwright runtime
+
+- `browserType.launch: Executable doesn't exist`
+- ชี้ว่าบนเครื่องยังไม่มี Chromium binary ตาม path ที่ Playwright คาดหวัง
+
+### 4.2 Playwright install
+
+- `Failed to download Chrome for Testing ...`
+- ต้นเหตุหลัก: HTTP 403 และข้อความ `Domain forbidden` จาก `https://cdn.playwright.dev/...`
+
+---
+
+## 5) ข้อเสนอแนะเพื่อปิด full-system test ให้ครบ
+
+1. ตั้งค่า browser mirror ภายในองค์กร หรือ allowlist `cdn.playwright.dev`
+2. หรือใช้ prebuilt Docker image ที่ bundle browser มาแล้ว
+3. ตั้ง `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` ให้ชี้ binary ที่ใช้ได้จริง
+4. หลังแก้ infra แล้ว re-run:
+   - `npm run test:e2e:install`
+   - `npm run test:e2e`
+   - `npm run test:e2e:live` (ถ้าต้องการ live Supabase flow)
+
+---
+
+## 6) คำสรุป
+
+- ฝั่ง unit/integration/failure/migration ของโค้ดผ่านตามที่รันในวันนี้
+- จุดค้างหลักยังเป็น E2E browser provisioning (environment boundary) จึงยังไม่สามารถยืนยัน "เทสทั้งระบบแบบ browser flow ครบทุกหน้า" ได้จนกว่า infra จะพร้อม
+

--- a/docs/OPERATOR_SETUP_CHECKLIST.md
+++ b/docs/OPERATOR_SETUP_CHECKLIST.md
@@ -100,7 +100,7 @@ After signup/login succeeds and an org-scoped operator session exists, verify:
 
 1. Go to `/login`
 2. Click **Start Free Trial** tab
-3. Enter email: `t.dealer01@dsg.pics`
+3. Enter organization test email from your secure credential vault (do not hardcode in docs)
 4. Enter Workspace name, for example `DSG Ops`
 5. Click **Start free trial**
 6. Check email for magic link → click to complete login

--- a/docs/QA_FULL_SURFACE_MANUAL_TEST_PLAN_TH.md
+++ b/docs/QA_FULL_SURFACE_MANUAL_TEST_PLAN_TH.md
@@ -1,0 +1,130 @@
+# QA Full-Surface Manual Test Plan (Thai)
+
+อัปเดตล่าสุด: 2026-04-17 (UTC)
+
+ผลการรันล่าสุดดูที่: `docs/FULL_SYSTEM_TEST_REPORT_2026-04-17_TH.md`
+
+## 1) Test account และ role matrix
+
+- **Credential policy:** ห้ามใส่ user/password จริงในเอกสารหรือ PR
+- **Credential source:** ใช้ Secret Manager/CI variables/1Password ของทีม
+- **Role ที่ต้องทดสอบ:**
+  - `operator`
+  - `admin`
+
+> หมายเหตุ: หากระบบมี role switcher หรือจำเป็นต้อง sign out/in ใหม่ ให้รัน flow แยกต่อ role เพื่อแยกหลักฐาน pass/fail ชัดเจน
+
+---
+
+## 2) ขอบเขตการทดสอบ (Scope)
+
+ต้องครอบคลุม **ทุกหน้า / ทุกปุ่ม / ทุกฟอร์ม / ทุก flow หลัก** ตาม surface ด้านล่าง:
+
+1. Public pages (`/`, `/pricing`, `/docs`, `/quickstart`, `/marketplace`, `/request-access`)
+2. Auth pages (`/login`, `/password-login`, `/signup`, `/auth/*`)
+3. Dashboard pages (`/dashboard/*` ทุกหน้า)
+4. Core operator APIs (`/api/usage`, `/api/execute`, `/api/executions`, `/api/policies`, `/api/capacity`, `/api/audit`)
+5. Billing/enterprise flows (`/dashboard/billing`, enterprise proof flows)
+
+---
+
+## 3) เกณฑ์ pass / fail
+
+### Fail ทันที (Hard fail)
+
+- พบ HTTP **5xx** จาก flow ที่ผู้ใช้เรียกใช้งาน
+- พบ **JavaScript runtime error** ที่กระทบการใช้งาน
+- เกิด **broken flow** (กดต่อไม่ได้, redirect loop, submit ไม่ได้, state เพี้ยนจนจบ flow ไม่ได้)
+
+### Pass
+
+- ไม่มี hard fail ด้านบน
+- แต่ละ flow หลักจบได้ครบตาม expected outcome ของ role
+
+---
+
+## 4) Connector และหลักฐานที่ต้องเก็บ
+
+ใช้หลักฐานครบ 3 ส่วน:
+
+1. **Browser**
+   - เก็บภาพหน้าจอจุดสำคัญ: before action / after action / error state (ถ้ามี)
+2. **GitHub**
+   - เปิด issue ต่อ defect ที่เข้าเกณฑ์ fail
+   - ใส่ขั้นตอน reproduce + expected/actual + severity + ภาพหน้าจอ
+3. **Screenshots**
+   - ชื่อไฟล์แนะนำ: `YYYYMMDD-role-page-flow-step.png`
+   - ตัวอย่าง: `20260417-admin-dashboard-billing-submit-01.png`
+
+---
+
+## 5) Execution checklist (ย่อ)
+
+> ให้ทำ checklist ต่อ role (`operator`, `admin`) แยกกัน
+
+### A. Authentication & Session
+
+- [ ] Login ด้วย email/password สำเร็จ
+- [ ] Logout และ login ซ้ำสำเร็จ
+- [ ] Session timeout/refresh ยังใช้งานได้ตามคาด
+- [ ] Unauthorized route ถูกกันสิทธิ์ถูกต้อง
+
+### B. Navigation & UI actions
+
+- [ ] เข้าทุกเมนูหลักได้
+- [ ] ปุ่ม action ทุกจุดที่มองเห็นได้กดแล้วมีผลลัพธ์ชัดเจน
+- [ ] ไม่พบปุ่ม dead-click
+- [ ] Loading/empty/error state แสดงผลไม่พัง
+
+### C. Forms
+
+- [ ] Validation client-side ทำงาน
+- [ ] Validation server-side ทำงาน
+- [ ] Submit success path ทำงานครบ
+- [ ] Submit failure path แสดงข้อความที่ actionable
+
+### D. Main product flows
+
+- [ ] Agent management flow
+- [ ] Policy flow
+- [ ] Execute/intent flow
+- [ ] Ledger/audit/proofs flow
+- [ ] Billing/seat/checkout flow
+- [ ] Settings/integration flow
+
+### E. Error handling & observability
+
+- [ ] ไม่พบ 5xx ใน flow ปกติ
+- [ ] ไม่พบ JS error ใน console ที่กระทบการใช้งาน
+- [ ] กรณี fail เก็บ evidence ครบ (screenshot + request/response + issue link)
+
+---
+
+## 6) Test case result template
+
+ใช้ format นี้ต่อ 1 test case:
+
+- **Case ID:**
+- **Role:** (`operator` / `admin`)
+- **Page/Flow:**
+- **Steps:**
+- **Expected:**
+- **Actual:**
+- **Result:** (`PASS` / `FAIL`)
+- **Evidence:** (screenshot path + GitHub issue link)
+- **Notes:**
+
+---
+
+## 7) Exit criteria
+
+ปล่อยงานได้เมื่อ:
+
+1. Test checklist ครบทุก scope
+2. ไม่มี hard fail ค้างอยู่
+3. ทุก defect ที่เหลือถูกบันทึกใน GitHub พร้อมหลักฐานครบ
+4. มีสรุปผลท้ายรอบเป็น:
+   - จำนวนทั้งหมด / pass / fail
+   - Top risk 3 อันดับ
+   - ข้อเสนอแนะก่อน production cutover
+


### PR DESCRIPTION
### Motivation

- Provide Thai-language QA artifacts including a full-system test report and a full-surface manual test plan to support QA runs and operator communication.
- Document current test outcomes and remediation steps for E2E/browser provisioning issues in a machine-readable report.
- Remove a hardcoded example email from operator setup guidance to avoid embedding credentials in docs and direct readers to use a secure credential vault.

### Description

- Added `docs/FULL_SYSTEM_TEST_REPORT_2026-04-17_TH.md` containing the results and analysis of a full test run and recommendations for resolving E2E/browser infra issues.
- Added `docs/QA_FULL_SURFACE_MANUAL_TEST_PLAN_TH.md` which defines the QA scope, pass/fail criteria, evidence requirements, role matrix, and execution checklist in Thai.
- Updated `docs/OPERATOR_SETUP_CHECKLIST.md` by replacing the hardcoded example email with guidance to use an organization test email from a secure credential vault (do not hardcode in docs).
- Included actionable remediation steps in the report such as using a browser mirror, prebuilt Docker image, or setting `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` for CI environments.

### Testing

- Ran `npm run test:unit` which passed (29 files, 109 tests passed).
- Ran `npm run test:integration` which passed with skips (28 files passed, 1 file skipped; 65 tests passed, 3 tests skipped).
- Ran `npm run test:failure` which passed (1 file, 4 tests passed) and `npm run test:migrations` which passed (4 files, 7 tests passed).
- `npm run test:e2e:install` and `npm run test:e2e` failed due to environment/browser provisioning issues (Chromium download returned HTTP 403 `Domain forbidden` and `browserType.launch: Executable doesn't exist`), and details are recorded in `docs/FULL_SYSTEM_TEST_REPORT_2026-04-17_TH.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e255d5a77c8326b62699e75e6f13ff)