### PR TITLE
Launch-ready finance governance control layer and deployment readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ APPROVED_AUTO_JOIN_DOMAINS=
 
 # ============ Internal Services ============
 INTERNAL_SERVICE_TOKEN=
+INTERNAL_SERVICE_TOKENS=
 
 # ============ Rate Limiting (recommended for serverless) ============
 UPSTASH_REDIS_REST_URL=
@@ -59,3 +60,7 @@ RESEND_API_KEY=
 
 # ============ OpenRouter (Multi-Model) ============
 OPENROUTER_API_KEY=
+
+# ============ Auth ============
+NEXTAUTH_SECRET=
+DSG_FINANCE_GOVERNANCE_ENABLED=true

--- a/.github/workflows/launch-readiness.yml
+++ b/.github/workflows/launch-readiness.yml
@@ -1,0 +1,21 @@
+name: launch-readiness
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build
+      - name: production-manifest
+        run: test -f .env.example

--- a/app/api/finance-governance/cases/[id]/decisions/route.ts
+++ b/app/api/finance-governance/cases/[id]/decisions/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
+import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
+
+const repository = new FinanceGovernanceRepository();
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const orgId = resolveOrgId(request);
+    const { id } = await context.params;
+    const decisions = await repository.getDecisions(orgId, id);
+    return NextResponse.json({ decisions });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/finance-governance/cases/[id]/evidence/route.ts
+++ b/app/api/finance-governance/cases/[id]/evidence/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
+import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
+
+const repository = new FinanceGovernanceRepository();
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const orgId = resolveOrgId(request);
+    const { id } = await context.params;
+    const bundles = await repository.getEvidenceBundles(orgId, id);
+    return NextResponse.json({ bundles });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/finance-governance/cases/[id]/exceptions/route.ts
+++ b/app/api/finance-governance/cases/[id]/exceptions/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
+import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
+
+const repository = new FinanceGovernanceRepository();
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const orgId = resolveOrgId(request);
+    const { id } = await context.params;
+    const exceptions = await repository.getExceptions(orgId, id);
+    return NextResponse.json({ exceptions });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown_error';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { getDSGCoreHealth } from '../../../lib/dsg-core';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { getDeploymentReadiness } from '../../../lib/deployment/readiness';
 import { handleApiError } from '../../../lib/security/api-error';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../lib/security/rate-limit';
 
@@ -27,7 +28,10 @@ export async function GET(request: Request) {
       dbOk = false;
     }
 
-    const core = await getDSGCoreHealth();
+    const [core, readiness] = await Promise.all([
+      getDSGCoreHealth(),
+      getDeploymentReadiness(),
+    ]);
     const coreDetails = core as {
       status?: unknown;
       version?: unknown;
@@ -36,19 +40,20 @@ export async function GET(request: Request) {
     };
 
     return Response.json({
-      ok: core.ok && dbOk,
+      ok: core.ok && dbOk && readiness.ok,
       service: 'dsg-control-plane',
       timestamp: new Date().toISOString(),
       core_ok: core.ok,
       db_ok: dbOk,
-      error: (core.ok && dbOk) ? null : (!dbOk ? 'db_unreachable' : (coreDetails.error ?? null)),
+      error: (core.ok && dbOk && readiness.ok) ? null : (!dbOk ? 'db_unreachable' : (coreDetails.error ?? 'release_not_ready')),
       core: {
-        ok: core.ok && dbOk,
+        ok: core.ok && dbOk && readiness.ok,
         status: coreDetails.status ?? null,
         version: coreDetails.version ?? null,
         timestamp: coreDetails.timestamp ?? null,
         error: core.ok ? null : coreDetails.error ?? 'core_unreachable',
       },
+      readiness,
     }, { headers: buildRateLimitHeaders(rateLimit, 60) });
   } catch (error) {
     return handleApiError('api/health', error);

--- a/app/api/readiness/route.ts
+++ b/app/api/readiness/route.ts
@@ -1,0 +1,13 @@
+import { getDeploymentReadiness } from '../../../lib/deployment/readiness';
+import { handleApiError } from '../../../lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const readiness = await getDeploymentReadiness();
+    return Response.json(readiness, { status: readiness.ok ? 200 : 503 });
+  } catch (error) {
+    return handleApiError('api/readiness', error);
+  }
+}

