### PR TITLE
M1: Customer-usable flow (remove mock + bind org + real workflow)

### DIFF
--- a/app/api/cases/route.ts
+++ b/app/api/cases/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { getOrg } from '../../../lib/server/getOrg';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { handleApiError } from '../../../lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+async function hasTable(admin: any, table: string) {
+  const { error } = await admin.from(table).select('id').limit(1);
+  return !error;
+}
+
+export async function GET() {
+  try {
+    const orgId = await getOrg();
+    const admin = getSupabaseAdmin() as any;
+
+    if (await hasTable(admin, 'finance_workflow_cases')) {
+      const { data, error } = await admin
+        .from('finance_workflow_cases')
+        .select('id,status,vendor,amount,currency,workflow,updated_at,created_at')
+        .eq('org_id', orgId)
+        .order('updated_at', { ascending: false });
+
+      if (error) {
+        throw error;
+      }
+
+      return NextResponse.json({ cases: data ?? [] });
+    }
+
+    const { data, error } = await admin
+      .from('finance_transactions')
+      .select('id,status,vendor,amount,currency,workflow_case_id,updated_at,created_at')
+      .eq('org_id', orgId)
+      .order('updated_at', { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    const cases = (data ?? []).map((item: any) => ({
+      id: item.workflow_case_id || item.id,
+      status: item.status,
+      vendor: item.vendor,
+      amount: item.amount,
+      currency: item.currency,
+      workflow: 'Finance governance control layer',
+      updated_at: item.updated_at,
+      created_at: item.created_at,
+    }));
+
+    return NextResponse.json({ cases });
+  } catch (error) {
+    return handleApiError('api/cases', error);
+  }
+}

--- a/app/api/finance-governance/approvals/route.ts
+++ b/app/api/finance-governance/approvals/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
-import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/repository';
+import { getOrg } from '../../../../lib/server/getOrg';
 
 export const dynamic = 'force-dynamic';
 
 const repository = new FinanceGovernanceRepository();
 
-export async function GET(request: Request) {
+export async function GET() {
   try {
-    const orgId = resolveOrgId(request);
+    const orgId = await getOrg();
     const approvals = await repository.getApprovals(orgId);
     return NextResponse.json({ approvals });
   } catch (error) {

--- a/app/api/finance-governance/onboarding/route.ts
+++ b/app/api/finance-governance/onboarding/route.ts
@@ -1,15 +1,60 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
-import { getOnboardingSteps } from '../../../../lib/finance-governance/mock-data';
-import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
+import { getOrg } from '../../../../lib/server/getOrg';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
+type ChecklistPayload = {
+  steps?: Array<string | { id?: string; label?: string; status?: 'todo' | 'in_progress' | 'done' }>;
+  next_action?: string;
+} | null;
+
+function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: string | null | undefined) {
+  const rawSteps = Array.isArray(checklist?.steps) ? checklist.steps : [];
+
+  return rawSteps.map((step, index) => {
+    if (typeof step === 'string') {
+      return {
+        id: `step-${index + 1}`,
+        label: step,
+        status: bootstrapStatus === 'completed' ? 'done' : index === 0 ? 'in_progress' : 'todo',
+      };
+    }
+
+    return {
+      id: step.id || `step-${index + 1}`,
+      label: step.label || `Step ${index + 1}`,
+      status:
+        step.status ||
+        (bootstrapStatus === 'completed' ? 'done' : index === 0 ? 'in_progress' : 'todo'),
+    };
+  });
+}
+
+export async function GET() {
   try {
-    resolveOrgId(request);
+    const orgId = await getOrg();
+    const admin = getSupabaseAdmin() as any;
+    const { data, error } = await admin
+      .from('org_onboarding_states')
+      .select('bootstrap_status, checklist, bootstrapped_at')
+      .eq('org_id', orgId)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    const steps = mapChecklistToSteps(data?.checklist ?? null, data?.bootstrap_status);
+    const completedCount = steps.filter((step) => step.status === 'done').length;
+    const progress = steps.length === 0 ? 0 : completedCount / steps.length;
+
     return NextResponse.json({
-      steps: getOnboardingSteps(),
+      steps,
+      progress,
+      nextAction: data?.checklist?.next_action ?? null,
+      onboarding: data ?? null,
     });
   } catch (error) {
     return handleFinanceGovernanceApiError('api/finance-governance', error);

--- a/app/api/finance-governance/submit/route.ts
+++ b/app/api/finance-governance/submit/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
 import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/repository';
-import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
+import { getOrg } from '../../../../lib/server/getOrg';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,9 +9,14 @@ const repository = new FinanceGovernanceRepository();
 
 export async function POST(request: Request) {
   try {
-    const orgId = resolveOrgId(request);
+    const orgId = await getOrg();
     const body = await request.json().catch(() => null);
-    const caseId = typeof body?.caseId === 'string' && body.caseId.trim().length > 0 ? body.caseId.trim() : 'sample-case';
+    const caseId = typeof body?.caseId === 'string' && body.caseId.trim().length > 0 ? body.caseId.trim() : '';
+
+    if (!caseId) {
+      return NextResponse.json({ error: 'caseId is required' }, { status: 400 });
+    }
+
     const result = await repository.submit(orgId, caseId);
     return NextResponse.json(result, { status: 200 });
   } catch (error) {

--- a/app/api/finance-governance/workspace/summary/route.ts
+++ b/app/api/finance-governance/workspace/summary/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../../lib/finance-governance/api-error';
-import { resolveOrgId } from '../../../../../lib/finance-governance/org-scope';
 import { FinanceGovernanceRepository } from '../../../../../lib/finance-governance/repository';
+import { getOrg } from '../../../../../lib/server/getOrg';
 
 export const dynamic = 'force-dynamic';
 
 const repository = new FinanceGovernanceRepository();
 
-export async function GET(request: Request) {
+export async function GET() {
   try {
-    const orgId = resolveOrgId(request);
+    const orgId = await getOrg();
     const workspace = await repository.getWorkspaceSummary(orgId);
     return NextResponse.json({ workspace });
   } catch (error) {

--- a/app/finance-governance/live/request.ts
+++ b/app/finance-governance/live/request.ts
@@ -1,28 +1,3 @@
-const ORG_STORAGE_KEY = 'finance-governance-org-id';
-
-function resolveOrgId() {
-  if (typeof window === 'undefined') {
-    return '';
-  }
-
-  const overrideOrgId = window.localStorage.getItem(ORG_STORAGE_KEY)?.trim();
-  if (overrideOrgId) {
-    return overrideOrgId;
-  }
-
-  const htmlOrgId = document.documentElement.getAttribute('data-org-id')?.trim();
-  return htmlOrgId || '';
-}
-
 export function financeGovernanceFetch(input: string | URL | globalThis.Request, init: RequestInit = {}) {
-  const headers = new Headers(init.headers);
-  const orgId = resolveOrgId();
-  if (orgId) {
-    headers.set('x-org-id', orgId);
-  }
-
-  return fetch(input, {
-    ...init,
-    headers,
-  });
+  return fetch(input, init);
 }

--- a/app/finance-governance/live/workflow/page.tsx
+++ b/app/finance-governance/live/workflow/page.tsx
@@ -24,6 +24,19 @@ type ApprovalsResponse = {
   }>;
 };
 
+type CaseItem = {
+  id: string;
+  vendor?: string;
+  amount?: string | number;
+  currency?: string;
+  status?: string;
+  workflow?: string;
+};
+
+type CasesResponse = {
+  cases: CaseItem[];
+};
+
 type ActionResponse = {
   ok: true;
   action: 'submit' | 'approve' | 'reject' | 'escalate';
@@ -41,6 +54,8 @@ type ActionBanner = {
 export default function FinanceGovernanceLiveWorkflowPage() {
   const [workspace, setWorkspace] = useState<WorkspaceSummaryResponse['workspace'] | null>(null);
   const [approvals, setApprovals] = useState<ApprovalsResponse['approvals']>([]);
+  const [cases, setCases] = useState<CaseItem[]>([]);
+  const [selectedCaseId, setSelectedCaseId] = useState('');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
@@ -56,20 +71,25 @@ export default function FinanceGovernanceLiveWorkflowPage() {
       }
       setError('');
 
-      const [workspaceResponse, approvalsResponse] = await Promise.all([
+      const [workspaceResponse, approvalsResponse, casesResponse] = await Promise.all([
         financeGovernanceFetch('/api/finance-governance/workspace/summary', { cache: 'no-store' }),
         financeGovernanceFetch('/api/finance-governance/approvals', { cache: 'no-store' }),
+        financeGovernanceFetch('/api/cases', { cache: 'no-store' }),
       ]);
 
       const workspaceJson = (await workspaceResponse.json()) as WorkspaceSummaryResponse;
       const approvalsJson = (await approvalsResponse.json()) as ApprovalsResponse;
+      const casesJson = (await casesResponse.json()) as CasesResponse;
 
-      if (!workspaceResponse.ok || !approvalsResponse.ok) {
+      if (!workspaceResponse.ok || !approvalsResponse.ok || !casesResponse.ok) {
         throw new Error('Failed to refresh workflow data');
       }
 
+      const nextCases = casesJson.cases ?? [];
       setWorkspace(workspaceJson.workspace);
       setApprovals(approvalsJson.approvals);
+      setCases(nextCases);
+      setSelectedCaseId((current) => current || nextCases[0]?.id || '');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to refresh workflow data');
     } finally {
@@ -87,12 +107,16 @@ export default function FinanceGovernanceLiveWorkflowPage() {
       setBusyKey('submit');
       setBanner(null);
 
+      if (!selectedCaseId) {
+        throw new Error('No workflow case is available to submit. Create or import a case first.');
+      }
+
       const response = await financeGovernanceFetch('/api/finance-governance/submit', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ caseId: 'case-001' }),
+        body: JSON.stringify({ caseId: selectedCaseId }),
       });
       const json = (await response.json()) as ActionResponse;
 
@@ -154,16 +178,35 @@ export default function FinanceGovernanceLiveWorkflowPage() {
         </p>
       </div>
 
-      <div className="mt-8 flex flex-wrap gap-4">
+      <div className="mt-8 grid gap-4 rounded-[1.75rem] border border-white/10 bg-white/5 p-5 md:grid-cols-[1fr_auto_auto] md:items-end">
+        <label className="block">
+          <span className="text-sm font-semibold text-slate-200">Workflow case</span>
+          <select
+            value={selectedCaseId}
+            onChange={(event) => setSelectedCaseId(event.target.value)}
+            disabled={busyKey !== null || cases.length === 0}
+            className="mt-2 w-full rounded-2xl border border-white/10 bg-slate-950 px-4 py-3 text-white disabled:opacity-70"
+          >
+            {cases.length === 0 ? (
+              <option value="">No workflow cases available</option>
+            ) : (
+              cases.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.vendor ? `${item.vendor} - ` : ''}{item.id} {item.status ? `(${item.status})` : ''}
+                </option>
+              ))
+            )}
+          </select>
+        </label>
         <button
           type="button"
           onClick={() => {
             void runSubmit();
           }}
-          disabled={busyKey !== null}
+          disabled={busyKey !== null || !selectedCaseId}
           className="rounded-2xl bg-emerald-400 px-6 py-3 font-semibold text-slate-950 disabled:opacity-70"
         >
-          {busyKey === 'submit' ? 'Submitting...' : 'Submit sample workflow item'}
+          {busyKey === 'submit' ? 'Submitting...' : 'Submit selected workflow item'}
         </button>
         <button
           type="button"

--- a/lib/finance-governance/api-error.ts
+++ b/lib/finance-governance/api-error.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handleApiError } from '../security/api-error';
+import { OrgAuthError } from '../server/getOrg';
 
 const KNOWN_FINANCE_GOVERNANCE_ERRORS: Record<string, number> = {
   missing_org_id: 400,
@@ -8,6 +9,10 @@ const KNOWN_FINANCE_GOVERNANCE_ERRORS: Record<string, number> = {
 };
 
 export function handleFinanceGovernanceApiError(route: string, error: unknown) {
+  if (error instanceof OrgAuthError) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: error.status });
+  }
+
   const message = error instanceof Error ? error.message : 'unknown_error';
   const knownStatus = KNOWN_FINANCE_GOVERNANCE_ERRORS[message];
 

--- a/lib/server/getOrg.ts
+++ b/lib/server/getOrg.ts
@@ -1,0 +1,39 @@
+import { createClient } from '../supabase/server';
+import { getSupabaseAdmin } from '../supabase-server';
+
+export async function getOrg() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user?.id) {
+    throw new Error('unauthorized');
+  }
+
+  const admin = getSupabaseAdmin() as any;
+
+  const profile = await admin
+    .from('users')
+    .select('org_id, is_active')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (profile.data?.org_id && profile.data.is_active !== false) {
+    return String(profile.data.org_id);
+  }
+
+  const orgMembership = await admin
+    .from('org_members')
+    .select('org_id')
+    .eq('auth_user_id', user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (orgMembership.data?.org_id) {
+    return String(orgMembership.data.org_id);
+  }
+
+  throw new Error(profile.error?.message || orgMembership.error?.message || 'unauthorized');
+}

--- a/lib/server/getOrg.ts
+++ b/lib/server/getOrg.ts
@@ -1,6 +1,16 @@
 import { createClient } from '../supabase/server';
 import { getSupabaseAdmin } from '../supabase-server';
 
+export class OrgAuthError extends Error {
+  status: number;
+
+  constructor(message = 'Unauthorized', status = 401) {
+    super(message);
+    this.name = 'OrgAuthError';
+    this.status = status;
+  }
+}
+
 export async function getOrg() {
   const supabase = await createClient();
   const {
@@ -9,7 +19,7 @@ export async function getOrg() {
   } = await supabase.auth.getUser();
 
   if (authError || !user?.id) {
-    throw new Error('unauthorized');
+    throw new OrgAuthError('Unauthorized', 401);
   }
 
   const admin = getSupabaseAdmin() as any;
@@ -20,20 +30,13 @@ export async function getOrg() {
     .eq('auth_user_id', user.id)
     .maybeSingle();
 
-  if (profile.data?.org_id && profile.data.is_active !== false) {
-    return String(profile.data.org_id);
+  if (profile.error) {
+    throw profile.error;
   }
 
-  const orgMembership = await admin
-    .from('org_members')
-    .select('org_id')
-    .eq('auth_user_id', user.id)
-    .limit(1)
-    .maybeSingle();
-
-  if (orgMembership.data?.org_id) {
-    return String(orgMembership.data.org_id);
+  if (!profile.data?.org_id || profile.data.is_active !== true) {
+    throw new OrgAuthError('Unauthorized', 401);
   }
 
-  throw new Error(profile.error?.message || orgMembership.error?.message || 'unauthorized');
+  return String(profile.data.org_id);
 }


### PR DESCRIPTION
## Summary

- remove mock onboarding
- remove hardcoded case id
- bind org from authenticated session
- make workflow write/read real DB state
- make agent perform actions instead of chat-only behavior

## Target flow

login -> onboarding -> live workflow -> dashboard -> audit

## Acceptance

- login แล้วเห็น onboarding จริง
- submit/approve/reject ได้จริง
- dashboard ตรงกับ DB
- audit trace มี
- ไม่มี `case-001` hardcode
- ไม่มี `x-org-id` manual ใน main flow

## Notes

This PR branch already existed, so I opened the PR from the existing `fix/customer-usable-flow` branch. The current main branch still has evidence of the gaps this PR is meant to close: `app/api/finance-governance/onboarding/route.ts` uses `getOnboardingSteps()` from mock data, `lib/finance-governance/org-scope.ts` requires `x-org-id`, and `app/finance-governance/live/workflow/page.tsx` submits `case-001`.