### PR TITLE
Harden onboarding bootstrap and auto-setup failure signaling

### DIFF
--- a/app/api/setup/auto/route.ts
+++ b/app/api/setup/auto/route.ts
@@ -65,6 +65,16 @@ export async function POST(_request: Request) {
     let onboardingStatus: SetupStatus = 'FAIL';
     let runtimeRolesStatus: SetupStatus = 'FAIL';
 
+    const fail = (payload: Record<string, unknown>, status = 500) =>
+      NextResponse.json(
+        {
+          ...results,
+          ...payload,
+          ok: false,
+        },
+        { status },
+      );
+
     let { error: policyError } = await admin.from('policies').upsert(
       {
         id: 'policy_default',
@@ -95,11 +105,21 @@ export async function POST(_request: Request) {
       policyStatus = 'FAIL';
     }
 
-    const { data: existingAgents } = await admin
+    const existingAgentsResult = await admin
       .from('agents')
       .select('id, name')
       .eq('org_id', orgId)
       .limit(1);
+
+    if (existingAgentsResult.error) {
+      agentStatus = 'FAIL';
+      (results.steps as string[]).push(`agent_lookup: FAIL (${existingAgentsResult.error.message})`);
+      return fail({
+        error: 'Failed to inspect existing agents before Auto-Setup.',
+      });
+    }
+
+    const existingAgents = existingAgentsResult.data ?? [];
 
     let agentId: string;
     let apiKey: string | null = null;
@@ -167,6 +187,7 @@ export async function POST(_request: Request) {
           (results.steps as string[]).push(`approval: FAIL (${approvalError.message})`);
           (results.steps as string[]).push(`rpc_commit: FAIL (${legacyExecError?.message || 'legacy execution failed'})`);
           rpcCommitStatus = 'FAIL';
+          checkpointStatus = 'FAIL';
         } else {
           results.execution_id = execution.id;
           await admin.from('audit_logs').insert({
@@ -180,6 +201,7 @@ export async function POST(_request: Request) {
           });
           (results.steps as string[]).push('approval: OK (legacy fallback)');
           (results.steps as string[]).push(`rpc_commit: OK (legacy execution=${execution.id})`);
+          (results.steps as string[]).push('checkpoint: FAIL (legacy fallback did not create runtime checkpoint)');
           rpcCommitStatus = 'OK';
         }
       } else {
@@ -228,7 +250,7 @@ export async function POST(_request: Request) {
             latestTruthSequence: Number(row.truth_sequence || 0),
           });
 
-          await admin.from('runtime_checkpoints').upsert(
+          const { error: checkpointError } = await admin.from('runtime_checkpoints').upsert(
             {
               org_id: orgId,
               agent_id: agentId,
@@ -239,10 +261,17 @@ export async function POST(_request: Request) {
             },
             { onConflict: 'org_id,agent_id,checkpoint_hash', ignoreDuplicates: true },
           );
-          (results.steps as string[]).push('checkpoint: OK');
-          checkpointStatus = 'OK';
+
+          if (checkpointError) {
+            (results.steps as string[]).push(`checkpoint: FAIL (${checkpointError.message})`);
+            checkpointStatus = 'FAIL';
+          } else {
+            (results.steps as string[]).push('checkpoint: OK');
+            checkpointStatus = 'OK';
+          }
         } else {
           (results.steps as string[]).push('checkpoint: FAIL (missing ledger/truth references from runtime commit)');
+          checkpointStatus = 'FAIL';
         }
       }
     }
@@ -292,7 +321,7 @@ export async function POST(_request: Request) {
       onboardingStatus = 'FAIL';
     }
 
-    await admin.from('runtime_roles').upsert(
+    const { error: runtimeRolesError } = await admin.from('runtime_roles').upsert(
       [
         { org_id: orgId, user_id: access.userId, role: 'org_admin' },
         { org_id: orgId, user_id: access.userId, role: 'operator' },
@@ -301,8 +330,14 @@ export async function POST(_request: Request) {
       ],
       { onConflict: 'org_id,user_id,role', ignoreDuplicates: true },
     );
-    (results.steps as string[]).push('runtime_roles: OK');
-    runtimeRolesStatus = 'OK';
+
+    if (runtimeRolesError) {
+      (results.steps as string[]).push(`runtime_roles: FAIL (${runtimeRolesError.message})`);
+      runtimeRolesStatus = 'FAIL';
+    } else {
+      (results.steps as string[]).push('runtime_roles: OK');
+      runtimeRolesStatus = 'OK';
+    }
 
     const coreMode = process.env.DSG_CORE_MODE;
     results.env_check = {

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -252,13 +252,31 @@ export async function GET(request: NextRequest) {
     source: 'auth_confirm',
   });
 
+  const appUserId = provisionedUser?.id || existingUser?.id || null;
+
+  if (appUserId) {
+    const { error: runtimeRolesError } = await admin.from('runtime_roles').upsert(
+      [
+        { org_id: orgId, user_id: appUserId, role: 'org_admin' },
+        { org_id: orgId, user_id: appUserId, role: 'operator' },
+        { org_id: orgId, user_id: appUserId, role: 'runtime_auditor' },
+        { org_id: orgId, user_id: appUserId, role: 'billing_admin' },
+      ],
+      { onConflict: 'org_id,user_id,role', ignoreDuplicates: true },
+    );
+
+    if (runtimeRolesError) {
+      console.error('[auth-confirm] runtime_roles bootstrap failed:', runtimeRolesError);
+    }
+  }
+
   try {
-    await bootstrapOrgStarterState(orgId, { initiatedByUserId: user.id });
+    await bootstrapOrgStarterState(orgId, { initiatedByUserId: appUserId });
   } catch (bootstrapError) {
     console.error('[auth-confirm] bootstrap failed:', bootstrapError);
     await admin.from('org_onboarding_states').upsert({
       org_id: orgId,
-      bootstrap_status: 'failed',
+      bootstrap_status: 'pending',
       checklist: {
         steps: [
           'Create or inspect your first agent',
@@ -267,7 +285,7 @@ export async function GET(request: NextRequest) {
           'Inspect evidence or audit output',
           'Review quota/billing basics',
         ],
-        next_action: 'Set up starter workspace',
+        next_action: 'Complete Auto-Setup in Skills to create your first execution',
       },
       updated_at: nowIso,
     }, { onConflict: 'org_id' });

--- a/lib/onboarding/bootstrap.ts
+++ b/lib/onboarding/bootstrap.ts
@@ -12,23 +12,49 @@ export async function bootstrapOrgStarterState(orgId: string, opts?: { initiated
   const admin = getSupabaseAdmin();
   const existing = await admin.from('org_onboarding_states').select('id, bootstrap_status').eq('org_id', orgId).maybeSingle();
   if (existing.error) throw existing.error;
-  if (existing.data?.bootstrap_status === 'completed') return { status: 'completed' as const, created: false };
 
   const agents = await admin.from('agents').select('id', { count: 'exact', head: true }).eq('org_id', orgId);
   if (agents.error) throw agents.error;
 
+  const executions = await admin.from('executions').select('id', { count: 'exact', head: true }).eq('org_id', orgId);
+  if (executions.error) throw executions.error;
+
+  const hasAgent = (agents.count ?? 0) > 0;
+  const hasFirstExecution = (executions.count ?? 0) > 0;
   const now = new Date().toISOString();
   const checklist = {
     steps: STARTER_STEPS,
-    next_action: (agents.count ?? 0) > 0 ? 'Open executions dashboard to validate your first controlled execution' : 'Complete Auto-Setup in Skills to create your first execution',
+    next_action: hasFirstExecution
+      ? 'Open executions dashboard to inspect your first controlled execution'
+      : hasAgent
+        ? 'Complete Auto-Setup in Skills to create your first execution'
+        : 'Complete Auto-Setup in Skills to create your first agent and first execution',
     initiated_by_user_id: opts?.initiatedByUserId ?? null,
   };
 
+  const bootstrapStatus = hasFirstExecution ? 'completed' : 'pending';
+  const bootstrappedAt = hasFirstExecution ? now : null;
+
   if (existing.data?.id) {
-    await admin.from('org_onboarding_states').update({ checklist, bootstrap_status: 'completed', bootstrapped_at: now, updated_at: now }).eq('id', existing.data.id);
+    await admin
+      .from('org_onboarding_states')
+      .update({
+        checklist,
+        bootstrap_status: bootstrapStatus,
+        bootstrapped_at: bootstrappedAt,
+        updated_at: now,
+      })
+      .eq('id', existing.data.id);
   } else {
-    await admin.from('org_onboarding_states').insert({ org_id: orgId, checklist, bootstrap_status: 'completed', bootstrapped_at: now, created_at: now, updated_at: now });
+    await admin.from('org_onboarding_states').insert({
+      org_id: orgId,
+      checklist,
+      bootstrap_status: bootstrapStatus,
+      bootstrapped_at: bootstrappedAt,
+      created_at: now,
+      updated_at: now,
+    });
   }
 
-  return { status: 'completed' as const, created: !existing.data?.id };
+  return { status: bootstrapStatus as 'completed' | 'pending', created: !existing.data?.id };
 }


### PR DESCRIPTION
### Motivation
- Prevent false-positive onboarding/auto-setup success states and ensure new users get runtime roles immediately after auth confirmation.
- Fail fast and surface real DB errors during Auto-Setup so the UI and operator can diagnose infra issues instead of proceeding with partial assumptions.

### Description
- Seed `runtime_roles` during auth confirmation using the app-level user id (`provisionedUser` / `existingUser`) and pass that id into `bootstrapOrgStarterState`, and mark onboarding fallback as `pending` with an updated `next_action` in `app/auth/confirm/route.ts`.
- Update `bootstrapOrgStarterState` to inspect `executions` and only return `completed` when the org has at least one execution, otherwise return `pending`, and adjust checklist `next_action` messaging in `lib/onboarding/bootstrap.ts`.
- Add a shared `fail()` helper and fail-fast handling when reading `agents` fails, mark checkpoint status explicitly for the legacy fallback, and check/report `runtime_checkpoints` upsert errors in `app/api/setup/auto/route.ts`.
- Check and report errors from `runtime_roles` upsert in `/api/setup/auto` and set step statuses accordingly in `app/api/setup/auto/route.ts`.

### Testing
- Attempted the three requested HTTP checks (`POST /api/setup/auto`, `GET /api/onboarding/state`, `GET /api/executions?limit=1`), but all requests failed to reach the application due to a CONNECT tunnel `403` (network/hosting gateway), so no end-to-end responses from the deployed app were obtained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2b23373848326af23b666aff56822)