### PR TITLE
Unify first-run onboarding around Auto-Setup execution path

### DIFF
--- a/app/api/onboarding/state/route.ts
+++ b/app/api/onboarding/state/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { handleApiError } from '../../../../lib/security/api-error';
+import { createClient } from '../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const admin = getSupabaseAdmin();
+    const profile = await admin
+      .from('users')
+      .select('org_id, is_active')
+      .eq('auth_user_id', user.id)
+      .maybeSingle();
+
+    if (profile.error || !profile.data?.org_id || !profile.data.is_active) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const orgId = String(profile.data.org_id);
+    const state = await admin
+      .from('org_onboarding_states')
+      .select('bootstrap_status, checklist, bootstrapped_at')
+      .eq('org_id', orgId)
+      .maybeSingle();
+
+    const agents = await admin.from('agents').select('id', { count: 'exact', head: true }).eq('org_id', orgId);
+    const executions = await admin.from('executions').select('id', { count: 'exact', head: true }).eq('org_id', orgId);
+
+    return NextResponse.json({
+      org_id: orgId,
+      onboarding: state.data ?? null,
+      is_empty: (agents.count ?? 0) === 0,
+      has_first_execution: (executions.count ?? 0) > 0,
+    });
+  } catch (error) {
+    return handleApiError('api/onboarding/state', error);
+  }
+}

