### PR TITLE
docs(readme): clarify deployment readiness vs test baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@
 
 ---
 
-## Latest Update (April 17, 2026)
+## Latest Update (April 18, 2026)
 
 - Synced README repo-truth to the committed April 17, 2026 evidence refresh.
 - Re-validated the full automated test suite and aligned this README with the authoritative artifact set (`qa-logs/npm-test-2026-04-17.log`, `qa-logs/npm-test.log`, `qa-logs/test-summary.md`, `docs/STATUS_SNAPSHOT_2026-04-17.md`).
 - Clarified production-readiness status: test baseline is green, but runbook go-live evidence remains open until deployment, environment, migration, smoke, operator, and live E2E checks are closed.
+- April 18, 2026 wording clarification: separated repository test truth from deployment go-live truth to avoid readiness ambiguity.
 
 ### Test Results (latest run)
 


### PR DESCRIPTION
### Motivation
- Clarify that a green repository test baseline does not by itself imply deployment/production readiness and record the README wording clarification date as April 18, 2026.

### Description
- Updated `README.md` header from `April 17, 2026` to `April 18, 2026` and added an explicit bullet noting this is an April 18 wording clarification that separates repository test truth from deployment go-live truth.

### Testing
- Documentation-only change; no code executed, verified the diff with `git diff` and committed with `git commit -m "docs(readme): clarify deployment readiness vs test baseline"`; repository test baseline remains green (`Vitest` suite: 85 tests passing, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2de707ff08326b2c68ac33635377c)