### PR TITLE
Bound health and readiness dependency checks with timeouts

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,8 +1,40 @@
 import { getDSGCoreHealth } from '../../../lib/dsg-core';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
-import { getDeploymentReadiness } from '../../../lib/deployment/readiness';
+import { getDeploymentReadiness, type ReadinessReport } from '../../../lib/deployment/readiness';
 import { handleApiError } from '../../../lib/security/api-error';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../lib/security/rate-limit';
+
+const HEALTH_TIMEOUT_MS = 5_000;
+const UNAVAILABLE_CHECK = { ok: false, detail: 'health_dependency_unavailable' };
+
+async function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = HEALTH_TIMEOUT_MS): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label}_timeout`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function unavailableReadiness(detail: string): ReadinessReport {
+  return {
+    ok: false,
+    checks: {
+      env: UNAVAILABLE_CHECK,
+      nextAuthSecret: UNAVAILABLE_CHECK,
+      supabaseServiceRole: { ok: false, detail },
+      dsgCoreConfig: { ok: false, detail },
+      dsgCoreHealth: { ok: false, detail },
+      financeGovernanceSurface: UNAVAILABLE_CHECK,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
 
 export async function GET(request: Request) {
   try {
@@ -18,20 +50,36 @@ export async function GET(request: Request) {
       );
     }
 
-
     let dbOk = false;
     try {
       const admin = getSupabaseAdmin();
-      const { error: dbError } = await admin.from('organizations').select('id').limit(1);
+      const { error: dbError } = await withTimeout(
+        admin.from('organizations').select('id').limit(1),
+        'health_db'
+      );
       dbOk = !dbError;
     } catch {
       dbOk = false;
     }
 
-    const [core, readiness] = await Promise.all([
-      getDSGCoreHealth(),
-      getDeploymentReadiness(),
+    const [coreResult, readinessResult] = await Promise.allSettled([
+      withTimeout(getDSGCoreHealth(), 'health_core'),
+      withTimeout(getDeploymentReadiness(), 'health_readiness', 7_000),
     ]);
+
+    const core = coreResult.status === 'fulfilled'
+      ? coreResult.value
+      : {
+          ok: false,
+          error: coreResult.reason instanceof Error ? coreResult.reason.message : 'core_unreachable',
+        };
+
+    const readiness = readinessResult.status === 'fulfilled'
+      ? readinessResult.value
+      : unavailableReadiness(
+          readinessResult.reason instanceof Error ? readinessResult.reason.message : 'readiness_unavailable'
+        );
+
     const coreDetails = core as {
       status?: unknown;
       version?: unknown;

--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -19,6 +19,8 @@ export type ReadinessReport = {
   timestamp: string;
 };
 
+const READINESS_TIMEOUT_MS = 5_000;
+
 function buildCheck(ok: boolean, detail?: string): CheckResult {
   return { ok, ...(detail ? { detail } : {}) };
 }
@@ -31,6 +33,20 @@ function parseBooleanFlag(value: string | undefined, fallback: boolean) {
   return fallback;
 }
 
+async function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = READINESS_TIMEOUT_MS): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label}_timeout`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export async function getDeploymentReadiness(): Promise<ReadinessReport> {
   const requiredEnv = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'DSG_CORE_MODE'];
   const missingEnv = requiredEnv.filter((name) => !process.env[name]);
@@ -41,7 +57,10 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
   let supabaseServiceRole = buildCheck(false, 'not_checked');
   try {
     const admin = getSupabaseAdmin() as any;
-    const { error } = await admin.from('organizations').select('id').limit(1);
+    const { error } = await withTimeout(
+      admin.from('organizations').select('id').limit(1),
+      'supabase_service_role'
+    );
     supabaseServiceRole = buildCheck(!error, error?.message);
   } catch (error) {
     supabaseServiceRole = buildCheck(false, error instanceof Error ? error.message : 'supabase_unreachable');
@@ -55,7 +74,10 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
     const missingRemoteUrl = config.mode === 'remote' && !config.url;
     dsgCoreConfig = buildCheck(!missingRemoteUrl, missingRemoteUrl ? 'DSG_CORE_URL missing for remote mode' : undefined);
 
-    const health = await getDSGCoreHealth() as Record<string, unknown>;
+    const health = await withTimeout(
+      getDSGCoreHealth() as Promise<Record<string, unknown>>,
+      'dsg_core_health'
+    );
     dsgCoreHealth = buildCheck(Boolean(health.ok), health.ok ? undefined : String(health.error ?? 'core_unreachable'));
   } catch (error) {
     const message = error instanceof Error ? error.message : 'dsg_core_unreachable';


### PR DESCRIPTION
## Summary
- adds explicit timeouts around readiness dependencies so `/api/readiness` fails fast instead of hanging when DSG core or Supabase stalls
- keeps `/api/health` responsive by bounding its DB/core/readiness checks and returning structured unhealthy output when dependencies are unavailable

## Why
The production site currently serves the public finance-governance surface, but the release gate is still blocked because `/api/health` and `/api/readiness` can stall instead of returning a usable verdict. That makes launch validation ambiguous and slows incident diagnosis.

## What changed
- added a timeout helper inside `lib/deployment/readiness.ts`
- bounded the Supabase service-role check and DSG core health check during readiness evaluation
- updated `app/api/health/route.ts` to bound DB, core, and readiness checks and fall back to a structured unhealthy payload instead of hanging

## Expected result
- `/api/readiness` should return a concrete JSON result within a bounded time window
- `/api/health` should return a concrete JSON result within a bounded time window
- go/no-go should now fail clearly on dependency health instead of timing out ambiguously

## Risk
- low to moderate
- behavior changes only affect failure mode and latency bounds for health/readiness checks
- healthy environments should continue to pass normally

## Validation
- hit `/api/readiness` and confirm it returns promptly
- hit `/api/health` and confirm it returns promptly
- rerun `./scripts/go-no-go-gate.sh <production-url>` after deployment

## Release context
- follow-up to the launch baseline already merged on `main`
- intended to unblock the final production launch verdict