### PR TITLE
Add URL extraction and browser navigation intent to agent planner

### DIFF
--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -15,6 +15,11 @@ function extractQuotedName(message: string) {
   return match ? match[1].trim() : '';
 }
 
+function extractUrl(message: string) {
+  const match = message.match(/https?:\/\/[^\s)]+/i);
+  return match ? match[0] : '';
+}
+
 function nextStep(id: number, toolId: string, params: Record<string, unknown>): AgentPlanStep {
   return { id: `s${id}`, toolId, params };
 }
@@ -115,6 +120,18 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
 
   if (/quota|capacity|โควต้า/.test(lower)) {
     return { steps: [nextStep(1, 'capacity', {})] };
+  }
+
+  if (/browser|navigate|open url|เปิดเว็บ|เปิดลิงก์|เข้าเว็บ/.test(lower)) {
+    return {
+      steps: [
+        nextStep(1, 'browser_navigate', {
+          agent_id: agentId,
+          url: extractUrl(text),
+          extract: '',
+        }),
+      ],
+    };
   }
 
   if (/search|ค้นหา|ออนไลน์|online|เว็บ|web/.test(lower)) {

--- a/tests/unit/agent/planner.test.ts
+++ b/tests/unit/agent/planner.test.ts
@@ -20,6 +20,16 @@ describe('agent planner chatbot intents', () => {
     expect(plan.steps[0]?.params).toMatchObject({ query: 'ค้นหาข่าว bitcoin online ตอนนี้' });
   });
 
+  it('routes browser control prompt to browser navigate tool', () => {
+    const plan = planGoal('เปิดเว็บ https://example.com ด้วย browser ให้หน่อย agt_ops_01');
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0]?.toolId).toBe('browser_navigate');
+    expect(plan.steps[0]?.params).toMatchObject({
+      agent_id: 'agt_ops_01',
+      url: 'https://example.com',
+    });
+  });
+
 
   it('uses page context for help prompt', () => {
     const plan = planGoal('help', '/dashboard/policies');


### PR DESCRIPTION
### Motivation

- Support user prompts that ask the assistant to open or navigate to web pages by recognizing browser/navigation phrases and URLs.

### Description

- Add `extractUrl` helper to parse the first `http(s)://` URL from a prompt.
- Map browser/navigation phrases to a `browser_navigate` step in `planGoal`, passing `agent_id`, `url`, and `extract` parameters.
- Add a unit test in `tests/unit/agent/planner.test.ts` to validate the `browser_navigate` routing and URL/agent extraction.

### Testing

- Ran unit tests with `vitest` and the test suite including the new `browser_navigate` test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e85e6179bc832684a0187dfeab3ba9)