### PR TITLE
Align first-run flow messaging to Auto-Setup and /api/execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ A product can have a public AI-readable narrative for positioning, while still k
 - trial signup and provisioning flow
 
 ### Agent and execution layer
-- starter-agent creation
+- Auto-Setup creates policy + agent + execution + billing subscription + onboarding + runtime roles
 - one-time API key generation
-- sample execution path
+- stable real-run execution path via `POST /api/execute`
 - execution decisions, latency, and audit references
 
 ### Monitoring and control-plane surfaces
@@ -169,23 +169,23 @@ This surface is:
 
 ---
 
-## Quickstart Experience
+## First-Run Experience (Auto-Setup)
 
-A new workspace can be evaluated through a guided flow:
+A new workspace should follow the main first-run flow:
 
 1. Sign up for a trial workspace
 2. Confirm the magic link
-3. Enter `/quickstart`
-4. Create the first starter agent
-5. Copy the one-time API key
-6. Run the first sample execution through `/api/execute`
-7. Inspect mission, app-shell, and enterprise-proof surfaces
+3. Open `/dashboard/skills`
+4. Run **Auto-Setup** (creates policy + agent + execution + billing subscription + onboarding + runtime roles)
+5. Copy the one-time API key after setup completes
+6. Run real execution through `/api/execute` (stable entry point)
+7. Continue from `/dashboard/executions` for post-setup operations
 
-Quickstart currently includes:
+First-run Auto-Setup currently includes:
 - 14-day trial
 - 1,000 included executions
-- first-agent creation
-- first-execution walkthrough
+- first agent creation + first execution in one flow
+- post-setup landing at `/dashboard/executions`
 - links into live monitoring surfaces
 
 ---
@@ -202,7 +202,7 @@ Use this as the anonymous/public baseline availability probe for deployment and 
 ### Stable execution compatibility entry
 - `POST /api/execute`
 
-This is the stable compatibility entry used by quickstart and sample execution flows.
+This is the stable execution entry used for real-run traffic after first-run setup.
 
 Important:
 - this route is **not** an anonymous public execution endpoint
@@ -336,7 +336,7 @@ This path:
 - creates a pending trial-signup record
 - sends a magic link
 - provisions organization, user, and trial subscription during confirmation
-- redirects the user into `/quickstart`
+- redirects the user into `/dashboard/skills`
 
 ### `/login`
 For already provisioned operator accounts only.
@@ -373,7 +373,7 @@ Organizations using DSG ONE get:
 - a clearer runtime control layer for AI execution
 - better operational evidence for review
 - separation between public positioning and real runtime proof
-- visible quickstart paths from signup to first execution
+- visible first-run Auto-Setup path from signup to first execution
 - operator-facing surfaces for mission, execution, and readiness workflows
 - an architecture designed for review, not only for demos
 
@@ -409,8 +409,8 @@ It is through inspection.
 Review:
 - signup and login behavior
 - provisioning rules
-- quickstart flow
-- starter-agent creation
+- first-run Auto-Setup flow
+- Auto-Setup creates policy + agent + execution + billing subscription + onboarding + runtime roles
 - execution path and returned decision data
 - public enterprise-proof surfaces
 - verified runtime proof surfaces
@@ -431,8 +431,8 @@ A practical evaluation path is:
 1. Open the public proof narrative
 2. Start a trial workspace
 3. Complete magic-link confirmation
-4. Use quickstart to create the first agent
-5. Run the first execution
+4. Run Auto-Setup in `/dashboard/skills`
+5. Continue in `/dashboard/executions`
 6. Open mission and dashboard surfaces
 7. Inspect the verified runtime proof path
 8. Compare runtime behavior against the product claims and research direction
@@ -494,7 +494,7 @@ If your organization needs AI systems to operate with:
 - explicit runtime control
 - visible execution evidence
 - authenticated operator workflows
