### PR TITLE
docs: expand Vercel CLI bypass closeout checklist

### DIFF
--- a/docs/RUNBOOK_DEPLOY.md
+++ b/docs/RUNBOOK_DEPLOY.md
@@ -127,7 +127,22 @@ Workflow behavior:
 4. Publishes deployment URL + health endpoint in workflow summary.
 
 After workflow success:
-1. Continue with production gate checks (`Production Readiness Check` / `go-no-go`).
+1. Capture `Deployment URL` and `Health endpoint` from the workflow summary for incident log/audit.
+2. Verify the production alias points to the new deployment (Vercel dashboard or `vercel ls`).
+3. Re-check health endpoint manually:
+
+```bash
+curl -fsSL "<deployment-url>/api/health"
+```
+
+4. Continue with production gate checks (`Production Readiness Check` / `go-no-go`).
+
+#### One-run closeout checklist (recommended)
+Use this when Vercel Git integration keeps returning `CANCELED` before build:
+1. Run **Vercel Production CLI Bypass** on `main`.
+2. Confirm workflow steps complete: `npm ci` → `vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod`.
+3. Confirm workflow health gate is green (`/api/health` contains `ok: true`).
+4. Record the summary links (`Deployment URL`, `Health endpoint`) in the ticket/incident.
 
 ### CLI-first recovery when deployment is canceled
 If the unverified commit issue cannot be resolved immediately, use Vercel CLI to deploy directly:


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable closeout sequence after using the GitHub Actions `Vercel Production CLI Bypass` workflow when Vercel Git integration cancels deployments before build. 
- Reduce incident ambiguity by documenting the exact evidence and verification steps operators must collect after the bypass succeeds.

### Description
- Update `docs/RUNBOOK_DEPLOY.md` to capture `Deployment URL` and `Health endpoint` from the workflow summary for audit purposes. 
- Add an explicit verification step to ensure the production alias points to the new deployment (dashboard or `vercel ls`) and a manual health re-check using `curl -fsSL "<deployment-url>/api/health"`. 
- Introduce a `One-run closeout checklist (recommended)` that lists the required sequence to close incidents where Vercel Git integration returns `CANCELED` before build. 
- This change is docs-only and modifies `docs/RUNBOOK_DEPLOY.md`.

### Testing
- Docs-only change; no unit/integration code paths modified and no new runtime tests required. 
- Verified the updated section with text checks (`rg` for key phrases) and inspected the file region with `nl -ba docs/RUNBOOK_DEPLOY.md | sed -n '108,170p'`, and committed the change. 
- Repository test status remains unchanged (Vitest suite previously reported `85 tests` across `41` files with `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebd6d795b08326b5ff63ad9a89559f)