### PR TITLE
Add pricing + upgrade CTA (paid plan scaffold)

### DIFF
--- a/app/api/release-gate/checkout/route.ts
+++ b/app/api/release-gate/checkout/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(_req: NextRequest) {
+  // Placeholder until Stripe keys are configured.
+  return NextResponse.json({
+    error: 'stripe_not_configured',
+    message: 'Set STRIPE_SECRET_KEY and STRIPE_PRICE_ID to enable checkout.',
+  }, { status: 501 });
+}

--- a/app/release-gate/page.tsx
+++ b/app/release-gate/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { releaseGatePlans } from '@/lib/release-gate/plans';
 
 export default function ReleaseGatePage() {
   const [url, setUrl] = useState('');
@@ -19,8 +20,13 @@ export default function ReleaseGatePage() {
     }
   }
 
+  async function upgrade() {
+    await fetch('/api/release-gate/checkout', { method: 'POST' });
+    alert('Stripe not configured yet. Add STRIPE_SECRET_KEY to enable.');
+  }
+
   return (
-    <div style={{ padding: 24, maxWidth: 600, margin: '0 auto' }}>
+    <div style={{ padding: 24, maxWidth: 700, margin: '0 auto' }}>
       <h1>Release Gate</h1>
       <p>Check if your app is ready to launch</p>
 
@@ -37,10 +43,7 @@ export default function ReleaseGatePage() {
 
       {result && (
         <div style={{ marginTop: 20 }}>
-          <h2>
-            Verdict: {result.verdict}
-          </h2>
-
+          <h2>Verdict: {result.verdict}</h2>
           <ul>
             {result.checks?.map((c: any) => (
               <li key={c.name}>
@@ -50,6 +53,26 @@ export default function ReleaseGatePage() {
           </ul>
         </div>
       )}
+
+      <hr style={{ margin: '32px 0' }} />
+
+      <h2>Plans</h2>
+      <div style={{ display: 'grid', gap: 12 }}>
+        {releaseGatePlans.map((p) => (
+          <div key={p.id} style={{ border: '1px solid #333', padding: 12 }}>
+            <h3>{p.name} — {p.price}</h3>
+            <p>{p.description}</p>
+            <ul>
+              {p.features.map((f) => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+            {p.id !== 'free' && (
+              <button onClick={upgrade}>Upgrade</button>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/lib/release-gate/plans.ts
+++ b/lib/release-gate/plans.ts
@@ -1,0 +1,37 @@
+export type ReleaseGatePlanId = 'free' | 'pro' | 'enterprise';
+
+export type ReleaseGatePlan = {
+  id: ReleaseGatePlanId;
+  name: string;
+  price: string;
+  description: string;
+  features: string[];
+  limitLabel: string;
+};
+
+export const releaseGatePlans: ReleaseGatePlan[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    price: '$0',
+    description: 'Quick launch readiness check for one-off URLs.',
+    limitLabel: 'Manual checks only',
+    features: ['Trust pages', 'Health endpoint', 'Readiness endpoint', 'GO / NO-GO verdict'],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: '$29/mo',
+    description: 'Saved reports and repeat checks for active products.',
+    limitLabel: 'Saved reports + scheduled checks',
+    features: ['Everything in Free', 'Report history', 'Shareable evidence links', 'Daily scheduled checks'],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    price: 'Custom',
+    description: 'User-flow and audit evidence gates for production launches.',
+    limitLabel: 'Custom user-flow and audit gates',
+    features: ['Everything in Pro', 'User-flow verification', 'Audit evidence validation', 'Launch readiness support'],
+  },
+];


### PR DESCRIPTION
## Paid Plan Scaffold

Adds pricing section and upgrade CTA to Release Gate SaaS.

### Includes
- Plan definitions (Free / Pro / Enterprise)
- Pricing UI on `/release-gate`
- Placeholder checkout route (`/api/release-gate/checkout`)

### Notes
- Stripe not wired yet (returns 501)
- Next step: integrate Stripe checkout + user auth

Build-safe: no changes to existing gate logic.