### PR TITLE
Fix readiness timeout Supabase probe typing

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -6,6 +6,9 @@ import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../..
 
 const HEALTH_TIMEOUT_MS = 5_000;
 const UNAVAILABLE_CHECK = { ok: false, detail: 'health_dependency_unavailable' };
+type SupabaseProbeResult = {
+  error: { message?: string } | null;
+};
 
 async function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = HEALTH_TIMEOUT_MS): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -53,10 +56,11 @@ export async function GET(request: Request) {
     let dbOk = false;
     try {
       const admin = getSupabaseAdmin();
-      const { error: dbError } = await withTimeout(
-        admin.from('organizations').select('id').limit(1),
+      const dbResult = await withTimeout<SupabaseProbeResult>(
+        admin.from('organizations').select('id').limit(1) as Promise<SupabaseProbeResult>,
         'health_db'
       );
+      const dbError = dbResult.error;
       dbOk = !dbError;
     } catch {
       dbOk = false;

--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -20,6 +20,9 @@ export type ReadinessReport = {
 };
 
 const READINESS_TIMEOUT_MS = 5_000;
+type SupabaseProbeResult = {
+  error: { message?: string } | null;
+};
 
 function buildCheck(ok: boolean, detail?: string): CheckResult {
   return { ok, ...(detail ? { detail } : {}) };
@@ -57,10 +60,11 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
   let supabaseServiceRole = buildCheck(false, 'not_checked');
   try {
     const admin = getSupabaseAdmin() as any;
-    const { error } = await withTimeout(
-      admin.from('organizations').select('id').limit(1),
+    const probeResult = await withTimeout<SupabaseProbeResult>(
+      admin.from('organizations').select('id').limit(1) as Promise<SupabaseProbeResult>,
       'supabase_service_role'
     );
+    const error = probeResult.error;
     supabaseServiceRole = buildCheck(!error, error?.message);
   } catch (error) {
     supabaseServiceRole = buildCheck(false, error instanceof Error ? error.message : 'supabase_unreachable');


### PR DESCRIPTION
## Summary
- fixes the TypeScript build error introduced by the readiness/health timeout follow-up
- makes the Supabase probe result explicit so `.error` is read from a typed object instead of an inferred `{}`

## Why
The latest Vercel build failed with:

`Type error: Property 'error' does not exist on type '{}'`

That failure occurs because `withTimeout(...)` did not preserve enough type information for the Supabase probe result in two places.

## What changed
- added a local `SupabaseProbeResult` type in `app/api/health/route.ts`
- added a local `SupabaseProbeResult` type in `lib/deployment/readiness.ts`
- replaced direct destructuring from `await withTimeout(...)` with a typed intermediate result before reading `.error`

## Expected result
- `npm run build` should get past the current TypeScript error
- the timeout-based readiness and health behavior from PR #369 stays intact

## Validation
- rerun Vercel build for the current production deployment
- confirm the previous `Property 'error' does not exist on type '{}'` error is gone
- recheck `/api/health`, `/api/readiness`, and live go/no-go after deploy

## Release context
- follow-up to PR #369
- intended to unblock the final production deployment