--- a/docs/launch/PRODUCT_LAUNCH_STANDARD_2026-04-24.md
+++ b/docs/launch/PRODUCT_LAUNCH_STANDARD_2026-04-24.md
@@ -1,0 +1,11 @@
+# Product Launch Standard — 2026-04-24
+
+## Release gates
+- `/api/health` must return `ok: true`.
+- `/api/readiness` must return `ok: true`.
+- DSG core mode must be explicitly configured (`internal` or `remote`).
+- Finance governance control-layer migration must be applied.
+
+## Operational checks
+- Run `scripts/go-no-go-gate.sh <base-url>`.
+- Confirm enterprise trust surface pages and finance-governance APIs are reachable.

--- a/docs/launch/REVENUE_READINESS_2026-04-24.md
+++ b/docs/launch/REVENUE_READINESS_2026-04-24.md
@@ -1,0 +1,10 @@
+# Revenue Readiness — 2026-04-24
+
+## Commercial controls
+- Approval actions create immutable decision records.
+- Escalations create exception records for compliance follow-up.
+- Approvals generate evidence bundles for audit/export workflows.
+
+## GTM posture
+- Positioning: Finance Governance Control Plane.
+- Value: policy-enforced routing, maker-checker controls, exception tracking, audit-ready evidence bundles.

--- a/docs/pr/PR_LAUNCH_READY_FINANCE_GOVERNANCE.md
+++ b/docs/pr/PR_LAUNCH_READY_FINANCE_GOVERNANCE.md
@@ -1,0 +1,15 @@
+## Summary
+This PR prepares the control plane for enterprise finance governance launch readiness.
+
+## What changed
+- Added deployment readiness API and checks (`/api/readiness`) and surfaced readiness from `/api/health`.
+- Fixed DSG core remote mode execution path to execute on remote core instead of local gate fallback.
+- Hardened internal service authentication with digest-based timing-safe verification and rotating token support.
+- Added finance governance control-layer migration tables with backfill from legacy workflow tables.
+- Enhanced finance governance repository with control-layer-first reads/writes and fallback compatibility.
+- Added case-level decisions/exceptions/evidence endpoints.
+- Added launch readiness CI workflow and launch/revenue docs.
+
+## Validation
+- `npm test`
+- `npm run typecheck`

