### PR TITLE
Align Playwright device preset and pin @playwright/test version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "stripe": "^14.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "1.58.2",
     "@types/node": "^20.17.0",
     "@types/react": "^18.2.79",
     "@vitest/coverage-v8": "^2.1.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chromium'] },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
 });


### PR DESCRIPTION
### Motivation
- Ensure Playwright CI and local test config remain compatible by using the documented device preset and preventing image/package version drift between the pinned Playwright Docker image and the test runner dependency.

### Description
- Updated `playwright.config.ts` to use `use: { ...devices['Desktop Chrome'] }` instead of `devices['Desktop Chromium']` to match Playwright documented presets.
- Updated `package.json` to pin `@playwright/test` from `^1.58.2` to `1.58.2` so the dependency version stays in lockstep with the CI Playwright image tag.

### Testing
- Ran `npm run test:unit`, which passed (29 files, 109 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2d953069c8326bef382252d7053fd)