### PR TITLE
Fix go-no-go legacy endpoint scan false positive

### DIFF
--- a/scripts/go-no-go-gate.sh
+++ b/scripts/go-no-go-gate.sh
@@ -48,7 +48,7 @@ else
   failures=$((failures + 1))
 fi
 
-if rg -n '/api/finance-governance/server-store/' app lib components scripts; then
+if rg -n --glob '!scripts/go-no-go-gate.sh' '/api/finance-governance/server-store/' app lib components scripts; then
   echo "❌ Legacy server-store caller(s) found"
   failures=$((failures + 1))
 else


### PR DESCRIPTION
## Summary
- fixes the `go-no-go` release gate so it does not match the scan pattern inside `scripts/go-no-go-gate.sh` itself
- preserves the broader readiness scan while removing the self-hit that can force a false `NO-GO`

## Why
PR #367 widened the legacy endpoint scan to include `components` and `scripts`, which improved coverage but also caused the gate script to find its own literal search pattern. That makes the readiness gate increment `failures` even when there are no real legacy callers left in the app.

## Problem
- current behavior can report `NO-GO` even when the repository is actually clean
- this is a release-gate correctness issue, not just a cosmetic script issue
- the bug affects trust in the final production readiness check

## Proposed fix
- exclude `scripts/go-no-go-gate.sh` from the `rg` search while keeping `components` and other real caller paths in scope
- keep the legacy endpoint detection strict for real callers

## Validation
- `bash -n scripts/go-no-go-gate.sh`
- run the legacy endpoint scan directly and confirm it no longer returns the gate script itself
- run `./scripts/go-no-go-gate.sh <url>` against the deployed target after the fix lands

## Risk
- low implementation risk
- high release value because this restores trust in the final go/no-go verdict

## Related context
- follow-up to #367: `Harden protected routes and split AppShell into server wrapper + client`
- closes the remaining release-gate correctness blocker before open launch