### PR TITLE
Add Vercel Production CLI bypass GitHub Action and runbook instructions

### DIFF
--- a/.github/workflows/vercel-prod-cli-bypass.yml
+++ b/.github/workflows/vercel-prod-cli-bypass.yml
@@ -1,0 +1,113 @@
+name: Vercel Production CLI Bypass
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to deploy (branch, tag, or SHA)'
+        required: true
+        default: 'main'
+      reason:
+        description: 'Why this bypass deploy is needed'
+        required: true
+        default: 'Unverified-commit gate blocked Git integration deploys'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vercel-prod-cli-bypass
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Production via Vercel CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - name: Guardrail (main only)
+        if: ${{ github.event.inputs.ref != 'main' }}
+        run: |
+          echo "Only ref=main is permitted for this production bypass workflow."
+          exit 1
+
+      - name: Validate required secrets
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          missing=0
+          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!key}" ]; then
+              echo "Missing secret: $key"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pull Vercel project settings
+        run: npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build prebuilt artifacts
+        run: npx vercel build --prod --token="${{ secrets.VERCEL_TOKEN }}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to production
+        id: deploy
+        run: |
+          url=$(npx vercel deploy --prebuilt --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          echo "deployment_url=$url" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Health check (/api/health)
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+        run: |
+          endpoint="${DEPLOYMENT_URL%/}/api/health"
+          echo "Checking $endpoint"
+          for attempt in 1 2 3 4 5; do
+            if curl -fsS "$endpoint" | tee /tmp/health.json | grep -q '"ok"[[:space:]]*:[[:space:]]*true'; then
+              echo "Health check passed on attempt $attempt"
+              exit 0
+            fi
+            echo "Health check failed on attempt $attempt, retrying..."
+            sleep 5
+          done
+          echo "Health check did not return ok:true"
+          exit 1
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "### Vercel production deploy (CLI bypass)"
+            echo ""
+            echo "- Ref: ${{ github.event.inputs.ref }}"
+            echo "- Reason: ${{ github.event.inputs.reason }}"
+            echo "- Deployment URL: ${{ steps.deploy.outputs.deployment_url }}"
+            echo "- Health endpoint: ${{ steps.deploy.outputs.deployment_url }}/api/health"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RUNBOOK_DEPLOY.md
+++ b/docs/RUNBOOK_DEPLOY.md
@@ -108,6 +108,27 @@ Use this checklist:
    - temporarily disable `Require Verified Commits` (only with explicit approval).
 5. Redeploy only after commit verification is fixed; otherwise cancellation will repeat.
 
+
+### Emergency bypass with GitHub Actions (no Vercel Git integration)
+If Git integration keeps canceling deployment before build (for example from `Require Verified Commits`), run the manual workflow:
+- **GitHub Actions → `Vercel Production CLI Bypass` → Run workflow**
+- Input `ref` must be `main` (workflow guardrail blocks non-main refs for production).
+- This workflow deploys with Vercel CLI (`vercel pull` + `vercel build` + `vercel deploy --prebuilt --prod`) and does not depend on Vercel Git checks.
+
+Required GitHub repository secrets:
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+Workflow behavior:
+1. Fails fast if required secrets are missing.
+2. Deploys the selected `main` ref to production.
+3. Runs `/api/health` check automatically and requires `ok: true`.
+4. Publishes deployment URL + health endpoint in workflow summary.
+
+After workflow success:
+1. Continue with production gate checks (`Production Readiness Check` / `go-no-go`).
+
 ### CLI-first recovery when deployment is canceled
 If the unverified commit issue cannot be resolved immediately, use Vercel CLI to deploy directly:
 


### PR DESCRIPTION
### Motivation
- Provide an emergency path to deploy to Vercel when Vercel Git integration blocks builds (e.g. `Require Verified Commits` causing "unverified commit" cancellations).
- Document the manual bypass procedure in the deployment runbook so on-call engineers can run a vetted workflow instead of ad-hoc CLI commands.

### Description
- Add `/.github/workflows/vercel-prod-cli-bypass.yml`, a `workflow_dispatch` job that accepts `ref` and `reason`, validates required secrets, and only permits `ref=main` as a guardrail.
- The workflow checks out the requested ref, sets up Node.js, runs `npx vercel pull`, `npx vercel build --prod`, and `npx vercel deploy --prebuilt --prod`, then exposes the deployment URL as an output.
- The workflow performs a health check against `/api/health` (up to 5 attempts) and fails if the endpoint does not return `ok: true`, and writes a deployment summary to the GitHub step summary.
- Update `docs/RUNBOOK_DEPLOY.md` with an "Emergency bypass" section that explains how to run the `Vercel Production CLI Bypass` workflow, required secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`), workflow behavior, and follow-up steps.

### Testing
- No automated tests were executed for this change; the workflow is intended to be triggered manually via `workflow_dispatch` for emergency use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebc8206f788326ae5d63f20706db4b)