### PR TITLE
feat: route UI /api calls to remote control-plane API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
 # ============ DSG Core ============
+# Optional: route all /api/* calls from UI to a real remote Control Plane API origin
+# Example: https://dsg-control-plane-production.vercel.app
+DSG_REMOTE_API_URL=
+NEXT_PUBLIC_DSG_REMOTE_API_URL=
+
 DSG_CORE_MODE=internal
 DSG_CORE_URL=
 DSG_CORE_API_KEY=

--- a/next.config.js
+++ b/next.config.js
@@ -17,10 +17,15 @@ function unique(values) {
   return Array.from(new Set(values.filter(Boolean)));
 }
 
+function resolveRemoteApiOrigin() {
+  return parseOrigin(process.env.DSG_REMOTE_API_URL || process.env.NEXT_PUBLIC_DSG_REMOTE_API_URL);
+}
+
 function buildConnectSrc() {
   const coreOrigin = parseOrigin(process.env.DSG_CORE_URL);
+  const remoteApiOrigin = resolveRemoteApiOrigin();
 
-  return unique(["'self'", 'https://*.supabase.co', 'https://api.stripe.com', coreOrigin]).join(' ');
+  return unique(["'self'", 'https://*.supabase.co', 'https://api.stripe.com', coreOrigin, remoteApiOrigin]).join(' ');
 }
 
 function buildScriptSrc() {
@@ -32,6 +37,19 @@ function buildScriptSrc() {
 }
 
 const nextConfig = {
+
+  async rewrites() {
+    const remoteApiOrigin = resolveRemoteApiOrigin();
+    if (!remoteApiOrigin) return [];
+
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${remoteApiOrigin}/api/:path*`,
+      },
+    ];
+  },
+
   async headers() {
     // API CORS is intentionally handled at route level via lib/security/cors.ts.
     return [


### PR DESCRIPTION
### Motivation
- Enable running the existing UI (dashboard, monitors, chatbot/command-center and other pages that call `/api/*`) against a real remote production control-plane API without changing each page-level `fetch`.
- Ensure browser security policies allow calls to the remote API origin used by the UI.

### Description
- Added `resolveRemoteApiOrigin()` and a Next.js `rewrites()` entry in `next.config.js` to proxy `'/api/:path*'` to the configured remote origin when `DSG_REMOTE_API_URL` or `NEXT_PUBLIC_DSG_REMOTE_API_URL` is set.
- Extended CSP `connect-src` generation in `next.config.js` to include the resolved remote API origin so in-browser `fetch('/api/...')` calls remain policy-compliant.
- Documented the two new environment variables by adding `DSG_REMOTE_API_URL` and `NEXT_PUBLIC_DSG_REMOTE_API_URL` (with an example comment) to `.env.example`.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit -p tsconfig.typecheck.json`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e56d4331808326a50b2d3cf5295227)