### PR TITLE
Improve agent chat output readability and event handling in dashboard

### DIFF
--- a/app/app-shell/page.tsx
+++ b/app/app-shell/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import EntropyField from '../../components/canvas/EntropyField';
+import { parseSseData, formatAgentEventMessage } from '../../lib/agent/chat-event';
 
 type MonitorPayload = {
   ok: boolean;
@@ -204,17 +205,18 @@ export default function AppShellPage() {
 
         for (const raw of events) {
           if (!raw.startsWith('data: ')) continue;
-          const event = JSON.parse(raw.slice(6));
-          if (event.type === 'step_result' || event.type === 'step_error') {
-            setMessages((prev) => [
-              ...prev,
-              {
-                id: `a-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-                role: 'assistant',
-                content: JSON.stringify(event, null, 2),
-              },
-            ]);
-          }
+          const event = parseSseData(raw);
+          if (!event) continue;
+          const message = formatAgentEventMessage(event);
+          if (!message) continue;
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `a-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+              role: 'assistant',
+              content: message,
+            },
+          ]);
         }
       }
     } catch (err) {

--- a/app/dashboard/command-center/page.tsx
+++ b/app/dashboard/command-center/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { parseSseData, formatAgentEventMessage } from '../../../lib/agent/chat-event';
 
 type HealthPayload = {
   service?: string;
@@ -187,10 +188,11 @@ export default function CommandCenterPage() {
 
         for (const raw of events) {
           if (!raw.startsWith('data: ')) continue;
-          const event = JSON.parse(raw.slice(6));
-          if (event.type === 'step_result' || event.type === 'step_error') {
-            setChatOutput((prev) => [...prev, JSON.stringify(event, null, 2)]);
-          }
+          const event = parseSseData(raw);
+          if (!event) continue;
+          const message = formatAgentEventMessage(event);
+          if (!message) continue;
+          setChatOutput((prev) => [...prev, message]);
         }
       }
 

--- a/components/AgentChatWidget.tsx
+++ b/components/AgentChatWidget.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import { parseSseData, formatAgentEventMessage } from '../lib/agent/chat-event';
 
 type ChatLine = {
   id: string;
@@ -107,10 +108,11 @@ export default function AgentChatWidget() {
 
         for (const raw of events) {
           if (!raw.startsWith('data: ')) continue;
-          const event = JSON.parse(raw.slice(6));
-          if (event.type === 'step_result' || event.type === 'step_error') {
-            setLines((prev) => [...prev, makeLine('assistant', JSON.stringify(event, null, 2))]);
-          }
+          const event = parseSseData(raw);
+          if (!event) continue;
+          const message = formatAgentEventMessage(event);
+          if (!message) continue;
+          setLines((prev) => [...prev, makeLine('assistant', message)]);
         }
       }
     } catch (err) {

--- a/lib/agent/chat-event.ts
+++ b/lib/agent/chat-event.ts
@@ -1,0 +1,87 @@
+export type AgentChatEvent = {
+  type?: string;
+  step?: string;
+  tool?: string;
+  error?: string;
+  reply?: string;
+  model?: string;
+  steps?: Array<{ id?: string; toolId?: string }>;
+  result?: unknown;
+};
+
+function toPlain(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '-';
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatStepResult(step: string, result: unknown): string {
+  if (!result || typeof result !== 'object') {
+    return `ผลลัพธ์ ${step}: ${toPlain(result)}`;
+  }
+
+  const data = result as Record<string, unknown>;
+  const items = Array.isArray(data.items) ? data.items : null;
+  const pagination = data.pagination as Record<string, unknown> | undefined;
+
+  if (typeof data.status === 'string') {
+    return `Readiness ${step}: ${data.status}`;
+  }
+
+  if (items && pagination && typeof pagination.total === 'number') {
+    return `สำเร็จ ${step}: พบ ${pagination.total} รายการ`;
+  }
+
+  if (typeof data.ok === 'boolean') {
+    return `สำเร็จ ${step}: ${data.ok ? 'พร้อมใช้งาน' : 'พบปัญหา'}`;
+  }
+
+  return `ผลลัพธ์ ${step}:\n${toPlain(result)}`;
+}
+
+export function formatAgentEventMessage(event: AgentChatEvent): string | null {
+  const type = String(event?.type || '');
+
+  if (type === 'assistant_reply') {
+    if (!event.reply) return null;
+    return event.model ? `${event.reply}\n\n(model: ${event.model})` : event.reply;
+  }
+
+  if (type === 'plan') {
+    const steps = Array.isArray(event.steps) ? event.steps : [];
+    if (steps.length === 0) return 'กำลังประมวลผลคำสั่ง...';
+    const list = steps.map((s) => `${s.id || '-'}:${s.toolId || '-'}`).join(', ');
+    return `แผนการทำงาน: ${list}`;
+  }
+
+  if (type === 'step_start') {
+    return `กำลังรัน ${event.step || '-'} • ${event.tool || 'tool'}`;
+  }
+
+  if (type === 'step_error') {
+    return `ไม่สำเร็จ ${event.step || '-'}: ${event.error || 'เกิดข้อผิดพลาด'}`;
+  }
+
+  if (type === 'step_result') {
+    return formatStepResult(event.step || '-', event.result);
+  }
+
+  if (type === 'done') {
+    return 'ทำงานเสร็จแล้ว';
+  }
+
+  return null;
+}
+
+export function parseSseData(raw: string): AgentChatEvent | null {
+  if (!raw.startsWith('data: ')) return null;
+  try {
+    return JSON.parse(raw.slice(6)) as AgentChatEvent;
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/agent/chat-event.test.ts
+++ b/tests/unit/agent/chat-event.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { formatAgentEventMessage, parseSseData } from '../../../lib/agent/chat-event';
+
+describe('parseSseData', () => {
+  it('parses a valid SSE data line', () => {
+    const event = parseSseData('data: {"type":"done"}');
+    expect(event).toEqual({ type: 'done' });
+  });
+
+  it('returns null when payload is not data line', () => {
+    expect(parseSseData('event: message')).toBeNull();
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseSseData('data: not-json')).toBeNull();
+  });
+});
+
+describe('formatAgentEventMessage', () => {
+  it('formats step error as human-readable text', () => {
+    const text = formatAgentEventMessage({ type: 'step_error', step: 's1', error: 'Internal server error' });
+    expect(text).toBe('ไม่สำเร็จ s1: Internal server error');
+  });
+
+  it('formats paginated list results as summary count', () => {
+    const text = formatAgentEventMessage({
+      type: 'step_result',
+      step: 's2',
+      result: {
+        items: [{ id: 1 }],
+        pagination: { page: 1, per_page: 10, total: 1, total_pages: 1 },
+      },
+    });
+    expect(text).toBe('สำเร็จ s2: พบ 1 รายการ');
+  });
+
+  it('formats plan steps list', () => {
+    const text = formatAgentEventMessage({
+      type: 'plan',
+      steps: [{ id: 's1', toolId: 'readiness' }, { id: 's2', toolId: 'list_agents' }],
+    });
+
+    expect(text).toBe('แผนการทำงาน: s1:readiness, s2:list_agents');
+  });
+});


### PR DESCRIPTION
### Motivation
- Users were seeing raw SSE JSON (e.g., `step_result` / `step_error`) in chat surfaces, which is hard to read and not user friendly.
- The goal is to present streamed agent events as concise, human-readable messages (Thai-first where appropriate) and preserve progress semantics across dashboard chat panels.

### Description
- Add a shared SSE parser/formatter utility at `lib/agent/chat-event.ts` that implements `parseSseData` and `formatAgentEventMessage` and supports `assistant_reply`, `plan`, `step_start`, `step_result`, `step_error`, and `done` events.
- Update `components/AgentChatWidget.tsx` to use the parser/formatter and stop dumping raw `JSON.stringify` payloads into the chat stream.
- Update `app/app-shell/page.tsx` and `app/dashboard/command-center/page.tsx` to use the same parser/formatter for their chat panels and replace raw JSON output with human-readable messages.
- Add unit tests at `tests/unit/agent/chat-event.test.ts` to exercise parsing and formatting behaviors including `step_error`, paginated `step_result`, and `plan` formatting.

### Testing
- Ran `npm run test -- tests/unit/agent/chat-event.test.ts tests/integration/ui/command-center-capabilities.test.tsx` and both test files passed (all tests green).
- Ran `npm run typecheck` and TypeScript typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e57be33bec83268c9777b47b3b21d9)