### PR TITLE
fix: add supabase fallback for agent create and runtime auth

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -174,7 +174,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'monthly_limit must be between 1 and 1000000' }, { status: 400, headers });
     }
 
-    const supabase = getSupabaseAdmin();
+    let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>> | ReturnType<typeof getSupabaseAdmin>;
+    try {
+      supabase = getSupabaseAdmin();
+    } catch {
+      // Fallback for environments that only expose public Supabase keys.
+      supabase = await createSupabaseServerClient();
+    }
     const { count: existingCount, error: countError } = await supabase
       .from('agents')
       .select('id', { count: 'exact', head: true })

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -34,7 +34,13 @@ export async function requireOrgRole(requiredRoles: RuntimeRole[]){
     };
   }
 
-  const admin = getSupabaseAdmin();
+  let admin: Awaited<ReturnType<typeof createClient>> | ReturnType<typeof getSupabaseAdmin>;
+  try {
+    admin = getSupabaseAdmin();
+  } catch {
+    // Fallback for deployments that only expose public Supabase keys.
+    admin = await createClient();
+  }
 
   // runtime_roles.user_id references public.users.id, NOT auth.users.id.
   // Map auth.users.id -> public.users.id first.


### PR DESCRIPTION
### Motivation
- Prevent internal server errors when `SUPABASE_SERVICE_ROLE_KEY` is not available so agent creation and runtime role checks continue to work in environments that only expose public Supabase keys.
- Stop command-center / agent-chat readiness steps (e.g. `s1`) from failing due to unavailable service-role credentials.

### Description
- Wrap `getSupabaseAdmin()` in `app/api/agents/route.ts` with a `try/catch` and fall back to `createSupabaseServerClient()` when the service-role client cannot be created. 
- Wrap `getSupabaseAdmin()` in `lib/authz.ts` with a `try/catch` and fall back to `createClient()` so `requireOrgRole` works without the service-role key. 
- Changes ensure the code uses a public-client fallback in deployments that expose only public Supabase env vars. 

### Testing
- Ran the unit test targeting authz with `npm run test:unit -- tests/unit/authz.test.ts` and it passed. 
- Unit test suite (including `tests/unit/authz.test.ts`) ran successfully in the local test run (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e85dda182c8326a3d153039edc9378)