### PR TITLE
Handle missing runtime_roles table with RBAC fallback

### DIFF
--- a/app/api/setup/auto/route.ts
+++ b/app/api/setup/auto/route.ts
@@ -10,7 +10,7 @@ import { handleApiError } from '../../../../lib/security/api-error';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
-type SetupStatus = 'OK' | 'CREATED' | 'EXISTS' | 'FAIL';
+type SetupStatus = 'OK' | 'CREATED' | 'EXISTS' | 'FAIL' | 'WARN';
 
 
 function logAutoSetupEvent(
@@ -356,8 +356,13 @@ export async function POST(_request: Request) {
     );
 
     if (runtimeRolesError) {
-      (results.steps as string[]).push(`runtime_roles: FAIL (${runtimeRolesError.message})`);
-      runtimeRolesStatus = 'FAIL';
+      if (isMissingInfraError(runtimeRolesError.message, 'runtime_roles')) {
+        (results.steps as string[]).push('runtime_roles: WARN (table missing in API cache: run runtime RBAC migrations)');
+        runtimeRolesStatus = 'WARN';
+      } else {
+        (results.steps as string[]).push(`runtime_roles: FAIL (${runtimeRolesError.message})`);
+        runtimeRolesStatus = 'FAIL';
+      }
     } else {
       (results.steps as string[]).push('runtime_roles: OK');
       runtimeRolesStatus = 'OK';
@@ -394,7 +399,7 @@ export async function POST(_request: Request) {
       checkpointStatus === 'OK' &&
       (billingStatus === 'OK' || billingStatus === 'CREATED' || billingStatus === 'EXISTS') &&
       onboardingStatus === 'OK' &&
-      runtimeRolesStatus === 'OK';
+      (runtimeRolesStatus === 'OK' || runtimeRolesStatus === 'WARN');
 
     results.first_run_complete = firstRunComplete;
     results.ok = firstRunComplete;

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -1,10 +1,22 @@
 import { createClient } from './supabase/server';
 import { getSupabaseAdmin } from './supabase-server';
+import { isMissingRelationError } from './supabase/resolve-policy';
 
 export type RuntimeRole = 'org_admin' | 'operator' | 'reviewer' | 'runtime_auditor' | 'billing_admin';
 
 function includesRequiredRole(userRoles: string[], requiredRoles: string[]) {
   return requiredRoles.some((role) => userRoles.includes(role));
+}
+
+function isMissingRuntimeRolesError(error: { message?: string; code?: string | null }) {
+  if (error.code === 'PGRST205') return true;
+  if (isMissingRelationError(error)) return true;
+
+  const message = String(error.message || '').toLowerCase();
+  return (
+    message.includes('schema cache') &&
+    message.includes('runtime_roles')
+  );
 }
 
 export async function requireOrgRole(requiredRoles: RuntimeRole[]){
@@ -59,6 +71,44 @@ export async function requireOrgRole(requiredRoles: RuntimeRole[]){
     .eq('user_id', appUserId);
 
   if (runtimeRolesResult.error) {
+    if (isMissingRuntimeRolesError(runtimeRolesResult.error)) {
+      const fallbackRoles = new Set<RuntimeRole>();
+
+      if (baseRole === 'owner' || baseRole === 'admin') {
+        fallbackRoles.add('org_admin');
+        fallbackRoles.add('operator');
+        fallbackRoles.add('reviewer');
+        fallbackRoles.add('runtime_auditor');
+        fallbackRoles.add('billing_admin');
+      } else if (baseRole === 'viewer' || baseRole === 'guest_auditor') {
+        fallbackRoles.add('reviewer');
+      } else if (
+        baseRole === 'operator' ||
+        baseRole === 'reviewer' ||
+        baseRole === 'runtime_auditor' ||
+        baseRole === 'billing_admin'
+      ) {
+        fallbackRoles.add(baseRole);
+      }
+
+      const fallbackList = Array.from(fallbackRoles);
+      if (!includesRequiredRole(fallbackList, requiredRoles)) {
+        return {
+          ok: false as const,
+          status: 403,
+          error: 'Forbidden',
+        };
+      }
+
+      return {
+        ok: true as const,
+        orgId,
+        userId: appUserId,
+        authUserId: String(user.id),
+        grantedRoles: fallbackList,
+      };
+    }
+
     return {
       ok: false as const,
       status: 500,

--- a/tests/unit/authz.test.ts
+++ b/tests/unit/authz.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getUser = vi.fn();
+const maybeSingle = vi.fn();
+const runtimeRolesEq = vi.fn();
+
+vi.mock('../../lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser,
+    },
+  })),
+}));
+
+vi.mock('../../lib/supabase-server', () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      if (table === 'users') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle,
+            })),
+          })),
+        };
+      }
+
+      if (table === 'runtime_roles') {
+        return {
+          select: vi.fn(() => ({
+            eq: runtimeRolesEq,
+          })),
+        };
+      }
+
+      return {};
+    }),
+  })),
+}));
+
+describe('requireOrgRole runtime_roles fallback', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('falls back to base admin role when runtime_roles relation is missing', async () => {
+    getUser.mockResolvedValue({ data: { user: { id: 'auth-1' } }, error: null });
+    maybeSingle.mockResolvedValue({
+      data: { id: 'user-1', org_id: 'org-1', is_active: true, role: 'admin' },
+      error: null,
+    });
+    runtimeRolesEq.mockReturnValue({
+      eq: vi.fn(async () => ({
+        data: null,
+        error: { message: "Could not find the table 'public.runtime_roles' in the schema cache" },
+      })),
+    });
+
+    const { requireOrgRole } = await import('../../lib/authz');
+    const result = await requireOrgRole(['org_admin']);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.grantedRoles).toContain('org_admin');
+      expect(result.grantedRoles).toContain('operator');
+    }
+  });
+
+  it('returns forbidden when fallback role set does not satisfy required role', async () => {
+    getUser.mockResolvedValue({ data: { user: { id: 'auth-1' } }, error: null });
+    maybeSingle.mockResolvedValue({
+      data: { id: 'user-1', org_id: 'org-1', is_active: true, role: 'viewer' },
+      error: null,
+    });
+    runtimeRolesEq.mockReturnValue({
+      eq: vi.fn(async () => ({
+        data: null,
+        error: { message: "Could not find the table 'public.runtime_roles' in the schema cache" },
+      })),
+    });
+
+    const { requireOrgRole } = await import('../../lib/authz');
+    const result = await requireOrgRole(['operator']);
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'Forbidden' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent 500s when `public.runtime_roles` is temporarily missing from the PostgREST schema cache so RBAC checks don't break UI/API flows.  
- Allow first-run Auto-Setup to complete when `runtime_roles` is the only missing piece instead of treating it as a hard failure.  
- Provide a safe fallback that derives runtime permissions from the base `users.role` mapping to reduce outage surface during migrations.

### Description
- Add a defensive fallback in `requireOrgRole` (`lib/authz.ts`) that detects missing `runtime_roles` errors and derives `grantedRoles` from `users.role` (owner/admin → `org_admin`, `operator`, `reviewer`, `runtime_auditor`, `billing_admin`; viewer/guest_auditor → `reviewer`; passthrough for matching runtime role names).  
- Introduce `isMissingRuntimeRolesError` helper that recognizes PostgREST schema-cache and relation-missing errors (uses existing `isMissingRelationError`).  
- Update Auto-Setup (`app/api/setup/auto/route.ts`) to treat missing `runtime_roles` as `WARN` (with migration guidance) and allow `first_run_complete` to succeed when `runtime_roles` is the only warning.  
- Extend `SetupStatus` union to include `'WARN'`.  
- Add targeted unit tests `tests/unit/authz.test.ts` covering the missing-table fallback and permission-denied behavior.

### Testing
- Ran typecheck with `npm run typecheck` and it succeeded.  
- Ran the new unit tests with `npx vitest run tests/unit/authz.test.ts` and they passed.  
- Ran integration suite with `npm run test:integration` and observed integration tests pass (with existing, unrelated skips); overall test runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2e50614208326a8d955c94bf7c478)