-- structured quickstart-to-production paths
+- structured first-run-to-production paths
 - public proof for external evaluation
 - verified proof for real runtime review
 

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -60,7 +60,7 @@ export default function DocsPage() {
           <h1 className="text-4xl font-bold md:text-5xl">DSG Control Plane Documentation</h1>
           <p className="mt-4 text-lg text-slate-300">
             Current product documentation for DSG ONE Control Plane,
-            including route overview, quickstart flow, and operator/runtime
+            including route overview, first-run Auto-Setup, and operator/runtime
             entry points.
           </p>
         </div>
@@ -105,14 +105,14 @@ export default function DocsPage() {
         <section className="mt-10 rounded-2xl border border-slate-800 bg-slate-900 p-6">
           <h2 className="text-xl font-semibold">Execution Compatibility</h2>
           <p className="mt-4 text-sm text-slate-300">
-            Use <code>/api/execute</code> as the stable entry shown in quickstart.
+            Use <code>/api/execute</code> as the stable real-run entry after Auto-Setup.
             The current implementation forwards to the spine execution handler,
             so the execution logic remains centralized while the public path stays stable.
           </p>
         </section>
 
         <section className="mt-10 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-xl font-semibold">Quickstart</h2>
+          <h2 className="text-xl font-semibold">Real-run Example</h2>
           <pre className="mt-4 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`curl -X POST http://localhost:3000/api/execute \\
   -H "Authorization: Bearer dsg_live_demo" \\
   -H "Content-Type: application/json" \\

--- a/docs/AI_AUTOMATION_ENTERPRISE_GAP_SIMULATION_TH.md
+++ b/docs/AI_AUTOMATION_ENTERPRISE_GAP_SIMULATION_TH.md
@@ -356,7 +356,7 @@ Response:
       },
       {
         "key": "first_execution",
-        "label": "Run your first execution",
+        "label": "Complete Auto-Setup",
         "status": "not_started",
         "route": "/dashboard/command-center"
       }
@@ -1427,7 +1427,7 @@ Audit / reporting
   - Set roles and access
   - Create first policy
   - Connect integration
-  - Run first execution
+  - Complete Auto-Setup
 
 #### Checklist component structure
 Each item must include:

--- a/docs/OPERATOR_SETUP_CHECKLIST.md
+++ b/docs/OPERATOR_SETUP_CHECKLIST.md
@@ -92,7 +92,7 @@ After signup/login succeeds and an org-scoped operator session exists, verify:
 
 ### Execution route note
 
-- `POST /api/execute` is the stable compatibility entry for sample execution and quickstart use.
+- `POST /api/execute` is the stable execution entry for real-run traffic after Auto-Setup.
 - The current implementation forwards into the spine execution handler.
 - Do not treat `/api/usage` as a public health check; it is an authenticated operator route.
 

--- a/docs/REPO_TRUTH.md
+++ b/docs/REPO_TRUTH.md
@@ -49,7 +49,7 @@ This is the baseline public availability probe for deployment and smoke-check pu
 ### Stable execution entry
 - `POST /api/execute`
 
-This path remains the stable compatibility entry for sample and quickstart execution.
+This path remains the stable execution entry for real-run traffic after first-run setup.
 Internally, it forwards to the current spine execution handler.
 
 ### Current execution implementation layer

--- a/docs/ops/GO_NO_GO.md
+++ b/docs/ops/GO_NO_GO.md
@@ -96,7 +96,7 @@
 
 ### 7) Quickstart / Auth flows
 
-- **What:** Signup -> magic-link -> quickstart -> create starter-agent -> first execution -> inspect enterprise-proof & verified runtime.
+- **What:** Signup -> magic-link -> /dashboard/skills -> run Auto-Setup -> verify first execution -> land on /dashboard/executions -> inspect enterprise-proof & verified runtime.
 - **Expected evidence:** Screenshots / session trace / Playwright E2E logs showing flow success. 
 
 ### 8) Monitoring & Alerts

--- a/tests/integration/api/auth-continue-org-sso.test.ts
+++ b/tests/integration/api/auth-continue-org-sso.test.ts
@@ -4,7 +4,7 @@ function buildReq() {
   const form = new FormData();
   form.set('email', 'user@acme.com');
   form.set('org', 'acme');
-  form.set('next', '/quickstart');
+  form.set('next', '/dashboard/skills');
   return new Request('http://localhost/auth/continue', { method: 'POST', body: form });
 }
 


### PR DESCRIPTION
### Motivation

- Internal docs and UI should present Auto-Setup at `/dashboard/skills` as the canonical first-run path and `POST /api/execute` as the stable real-run entry point for executions. 
- Remove user-facing guidance that routes newcomers into the legacy quickstart flow so new users are guided to Auto-Setup → executions instead. 
- Preserve `/quickstart` only as a compatibility redirect to the new Auto-Setup entry to avoid breaking existing links.

### Description

- Updated product copy and first-run guidance in `README.md` to describe the first-run flow as Auto-Setup at `/dashboard/skills`, real-run execution via `POST /api/execute`, and post-setup landing at `/dashboard/executions`. 
- Updated the in-app docs page `app/docs/page.tsx` to replace quickstart framing with Auto-Setup / real-run guidance and a real-run example calling `/api/execute`. 
- Adjusted operational docs `docs/OPERATOR_SETUP_CHECKLIST.md`, `docs/REPO_TRUTH.md`, and `docs/ops/GO_NO_GO.md` to reflect the Auto-Setup first-run flow and `POST /api/execute` as the stable execution entry. 
- Replaced checklist wording in `docs/AI_AUTOMATION_ENTERPRISE_GAP_SIMULATION_TH.md` from "Run your first execution" to "Complete Auto-Setup". 
- Updated an integration test fixture in `tests/integration/api/auth-continue-org-sso.test.ts` to set `next` to `/dashboard/skills` instead of `/quickstart`. 
- Kept `app/quickstart/page.tsx` as a compatibility redirect to `/dashboard/skills` and left historical references in audit/history docs where they serve as context.

### Testing

- Ran `npm run typecheck` and the typecheck completed successfully. 
- Ran `npm run lint` and ESLint reported no errors. 
- Ran `npm run build` which completed successfully with non-blocking dependency warnings. 
- Ran the changed integration test with `npm run test -- tests/integration/api/auth-continue-org-sso.test.ts` and it passed. 
- Performed repo searches (`rg`/`grep`) to confirm quickstart references were limited to the compatibility redirect or historical docs and found no remaining first-run UI references to `/quickstart`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2b52d48048326992deb3b3502c178)