### PR TITLE
docs: align baseline truth and production-readiness gaps

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -74,3 +74,21 @@ Authoritative evidence:
 Interpretation rule:
 - Keep April 11 documents for historical traceability.
 - Treat April 17 committed evidence as current truth until superseded by a newer committed run.
+
+
+### Decision 007
+Status: accepted
+Type: production-readiness gating
+
+The April 17, 2026 Vitest baseline (**185 passed, 3 skipped, 0 failed**) is necessary but not sufficient to declare production go-live complete.
+
+Go-live remains blocked until RUNBOOK evidence is closed for:
+- Vercel production deployment status = `Ready`
+- production environment variables complete and validated
+- Supabase migrations applied in-order on target environment
+- `/api/health` smoke check passes on deployed target
+- `/api/core/monitor` and authenticated operator checks pass
+- staging/live E2E validation is recorded
+
+Documentation rule:
+- keep test-baseline truth and production-readiness truth as separate sections so test success is not misread as full cutover completion.

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -64,6 +64,16 @@ Authoritative evidence files:
 
 Working rule: preserve older snapshots as historical context, but treat the April 17, 2026 artifact set as the current repo baseline until superseded by a newer committed run.
 
+
+## Production-readiness status boundary
+
+Repository test truth and production go-live truth are intentionally separate:
+
+- Test truth (current): April 17, 2026 committed Vitest baseline = `185 passed, 3 skipped, 0 failed`.
+- Go-live truth (current): **not yet complete** until runbook evidence is closed for deployment readiness, env validation, migration apply state, deployed smoke checks, authenticated operator checks, and live staging/E2E validation.
+
+Do not claim full production readiness from Vitest evidence alone.
+
 ## Working rule for future sessions
 
 Before patching, deploying, or updating docs:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 - Synced README repo-truth to the committed April 17, 2026 evidence refresh.
 - Re-validated the full automated test suite and aligned this README with the authoritative artifact set (`qa-logs/npm-test-2026-04-17.log`, `qa-logs/npm-test.log`, `qa-logs/test-summary.md`, `docs/STATUS_SNAPSHOT_2026-04-17.md`).
+- Clarified production-readiness status: test baseline is green, but runbook go-live evidence remains open until deployment, environment, migration, smoke, operator, and live E2E checks are closed.
 
 ### Test Results (latest run)
 
@@ -39,6 +40,7 @@ npm run test  # PASS (62 files passed, 1 skipped; 185 tests passed, 3 skipped)
 Notes:
 - The skipped file is `tests/integration/api/finance-governance-live-db.test.ts` (live DB integration guard).
 - E2E Playwright depends on browser availability in environment setup.
+- `npm run test` PASS alone is not equivalent to production cutover completion; follow `docs/RUNBOOK_DEPLOY.md` for go-live validation gates.
 
 ---
 

--- a/docs/REPO_TRUTH.md
+++ b/docs/REPO_TRUTH.md
@@ -116,6 +116,24 @@ Evidence pointers:
 Historical context:
 - The April 11 snapshot below remains preserved for timeline/history purposes only.
 
+
+## Production-readiness gap snapshot (April 17, 2026)
+
+Runbook-aligned status is **not yet closed** from repository evidence alone.
+
+| Runbook requirement (`docs/RUNBOOK_DEPLOY.md`) | Current repo evidence status |
+|---|---|
+| Vercel production deployment is `Ready` | Not proven by committed artifact in this repository. |
+| Production env vars complete/validated | Not proven by committed artifact in this repository. |
+| Supabase migrations applied on target environment | Migration files exist; applied-state evidence for production target is not committed here. |
+| Deployed smoke check `GET /api/health` | Not proven against deployed production target in committed evidence set. |
+| `/api/core/monitor` + authenticated operator checks | Not proven against deployed production target in committed evidence set. |
+| Live E2E/staging validation | Not fully proven; Vitest baseline is green, but live browser/E2E evidence is incomplete. |
+
+Interpretation:
+- Treat the April 17 test baseline as repository-test truth.
+- Do **not** mark go-live complete until the runbook evidence above is collected and recorded.
+
 ## Historical production-ready inventory snapshot (April 11, 2026)
 
 This historical snapshot records production-ready file coverage and validated test status as of April 11, 2026 in `tdealer01-crypto-dsg-control-plane`.


### PR DESCRIPTION
### Motivation

- Resolve inconsistent test / production-readiness messaging across `PROJECT_TRUTH.md`, `DECISION_LOG.md`, `docs/REPO_TRUTH.md`, and `README.md` after the April 17, 2026 evidence refresh. 
- Make an explicit policy decision that a green Vitest baseline is necessary but not sufficient for production cutover and that runbook evidence must be collected first. 
- Surface the outstanding runbook gates from `docs/RUNBOOK_DEPLOY.md` so the repo does not imply go-live without deployment/migration/smoke/operator/E2E evidence.

### Description

- Added `Decision 007` to `DECISION_LOG.md` to record that the April 17 Vitest baseline is necessary but not sufficient for production-readiness and to list the runbook gates required before declaring go-live. 
- Inserted a `Production-readiness gap snapshot (April 17, 2026)` table into `docs/REPO_TRUTH.md` that maps `docs/RUNBOOK_DEPLOY.md` requirements to current repo evidence status. 
- Added a `Production-readiness status boundary` section to `PROJECT_TRUTH.md` clarifying separation between test truth and go-live truth. 
- Updated `README.md` Latest Update / Notes to clearly state that `npm run test` passing alone does not imply production cutover is complete. 
- Docs-only change; no runtime or application code was modified.

### Testing

- Confirmed the authoritative Vitest run evidence (`qa-logs/npm-test-2026-04-17.log`) shows `62 files passed, 1 skipped; 185 tests passed, 3 skipped` and remains the repository test baseline. 
- Performed repo verification commands (`git diff`, `nl -ba` views of modified files, and `git status`) to validate the intended edits were applied and readable. 
- No code changes were made so no additional unit/integration test runs were required beyond the existing Vitest evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e25cfee7c08326be9e8adb305cb1a6)