--- a/app/api/setup/auto/route.ts
+++ b/app/api/setup/auto/route.ts
@@ -10,6 +10,7 @@ import { handleApiError } from '../../../../lib/security/api-error';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
+type SetupStatus = 'OK' | 'CREATED' | 'EXISTS' | 'FAIL';
 
 function isMissingSchemaError(message: string, identifier: string) {
   const normalized = message.toLowerCase();
@@ -56,6 +57,13 @@ export async function POST(_request: Request) {
     const now = new Date().toISOString();
     const suffix = randomUUID().slice(0, 8);
     const results: Record<string, unknown> = { org_id: orgId, steps: [] as string[] };
+    let policyStatus: SetupStatus = 'OK';
+    let agentStatus: SetupStatus | null = null;
+    let rpcCommitStatus: SetupStatus = 'FAIL';
+    let checkpointStatus: SetupStatus = 'FAIL';
+    let billingStatus: SetupStatus = 'FAIL';
+    let onboardingStatus: SetupStatus = 'FAIL';
+    let runtimeRolesStatus: SetupStatus = 'FAIL';
 
     let { error: policyError } = await admin.from('policies').upsert(
       {
@@ -83,6 +91,9 @@ export async function POST(_request: Request) {
       policyError = retry.error;
     }
     (results.steps as string[]).push(toStepStatus('policy', policyError));
+    if (policyError) {
+      policyStatus = 'FAIL';
+    }
 
     const { data: existingAgents } = await admin
       .from('agents')
@@ -95,6 +106,8 @@ export async function POST(_request: Request) {
 
     if (existingAgents && existingAgents.length > 0) {
       agentId = String(existingAgents[0].id);
+      results.agent_id = agentId;
+      agentStatus = 'EXISTS';
       (results.steps as string[]).push(`agent: EXISTS (${agentId})`);
     } else {
       agentId = `agent-${suffix}`;
@@ -108,6 +121,8 @@ export async function POST(_request: Request) {
         api_key_hash: createHash('sha256').update(apiKey).digest('hex'),
         monthly_limit: 10000,
       });
+      results.agent_id = agentId;
+      agentStatus = agentError ? 'FAIL' : 'CREATED';
       (results.steps as string[]).push(agentError ? `agent: FAIL (${agentError.message})` : `agent: CREATED (${agentId})`);
     }
 
@@ -151,6 +166,7 @@ export async function POST(_request: Request) {
         if (legacyExecError || !execution) {
           (results.steps as string[]).push(`approval: FAIL (${approvalError.message})`);
           (results.steps as string[]).push(`rpc_commit: FAIL (${legacyExecError?.message || 'legacy execution failed'})`);
+          rpcCommitStatus = 'FAIL';
         } else {
           results.execution_id = execution.id;
           await admin.from('audit_logs').insert({
@@ -164,9 +180,11 @@ export async function POST(_request: Request) {
           });
           (results.steps as string[]).push('approval: OK (legacy fallback)');
           (results.steps as string[]).push(`rpc_commit: OK (legacy execution=${execution.id})`);
+          rpcCommitStatus = 'OK';
         }
       } else {
         (results.steps as string[]).push(toStepStatus('approval', approvalError));
+        rpcCommitStatus = 'FAIL';
       }
     } else {
       const { data: commit, error: commitError, mode: commitMode } = await invokeRuntimeCommitRpc(admin, {
@@ -191,6 +209,7 @@ export async function POST(_request: Request) {
 
       if (commitError) {
         (results.steps as string[]).push(`rpc_commit: FAIL (${commitError.message})`);
+        rpcCommitStatus = 'FAIL';
       } else {
         const row = Array.isArray(commit) ? commit[0] : commit;
         results.execution_id = row?.execution_id;
@@ -199,6 +218,7 @@ export async function POST(_request: Request) {
         (results.steps as string[]).push(
           `rpc_commit: OK${commitMode === 'legacy' ? ' (legacy-signature)' : ''} (execution=${row?.execution_id})`,
         );
+        rpcCommitStatus = 'OK';
 
         if (row?.ledger_id && row?.truth_state_id) {
           const cpHash = buildCheckpointHash({
@@ -220,6 +240,9 @@ export async function POST(_request: Request) {
             { onConflict: 'org_id,agent_id,checkpoint_hash', ignoreDuplicates: true },
           );
           (results.steps as string[]).push('checkpoint: OK');
+          checkpointStatus = 'OK';
+        } else {
+          (results.steps as string[]).push('checkpoint: FAIL (missing ledger/truth references from runtime commit)');
         }
       }
     }
@@ -232,8 +255,10 @@ export async function POST(_request: Request) {
 
     if (existingSubError && isMissingInfraError(existingSubError.message, 'billing_subscriptions')) {
       (results.steps as string[]).push('billing: OK (trial-default fallback)');
+      billingStatus = 'OK';
     } else if (existingSubError) {
       (results.steps as string[]).push(`billing: FAIL (${existingSubError.message})`);
+      billingStatus = 'FAIL';
     } else
     if (!existingSub || existingSub.length === 0) {
       const { error: subError } = await admin.from('billing_subscriptions').insert({
@@ -250,17 +275,21 @@ export async function POST(_request: Request) {
       (results.steps as string[]).push(
         subError ? toStepStatus('billing', subError) : 'billing: CREATED (trial)',
       );
+      billingStatus = subError ? 'FAIL' : 'CREATED';
     } else {
       (results.steps as string[]).push('billing: EXISTS');
+      billingStatus = 'EXISTS';
     }
 
     try {
       await bootstrapOrgStarterState(orgId, { initiatedByUserId: access.userId });
       (results.steps as string[]).push('onboarding: OK');
+      onboardingStatus = 'OK';
     } catch (error) {
       (results.steps as string[]).push(
         `onboarding: FAIL (${error instanceof Error ? error.message : 'unknown'})`,
       );
+      onboardingStatus = 'FAIL';
     }
 
     await admin.from('runtime_roles').upsert(
@@ -273,6 +302,7 @@ export async function POST(_request: Request) {
       { onConflict: 'org_id,user_id,role', ignoreDuplicates: true },
     );
     (results.steps as string[]).push('runtime_roles: OK');
+    runtimeRolesStatus = 'OK';
 
     const coreMode = process.env.DSG_CORE_MODE;
     results.env_check = {
@@ -288,7 +318,27 @@ export async function POST(_request: Request) {
       results.api_key_warning = '⚠️ เก็บ key นี้ไว้ — จะไม่แสดงอีก';
     }
 
-    results.ok = true;
+    results.policy = policyStatus;
+    results.agent = agentStatus ?? 'FAIL';
+    results.rpc_commit = rpcCommitStatus;
+    results.checkpoint = checkpointStatus;
+    results.billing = billingStatus;
+    results.onboarding = onboardingStatus;
+    results.runtime_roles = runtimeRolesStatus;
+
+    const hasFirstExecution = typeof results.execution_id === 'string' && results.execution_id.length > 0;
+    const firstRunComplete =
+      hasFirstExecution &&
+      policyStatus !== 'FAIL' &&
+      (agentStatus === 'CREATED' || agentStatus === 'EXISTS') &&
+      rpcCommitStatus === 'OK' &&
+      checkpointStatus === 'OK' &&
+      (billingStatus === 'OK' || billingStatus === 'CREATED' || billingStatus === 'EXISTS') &&
+      onboardingStatus === 'OK' &&
+      runtimeRolesStatus === 'OK';
+
+    results.first_run_complete = firstRunComplete;
+    results.ok = firstRunComplete;
     results.next_steps = [] as string[];
     if (!coreMode) {
       (results.next_steps as string[]).push('ตั้ง DSG_CORE_MODE=internal บน Vercel');
@@ -297,7 +347,17 @@ export async function POST(_request: Request) {
       (results.next_steps as string[]).push('ตั้ง STRIPE_SECRET_KEY บน Vercel (ถ้าจะใช้ billing)');
     }
 
-    return NextResponse.json(results);
+    if (!firstRunComplete) {
+      return NextResponse.json(
+        {
+          ...results,
+          error: 'Auto-Setup did not complete first-run requirements. Check step statuses and fix failing infrastructure.',
+        },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(results, { status: 200 });
   } catch (error) {
     return handleApiError('api/setup/auto', error);
   }

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -273,6 +273,6 @@ export async function GET(request: NextRequest) {
     }, { onConflict: 'org_id' });
   }
 
-  const redirectTo = new URL(next || '/quickstart', request.url);
+  const redirectTo = new URL(next || '/dashboard/skills', request.url);
   return NextResponse.redirect(redirectTo, { status: 302 });
 }

--- a/app/auth/continue/route.ts
+++ b/app/auth/continue/route.ts
@@ -323,7 +323,7 @@ async function handleTrialSignup(args: {
   });
 
   const confirmUrl = new URL('/auth/confirm', getTrustedAppOrigin(args.request));
-  confirmUrl.searchParams.set('next', '/quickstart');
+  confirmUrl.searchParams.set('next', '/dashboard/skills');
   confirmUrl.searchParams.set('signup', 'trial');
 
   const { error } = await sendMagicLink(

--- a/app/dashboard/executions/page.tsx
+++ b/app/dashboard/executions/page.tsx
@@ -322,16 +322,16 @@ export default function ExecutionsPage() {
 
                     <div className="mt-4 flex gap-2">
                       <Link
-                        href="/quickstart"
+                        href="/dashboard/skills"
                         className="rounded-xl bg-[#81ecff] px-4 py-3 text-sm font-semibold text-black"
                       >
-                        Run first execution
+                        Run Auto-Setup
                       </Link>
                       <Link
-                        href="/quickstart"
+                        href="/dashboard/skills"
                         className="rounded-xl border border-[#81ecff]/40 px-4 py-3 text-sm font-semibold text-[#81ecff] hover:bg-[#81ecff]/10"
                       >
-                        Open quickstart
+                        Open Skills
                       </Link>
                     </div>
                   </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -179,7 +179,7 @@ export default function DashboardPage() {
             ok: r.ok,
             json: await r.json(),
           })),
-          fetch("/api/quickstart/onboarding", { cache: "no-store" }).then(async (r) => ({
+          fetch("/api/onboarding/state", { cache: "no-store" }).then(async (r) => ({
             ok: r.ok,
             json: await r.json(),
           })),
@@ -343,8 +343,8 @@ export default function DashboardPage() {
                 {onboardingProgress.completed}/{onboardingProgress.total} completed
               </p>
             </div>
-            <Link href="/quickstart" className="rounded-xl border border-emerald-200/40 px-4 py-2 text-sm font-semibold text-emerald-100">
-              Continue quickstart
+            <Link href="/dashboard/skills" className="rounded-xl border border-emerald-200/40 px-4 py-2 text-sm font-semibold text-emerald-100">
+              Run Auto-Setup
             </Link>
           </div>
           <div className="mt-4 h-2 w-full rounded-full bg-slate-800">
@@ -359,9 +359,9 @@ export default function DashboardPage() {
           <div className="mt-6 rounded-2xl border border-emerald-400/30 bg-emerald-400/10 p-6">
             <p className="text-lg font-semibold text-emerald-100">Welcome to DSG Control Plane</p>
             <p className="mt-2 text-sm leading-7 text-emerald-200/80">
-              Your authenticated dashboard is still empty. Head to the{" "}
-              <Link href="/quickstart" className="underline font-semibold text-emerald-200">Quickstart</Link>{" "}
-              page to create your first agent and run a sample execution, or visit{" "}
+              Your authenticated dashboard is still empty. Head to{" "}
+              <Link href="/dashboard/skills" className="underline font-semibold text-emerald-200">Skills Auto-Setup</Link>{" "}
+              to provision your first agent and first execution through the production runtime path, or visit{" "}
               <Link href="/pricing" className="underline font-semibold text-emerald-200">Pricing</Link>{" "}
               to review plan changes.
             </p>

--- a/app/dashboard/skills/page.tsx
+++ b/app/dashboard/skills/page.tsx
@@ -59,7 +59,7 @@ export default function SkillsPage() {
       } else {
         setResult(json);
         if (json?.ok) {
-          setTimeout(() => router.push("/dashboard"), 1200);
+          setTimeout(() => router.push("/dashboard/executions"), 1200);
         }
       }
     } catch (e) {
@@ -166,7 +166,7 @@ export default function SkillsPage() {
                     Copy to clipboard
                   </button>
                   {copyStatus ? <p className="mt-2 text-xs text-amber-100">{copyStatus}</p> : null}
-                  {result.ok ? <p className="mt-2 text-xs text-emerald-200">Setup complete. Redirecting to dashboard...</p> : null}
+                  {result.ok ? <p className="mt-2 text-xs text-emerald-200">Setup complete. Redirecting to executions...</p> : null}
                 </div>
               )}
 

--- a/lib/onboarding/bootstrap.ts
+++ b/lib/onboarding/bootstrap.ts
@@ -20,7 +20,7 @@ export async function bootstrapOrgStarterState(orgId: string, opts?: { initiated
   const now = new Date().toISOString();
   const checklist = {
     steps: STARTER_STEPS,
-    next_action: (agents.count ?? 0) > 0 ? 'Open quickstart and run your first controlled execution' : 'Set up starter workspace',
+    next_action: (agents.count ?? 0) > 0 ? 'Open executions dashboard to validate your first controlled execution' : 'Complete Auto-Setup in Skills to create your first execution',
     initiated_by_user_id: opts?.initiatedByUserId ?? null,
   };
 


### PR DESCRIPTION
### Motivation
- Ensure new users follow the same production execution path (no special one-shot quickstart flow) so the first execution is a real execution visible in the dashboard. 
- Make the single Auto-Setup flow the canonical first-run path and surface any infra failures clearly rather than allowing silent or partial success. 
- Reduce onboarding state branching and point CTAs to the Auto-Setup proof-of-value (executions) experience.

### Description
- Redirect first-run/trial flow to the Auto-Setup UI by changing magic-link continuations to `'/dashboard/skills'` in `app/auth/continue/route.ts` and `app/auth/confirm/route.ts`.
- Add a new onboarding API `GET /api/onboarding/state` at `app/api/onboarding/state/route.ts` and update the dashboard to fetch onboarding from it instead of `/api/quickstart/onboarding` (`app/dashboard/page.tsx`).
- Update UI CTAs so empty states and quickstart links point to Skills Auto-Setup (`app/dashboard/page.tsx`, `app/dashboard/executions/page.tsx`, `app/dashboard/skills/page.tsx`) and change the skills success redirect to `'/dashboard/executions'` for proof-of-value.
- Harden `POST /api/setup/auto` (`app/api/setup/auto/route.ts`) to expose an explicit step contract (`policy`, `agent`, `rpc_commit`, `checkpoint`, `billing`, `onboarding`, `runtime_roles`, `first_run_complete`) and return a 500 error when the hard first-run requirements (including a real first execution and checkpoint) are not met.
- Update onboarding bootstrap copy to point to Auto-Setup + executions as the next action (`lib/onboarding/bootstrap.ts`).

### Testing
- Type checking was run with `npm run typecheck` and completed successfully. 
- Linting was run with `npm run lint` (ESLint via Next) and completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2afa862ec8326aaf9cfaf3984173f)