### PR TITLE
Fix Auto-Setup: relax checkpoint requirement and surface diagnostics

### DIFF
--- a/app/api/setup/auto/route.ts
+++ b/app/api/setup/auto/route.ts
@@ -225,8 +225,9 @@ export async function POST(_request: Request) {
           });
           (results.steps as string[]).push('approval: OK (legacy fallback)');
           (results.steps as string[]).push(`rpc_commit: OK (legacy execution=${execution.id})`);
-          (results.steps as string[]).push('checkpoint: FAIL (legacy fallback did not create runtime checkpoint)');
+          (results.steps as string[]).push('checkpoint: WARN (legacy fallback did not create runtime checkpoint)');
           rpcCommitStatus = 'OK';
+          checkpointStatus = 'WARN';
         }
       } else {
         (results.steps as string[]).push(toStepStatus('approval', approvalError));
@@ -287,8 +288,13 @@ export async function POST(_request: Request) {
           );
 
           if (checkpointError) {
-            (results.steps as string[]).push(`checkpoint: FAIL (${checkpointError.message})`);
-            checkpointStatus = 'FAIL';
+            if (isMissingInfraError(checkpointError.message, 'runtime_checkpoints')) {
+              (results.steps as string[]).push('checkpoint: WARN (table missing in API cache: run runtime spine migrations)');
+              checkpointStatus = 'WARN';
+            } else {
+              (results.steps as string[]).push(`checkpoint: FAIL (${checkpointError.message})`);
+              checkpointStatus = 'FAIL';
+            }
           } else {
             (results.steps as string[]).push('checkpoint: OK');
             checkpointStatus = 'OK';
@@ -396,7 +402,7 @@ export async function POST(_request: Request) {
       policyStatus !== 'FAIL' &&
       (agentStatus === 'CREATED' || agentStatus === 'EXISTS') &&
       rpcCommitStatus === 'OK' &&
-      checkpointStatus === 'OK' &&
+      (checkpointStatus === 'OK' || checkpointStatus === 'WARN') &&
       (billingStatus === 'OK' || billingStatus === 'CREATED' || billingStatus === 'EXISTS') &&
       onboardingStatus === 'OK' &&
       (runtimeRolesStatus === 'OK' || runtimeRolesStatus === 'WARN');

--- a/app/dashboard/skills/page.tsx
+++ b/app/dashboard/skills/page.tsx
@@ -54,10 +54,10 @@ export default function SkillsPage() {
     try {
       const res = await fetch("/api/setup/auto", { method: "POST", cache: "no-store" });
       const json = await res.json();
+      setResult(json);
       if (!res.ok) {
         setError(json.error || `Setup failed (${res.status})`);
       } else {
-        setResult(json);
         if (json?.ok) {
           setTimeout(() => router.push("/dashboard/executions"), 1200);
         }


### PR DESCRIPTION
### Motivation
- Auto-Setup could report a false negative first-run failure when optional checkpoint infra was not yet available or when legacy fallback produced an execution but no runtime checkpoint. The UI also hid detailed step diagnostics when the API returned non-2xx.
- Make the Auto-Setup flow tolerant to checkpoint infra drift while preserving hard failures for critical steps, and ensure operators can see failing step details in the UI immediately.

### Description
- Downgrade legacy fallback missing checkpoint from `FAIL` to `WARN` and set `checkpointStatus = 'WARN'` when legacy execution produced no runtime checkpoint in `app/api/setup/auto/route.ts`.
- Treat missing `runtime_checkpoints` relation/schema-cache errors as `WARN` (not hard `FAIL`) when upserting checkpoints, and surface a descriptive warning step message in `app/api/setup/auto/route.ts`.
- Relax `first_run_complete` logic to accept `checkpointStatus === 'WARN'` in addition to `OK` so Auto-Setup can complete when other critical steps succeed, implemented in `app/api/setup/auto/route.ts`.
- Preserve API response JSON for the Skills Auto-Setup UI even when the server returns non-2xx by calling `setResult(json)` before checking `res.ok`, implemented in `app/dashboard/skills/page.tsx` so operators immediately see `steps`, `env_check`, and `next_steps` details.

### Testing
- Ran type checking with `npm run typecheck` which succeeded.
- Ran the integration UI test file `tests/integration/ui/enterprise-proof-pages.test.tsx` with `npm run test -- tests/integration/ui/enterprise-proof-pages.test.tsx` and it passed (4 tests).
- Verified local edits compile and the modified Auto-Setup path now records `WARN` for checkpoint drift while leaving other failure semantics unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e57c2eead48326bf395998ea16ab71)