### PR TITLE
ci: simplify launch readiness workflow after merge

### DIFF
--- a/.github/workflows/launch-readiness.yml
+++ b/.github/workflows/launch-readiness.yml
@@ -2,12 +2,12 @@ name: launch-readiness
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: launch-readiness-${{ github.workflow }}-${{ github.ref }}
@@ -21,91 +21,26 @@ jobs:
       CI: true
       NEXT_TELEMETRY_DISABLED: 1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
 
-      - name: Run launch readiness diagnostics
-        id: diagnostics
-        shell: bash
-        run: |
-          set +e
-          rm -f launch-readiness-report.md launch-readiness-summary.md
+      - name: Install dependencies
+        run: npm ci
 
-          run_check() {
-            local name="$1"
-            shift
-            local log_file="launch-${name}.log"
-            echo "## ${name}" >> launch-readiness-report.md
-            echo '```text' >> launch-readiness-report.md
-            "$@" > "${log_file}" 2>&1
-            local status=$?
-            tail -n 80 "${log_file}" >> launch-readiness-report.md
-            echo '```' >> launch-readiness-report.md
-            echo "exit_code=${status}" >> launch-readiness-report.md
-            echo "" >> launch-readiness-report.md
-            echo "${name}=${status}" >> "$GITHUB_OUTPUT"
-            return 0
-          }
+      - name: Typecheck
+        run: npm run typecheck
 
-          run_check npm_ci npm ci
-          npm_ci_status=$?
-          npm_ci_status=$(grep '^npm_ci=' "$GITHUB_OUTPUT" | tail -n 1 | cut -d= -f2)
+      - name: Test
+        run: npm test
 
-          run_check typecheck npm run typecheck
-          typecheck_status=$(grep '^typecheck=' "$GITHUB_OUTPUT" | tail -n 1 | cut -d= -f2)
+      - name: Build
+        run: npm run build
 
-          run_check test npm test
-          test_status=$(grep '^test=' "$GITHUB_OUTPUT" | tail -n 1 | cut -d= -f2)
-
-          run_check build npm run build
-          build_status=$(grep '^build=' "$GITHUB_OUTPUT" | tail -n 1 | cut -d= -f2)
-
-          run_check manifest npm run verify:production-manifest
-          manifest_status=$(grep '^manifest=' "$GITHUB_OUTPUT" | tail -n 1 | cut -d= -f2)
-
-          {
-            echo "### Launch readiness diagnostic summary"
-            echo ""
-            echo "| Check | Exit |"
-            echo "| --- | ---: |"
-            echo "| npm ci | ${npm_ci_status:-missing} |"
-            echo "| typecheck | ${typecheck_status:-missing} |"
-            echo "| test | ${test_status:-missing} |"
-            echo "| build | ${build_status:-missing} |"
-            echo "| manifest | ${manifest_status:-missing} |"
-          } > launch-readiness-summary.md
-
-      - name: Comment launch readiness diagnostics
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const summary = fs.readFileSync('launch-readiness-summary.md', 'utf8');
-            const details = fs.readFileSync('launch-readiness-report.md', 'utf8');
-            const body = `${summary}\n\n<details><summary>Command output tails</summary>\n\n${details}\n</details>`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-
-      - name: Enforce launch readiness gate
-        shell: bash
-        run: |
-          failed=0
-          for status in \
-            "${{ steps.diagnostics.outputs.npm_ci }}" \
-            "${{ steps.diagnostics.outputs.typecheck }}" \
-            "${{ steps.diagnostics.outputs.test }}" \
-            "${{ steps.diagnostics.outputs.build }}" \
-            "${{ steps.diagnostics.outputs.manifest }}"; do
-            if [ "$status" != "0" ]; then
-              failed=1
-            fi
-          done
-          exit "$failed"
+      - name: Production manifest gate
+        run: npm run verify:production-manifest


### PR DESCRIPTION
## Summary
- Simplify `launch-readiness` back to a normal GitHub Actions job with real steps/logs.
- Keep the production manifest gate after Linux build.
- Add `push` on `main` so launch-readiness validates merged code too.
- Remove PR comment diagnostics because the workflow was failing too early and producing empty/no logs.

## Why
After PR #374 was merged, GitHub Checks showed workflow failures after ~2s with no steps/logs available through the API. This patch reduces workflow complexity so failures occur inside normal steps with readable logs.

## Gate status
This does not deploy production. Market launch remains NO-GO until Linux CI, Vercel build, `/api/health`, `/api/readiness`, and go/no-go pass.