### PR TITLE
ci(e2e): sync lockfile for pinned Playwright version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "stripe": "^14.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "1.58.2",
         "@types/node": "^20.17.0",
         "@types/react": "^18.2.79",
         "@vitest/coverage-v8": "^2.1.9",


### PR DESCRIPTION
### Motivation
- Ensure `package-lock.json` is consistent with `package.json` after pinning `@playwright/test` to `1.58.2` so CI lockfile-sync checks pass.

### Description
- Updated the root `package-lock.json` devDependency entry for `@playwright/test` from `^1.58.2` to `1.58.2` to match `package.json` and committed the lockfile.

### Testing
- Ran `npm install` to regenerate and verify the lockfile, which completed successfully.
- Repository test suite (`vitest`) is green: `85` tests (41 files) with `0` failures per existing CI state.
- Playwright E2E status remains a browser install issue in CI and is unrelated to this lockfile change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2dad66c0c832690f9994c55b2ed7a)