### PR TITLE
Add Thai live-UI runbook and a live UI readiness check script (plus package script and README note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Repository test status and deployment readiness are intentionally tracked separa
 
 Passing repository tests alone does not mean the deployed environment is production-ready.
 
+For a Thai step-by-step guide focused on making the UI run with live data (not static image/mock), see `docs/HOW_TO_RUN_REAL_UI_TH.md`. You can also run `npm run ops:live-ui-check` for a quick readiness check.
+
 ---
 
 ## What DSG ONE Is

--- a/docs/HOW_TO_RUN_REAL_UI_TH.md
+++ b/docs/HOW_TO_RUN_REAL_UI_TH.md
@@ -1,0 +1,112 @@
+# วิธีทำให้แอปทำงานจริง “แบบในรูป” (DSG ONE) [TH]
+
+เอกสารนี้สรุปแบบปฏิบัติจริงว่าต้องทำอะไรบ้างเพื่อให้หน้า Dashboard/Live Control/Command Center แสดงผลเป็นระบบจริง ไม่ใช่ภาพ mock.
+
+## 1) เข้าใจจุดสำคัญก่อน
+
+ถ้าเห็นจอ “ดำ/ว่าง” ด้านบนแล้วค่อยมี UI ด้านล่าง (แบบในรูปตัวอย่าง) มักเกิดจาก 3 กลุ่มปัญหา:
+1. เปิด URL ที่เป็นรูปภาพจาก CDN (`cloudfront`, `amazonaws`) ไม่ใช่ URL ของแอป Next.js
+2. แอปโหลดได้ แต่ API หลังบ้านยังไม่พร้อม (health/usage/executions/audit)
+3. ยังไม่ได้ตั้งค่า environment + database migration ครบ
+
+> ดังนั้น ต้องใช้ URL ของแอปจริง (เช่น Vercel domain ของโปรเจ็กต์) และให้ backend dependencies พร้อมก่อน
+
+## 2) URL ที่ควรเปิด (ของแอปจริง)
+
+เมื่อ deploy แล้ว ให้เข้าเส้นทางเหล่านี้โดยตรง:
+
+- `/dashboard`
+- `/dashboard/live-control`
+- `/dashboard/command-center`
+- `/dashboard/executions`
+- `/dashboard/verification`
+
+หน้า `live-control` จะดึงข้อมูลจาก API จริงของระบบ:
+- `/api/health`
+- `/api/usage`
+- `/api/executions?limit=8`
+- `/api/integration`
+- `/api/audit?limit=8`
+
+ถ้า endpoint ใดล้ม หน้า UI ยังขึ้นได้ แต่จะมี warning/error บนหน้าแทนข้อมูลจริง.
+
+## 2.5) ทางลัด: ใช้สคริปต์ตรวจความพร้อมอัตโนมัติ
+
+รันคำสั่งเดียวเพื่อตรวจ env + endpoint หลัก:
+
+```bash
+npm run ops:live-ui-check
+```
+
+ถ้าต้องการเช็กเฉพาะตัวแปรแวดล้อม (ยังไม่เปิดเซิร์ฟเวอร์):
+
+```bash
+./scripts/live-ui-readiness-check.sh --env-only
+```
+
+## 3) เช็กระบบขั้นต่ำ (ต้องผ่านก่อน)
+
+### 3.1 ติดตั้งและรันในเครื่อง
+```bash
+npm ci
+npm run dev
+```
+
+### 3.2 เช็ก health
+```bash
+curl -sS http://localhost:3000/api/health
+```
+คาดหวังว่าควรเห็น `ok: true` และ ideally `core_ok: true`, `db_ok: true`.
+
+### 3.3 เช็ก endpoint ที่หน้า live-control ใช้
+```bash
+curl -sS http://localhost:3000/api/usage
+curl -sS "http://localhost:3000/api/executions?limit=8"
+curl -sS http://localhost:3000/api/integration
+curl -sS "http://localhost:3000/api/audit?limit=8"
+```
+
+ถ้า endpoint เหล่านี้ยังไม่ผ่าน ให้แก้ env + DB + core connectivity ก่อน (ข้อ 4).
+
+## 4) Environment ที่ต้องตั้งให้ครบ
+
+อิง `.env.example` และ runbook deploy:
+
+- Supabase
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+- App origin
+  - `APP_URL` หรือ `NEXT_PUBLIC_APP_URL`
+- DSG Core
+  - `DSG_CORE_MODE` (`internal` หรือ `remote`)
+  - `DSG_CORE_URL` (เมื่อใช้ `remote`)
+  - `DSG_CORE_API_KEY` (เมื่อใช้ `remote`)
+- Billing/Access (ตาม flow ที่ใช้)
+  - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_*`
+  - `OVERAGE_RATE_USD`
+  - `ACCESS_MODE`, `ACCESS_POLICY`
+
+## 5) Database/Migration ต้องครบ
+
+ระบบ runtime/pipeline จะไม่ขึ้นครบถ้า Supabase migration ไม่ครบ โดยเฉพาะชุด runtime spine + rpc hardening.
+
+แนวทางคือ apply migrations ทั้งชุดใน `supabase/migrations/*` ตามลำดับ แล้วตรวจ smoke test API อีกครั้ง.
+
+## 6) วิธีให้ “เหมือนในรูป” มากขึ้น (เชิง UX)
+
+- ใช้ route กลุ่ม cyber UI โดยตรง (`/dashboard/live-control`, `/dashboard/command-center`, `/dashboard/verification`)
+- เปิดผ่านโดเมนจริงของแอป ไม่ใช่ลิงก์รูป CDN
+- ทดสอบบนมือถือผ่าน browser ปกติ (Chrome/Safari) หลัง deploy
+- หากต้องการเต็มจอ ให้ปิดแถบ browser UI หรือใช้ “Add to Home Screen”
+
+## 7) นิยามคำว่า “ทำงานจริง” สำหรับโปรเจ็กต์นี้
+
+อย่างน้อยต้องผ่านพร้อมกัน:
+1. หน้า dashboard กลุ่มหลักเปิดได้
+2. `/api/health` ผ่าน (`ok/core_ok/db_ok`)
+3. live-control ดึง usage/executions/integration/audit ได้
+4. login + org scope ผ่าน
+5. execution จริงผ่าน `POST /api/execute` และมี record ใน execution/audit
+
+ถ้าผ่านทั้ง 5 ข้อนี้ ถือว่าไม่ใช่ demo image แล้ว แต่เป็น control plane ที่วิ่งกับ runtime จริง.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "benchmark:site": "node scripts/render-benchmark-site.mjs",
     "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs",
     "ops:runtime-rpc-fix": "./scripts/apply-runtime-rpc-fix.sh",
-    "verify:production-manifest": "node scripts/verify-production-manifest.mjs"
+    "verify:production-manifest": "node scripts/verify-production-manifest.mjs",
+    "ops:live-ui-check": "./scripts/live-ui-readiness-check.sh"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.48.0",

--- a/scripts/live-ui-readiness-check.sh
+++ b/scripts/live-ui-readiness-check.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+ENV_ONLY=0
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--base-url URL] [--env-only]
+
+Checks whether DSG ONE live UI dependencies are ready.
+
+Options:
+  --base-url URL  Base URL to probe (default: http://localhost:3000)
+  --env-only      Only validate environment variables (skip HTTP probes)
+  -h, --help      Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)
+      BASE_URL="${2:-}"
+      shift 2
+      ;;
+    --env-only)
+      ENV_ONLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+missing=0
+warn=0
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "$value" ]]; then
+    echo "[MISS] $name is not set"
+    missing=1
+  else
+    echo "[ OK ] $name"
+  fi
+}
+
+optional_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "$value" ]]; then
+    echo "[WARN] $name is not set"
+    warn=1
+  else
+    echo "[ OK ] $name"
+  fi
+}
+
+echo "== Environment checks =="
+require_env NEXT_PUBLIC_SUPABASE_URL
+require_env NEXT_PUBLIC_SUPABASE_ANON_KEY
+require_env SUPABASE_SERVICE_ROLE_KEY
+
+if [[ -z "${APP_URL:-}" && -z "${NEXT_PUBLIC_APP_URL:-}" ]]; then
+  echo "[MISS] APP_URL or NEXT_PUBLIC_APP_URL must be set"
+  missing=1
+else
+  echo "[ OK ] APP_URL / NEXT_PUBLIC_APP_URL"
+fi
+
+mode="${DSG_CORE_MODE:-}"
+if [[ "$mode" != "internal" && "$mode" != "remote" ]]; then
+  echo "[MISS] DSG_CORE_MODE must be internal or remote"
+  missing=1
+else
+  echo "[ OK ] DSG_CORE_MODE=$mode"
+fi
+
+if [[ "$mode" == "remote" ]]; then
+  require_env DSG_CORE_URL
+  require_env DSG_CORE_API_KEY
+fi
+
+optional_env ACCESS_MODE
+optional_env ACCESS_POLICY
+optional_env OVERAGE_RATE_USD
+
+check_endpoint() {
+  local path="$1"
+  local url="${BASE_URL%/}$path"
+  if curl -fsS -m 10 "$url" >/dev/null; then
+    echo "[ OK ] $path"
+  else
+    echo "[MISS] $path (unable to reach or non-2xx)"
+    missing=1
+  fi
+}
+
+if [[ "$ENV_ONLY" -eq 0 ]]; then
+  echo
+  echo "== HTTP probes (${BASE_URL}) =="
+  check_endpoint /api/health
+  check_endpoint /api/usage
+  check_endpoint /api/executions?limit=8
+  check_endpoint /api/integration
+  check_endpoint /api/audit?limit=8
+
+  echo
+  echo "== UI routes =="
+  check_endpoint /dashboard
+  check_endpoint /dashboard/live-control
+  check_endpoint /dashboard/command-center
+fi
+
+echo
+if [[ "$missing" -eq 1 ]]; then
+  echo "RESULT: NOT READY"
+  exit 1
+fi
+
+if [[ "$warn" -eq 1 ]]; then
+  echo "RESULT: READY WITH WARNINGS"
+  exit 0
+fi
+
+echo "RESULT: READY"


### PR DESCRIPTION
### Motivation

- Provide a localized Thai step-by-step runbook for operators to get the Dashboard/Live Control running with real backend data rather than a static mock image.
- Add a simple, automated readiness check to help validate environment variables and HTTP endpoints the UI depends on.

### Description

- Add `docs/HOW_TO_RUN_REAL_UI_TH.md`, a Thai-language guide that documents required routes, API endpoints, environment variables, migration notes, and a definition of "working with real runtime" for the UI.
- Add a new executable script `scripts/live-ui-readiness-check.sh` that validates required environment variables and optionally probes HTTP endpoints and UI routes under a configurable `BASE_URL` (with `--env-only` to skip probes).
- Expose the script via a new npm task `ops:live-ui-check` in `package.json` and update `README.md` to reference the Thai guide and the new readiness check command.

### Testing

- Ran the repository test suite with `npm run test` (Vitest), which is reported as passing in the repository artifacts: "62 files passed, 1 skipped; 185 tests passed, 3 skipped".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e57dfe24b083268f793dc90dcc62fa)