### PR TITLE
Final enterprise finance governance hardening (readiness, migration, RLS, ID mapping, API errors)

### DIFF
--- a/app/api/finance-governance/approvals/[id]/approve/route.ts
+++ b/app/api/finance-governance/approvals/[id]/approve/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 
@@ -15,8 +16,6 @@ export async function POST(request: Request, context: RouteContext) {
     const result = await repository.applyAction(orgId, id, 'approve');
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/approvals/[id]/escalate/route.ts
+++ b/app/api/finance-governance/approvals/[id]/escalate/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 
@@ -15,8 +16,6 @@ export async function POST(request: Request, context: RouteContext) {
     const result = await repository.applyAction(orgId, id, 'escalate');
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/approvals/[id]/reject/route.ts
+++ b/app/api/finance-governance/approvals/[id]/reject/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 
@@ -15,8 +16,6 @@ export async function POST(request: Request, context: RouteContext) {
     const result = await repository.applyAction(orgId, id, 'reject');
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/approvals/route.ts
+++ b/app/api/finance-governance/approvals/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
 import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/repository';
 
@@ -12,8 +13,6 @@ export async function GET(request: Request) {
     const approvals = await repository.getApprovals(orgId);
     return NextResponse.json({ approvals });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/cases/[id]/decisions/route.ts
+++ b/app/api/finance-governance/cases/[id]/decisions/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 
@@ -13,7 +14,6 @@ export async function GET(request: Request, context: RouteContext) {
     const decisions = await repository.getDecisions(orgId, id);
     return NextResponse.json({ decisions });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/cases/[id]/evidence/route.ts
+++ b/app/api/finance-governance/cases/[id]/evidence/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 
@@ -13,7 +14,6 @@ export async function GET(request: Request, context: RouteContext) {
     const bundles = await repository.getEvidenceBundles(orgId, id);
     return NextResponse.json({ bundles });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/cases/[id]/exceptions/route.ts
+++ b/app/api/finance-governance/cases/[id]/exceptions/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 
@@ -13,7 +14,6 @@ export async function GET(request: Request, context: RouteContext) {
     const exceptions = await repository.getExceptions(orgId, id);
     return NextResponse.json({ exceptions });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/cases/[id]/route.ts
+++ b/app/api/finance-governance/cases/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../lib/finance-governance/api-error';
 import { resolveOrgId } from '../../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../../lib/finance-governance/repository';
 
@@ -15,8 +16,6 @@ export async function GET(request: Request, context: RouteContext) {
     const detail = await repository.getCaseDetail(orgId, id);
     return NextResponse.json({ case: detail });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : message === 'case_not_found' ? 404 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/onboarding/route.ts
+++ b/app/api/finance-governance/onboarding/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
 import { getOnboardingSteps } from '../../../../lib/finance-governance/mock-data';
 import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
 
@@ -11,8 +12,6 @@ export async function GET(request: Request) {
       steps: getOnboardingSteps(),
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/submit/route.ts
+++ b/app/api/finance-governance/submit/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
 import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
 
@@ -14,8 +15,6 @@ export async function POST(request: Request) {
     const result = await repository.submit(orgId, caseId);
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/app/api/finance-governance/workspace/summary/route.ts
+++ b/app/api/finance-governance/workspace/summary/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../lib/finance-governance/api-error';
 import { resolveOrgId } from '../../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../../lib/finance-governance/repository';
 
@@ -12,8 +13,6 @@ export async function GET(request: Request) {
     const workspace = await repository.getWorkspaceSummary(orgId);
     return NextResponse.json({ workspace });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown_error';
-    const status = message === 'missing_org_id' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return handleFinanceGovernanceApiError('api/finance-governance', error);
   }
 }

--- a/docs/pr/PR_FINAL_ENTERPRISE_LAUNCH_HARDENING.md
+++ b/docs/pr/PR_FINAL_ENTERPRISE_LAUNCH_HARDENING.md
@@ -1,0 +1,25 @@
+# Final PR: Enterprise Launch Hardening (Finance Governance)
+
+## Summary
+- Fix `/api/readiness` boolean parsing for `DSG_FINANCE_GOVERNANCE_ENABLED=false`.
+- Make finance governance migration resilient on fresh Supabase projects by guarding legacy backfill with `to_regclass(...)`.
+- Harden finance governance schema with RLS baseline, org-scoped authenticated select policies, indexes, constraints, and `updated_at` triggers.
+- Fix approval action ID mapping by resolving approval request IDs to `transaction_id` before transaction updates.
+- Improve case detail/decision/exception/evidence lookups so they accept transaction IDs, case IDs, or approval request IDs.
+- Defer final evidence bundle generation until required approval steps are fully completed.
+- Standardize finance governance API error handling so known domain errors remain explicit and unknown/internal errors pass through safe error handling.
+
+## Why this PR
+This PR closes launch-blocking reliability and data-safety gaps that were still possible after the base finance governance merge:
+- false-positive readiness gating from string booleans,
+- migration failure on new database projects with no legacy tables,
+- incorrect row updates when action IDs were treated as transaction IDs,
+- brittle case/evidence lookup behavior when queue inputs used approval IDs,
+- premature evidence bundle creation,
+- and inconsistent API error behavior for unknown internal failures.
+
+## Validation checklist
+- [x] `git diff --cached --check`
+- [ ] `npm run typecheck` *(requires `npm ci`/dependencies in this environment)*
+- [ ] `npm test` *(requires `npm ci`/dependencies in this environment)*
+- [ ] `npm run build` *(requires `npm ci`/dependencies in this environment)*

--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -23,6 +23,14 @@ function buildCheck(ok: boolean, detail?: string): CheckResult {
   return { ok, ...(detail ? { detail } : {}) };
 }
 
+function parseBooleanFlag(value: string | undefined, fallback: boolean) {
+  if (value == null) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
 export async function getDeploymentReadiness(): Promise<ReadinessReport> {
   const requiredEnv = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'DSG_CORE_MODE'];
   const missingEnv = requiredEnv.filter((name) => !process.env[name]);
@@ -55,9 +63,10 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
     dsgCoreHealth = buildCheck(false, message);
   }
 
+  const financeGovernanceEnabled = parseBooleanFlag(process.env.DSG_FINANCE_GOVERNANCE_ENABLED, true);
   const financeGovernanceSurface = buildCheck(
-    Boolean(process.env.DSG_FINANCE_GOVERNANCE_ENABLED ?? 'true'),
-    process.env.DSG_FINANCE_GOVERNANCE_ENABLED === 'false' ? 'finance_governance_disabled' : undefined
+    financeGovernanceEnabled,
+    financeGovernanceEnabled ? undefined : 'finance_governance_disabled'
   );
 
   const checks = {

--- a/lib/finance-governance/api-error.ts
+++ b/lib/finance-governance/api-error.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { handleApiError } from '../security/api-error';
+
+const KNOWN_FINANCE_GOVERNANCE_ERRORS: Record<string, number> = {
+  missing_org_id: 400,
+  case_not_found: 404,
+  approval_not_found: 404,
+};
+
+export function handleFinanceGovernanceApiError(route: string, error: unknown) {
+  const message = error instanceof Error ? error.message : 'unknown_error';
+  const knownStatus = KNOWN_FINANCE_GOVERNANCE_ERRORS[message];
+
+  if (knownStatus) {
+    return NextResponse.json({ ok: false, error: message }, { status: knownStatus });
+  }
+
+  return handleApiError(route, error);
+}

--- a/lib/finance-governance/repository.ts
+++ b/lib/finance-governance/repository.ts
@@ -85,19 +85,22 @@ export class FinanceGovernanceRepository {
     const supabase = getSupabaseAdmin() as any;
 
     if (await this.hasControlLayerTables(supabase)) {
+      const mapping = await this.resolveApprovalMapping(orgId, id, supabase);
+      const transactionId = mapping?.transactionId ?? id;
       const { data: row, error } = await supabase
         .from('finance_transactions')
         .select('id,status,vendor,amount,currency')
         .eq('org_id', orgId)
-        .eq('id', id)
+        .eq('id', transactionId)
         .maybeSingle();
 
       if (!error && row) {
+        const approvalRequestId = mapping?.approvalId ?? await this.resolveApprovalRequestId(orgId, row.id, supabase);
         const { data: decisions } = await supabase
           .from('finance_approval_decisions')
           .select('decision,reason')
           .eq('org_id', orgId)
-          .eq('approval_request_id', id)
+          .eq('approval_request_id', approvalRequestId ?? id)
           .order('created_at', { ascending: true });
 
         return {
@@ -155,11 +158,12 @@ export class FinanceGovernanceRepository {
     const supabase = getSupabaseAdmin() as any;
 
     if (await this.hasControlLayerTables(supabase)) {
+      const approvalId = await this.resolveApprovalReference(orgId, caseOrApprovalId, supabase);
       const { data, error } = await supabase
         .from('finance_approval_decisions')
         .select('id,decision,reason,actor,created_at')
         .eq('org_id', orgId)
-        .eq('approval_request_id', caseOrApprovalId)
+        .eq('approval_request_id', approvalId)
         .order('created_at', { ascending: true });
       if (!error) return data ?? [];
     }
@@ -184,11 +188,12 @@ export class FinanceGovernanceRepository {
     const supabase = getSupabaseAdmin() as any;
 
     if (await this.hasControlLayerTables(supabase)) {
+      const approvalId = await this.resolveApprovalReference(orgId, caseOrApprovalId, supabase);
       const { data, error } = await supabase
         .from('finance_exceptions')
         .select('id,status,reason,created_at,resolved_at')
         .eq('org_id', orgId)
-        .eq('approval_request_id', caseOrApprovalId)
+        .eq('approval_request_id', approvalId)
         .order('created_at', { ascending: false });
       if (!error) return data ?? [];
     }
@@ -200,11 +205,12 @@ export class FinanceGovernanceRepository {
     const supabase = getSupabaseAdmin() as any;
 
     if (await this.hasControlLayerTables(supabase)) {
+      const approvalId = await this.resolveApprovalReference(orgId, caseOrApprovalId, supabase);
       const { data, error } = await supabase
         .from('finance_evidence_bundles')
         .select('id,status,uri,created_at')
         .eq('org_id', orgId)
-        .eq('approval_request_id', caseOrApprovalId)
+        .eq('approval_request_id', approvalId)
         .order('created_at', { ascending: false });
       if (!error) return data ?? [];
     }
@@ -228,10 +234,15 @@ export class FinanceGovernanceRepository {
     const useControlLayer = await this.hasControlLayerTables(supabase);
 
     if (useControlLayer) {
+      const mapping = await this.resolveApprovalMapping(orgId, approvalId, supabase);
+      if (!mapping) {
+        throw new Error('approval_not_found');
+      }
+
       const now = new Date().toISOString();
       await supabase.from('finance_approval_decisions').insert({
         org_id: orgId,
-        approval_request_id: approvalId,
+        approval_request_id: mapping.approvalId,
         decision: action,
         reason: result.message,
         actor: 'api',
@@ -243,29 +254,29 @@ export class FinanceGovernanceRepository {
         .from('finance_approval_requests')
         .update({ status: result.nextStatus, updated_at: now })
         .eq('org_id', orgId)
-        .eq('id', approvalId);
+        .eq('id', mapping.approvalId);
 
       await supabase
         .from('finance_transactions')
         .update({ status: result.nextStatus, updated_at: now })
         .eq('org_id', orgId)
-        .eq('id', approvalId);
+        .eq('id', mapping.transactionId);
 
       if (action === 'escalate') {
         await supabase.from('finance_exceptions').insert({
           org_id: orgId,
-          approval_request_id: approvalId,
+          approval_request_id: mapping.approvalId,
           status: 'open',
           reason: result.message,
         });
       }
 
-      if (action === 'approve') {
+      if (action === 'approve' && await this.canCreateFinalEvidenceBundle(orgId, mapping.approvalId, supabase)) {
         await supabase.from('finance_evidence_bundles').insert({
           org_id: orgId,
-          approval_request_id: approvalId,
+          approval_request_id: mapping.approvalId,
           status: 'ready',
-          uri: `evidence://${approvalId}`,
+          uri: `evidence://${mapping.approvalId}`,
         });
       }
     }
@@ -343,5 +354,85 @@ export class FinanceGovernanceRepository {
     if (error) {
       throw new Error(`failed_to_write_action:${error.message}`);
     }
+  }
+
+  private async resolveApprovalReference(orgId: string, id: string, supabase: any): Promise<string> {
+    const mapping = await this.resolveApprovalMapping(orgId, id, supabase);
+    if (!mapping) {
+      throw new Error('approval_not_found');
+    }
+    return mapping.approvalId;
+  }
+
+  private async resolveApprovalRequestId(orgId: string, transactionId: string, supabase: any): Promise<string | null> {
+    const { data } = await supabase
+      .from('finance_approval_requests')
+      .select('id')
+      .eq('org_id', orgId)
+      .eq('transaction_id', transactionId)
+      .maybeSingle();
+    return data?.id ?? null;
+  }
+
+  private async resolveApprovalMapping(orgId: string, id: string, supabase: any): Promise<{ approvalId: string; transactionId: string } | null> {
+    const { data: direct } = await supabase
+      .from('finance_approval_requests')
+      .select('id,transaction_id')
+      .eq('org_id', orgId)
+      .eq('id', id)
+      .maybeSingle();
+
+    if (direct?.id && direct?.transaction_id) {
+      return { approvalId: direct.id, transactionId: direct.transaction_id };
+    }
+
+    const { data: byTransaction } = await supabase
+      .from('finance_approval_requests')
+      .select('id,transaction_id')
+      .eq('org_id', orgId)
+      .eq('transaction_id', id)
+      .maybeSingle();
+
+    if (byTransaction?.id && byTransaction?.transaction_id) {
+      return { approvalId: byTransaction.id, transactionId: byTransaction.transaction_id };
+    }
+
+    const { data: byWorkflowCase } = await supabase
+      .from('finance_transactions')
+      .select('id')
+      .eq('org_id', orgId)
+      .eq('workflow_case_id', id)
+      .maybeSingle();
+
+    if (!byWorkflowCase?.id) {
+      return null;
+    }
+
+    const { data: byCaseTransaction } = await supabase
+      .from('finance_approval_requests')
+      .select('id,transaction_id')
+      .eq('org_id', orgId)
+      .eq('transaction_id', byWorkflowCase.id)
+      .maybeSingle();
+
+    if (byCaseTransaction?.id && byCaseTransaction?.transaction_id) {
+      return { approvalId: byCaseTransaction.id, transactionId: byCaseTransaction.transaction_id };
+    }
+
+    return null;
+  }
+
+  private async canCreateFinalEvidenceBundle(orgId: string, approvalId: string, supabase: any): Promise<boolean> {
+    const { data: steps, error } = await supabase
+      .from('finance_approval_steps')
+      .select('status')
+      .eq('org_id', orgId)
+      .eq('approval_request_id', approvalId);
+
+    if (error || !Array.isArray(steps) || steps.length === 0) {
+      return false;
+    }
+
+    return steps.every((step: { status: string }) => step.status === 'approved');
   }
 }

--- a/supabase/migrations/20260424010000_finance_governance_control_layer.sql
+++ b/supabase/migrations/20260424010000_finance_governance_control_layer.sql
@@ -69,13 +69,134 @@ create table if not exists public.finance_export_jobs (
   created_at timestamptz not null default now()
 );
 
-insert into public.finance_transactions (id, org_id, workflow_case_id, vendor, amount, currency, status)
-select c.id, c.org_id, c.id, c.vendor, c.amount, c.currency, c.status
-from public.finance_workflow_cases c
-on conflict (id) do nothing;
+do $$
+begin
+  if to_regclass('public.finance_workflow_cases') is not null then
+    insert into public.finance_transactions (id, org_id, workflow_case_id, vendor, amount, currency, status)
+    select c.id, c.org_id, c.id, c.vendor, c.amount, c.currency, c.status
+    from public.finance_workflow_cases c
+    on conflict (id) do nothing;
+  end if;
 
-insert into public.finance_approval_requests (id, org_id, transaction_id, status, risk)
-select a.id, a.org_id, a.case_id, a.status, a.risk
-from public.finance_workflow_approvals a
-where exists (select 1 from public.finance_transactions t where t.id = a.case_id)
-on conflict (id) do nothing;
+  if to_regclass('public.finance_workflow_approvals') is not null then
+    insert into public.finance_approval_requests (id, org_id, transaction_id, status, risk)
+    select a.id, a.org_id, a.case_id, a.status, a.risk
+    from public.finance_workflow_approvals a
+    where exists (select 1 from public.finance_transactions t where t.id = a.case_id)
+    on conflict (id) do nothing;
+  end if;
+end $$;
+
+create index if not exists idx_finance_transactions_org_status
+  on public.finance_transactions (org_id, status, updated_at desc);
+create index if not exists idx_finance_transactions_workflow_case_id
+  on public.finance_transactions (workflow_case_id);
+create index if not exists idx_finance_approval_requests_org_status
+  on public.finance_approval_requests (org_id, status, updated_at desc);
+create index if not exists idx_finance_approval_requests_org_transaction
+  on public.finance_approval_requests (org_id, transaction_id);
+create index if not exists idx_finance_approval_steps_org_approval
+  on public.finance_approval_steps (org_id, approval_request_id, step_order);
+create index if not exists idx_finance_approval_decisions_org_approval
+  on public.finance_approval_decisions (org_id, approval_request_id, created_at desc);
+create index if not exists idx_finance_exceptions_org_approval
+  on public.finance_exceptions (org_id, approval_request_id, created_at desc);
+create index if not exists idx_finance_evidence_bundles_org_approval
+  on public.finance_evidence_bundles (org_id, approval_request_id, created_at desc);
+
+alter table public.finance_transactions
+  add constraint finance_transactions_amount_nonnegative check (amount >= 0) not valid;
+alter table public.finance_transactions validate constraint finance_transactions_amount_nonnegative;
+
+alter table public.finance_approval_requests
+  add constraint finance_approval_requests_status_valid
+  check (status in ('pending', 'approved', 'rejected', 'escalated', 'in_review')) not valid;
+alter table public.finance_approval_requests validate constraint finance_approval_requests_status_valid;
+
+alter table public.finance_approval_steps
+  add constraint finance_approval_steps_status_valid
+  check (status in ('pending', 'approved', 'rejected', 'skipped', 'in_progress')) not valid;
+alter table public.finance_approval_steps validate constraint finance_approval_steps_status_valid;
+
+alter table public.finance_approval_decisions
+  add constraint finance_approval_decisions_decision_valid
+  check (decision in ('approve', 'reject', 'escalate')) not valid;
+alter table public.finance_approval_decisions validate constraint finance_approval_decisions_decision_valid;
+
+alter table public.finance_exceptions
+  add constraint finance_exceptions_status_valid check (status in ('open', 'resolved')) not valid;
+alter table public.finance_exceptions validate constraint finance_exceptions_status_valid;
+
+alter table public.finance_evidence_bundles
+  add constraint finance_evidence_bundles_status_valid check (status in ('ready', 'building', 'failed')) not valid;
+alter table public.finance_evidence_bundles validate constraint finance_evidence_bundles_status_valid;
+
+create or replace function public.set_finance_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_finance_transactions_updated_at on public.finance_transactions;
+create trigger trg_finance_transactions_updated_at
+before update on public.finance_transactions
+for each row execute function public.set_finance_updated_at();
+
+drop trigger if exists trg_finance_approval_requests_updated_at on public.finance_approval_requests;
+create trigger trg_finance_approval_requests_updated_at
+before update on public.finance_approval_requests
+for each row execute function public.set_finance_updated_at();
+
+alter table public.finance_transactions enable row level security;
+alter table public.finance_approval_requests enable row level security;
+alter table public.finance_approval_steps enable row level security;
+alter table public.finance_approval_decisions enable row level security;
+alter table public.finance_exceptions enable row level security;
+alter table public.finance_evidence_bundles enable row level security;
+alter table public.finance_export_jobs enable row level security;
+
+drop policy if exists finance_transactions_org_select on public.finance_transactions;
+create policy finance_transactions_org_select
+on public.finance_transactions
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));
+
+drop policy if exists finance_approval_requests_org_select on public.finance_approval_requests;
+create policy finance_approval_requests_org_select
+on public.finance_approval_requests
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));
+
+drop policy if exists finance_approval_steps_org_select on public.finance_approval_steps;
+create policy finance_approval_steps_org_select
+on public.finance_approval_steps
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));
+
+drop policy if exists finance_approval_decisions_org_select on public.finance_approval_decisions;
+create policy finance_approval_decisions_org_select
+on public.finance_approval_decisions
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));
+
+drop policy if exists finance_exceptions_org_select on public.finance_exceptions;
+create policy finance_exceptions_org_select
+on public.finance_exceptions
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));
+
+drop policy if exists finance_evidence_bundles_org_select on public.finance_evidence_bundles;
+create policy finance_evidence_bundles_org_select
+on public.finance_evidence_bundles
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));

--- a/tests/unit/finance-governance-repository.test.ts
+++ b/tests/unit/finance-governance-repository.test.ts
@@ -28,6 +28,9 @@ function buildClient() {
             }
             return Promise.resolve({ data: { id: 'sample-case', status: 'pending', export_status: 'Ready', vendor: 'v', amount: 1, currency: 'USD', workflow: 'wf' } });
           }
+          if (table === 'finance_approval_requests') {
+            return Promise.resolve({ data: { id: 'APR-1001', transaction_id: 'sample-case' } });
+          }
           return Promise.resolve({ data: { case_id: 'sample-case' } });
         },
         upsert(payload: unknown) {


### PR DESCRIPTION
### Motivation

- Prevent a false-positive readiness gate by correctly parsing `DSG_FINANCE_GOVERNANCE_ENABLED` so `false` is treated as disabled.  
- Make the finance control-layer migration safe to run on fresh Supabase projects and strengthen schema safety for enterprise launch.  
- Fix ID-mapping and evidence timing bugs so approval actions update the correct transaction rows and final evidence bundles are only created when all required approval steps are complete.

### Description

- Fixed readiness parsing by adding `parseBooleanFlag` and using it for `DSG_FINANCE_GOVERNANCE_ENABLED` in `lib/deployment/readiness.ts` so string values like `"false"` are handled correctly.  
- Introduced a centralized finance-governance API error helper `handleFinanceGovernanceApiError` in `lib/finance-governance/api-error.ts` and updated finance endpoints to use it so known domain errors (`missing_org_id`, `case_not_found`, `approval_not_found`) return explicit statuses while unknown/internal errors are routed through the safe error handler.  
- Hardened repository logic in `lib/finance-governance/repository.ts` by adding approval ↔ transaction mapping functions (`resolveApprovalMapping`, `resolveApprovalReference`, `resolveApprovalRequestId`), updating `getCaseDetail`, `getDecisions`, `getExceptions`, `getEvidenceBundles`, and `applyAction` to resolve IDs correctly, and deferring final evidence bundle creation until `canCreateFinalEvidenceBundle` confirms all steps are `approved`.  
- Made the control-layer migration in `supabase/migrations/20260424010000_finance_governance_control_layer.sql` resilient by guarding legacy backfills with `to_regclass(...)`, and added indexes, constraints, `updated_at` triggers, and org-scoped authenticated RLS select policies.  
- Added a short PR body doc at `docs/pr/PR_FINAL_ENTERPRISE_LAUNCH_HARDENING.md` and updated the unit test mock in `tests/unit/finance-governance-repository.test.ts` to exercise the new mapping path; updated finance-governance routes to import and call the new error helper.

### Testing

- Ran `git diff --check` and `git diff --cached --check`; both passed.  
- Ran unit tests for the modified repository: `npm run -s test -- tests/unit/finance-governance-repository.test.ts` and the tests passed.  
- Ran `npm run -s test -- tests/migrations/finance-governance-control-layer.test.ts tests/integration/api/finance-governance-api.test.ts` and both migration and integration tests passed.  
- Note: a full `npm ci && npm run typecheck && npm test && npm run build` was not executed in this environment due to dependency install constraints; subset tests above were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eaeaf3dbc88326840f34d7fe0f5ff9)