### PR TITLE
Add Stripe webhook + entitlement scaffold

### DIFF
--- a/app/api/release-gate/checkout/route.ts
+++ b/app/api/release-gate/checkout/route.ts
@@ -1,9 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
 
-export async function POST(_req: NextRequest) {
-  // Placeholder until Stripe keys are configured.
-  return NextResponse.json({
-    error: 'stripe_not_configured',
-    message: 'Set STRIPE_SECRET_KEY and STRIPE_PRICE_ID to enable checkout.',
-  }, { status: 501 });
+export async function POST(req: NextRequest) {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  const priceId = process.env.STRIPE_RELEASE_GATE_PRO_PRICE_ID;
+
+  if (!secretKey || !priceId) {
+    return NextResponse.json({
+      error: 'stripe_not_configured',
+      message: 'Set STRIPE_SECRET_KEY and STRIPE_RELEASE_GATE_PRO_PRICE_ID to enable checkout.',
+    }, { status: 501 });
+  }
+
+  const origin = req.headers.get('origin') ?? process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const stripe = new Stripe(secretKey);
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${origin}/release-gate?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${origin}/release-gate?checkout=cancelled`,
+  });
+
+  return NextResponse.json({ url: session.url });
 }

--- a/app/api/release-gate/checkout/route.ts
+++ b/app/api/release-gate/checkout/route.ts
@@ -20,6 +20,9 @@ export async function POST(req: NextRequest) {
     line_items: [{ price: priceId, quantity: 1 }],
     success_url: `${origin}/release-gate?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${origin}/release-gate?checkout=cancelled`,
+    metadata: {
+      product: 'release-gate-pro'
+    }
   });
 
   return NextResponse.json({ url: session.url });

--- a/app/api/release-gate/checkout/route.ts
+++ b/app/api/release-gate/checkout/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(_req: NextRequest) {
+  // Placeholder until Stripe keys are configured.
+  return NextResponse.json({
+    error: 'stripe_not_configured',
+    message: 'Set STRIPE_SECRET_KEY and STRIPE_PRICE_ID to enable checkout.',
+  }, { status: 501 });
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!secret || !webhookSecret) {
+    return NextResponse.json({ error: 'stripe_not_configured' }, { status: 501 });
+  }
+
+  const stripe = new Stripe(secret);
+  const sig = req.headers.get('stripe-signature');
+  const body = await req.text();
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(body, sig!, webhookSecret);
+  } catch (err) {
+    return NextResponse.json({ error: 'invalid_signature' }, { status: 400 });
+  }
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      console.log('checkout completed', session.id);
+      break;
+    }
+    case 'customer.subscription.updated': {
+      const sub = event.data.object as Stripe.Subscription;
+      console.log('subscription updated', sub.id, sub.status);
+      break;
+    }
+    case 'customer.subscription.deleted': {
+      const sub = event.data.object as Stripe.Subscription;
+      console.log('subscription deleted', sub.id);
+      break;
+    }
+    default:
+      console.log('unhandled event', event.type);
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/app/release-gate/page.tsx
+++ b/app/release-gate/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { releaseGatePlans } from '@/lib/release-gate/plans';
 
 export default function ReleaseGatePage() {
   const [url, setUrl] = useState('');
@@ -19,8 +20,13 @@ export default function ReleaseGatePage() {
     }
   }
 
+  async function upgrade() {
+    await fetch('/api/release-gate/checkout', { method: 'POST' });
+    alert('Stripe not configured yet. Add STRIPE_SECRET_KEY to enable.');
+  }
+
   return (
-    <div style={{ padding: 24, maxWidth: 600, margin: '0 auto' }}>
+    <div style={{ padding: 24, maxWidth: 700, margin: '0 auto' }}>
       <h1>Release Gate</h1>
       <p>Check if your app is ready to launch</p>
 
@@ -37,10 +43,7 @@ export default function ReleaseGatePage() {
 
       {result && (
         <div style={{ marginTop: 20 }}>
-          <h2>
-            Verdict: {result.verdict}
-          </h2>
-
+          <h2>Verdict: {result.verdict}</h2>
           <ul>
             {result.checks?.map((c: any) => (
               <li key={c.name}>
@@ -50,6 +53,26 @@ export default function ReleaseGatePage() {
           </ul>
         </div>
       )}
+
+      <hr style={{ margin: '32px 0' }} />
+
+      <h2>Plans</h2>
+      <div style={{ display: 'grid', gap: 12 }}>
+        {releaseGatePlans.map((p) => (
+          <div key={p.id} style={{ border: '1px solid #333', padding: 12 }}>
+            <h3>{p.name} — {p.price}</h3>
+            <p>{p.description}</p>
+            <ul>
+              {p.features.map((f) => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+            {p.id !== 'free' && (
+              <button onClick={upgrade}>Upgrade</button>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/lib/release-gate/plans.ts
+++ b/lib/release-gate/plans.ts
@@ -1,0 +1,37 @@
+export type ReleaseGatePlanId = 'free' | 'pro' | 'enterprise';
+
+export type ReleaseGatePlan = {
+  id: ReleaseGatePlanId;
+  name: string;
+  price: string;
+  description: string;
+  features: string[];
+  limitLabel: string;
+};
+
+export const releaseGatePlans: ReleaseGatePlan[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    price: '$0',
+    description: 'Quick launch readiness check for one-off URLs.',
+    limitLabel: 'Manual checks only',
+    features: ['Trust pages', 'Health endpoint', 'Readiness endpoint', 'GO / NO-GO verdict'],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: '$29/mo',
+    description: 'Saved reports and repeat checks for active products.',
+    limitLabel: 'Saved reports + scheduled checks',
+    features: ['Everything in Free', 'Report history', 'Shareable evidence links', 'Daily scheduled checks'],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    price: 'Custom',
+    description: 'User-flow and audit evidence gates for production launches.',
+    limitLabel: 'Custom user-flow and audit gates',
+    features: ['Everything in Pro', 'User-flow verification', 'Audit evidence validation', 'Launch readiness support'],
+  },
+];

--- a/supabase/migrations/20260426192000_release_gate_entitlements.sql
+++ b/supabase/migrations/20260426192000_release_gate_entitlements.sql
@@ -1,0 +1,19 @@
+create table if not exists public.release_gate_entitlements (
+  id uuid primary key default gen_random_uuid(),
+  email text,
+  stripe_customer_id text,
+  stripe_subscription_id text unique,
+  plan text not null default 'pro',
+  status text not null,
+  current_period_end timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_release_gate_entitlements_email
+  on public.release_gate_entitlements (email);
+
+create index if not exists idx_release_gate_entitlements_customer
+  on public.release_gate_entitlements (stripe_customer_id);
+
+alter table public.release_gate_entitlements enable row level security;


### PR DESCRIPTION
## Stripe Webhook + Entitlements

Adds minimal production-safe scaffold:

### Includes
- Stripe webhook endpoint `/api/stripe/webhook`
- Subscription event handling (log only for now)
- Supabase table for entitlements
- Metadata on checkout session

### Next step
- Persist subscription into DB
- Add auth + gate access

Safe: no breaking change to existing flow.