### PR TITLE
Add internal DSG core mode with org-scoped core calls; remove demo bootstrap; refine finance-governance persistence

### DIFF
--- a/app/api/audit/matrix/route.ts
+++ b/app/api/audit/matrix/route.ts
@@ -120,7 +120,7 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     const limit = clampLimit(url.searchParams.get("limit"), 100, 100);
 
-    const auditEvents = await getDSGCoreAuditEvents(limit);
+    const auditEvents = await getDSGCoreAuditEvents(limit, { orgId: access.orgId });
 
     const rawItems = Array.isArray(auditEvents?.items) ? auditEvents.items : [];
     const normalizedItems = rawItems
@@ -162,7 +162,7 @@ export async function GET(request: Request) {
 
     const determinism = await Promise.all(
       sequences.map(async (sequence) => {
-        const result = await getDSGCoreDeterminism(sequence);
+        const result = await getDSGCoreDeterminism(sequence, { orgId: access.orgId });
         const data = result.ok && "data" in result ? (result.data ?? null) : null;
         const error = result.ok
           ? null

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -35,19 +35,19 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     const limit = Math.min(Number(url.searchParams.get("limit") || "20"), 100);
 
-    const auditEvents = await getDSGCoreAuditEvents(limit);
+    const auditEvents = await getDSGCoreAuditEvents(limit, { orgId: access.orgId });
 
-    const sequences = Array.from(
-      new Set(
+    const sequences: number[] = Array.from(
+      new Set<number>(
         (auditEvents.items || [])
           .map((item) => Number(item.sequence))
-          .filter((n) => Number.isFinite(n))
+          .filter((n): n is number => Number.isFinite(n))
       )
     ).slice(0, 5);
 
     const determinismResults = await Promise.all(
       sequences.map(async (sequence) => {
-        const result = await getDSGCoreDeterminism(sequence);
+        const result = await getDSGCoreDeterminism(sequence, { orgId: access.orgId });
         const data = getDeterminismData(result);
 
         if (data) {

--- a/app/api/core/monitor/route.ts
+++ b/app/api/core/monitor/route.ts
@@ -68,9 +68,9 @@ export async function GET() {
       subscriptionRes,
     ] = await Promise.all([
       getDSGCoreHealth(),
-      getDSGCoreMetrics(),
-      getDSGCoreLedger(10),
-      getDSGCoreAuditEvents(10),
+      getDSGCoreMetrics({ orgId }),
+      getDSGCoreLedger(10, { orgId }),
+      getDSGCoreAuditEvents(10, { orgId }),
       admin
         .from("executions")
         .select("decision, latency_ms, created_at")
@@ -148,7 +148,7 @@ export async function GET() {
 
     const determinism =
       latestSequence > 0
-        ? await getDSGCoreDeterminism(latestSequence)
+        ? await getDSGCoreDeterminism(latestSequence, { orgId })
         : { ok: false as const, error: "No sequence available" };
 
     const billingOk = !subscriptionRes.error;

--- a/app/api/demo/bootstrap/route.ts
+++ b/app/api/demo/bootstrap/route.ts
@@ -1,125 +1,14 @@
-import { randomUUID, createHash } from 'crypto';
 import { NextResponse } from 'next/server';
-import { getSupabaseAdmin } from '../../../../lib/supabase-server';
-import { canonicalHash, canonicalJson } from '../../../../lib/runtime/canonical';
-import { buildCheckpointHash } from '../../../../lib/runtime/checkpoint';
-import { invokeRuntimeCommitRpc } from '../../../../lib/runtime/commit-rpc';
-import { getOverageRateUsd } from '../../../../lib/billing/overage-config';
-import { handleApiError } from '../../../../lib/security/api-error';
 
-function demoEnabled(request: Request) {
-  if (process.env.NODE_ENV === 'production') return false;
-  if (process.env.ENABLE_DEMO_BOOTSTRAP !== 'true') return false;
-  const expected = process.env.DEMO_BOOTSTRAP_TOKEN;
-  if (!expected) return false;
-  return request.headers.get('x-demo-token') === expected;
-}
+export const dynamic = 'force-dynamic';
 
-export async function POST(request: Request) {
-  try {
-    if (!demoEnabled(request)) {
-      return NextResponse.json({ error: 'Demo bootstrap disabled' }, { status: 403 });
-    }
-
-    const supabase = getSupabaseAdmin();
-    const suffix = randomUUID().slice(0, 8);
-    const orgId = `demo-org-${suffix}`;
-    const agentId = `demo-agent-${suffix}`;
-    const apiKey = `demo-${randomUUID()}`;
-    const approvalId = randomUUID();
-
-    await supabase.from('organizations').insert({ id: orgId, name: 'Enterprise Proof Demo' });
-    await supabase.from('policies').upsert({ id: 'policy_default', name: 'Default DSG Policy', version: 'v1', status: 'active', config: {} });
-    await supabase.from('agents').insert({
-      id: agentId,
-      org_id: orgId,
-      name: 'Enterprise Agent',
-      policy_id: 'policy_default',
-      status: 'active',
-      api_key_hash: createHash('sha256').update(apiKey).digest('hex'),
-      monthly_limit: 1000,
-    });
-
-    const canonical = {
-      action: 'enterprise_demo',
-      input: { amount: 100, asset: 'USDC' },
-      context: { source: 'enterprise_walkthrough' },
-      decision: 'ALLOW',
-      policyVersion: 'dsg-core-v1',
-      reason: 'Deterministic safe action',
-    };
-
-    await supabase.from('runtime_approval_requests').insert({
-      id: approvalId,
-      org_id: orgId,
-      agent_id: agentId,
-      approval_key: `demo-${suffix}`,
-      request_payload: canonical,
-      status: 'pending',
-      expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
-    });
-
-    const { data: commit, error: commitError } = await invokeRuntimeCommitRpc(supabase, {
-      p_org_id: orgId,
-      p_agent_id: agentId,
-      p_request_id: approvalId,
-      p_decision: 'ALLOW',
-      p_reason: 'Deterministic safe action',
-      p_metadata: { action: 'enterprise_demo', stability_score: 0.94 },
-      p_canonical_hash: canonicalHash(canonical),
-      p_canonical_json: JSON.parse(canonicalJson(canonical)),
-      p_latency_ms: 19,
-      p_request_payload: canonical.input,
-      p_context_payload: canonical.context,
-      p_policy_version: 'dsg-core-v1',
-      p_created_at: new Date().toISOString(),
-    });
-
-    if (commitError) {
-      return handleApiError('api/demo/bootstrap', commitError, { details: { stage: 'runtime-commit-execution' } });
-    }
-
-    const commitRow = Array.isArray(commit) ? commit[0] : commit;
-    if (!commitRow?.execution_id || !commitRow?.truth_state_id || !commitRow?.ledger_id) {
-      return handleApiError('api/demo/bootstrap', new Error('Commit bootstrap failed to produce runtime lineage'), { details: { stage: 'lineage-check' } });
-    }
-
-    const checkpointHash = buildCheckpointHash({
-      truthCanonicalHash: canonicalHash(canonical),
-      latestLedgerId: String(commitRow.ledger_id),
-      latestLedgerSequence: Number(commitRow.ledger_sequence || 0),
-      latestTruthSequence: Number(commitRow.truth_sequence || 0),
-    });
-
-    await supabase.from('runtime_checkpoints').insert({
-      org_id: orgId,
-      agent_id: agentId,
-      truth_state_id: commitRow.truth_state_id,
-      latest_ledger_entry_id: commitRow.ledger_id,
-      checkpoint_hash: checkpointHash,
-      metadata: { source: 'demo_bootstrap' },
-    });
-
-    await supabase.from('runtime_roles').insert([
-      { org_id: orgId, user_id: 'demo-user', role: 'org_admin' },
-      { org_id: orgId, user_id: 'demo-user', role: 'runtime_auditor' },
-      { org_id: orgId, user_id: 'demo-user', role: 'billing_admin' },
-    ]);
-
-    await supabase.from('usage_counters').insert({ org_id: orgId, agent_id: agentId, billing_period: new Date().toISOString().slice(0, 7), executions: 1 });
-    await supabase.from('usage_events').insert({
-      org_id: orgId,
-      agent_id: agentId,
-      execution_id: commitRow.execution_id,
-      event_type: 'execution',
-      quantity: 1,
-      unit: 'execution',
-      amount_usd: getOverageRateUsd(),
-      metadata: { source: 'enterprise_demo' },
-    });
-
-    return NextResponse.json({ org_id: orgId, agent_id: agentId, execution_id: commitRow.execution_id, demo_mode: true });
-  } catch (error) {
-    return handleApiError('api/demo/bootstrap', error, { details: { stage: 'unhandled' } });
-  }
+export async function POST() {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: 'Demo bootstrap endpoint has been removed',
+      code: 'DEMO_BOOTSTRAP_REMOVED',
+    },
+    { status: 410 }
+  );
 }

--- a/app/api/executions/route.ts
+++ b/app/api/executions/route.ts
@@ -50,8 +50,8 @@ export async function GET(request: Request) {
         .eq("org_id", access.orgId)
         .order("created_at", { ascending: false })
         .limit(limit),
-      getDSGCoreLedger(limit),
-      getDSGCoreMetrics(),
+      getDSGCoreLedger(limit, { orgId: access.orgId }),
+      getDSGCoreMetrics({ orgId: access.orgId }),
     ]);
 
     if (error) {

--- a/app/api/ledger/route.ts
+++ b/app/api/ledger/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
 
     const [auditExport, coreLedger] = await Promise.all([
       fetchAuditLogsForExport(access.orgId, limit),
-      getDSGCoreLedger(limit),
+      getDSGCoreLedger(limit, { orgId: access.orgId }),
     ]);
 
     if (!auditExport.ok) {

--- a/app/api/replay/[executionId]/route.ts
+++ b/app/api/replay/[executionId]/route.ts
@@ -1,11 +1,23 @@
 import { NextResponse } from "next/server";
 import { getDSGCoreLedger } from "../../../../lib/dsg-core";
+import { getLocalRuntimeLedger } from "../../../../lib/dsg-core/local-runtime";
+import { isInternalDSGCoreMode } from "../../../../lib/dsg-core/mode";
 import { requireOrgRole } from "../../../../lib/authz";
 import { RuntimeRouteRoles } from "../../../../lib/runtime/permissions";
 import { getSupabaseAdmin } from "../../../../lib/supabase-server";
 import { internalErrorMessage, logApiError } from "../../../../lib/security/api-error";
 
 export const dynamic = "force-dynamic";
+
+type CoreLedgerItem = {
+  id?: string;
+  metadata?: {
+    execution_id?: string;
+    audit_id?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
 
 export async function GET(
   _request: Request,
@@ -16,11 +28,12 @@ export async function GET(
     if (!access.ok) {
       return NextResponse.json({ error: access.error }, { status: access.status });
     }
+
     const supabase = getSupabaseAdmin();
-
     const { executionId } = await params;
+    const internalMode = isInternalDSGCoreMode();
 
-    const [{ data: execution, error: executionError }, { data: audit, error: auditError }, coreLedger] = await Promise.all([
+    const [{ data: execution, error: executionError }, { data: audit, error: auditError }] = await Promise.all([
       supabase
         .from("executions")
         .select(`
@@ -53,7 +66,6 @@ export async function GET(
         .order("created_at", { ascending: false })
         .limit(1)
         .maybeSingle(),
-      getDSGCoreLedger(50),
     ]);
 
     if (executionError) {
@@ -70,19 +82,28 @@ export async function GET(
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    const coreMatch = (coreLedger.items || []).find((item: { metadata?: { execution_id?: string; audit_id?: string } }) => {
-      const metadata = item?.metadata || {};
-      return metadata?.execution_id === executionId || metadata?.audit_id === audit?.id;
-    }) || null;
+    const coreLedger = internalMode
+      ? await getLocalRuntimeLedger(supabase as never, access.orgId, 50)
+      : await getDSGCoreLedger(50, { orgId: access.orgId });
+
+    const coreItems = Array.isArray(coreLedger.items) ? (coreLedger.items as CoreLedgerItem[]) : [];
+
+    const coreMatch =
+      coreItems.find((item) => {
+        const metadata = item?.metadata || {};
+        return metadata?.execution_id === executionId || metadata?.audit_id === audit?.id;
+      }) || null;
 
     return NextResponse.json({
       ok: true,
+      mode: internalMode ? "internal" : "remote",
+      source: internalMode ? "local_runtime_tables" : "external_dsg_core",
       execution,
       audit,
       core: {
         ledger_ok: coreLedger.ok,
         matched_item: coreMatch,
-        error: coreLedger.ok ? null : coreLedger.error,
+        error: coreLedger.ok ? null : ("error" in coreLedger ? coreLedger.error : null),
       },
     });
   } catch (error) {

--- a/app/finance-governance/live/actions/page.tsx
+++ b/app/finance-governance/live/actions/page.tsx
@@ -94,7 +94,7 @@ export default function FinanceGovernanceLiveActionsPage() {
   return (
     <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
       <div className="max-w-3xl">
-        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Live action demo</p>
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Live actions</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Trigger finance-governance workflow actions</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
           This page calls the submit, approve, reject, and escalate endpoints directly so the repo now has a concrete action surface on top of the live UI and API skeleton.

--- a/app/finance-governance/live/request.ts
+++ b/app/finance-governance/live/request.ts
@@ -1,22 +1,25 @@
-const DEMO_ORG_ID = 'org-demo-live';
-const DEMO_ORG_STORAGE_KEY = 'finance-governance-demo-org-id';
+const ORG_STORAGE_KEY = 'finance-governance-org-id';
 
 function resolveOrgId() {
   if (typeof window === 'undefined') {
-    return DEMO_ORG_ID;
+    return '';
   }
 
-  const overrideOrgId = window.localStorage.getItem(DEMO_ORG_STORAGE_KEY)?.trim();
+  const overrideOrgId = window.localStorage.getItem(ORG_STORAGE_KEY)?.trim();
   if (overrideOrgId) {
     return overrideOrgId;
   }
 
-  return DEMO_ORG_ID;
+  const htmlOrgId = document.documentElement.getAttribute('data-org-id')?.trim();
+  return htmlOrgId || '';
 }
 
 export function financeGovernanceFetch(input: string | URL | globalThis.Request, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
-  headers.set('x-org-id', resolveOrgId());
+  const orgId = resolveOrgId();
+  if (orgId) {
+    headers.set('x-org-id', orgId);
+  }
 
   return fetch(input, {
     ...init,

--- a/app/finance-governance/live/workflow-persistent/page.tsx
+++ b/app/finance-governance/live/workflow-persistent/page.tsx
@@ -76,7 +76,7 @@ export default function FinanceGovernanceLiveWorkflowPersistentPage() {
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextState));
     } catch {
-      // ignore localStorage failures in demo mode
+      // ignore localStorage failures in local runtime mode
     }
   }, []);
 
@@ -233,10 +233,10 @@ export default function FinanceGovernanceLiveWorkflowPersistentPage() {
   return (
     <main className="mx-auto min-h-screen max-w-7xl px-6 py-16 text-white">
       <div className="max-w-3xl">
-        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Persistent workflow demo</p>
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Persistent workflow state</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Workflow state that persists in the browser</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
-          This page starts from the finance-governance API, then keeps action results in local storage so approval statuses and summary counts stay changed across refreshes until you reset the demo.
+          This page starts from the finance-governance API, then keeps action results in local storage so approval statuses and summary counts stay changed across refreshes until you reset the local state.
         </p>
       </div>
 
@@ -248,7 +248,7 @@ export default function FinanceGovernanceLiveWorkflowPersistentPage() {
           {refreshing ? 'Refreshing...' : 'Refresh from storage'}
         </button>
         <button type="button" onClick={() => void resetDemo()} disabled={busyKey !== null || refreshing} className="rounded-2xl border border-red-400/30 bg-red-500/10 px-6 py-3 font-semibold text-red-100 disabled:opacity-70">
-          Reset demo state
+          Reset local state
         </button>
       </div>
 

--- a/app/finance-governance/live/workflow/page.tsx
+++ b/app/finance-governance/live/workflow/page.tsx
@@ -147,7 +147,7 @@ export default function FinanceGovernanceLiveWorkflowPage() {
   return (
     <main className="mx-auto min-h-screen max-w-7xl px-6 py-16 text-white">
       <div className="max-w-3xl">
-        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Live workflow demo</p>
+        <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Live workflow</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Read, act, and refresh in one workflow surface</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
           This page combines live reads from the finance-governance API with workflow actions and then refreshes the summary and queue so the state transition loop is visible in one place.

--- a/lib/dsg-core/index.ts
+++ b/lib/dsg-core/index.ts
@@ -1,16 +1,14 @@
 import {
-  executeOnInternalDSGCore,
   getInternalDSGCoreHealth,
 } from './internal';
 import {
-  executeOnRemoteDSGCore,
   getRemoteDSGCoreAuditEvents,
   getRemoteDSGCoreDeterminism,
   getRemoteDSGCoreHealth,
   getRemoteDSGCoreLedger,
   getRemoteDSGCoreMetrics,
 } from './remote';
-import type { DSGCoreMode } from './types';
+import type { DSGCoreAuditEvent, DSGCoreMode } from './types';
 
 export type {
   DSGCoreAuditEvent,
@@ -35,6 +33,130 @@ function getRemoteConfig() {
     url,
     apiKey: process.env.DSG_CORE_API_KEY || process.env.DSG_API_KEY || '',
   };
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function parseRegionFromEvidence(evidence: unknown) {
+  const obj = toObject(evidence);
+  const metadata = toObject(obj.metadata);
+  return String(
+    obj.region_id ?? obj.regionId ?? obj.region ?? metadata.region_id ?? metadata.region ?? 'internal-runtime'
+  );
+}
+
+async function fetchInternalAuditRows(limit = 20, orgId?: string) {
+  const { getSupabaseAdmin } = await import('../supabase-server');
+  const admin = getSupabaseAdmin() as any;
+
+  const { data, error } = await admin
+    .from('audit_logs')
+    .select('id, created_at, decision, evidence')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return { ok: false as const, items: [] as DSGCoreAuditEvent[], error: error.message };
+  }
+
+  const items = (data ?? []).map((row: any, index: number) => {
+    const evidence = toObject(row.evidence);
+    const coreResult = toObject(evidence.core_result);
+    const sequence =
+      toFiniteNumber(evidence.sequence) ??
+      toFiniteNumber(coreResult.sequence) ??
+      toFiniteNumber(evidence.epoch) ??
+      toFiniteNumber(coreResult.epoch) ??
+      index + 1;
+
+    return {
+      id: toFiniteNumber(row.id) ?? undefined,
+      epoch: sequence,
+      sequence,
+      region_id: parseRegionFromEvidence(row.evidence),
+      state_hash:
+        (evidence.state_hash as string | null | undefined) ??
+        (coreResult.state_hash as string | null | undefined) ??
+        (evidence.proof_hash as string | null | undefined) ??
+        null,
+      entropy:
+        toFiniteNumber(evidence.entropy) ??
+        toFiniteNumber(coreResult.entropy) ??
+        toFiniteNumber(evidence.stability_score) ??
+        null,
+      gate_result: (row.decision as string | null | undefined) ?? 'ALLOW',
+      z3_proof_hash:
+        (evidence.z3_proof_hash as string | null | undefined) ??
+        (coreResult.z3_proof_hash as string | null | undefined) ??
+        null,
+      signature:
+        (evidence.signature as string | null | undefined) ??
+        (coreResult.signature as string | null | undefined) ??
+        null,
+      metadata: evidence,
+      created_at: (row.created_at as string | null | undefined) ?? null,
+    } satisfies DSGCoreAuditEvent;
+  });
+
+  return { ok: true as const, items };
+}
+
+async function getInternalMetrics(orgId?: string) {
+  const { getSupabaseAdmin } = await import('../supabase-server');
+  const admin = getSupabaseAdmin() as any;
+
+  const [executionsRes, agentsRes] = await Promise.all([
+    admin.from('executions').select('id,decision,latency_ms,created_at').eq('org_id', orgId).order('created_at', { ascending: false }).limit(200),
+    admin.from('agents').select('*', { count: 'exact', head: true }).eq('org_id', orgId).eq('status', 'active'),
+  ]);
+
+  if (executionsRes.error) {
+    return { ok: false as const, error: executionsRes.error.message };
+  }
+
+  if (agentsRes.error) {
+    return { ok: false as const, error: agentsRes.error.message };
+  }
+
+  const rows = executionsRes.data ?? [];
+  const total = rows.length;
+  const avgLatencyMs = total
+    ? Math.round(rows.reduce((sum: number, row: any) => sum + Number(row.latency_ms || 0), 0) / total)
+    : 0;
+
+  return {
+    ok: true as const,
+    data: {
+      mode: 'internal',
+      executions_total: total,
+      decisions: {
+        ALLOW: rows.filter((row: any) => row.decision === 'ALLOW').length,
+        STABILIZE: rows.filter((row: any) => row.decision === 'STABILIZE').length,
+        BLOCK: rows.filter((row: any) => row.decision === 'BLOCK').length,
+      },
+      avg_latency_ms: avgLatencyMs,
+      active_agents: Number(agentsRes.count || 0),
+      generated_at: new Date().toISOString(),
+    },
+  };
+}
+
+
+
+function internalScopeError(operation: string) {
+  return { ok: false as const, error: `org_id is required for internal DSG core ${operation}` };
 }
 
 export function getDSGCoreConfig() {
@@ -63,34 +185,79 @@ export async function executeOnDSGCore(payload: import('./types').DSGCoreExecuti
   });
 }
 
-export async function getDSGCoreMetrics() {
+export async function getDSGCoreMetrics(options?: { orgId?: string }) {
   const mode = parseMode();
   if (mode === 'internal') {
-    return { ok: false, error: 'metrics endpoint is unavailable in internal DSG core mode' };
+    if (!options?.orgId) return internalScopeError('metrics');
+    return getInternalMetrics(options.orgId);
   }
   return getRemoteDSGCoreMetrics(getRemoteConfig());
 }
 
-export async function getDSGCoreLedger(limit = 20) {
+export async function getDSGCoreLedger(limit = 20, options?: { orgId?: string }) {
   const mode = parseMode();
   if (mode === 'internal') {
-    return { ok: false, items: [], error: 'ledger endpoint is unavailable in internal DSG core mode' };
+    if (!options?.orgId) return { ok: false as const, items: [], error: internalScopeError('ledger').error };
+    const audit = await fetchInternalAuditRows(limit, options.orgId);
+    if (!audit.ok) {
+      return { ok: false as const, items: [], error: audit.error };
+    }
+
+    const items = audit.items.map((item) => ({
+      sequence: item.sequence,
+      gate_result: item.gate_result,
+      state_hash: item.state_hash,
+      entropy: item.entropy,
+      created_at: item.created_at,
+      metadata: {
+        region_id: item.region_id,
+        ...toObject(item.metadata),
+      },
+    }));
+
+    return { ok: true as const, items };
   }
   return getRemoteDSGCoreLedger(getRemoteConfig(), limit);
 }
 
-export async function getDSGCoreAuditEvents(limit = 20) {
+export async function getDSGCoreAuditEvents(limit = 20, options?: { orgId?: string }) {
   const mode = parseMode();
   if (mode === 'internal') {
-    return { ok: false, items: [], error: 'audit events endpoint is unavailable in internal DSG core mode' };
+    if (!options?.orgId) return { ok: false as const, items: [], error: internalScopeError('audit events').error };
+    return fetchInternalAuditRows(limit, options.orgId);
   }
   return getRemoteDSGCoreAuditEvents(getRemoteConfig(), limit);
 }
 
-export async function getDSGCoreDeterminism(sequence: number) {
+export async function getDSGCoreDeterminism(sequence: number, options?: { orgId?: string }) {
   const mode = parseMode();
   if (mode === 'internal') {
-    return { ok: false, error: 'determinism endpoint is unavailable in internal DSG core mode' };
+    if (!options?.orgId) return internalScopeError('determinism');
+    const audit = await fetchInternalAuditRows(200, options.orgId);
+    if (!audit.ok) {
+      return { ok: false as const, error: audit.error };
+    }
+
+    const sameSequence = audit.items.filter((item) => item.sequence === sequence);
+    if (sameSequence.length === 0) {
+      return { ok: false as const, error: `No deterministic sample found for sequence ${sequence}` };
+    }
+
+    const uniqueHashes = new Set(
+      sameSequence.map((item) => item.state_hash).filter((hash): hash is string => Boolean(hash))
+    );
+
+    return {
+      ok: true as const,
+      data: {
+        sequence,
+        region_count: new Set(sameSequence.map((item) => item.region_id)).size,
+        unique_state_hashes: uniqueHashes.size,
+        max_entropy: Math.max(...sameSequence.map((item) => Number(item.entropy ?? 0)), 0),
+        deterministic: uniqueHashes.size <= 1,
+        gate_action: String(sameSequence[0]?.gate_result ?? 'ALLOW'),
+      },
+    };
   }
   return getRemoteDSGCoreDeterminism(getRemoteConfig(), sequence);
 }

--- a/lib/dsg-core/local-runtime.ts
+++ b/lib/dsg-core/local-runtime.ts
@@ -1,0 +1,52 @@
+type SupabaseLike = {
+  from: (table: string) => {
+    select: (columns: string) => any;
+  };
+};
+
+type LocalLedgerItem = {
+  id: string;
+  decision: string | null;
+  reason: string | null;
+  created_at: string | null;
+  metadata: {
+    execution_id?: string;
+    audit_id?: string;
+    [key: string]: unknown;
+  };
+  evidence: Record<string, unknown>;
+};
+
+export async function getLocalRuntimeLedger(
+  supabase: SupabaseLike,
+  orgId: string,
+  limit = 20
+): Promise<{ ok: true; items: LocalLedgerItem[] } | { ok: false; items: []; error: string }> {
+  const clampedLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
+
+  const { data, error } = await supabase
+    .from('audit_logs')
+    .select('id,execution_id,decision,reason,evidence,created_at')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(clampedLimit);
+
+  if (error) {
+    return { ok: false, items: [], error: error.message };
+  }
+
+  const items = (Array.isArray(data) ? data : []).map((row: any) => ({
+    id: String(row.id),
+    decision: row.decision ?? null,
+    reason: row.reason ?? null,
+    created_at: row.created_at ?? null,
+    metadata: {
+      execution_id: row.execution_id ?? undefined,
+      audit_id: row.id ?? undefined,
+      ...(row?.evidence && typeof row.evidence === 'object' ? row.evidence : {}),
+    },
+    evidence: row?.evidence && typeof row.evidence === 'object' ? row.evidence : {},
+  }));
+
+  return { ok: true, items };
+}

--- a/lib/dsg-core/mode.ts
+++ b/lib/dsg-core/mode.ts
@@ -1,0 +1,8 @@
+export function getDSGCoreMode() {
+  const mode = process.env.DSG_CORE_MODE;
+  return mode === 'internal' ? 'internal' : 'remote';
+}
+
+export function isInternalDSGCoreMode() {
+  return getDSGCoreMode() === 'internal';
+}

--- a/lib/finance-governance/repository.ts
+++ b/lib/finance-governance/repository.ts
@@ -1,55 +1,25 @@
-import { buildApprovalActionResult, buildSubmitResult, type FinanceGovernanceActionName, type FinanceGovernanceActionResult } from './actions';
-import type { FinanceGovernanceApprovalItem, FinanceGovernanceCaseDetail, FinanceGovernanceWorkspaceSummary } from './mock-data';
+import {
+  buildApprovalActionResult,
+  buildSubmitResult,
+  type FinanceGovernanceActionName,
+  type FinanceGovernanceActionResult,
+} from './actions';
+import type {
+  FinanceGovernanceApprovalItem,
+  FinanceGovernanceCaseDetail,
+  FinanceGovernanceWorkspaceSummary,
+} from './mock-data';
 import { getSupabaseAdmin } from '../supabase-server';
-
-const DEFAULT_APPROVALS: FinanceGovernanceApprovalItem[] = [
-  { id: 'APR-1001', vendor: 'Northwind Supply', amount: 'US$14,250', status: 'Needs approver', risk: 'Threshold exceeded' },
-  { id: 'APR-1002', vendor: 'Contoso Services', amount: 'US$2,480', status: 'Exception open', risk: 'Missing document' },
-  { id: 'APR-1003', vendor: 'Blue Ocean Partners', amount: 'US$31,900', status: 'Compliance review', risk: 'High-risk vendor' },
-];
-
-async function ensureSeedData(orgId: string) {
-  const supabase = getSupabaseAdmin() as any;
-  const { data: existing } = await supabase
-    .from('finance_workflow_approvals')
-    .select('id')
-    .eq('org_id', orgId)
-    .limit(1);
-
-  if (Array.isArray(existing) && existing.length > 0) {
-    return;
-  }
-
-  await supabase.from('finance_workflow_cases').upsert({
-    id: 'sample-case',
-    org_id: orgId,
-    status: 'compliance_review',
-    export_status: 'Ready',
-    vendor: 'Northwind Supply',
-    amount: 14250,
-    currency: 'USD',
-    workflow: 'Invoice approval governance',
-  });
-
-  await supabase.from('finance_workflow_approvals').upsert(
-    DEFAULT_APPROVALS.map((item) => ({
-      id: item.id,
-      org_id: orgId,
-      case_id: 'sample-case',
-      vendor: item.vendor,
-      amount: item.amount,
-      status: item.status,
-      risk: item.risk,
-    }))
-  );
-}
 
 export class FinanceGovernanceRepository {
   async getWorkspaceSummary(orgId: string): Promise<FinanceGovernanceWorkspaceSummary> {
-    await ensureSeedData(orgId);
     const approvals = await this.getApprovals(orgId);
-    const pendingApprovals = approvals.filter((item) => !['approved', 'rejected'].includes(item.status.toLowerCase())).length;
-    const openExceptions = approvals.filter((item) => item.status.toLowerCase().includes('exception')).length;
+    const pendingApprovals = approvals.filter(
+      (item) => !['approved', 'rejected'].includes(item.status.toLowerCase())
+    ).length;
+    const openExceptions = approvals.filter((item) =>
+      item.status.toLowerCase().includes('exception')
+    ).length;
 
     const supabase = getSupabaseAdmin() as any;
     const { data: events } = await supabase
@@ -68,13 +38,11 @@ export class FinanceGovernanceRepository {
       quickLinks: [
         { href: '/finance-governance/app/onboarding', label: 'Onboarding template' },
         { href: '/finance-governance/app/approvals', label: 'Approval queue' },
-        { href: '/finance-governance/app/cases/sample-case', label: 'Sample case detail' },
       ],
     };
   }
 
   async getApprovals(orgId: string): Promise<FinanceGovernanceApprovalItem[]> {
-    await ensureSeedData(orgId);
     const supabase = getSupabaseAdmin() as any;
     const { data, error } = await supabase
       .from('finance_workflow_approvals')
@@ -90,7 +58,6 @@ export class FinanceGovernanceRepository {
   }
 
   async getCaseDetail(orgId: string, id: string): Promise<FinanceGovernanceCaseDetail> {
-    await ensureSeedData(orgId);
     const supabase = getSupabaseAdmin() as any;
     const { data: row, error } = await supabase
       .from('finance_workflow_cases')
@@ -134,7 +101,11 @@ export class FinanceGovernanceRepository {
     return result;
   }
 
-  async applyAction(orgId: string, approvalId: string, action: Extract<FinanceGovernanceActionName, 'approve' | 'reject' | 'escalate'>) {
+  async applyAction(
+    orgId: string,
+    approvalId: string,
+    action: Extract<FinanceGovernanceActionName, 'approve' | 'reject' | 'escalate'>
+  ) {
     const result = buildApprovalActionResult(action, approvalId);
     const supabase = getSupabaseAdmin() as any;
 
@@ -159,21 +130,43 @@ export class FinanceGovernanceRepository {
     return result;
   }
 
-  private async writeAction(orgId: string, result: FinanceGovernanceActionResult, caseId: string | null, approvalId: string | null) {
+  private async writeAction(
+    orgId: string,
+    result: FinanceGovernanceActionResult,
+    caseId: string | null,
+    approvalId: string | null
+  ) {
     const supabase = getSupabaseAdmin() as any;
 
     if (caseId) {
-      await supabase.from('finance_workflow_cases').upsert({
-        id: caseId,
-        org_id: orgId,
-        status: result.nextStatus,
-        export_status: result.action === 'submit' ? 'Ready' : 'In review',
-        vendor: 'Northwind Supply',
-        amount: 14250,
-        currency: 'USD',
-        workflow: 'Invoice approval governance',
-        updated_at: new Date().toISOString(),
-      });
+      const { data: existingCase, error: caseReadError } = await supabase
+        .from('finance_workflow_cases')
+        .select('id')
+        .eq('org_id', orgId)
+        .eq('id', caseId)
+        .maybeSingle();
+
+      if (caseReadError) {
+        throw new Error(`failed_to_read_case:${caseReadError.message}`);
+      }
+
+      if (!existingCase) {
+        throw new Error('case_not_found');
+      }
+
+      const { error: caseUpdateError } = await supabase
+        .from('finance_workflow_cases')
+        .update({
+          status: result.nextStatus,
+          export_status: result.action === 'submit' ? 'Ready' : 'In review',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('org_id', orgId)
+        .eq('id', caseId);
+
+      if (caseUpdateError) {
+        throw new Error(`failed_to_update_case:${caseUpdateError.message}`);
+      }
     }
 
     const { error } = await supabase.from('finance_workflow_action_events').insert({

--- a/tests/integration/api/demo-bootstrap.test.ts
+++ b/tests/integration/api/demo-bootstrap.test.ts
@@ -1,9 +1,14 @@
 import { POST } from '../../../app/api/demo/bootstrap/route';
 
 describe('/api/demo/bootstrap', () => {
-  it('is disabled by default in tests', async () => {
-    const req = new Request('http://localhost/api/demo/bootstrap', { method: 'POST' });
-    const res = await POST(req);
-    expect(res.status).toBe(403);
+  it('returns 410 because demo bootstrap was removed', async () => {
+    const res = await POST();
+    expect(res.status).toBe(410);
+
+    const payload = await res.json();
+    expect(payload).toMatchObject({
+      ok: false,
+      code: 'DEMO_BOOTSTRAP_REMOVED',
+    });
   });
 });

--- a/tests/unit/finance-governance-repository.test.ts
+++ b/tests/unit/finance-governance-repository.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FinanceGovernanceRepository } from '../../lib/finance-governance/repository';
 
 const calls: Array<{ table: string; op: string; payload?: unknown }> = [];
+let caseExists = true;
 
 function buildClient() {
   return {
@@ -22,6 +23,9 @@ function buildClient() {
         },
         maybeSingle() {
           if (table === 'finance_workflow_cases') {
+            if (!caseExists) {
+              return Promise.resolve({ data: null });
+            }
             return Promise.resolve({ data: { id: 'sample-case', status: 'pending', export_status: 'Ready', vendor: 'v', amount: 1, currency: 'USD', workflow: 'wf' } });
           }
           return Promise.resolve({ data: { case_id: 'sample-case' } });
@@ -50,14 +54,25 @@ vi.mock('../../lib/supabase-server', () => ({
 describe('FinanceGovernanceRepository', () => {
   beforeEach(() => {
     calls.length = 0;
+    caseExists = true;
   });
 
   it('writes submit action to DB tables', async () => {
     const repository = new FinanceGovernanceRepository();
     await repository.submit('org-test', 'case-123');
 
-    expect(calls.some((c) => c.table === 'finance_workflow_cases' && c.op === 'upsert')).toBe(true);
+    expect(calls.some((c) => c.table === 'finance_workflow_cases' && c.op === 'update')).toBe(true);
     expect(calls.some((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert')).toBe(true);
+  });
+
+
+  it('does not write action event when submit case does not exist', async () => {
+    caseExists = false;
+    const repository = new FinanceGovernanceRepository();
+
+    await expect(repository.submit('org-test', 'case-404')).rejects.toThrow('case_not_found');
+
+    expect(calls.some((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert')).toBe(false);
   });
 
   it('updates approval status and logs action events', async () => {


### PR DESCRIPTION
### Motivation

- Introduce an internal DSG core mode that can read runtime data from local DB tables and ensure DSG core queries are scoped to an `org_id` when appropriate.
- Remove the demo bootstrap endpoint and replace it with a clear 410 response to avoid demo bootstrap behavior in deployed builds.
- Make finance-governance demo UI/storage more explicit and robust by removing hardcoded demo orgs, exposing org id handling, and tightening repository behavior around case existence.

### Description

- Added mode parsing and internal implementations to `lib/dsg-core` including org-scoped functions (`getDSGCoreMetrics`, `getDSGCoreLedger`, `getDSGCoreAuditEvents`, `getDSGCoreDeterminism`) and helper parsing/normalization utilities.
- Introduced `lib/dsg-core/local-runtime.ts` and `lib/dsg-core/mode.ts` to query local runtime tables and detect internal mode, and updated endpoints to call local or remote implementations and pass `{ orgId }` where required.
- Updated API routes (`/api/*`) to pass `orgId` into DSG core helpers, and changed replay route to use local runtime ledger when internal mode is active and to include source/mode metadata in responses.
- Removed the demo bootstrap logic and replaced `/api/demo/bootstrap` with a `410 Gone` response that returns `{ ok: false, code: 'DEMO_BOOTSTRAP_REMOVED' }`.
- Adjusted finance-governance code and UI copy: changed storage key and org-id resolution in `app/finance-governance/live/request.ts`, updated copy to remove "demo" wording in several pages, and hardened `FinanceGovernanceRepository` to require existing cases before updating and to use `update`/explicit reads instead of upserts/seed data.
- Added and updated unit/integration tests to reflect behavior changes (demo bootstrap now returns 410; repository tests updated for case existence and DB call expectations).

### Testing

- Ran the test suite with `vitest`, including updated unit and integration tests, and the test run completed successfully.
- Updated integration test `tests/integration/api/demo-bootstrap.test.ts` to assert `410` and payload shape, and it passed.
- Updated unit test `tests/unit/finance-governance-repository.test.ts` to cover case-not-found behavior and DB update semantics, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e7a3903d4083268ab166cbe62f7cde)