--- a/lib/auth/internal-service.ts
+++ b/lib/auth/internal-service.ts
@@ -1,3 +1,5 @@
+import { createHash, timingSafeEqual } from 'crypto';
+
 export type InternalServiceIdentity = {
   ok: true;
   orgId: string;
@@ -14,13 +16,45 @@ export type InternalServiceFailure = {
   error: string;
 };
 
+function digest(value: string): Buffer {
+  return createHash('sha256').update(value).digest();
+}
+
+function getExpectedTokenDigests(): Buffer[] {
+  const legacy = process.env.INTERNAL_SERVICE_TOKEN ?? '';
+  const rotated = (process.env.INTERNAL_SERVICE_TOKENS ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const candidates = [...rotated, ...(legacy ? [legacy] : [])];
+  return candidates.map((token) => digest(token));
+}
+
+function extractBearerToken(authHeader: string | null): string {
+  if (!authHeader) return '';
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return '';
+  return token;
+}
+
+function isAuthorized(authHeader: string | null): boolean {
+  const providedToken = extractBearerToken(authHeader);
+  if (!providedToken) return false;
+
+  const providedDigest = digest(providedToken);
+  const expectedDigests = getExpectedTokenDigests();
+  if (expectedDigests.length === 0) return false;
+
+  return expectedDigests.some((expectedDigest) => timingSafeEqual(providedDigest, expectedDigest));
+}
+
 export function requireInternalService(
   req: Request,
 ): InternalServiceIdentity | InternalServiceFailure {
-  const expected = process.env.INTERNAL_SERVICE_TOKEN;
   const auth = req.headers.get('authorization');
 
-  if (!expected || auth !== `Bearer ${expected}`) {
+  if (!isAuthorized(auth)) {
     return { ok: false, status: 401, error: 'unauthorized_internal_service' };
   }
 

--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -1,0 +1,77 @@
+import { getDSGCoreConfig, getDSGCoreHealth } from '../dsg-core';
+import { getSupabaseAdmin } from '../supabase-server';
+
+type CheckResult = {
+  ok: boolean;
+  detail?: string;
+};
+
+export type ReadinessReport = {
+  ok: boolean;
+  checks: {
+    env: CheckResult;
+    nextAuthSecret: CheckResult;
+    supabaseServiceRole: CheckResult;
+    dsgCoreConfig: CheckResult;
+    dsgCoreHealth: CheckResult;
+    financeGovernanceSurface: CheckResult;
+  };
+  timestamp: string;
+};
+
+function buildCheck(ok: boolean, detail?: string): CheckResult {
+  return { ok, ...(detail ? { detail } : {}) };
+}
+
+export async function getDeploymentReadiness(): Promise<ReadinessReport> {
+  const requiredEnv = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'DSG_CORE_MODE'];
+  const missingEnv = requiredEnv.filter((name) => !process.env[name]);
+  const envCheck = buildCheck(missingEnv.length === 0, missingEnv.length ? `missing:${missingEnv.join(',')}` : undefined);
+
+  const nextAuthSecret = buildCheck(Boolean(process.env.NEXTAUTH_SECRET), process.env.NEXTAUTH_SECRET ? undefined : 'NEXTAUTH_SECRET missing');
+
+  let supabaseServiceRole = buildCheck(false, 'not_checked');
+  try {
+    const admin = getSupabaseAdmin() as any;
+    const { error } = await admin.from('organizations').select('id').limit(1);
+    supabaseServiceRole = buildCheck(!error, error?.message);
+  } catch (error) {
+    supabaseServiceRole = buildCheck(false, error instanceof Error ? error.message : 'supabase_unreachable');
+  }
+
+  let dsgCoreConfig = buildCheck(false, 'not_checked');
+  let dsgCoreHealth = buildCheck(false, 'not_checked');
+
+  try {
+    const config = getDSGCoreConfig();
+    const missingRemoteUrl = config.mode === 'remote' && !config.url;
+    dsgCoreConfig = buildCheck(!missingRemoteUrl, missingRemoteUrl ? 'DSG_CORE_URL missing for remote mode' : undefined);
+
+    const health = await getDSGCoreHealth() as Record<string, unknown>;
+    dsgCoreHealth = buildCheck(Boolean(health.ok), health.ok ? undefined : String(health.error ?? 'core_unreachable'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'dsg_core_unreachable';
+    dsgCoreConfig = buildCheck(false, message);
+    dsgCoreHealth = buildCheck(false, message);
+  }
+
+  const financeGovernanceSurface = buildCheck(
+    Boolean(process.env.DSG_FINANCE_GOVERNANCE_ENABLED ?? 'true'),
+    process.env.DSG_FINANCE_GOVERNANCE_ENABLED === 'false' ? 'finance_governance_disabled' : undefined
+  );
+
+  const checks = {
+    env: envCheck,
+    nextAuthSecret,
+    supabaseServiceRole,
+    dsgCoreConfig,
+    dsgCoreHealth,
+    financeGovernanceSurface,
+  };
+
+  return {
+    ok: Object.values(checks).every((check) => check.ok),
+    checks,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/dsg-core/index.ts
+++ b/lib/dsg-core/index.ts
@@ -2,6 +2,7 @@ import {
   getInternalDSGCoreHealth,
 } from './internal';
 import {
+  executeOnRemoteDSGCore,
   getRemoteDSGCoreAuditEvents,
   getRemoteDSGCoreDeterminism,
   getRemoteDSGCoreHealth,
@@ -176,6 +177,11 @@ export async function getDSGCoreHealth() {
 }
 
 export async function executeOnDSGCore(payload: import('./types').DSGCoreExecutionRequest) {
+  const mode = parseMode();
+  if (mode === 'remote') {
+    return executeOnRemoteDSGCore(getRemoteConfig(), payload);
+  }
+
   const { resolveGate } = await import('../gate');
   const gate = resolveGate();
   return gate.evaluate({

--- a/lib/finance-governance/repository.ts
+++ b/lib/finance-governance/repository.ts
@@ -12,6 +12,11 @@ import type {
 import { getSupabaseAdmin } from '../supabase-server';
 
 export class FinanceGovernanceRepository {
+  private async hasControlLayerTables(supabase: any) {
+    const { error } = await supabase.from('finance_transactions').select('id').limit(1);
+    return !error;
+  }
+
   async getWorkspaceSummary(orgId: string): Promise<FinanceGovernanceWorkspaceSummary> {
     const approvals = await this.getApprovals(orgId);
     const pendingApprovals = approvals.filter(
@@ -44,6 +49,25 @@ export class FinanceGovernanceRepository {
 
   async getApprovals(orgId: string): Promise<FinanceGovernanceApprovalItem[]> {
     const supabase = getSupabaseAdmin() as any;
+
+    if (await this.hasControlLayerTables(supabase)) {
+      const { data, error } = await supabase
+        .from('finance_approval_requests')
+        .select('id,status,risk,finance_transactions(vendor,amount)')
+        .eq('org_id', orgId)
+        .order('created_at', { ascending: true });
+
+      if (!error && Array.isArray(data)) {
+        return data.map((row: any) => ({
+          id: row.id,
+          vendor: row.finance_transactions?.vendor ?? 'Unknown vendor',
+          amount: `US$${row.finance_transactions?.amount ?? '0'}`,
+          status: row.status,
+          risk: row.risk ?? 'N/A',
+        }));
+      }
+    }
+
     const { data, error } = await supabase
       .from('finance_workflow_approvals')
       .select('id,vendor,amount,status,risk')
@@ -59,6 +83,38 @@ export class FinanceGovernanceRepository {
 
   async getCaseDetail(orgId: string, id: string): Promise<FinanceGovernanceCaseDetail> {
     const supabase = getSupabaseAdmin() as any;
+
+    if (await this.hasControlLayerTables(supabase)) {
+      const { data: row, error } = await supabase
+        .from('finance_transactions')
+        .select('id,status,vendor,amount,currency')
+        .eq('org_id', orgId)
+        .eq('id', id)
+        .maybeSingle();
+
+      if (!error && row) {
+        const { data: decisions } = await supabase
+          .from('finance_approval_decisions')
+          .select('decision,reason')
+          .eq('org_id', orgId)
+          .eq('approval_request_id', id)
+          .order('created_at', { ascending: true });
+
+        return {
+          id: row.id,
+          status: row.status,
+          exportStatus: 'Ready',
+          transaction: {
+            vendor: row.vendor,
+            amount: String(row.amount),
+            currency: row.currency,
+            workflow: 'Finance governance control layer',
+          },
+          timeline: (decisions ?? []).map((item: { decision: string; reason: string }) => `${item.decision}: ${item.reason ?? ''}`),
+        };
+      }
+    }
+
     const { data: row, error } = await supabase
       .from('finance_workflow_cases')
       .select('id,status,export_status,vendor,amount,currency,workflow')
@@ -95,6 +151,67 @@ export class FinanceGovernanceRepository {
     };
   }
 
+  async getDecisions(orgId: string, caseOrApprovalId: string) {
+    const supabase = getSupabaseAdmin() as any;
+
+    if (await this.hasControlLayerTables(supabase)) {
+      const { data, error } = await supabase
+        .from('finance_approval_decisions')
+        .select('id,decision,reason,actor,created_at')
+        .eq('org_id', orgId)
+        .eq('approval_request_id', caseOrApprovalId)
+        .order('created_at', { ascending: true });
+      if (!error) return data ?? [];
+    }
+
+    const { data } = await supabase
+      .from('finance_workflow_action_events')
+      .select('id,action,message,created_at')
+      .eq('org_id', orgId)
+      .eq('approval_id', caseOrApprovalId)
+      .order('created_at', { ascending: true });
+
+    return (data ?? []).map((item: any) => ({
+      id: item.id,
+      decision: item.action,
+      reason: item.message,
+      actor: 'workflow',
+      created_at: item.created_at,
+    }));
+  }
+
+  async getExceptions(orgId: string, caseOrApprovalId: string) {
+    const supabase = getSupabaseAdmin() as any;
+
+    if (await this.hasControlLayerTables(supabase)) {
+      const { data, error } = await supabase
+        .from('finance_exceptions')
+        .select('id,status,reason,created_at,resolved_at')
+        .eq('org_id', orgId)
+        .eq('approval_request_id', caseOrApprovalId)
+        .order('created_at', { ascending: false });
+      if (!error) return data ?? [];
+    }
+
+    return [];
+  }
+
+  async getEvidenceBundles(orgId: string, caseOrApprovalId: string) {
+    const supabase = getSupabaseAdmin() as any;
+
+    if (await this.hasControlLayerTables(supabase)) {
+      const { data, error } = await supabase
+        .from('finance_evidence_bundles')
+        .select('id,status,uri,created_at')
+        .eq('org_id', orgId)
+        .eq('approval_request_id', caseOrApprovalId)
+        .order('created_at', { ascending: false });
+      if (!error) return data ?? [];
+    }
+
+    return [];
+  }
+
   async submit(orgId: string, caseId: string): Promise<FinanceGovernanceActionResult> {
     const result = buildSubmitResult(caseId);
     await this.writeAction(orgId, result, caseId, null);
@@ -108,6 +225,50 @@ export class FinanceGovernanceRepository {
   ) {
     const result = buildApprovalActionResult(action, approvalId);
     const supabase = getSupabaseAdmin() as any;
+    const useControlLayer = await this.hasControlLayerTables(supabase);
+
+    if (useControlLayer) {
+      const now = new Date().toISOString();
+      await supabase.from('finance_approval_decisions').insert({
+        org_id: orgId,
+        approval_request_id: approvalId,
+        decision: action,
+        reason: result.message,
+        actor: 'api',
+        metadata: result,
+        created_at: now,
+      });
+
+      await supabase
+        .from('finance_approval_requests')
+        .update({ status: result.nextStatus, updated_at: now })
+        .eq('org_id', orgId)
+        .eq('id', approvalId);
+
+      await supabase
+        .from('finance_transactions')
+        .update({ status: result.nextStatus, updated_at: now })
+        .eq('org_id', orgId)
+        .eq('id', approvalId);
+
+      if (action === 'escalate') {
+        await supabase.from('finance_exceptions').insert({
+          org_id: orgId,
+          approval_request_id: approvalId,
+          status: 'open',
+          reason: result.message,
+        });
+      }
+
+      if (action === 'approve') {
+        await supabase.from('finance_evidence_bundles').insert({
+          org_id: orgId,
+          approval_request_id: approvalId,
+          status: 'ready',
+          uri: `evidence://${approvalId}`,
+        });
+      }
+    }
 
     const { data: approval } = await supabase
       .from('finance_workflow_approvals')

--- a/scripts/go-no-go-gate.sh
+++ b/scripts/go-no-go-gate.sh
@@ -30,6 +30,7 @@ check_endpoint "/support"
 
 echo "== Runtime baseline checks =="
 check_endpoint "/api/health"
+check_endpoint "/api/readiness"
 
 monitor_code=$(curl -sS -o /tmp/go-no-go-monitor.json -w "%{http_code}" --max-time 20 "${BASE_URL%/}/api/core/monitor" || echo "000")
 if [[ "$monitor_code" == "200" ]]; then

--- a/supabase/migrations/20260424010000_finance_governance_control_layer.sql
+++ b/supabase/migrations/20260424010000_finance_governance_control_layer.sql
@@ -1,0 +1,81 @@
+create table if not exists public.finance_transactions (
+  id text primary key,
+  org_id text not null,
+  workflow_case_id text,
+  vendor text not null,
+  amount numeric(14,2) not null,
+  currency text not null default 'USD',
+  status text not null default 'pending',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.finance_approval_requests (
+  id text primary key,
+  org_id text not null,
+  transaction_id text not null references public.finance_transactions(id) on delete cascade,
+  status text not null default 'pending',
+  risk text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.finance_approval_steps (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  approval_request_id text not null references public.finance_approval_requests(id) on delete cascade,
+  step_order int not null,
+  approver_role text not null,
+  status text not null default 'pending',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.finance_approval_decisions (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  approval_request_id text not null references public.finance_approval_requests(id) on delete cascade,
+  decision text not null,
+  reason text,
+  actor text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.finance_exceptions (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  approval_request_id text not null references public.finance_approval_requests(id) on delete cascade,
+  status text not null default 'open',
+  reason text,
+  created_at timestamptz not null default now(),
+  resolved_at timestamptz
+);
+
+create table if not exists public.finance_evidence_bundles (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  approval_request_id text not null references public.finance_approval_requests(id) on delete cascade,
+  status text not null default 'ready',
+  uri text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.finance_export_jobs (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  bundle_id uuid references public.finance_evidence_bundles(id) on delete set null,
+  destination text,
+  status text not null default 'queued',
+  created_at timestamptz not null default now()
+);
+
+insert into public.finance_transactions (id, org_id, workflow_case_id, vendor, amount, currency, status)
+select c.id, c.org_id, c.id, c.vendor, c.amount, c.currency, c.status
+from public.finance_workflow_cases c
+on conflict (id) do nothing;
+
+insert into public.finance_approval_requests (id, org_id, transaction_id, status, risk)
+select a.id, a.org_id, a.case_id, a.status, a.risk
+from public.finance_workflow_approvals a
+where exists (select 1 from public.finance_transactions t where t.id = a.case_id)
+on conflict (id) do nothing;

--- a/tests/migrations/finance-governance-control-layer.test.ts
+++ b/tests/migrations/finance-governance-control-layer.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs';
+
+describe('finance governance control layer migration', () => {
+  it('creates control layer tables and backfill statements', () => {
+    const sql = readFileSync(
+      'supabase/migrations/20260424010000_finance_governance_control_layer.sql',
+      'utf8'
+    );
+
+    expect(sql).toContain('create table if not exists public.finance_transactions');
+    expect(sql).toContain('create table if not exists public.finance_approval_requests');
+    expect(sql).toContain('create table if not exists public.finance_approval_decisions');
+    expect(sql).toContain('create table if not exists public.finance_exceptions');
+    expect(sql).toContain('create table if not exists public.finance_evidence_bundles');
+    expect(sql).toContain('insert into public.finance_transactions');
+    expect(sql).toContain('insert into public.finance_approval_requests');
+  });
+});

--- a/tests/unit/dsg-core-remote-execution.test.ts
+++ b/tests/unit/dsg-core-remote-execution.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { executeOnDSGCore } from '../../lib/dsg-core';
+
+describe('executeOnDSGCore in remote mode', () => {
+  afterEach(() => {
+    delete process.env.DSG_CORE_MODE;
+    delete process.env.DSG_CORE_URL;
+    vi.unstubAllGlobals();
+  });
+
+  it('calls remote core /execute in remote mode', async () => {
+    process.env.DSG_CORE_MODE = 'remote';
+    process.env.DSG_CORE_URL = 'https://core.example.com';
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, source: 'remote' }),
+    });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const result = await executeOnDSGCore({
+      agent_id: 'agent-1',
+      action: 'run',
+      payload: { context: { risk_score: 0.2 } },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://core.example.com/execute',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect((result as any).source).toBe('remote');
+  });
+});

--- a/tests/unit/internal-service.test.ts
+++ b/tests/unit/internal-service.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { requireInternalService } from '../../lib/auth/internal-service';
+
+describe('requireInternalService', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_SERVICE_TOKEN = 'legacy-token';
+    process.env.INTERNAL_SERVICE_TOKENS = 'rotated-1,rotated-2';
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_SERVICE_TOKEN;
+    delete process.env.INTERNAL_SERVICE_TOKENS;
+  });
+
+  it('authorizes with rotated token list', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        authorization: 'Bearer rotated-2',
+        'x-org-id': 'org-1',
+      },
+    });
+
+    const result = requireInternalService(request);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects invalid token', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        authorization: 'Bearer invalid',
+        'x-org-id': 'org-1',
+      },
+    });
+
+    const result = requireInternalService(request);
+    expect(result).toEqual({ ok: false, status: 401, error: 'unauthorized_internal_service' });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prepare the control plane for enterprise launch with an explicit deployment readiness gate and visible health surface.
- Ship a first-class finance governance control layer (tables, backfill, APIs, repository updates) so production systems can use governed transactions rather than legacy workflow-only data.
- Harden backend service paths and authentication for safe remote operation and internal-service callers during rollout.

### Description
- Add an actionable deployment readiness report and endpoint via `lib/deployment/readiness.ts` and `app/api/readiness/route.ts`, and surface readiness from `app/api/health/route.ts` so `/api/readiness` can act as a release gate.
- Fix DSG core remote execution to call the remote core `execute` endpoint in `lib/dsg-core/index.ts` when `DSG_CORE_MODE=remote`, instead of silently falling back to the local gate.
- Harden internal service auth in `lib/auth/internal-service.ts` by supporting rotated tokens via `INTERNAL_SERVICE_TOKENS`, using SHA-256 digests and `timingSafeEqual` for comparisons, and update `.env.example` accordingly.
- Add a finance governance control-layer migration `supabase/migrations/20260424010000_finance_governance_control_layer.sql` (transactions, approval_requests, steps, decisions, exceptions, evidence_bundles, export_jobs) with backfill from legacy `finance_workflow_*` tables, update `lib/finance-governance/repository.ts` to prefer new schema with legacy fallback, and add case-level APIs in `app/api/finance-governance/cases/[id]/{decisions,exceptions,evidence}/route.ts` plus docs and a `launch-readiness` GitHub workflow.

### Testing
- Ran targeted tests with `npm test -- --run tests/unit/internal-service.test.ts tests/unit/dsg-core-remote-execution.test.ts tests/migrations/finance-governance-control-layer.test.ts tests/unit/finance-governance-repository.test.ts` and all selected tests passed.
- Ran `npm run typecheck` (TS check) and `npm run lint`, both completed successfully in the environment.
- Ran `git diff --check` to ensure no whitespace/merge errors and committed the patch as `Launch-ready finance governance control layer`.
- `npm run build` did not fully complete in this environment (Next.js build stalls at the combined lint/typecheck step); the PR includes a CI workflow that runs `npm run build` on CI to validate full production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eade176f4083269db60af71526bd22)