### PR TITLE
Clean Stripe webhook + entitlement setup (fix PR 389)

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!secret || !webhookSecret) {
+    return NextResponse.json({ error: 'stripe_not_configured' }, { status: 501 });
+  }
+
+  const stripe = new Stripe(secret);
+  const sig = req.headers.get('stripe-signature');
+  const body = await req.text();
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(body, sig!, webhookSecret);
+  } catch (err) {
+    return NextResponse.json({ error: 'invalid_signature' }, { status: 400 });
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    console.log('checkout completed', session.id);
+  }
+
+  if (event.type === 'customer.subscription.updated') {
+    const sub = event.data.object as Stripe.Subscription;
+    console.log('subscription updated', sub.id, sub.status);
+  }
+
+  if (event.type === 'customer.subscription.deleted') {
+    const sub = event.data.object as Stripe.Subscription;
+    console.log('subscription deleted', sub.id);
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/supabase/migrations/20260426193300_release_gate_entitlements.sql
+++ b/supabase/migrations/20260426193300_release_gate_entitlements.sql
@@ -1,0 +1,19 @@
+create table if not exists public.release_gate_entitlements (
+  id uuid primary key default gen_random_uuid(),
+  email text,
+  stripe_customer_id text,
+  stripe_subscription_id text unique,
+  plan text not null default 'pro',
+  status text not null,
+  current_period_end timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_release_gate_entitlements_email
+  on public.release_gate_entitlements (email);
+
+create index if not exists idx_release_gate_entitlements_customer
+  on public.release_gate_entitlements (stripe_customer_id);
+
+alter table public.release_gate_entitlements enable row level security;


### PR DESCRIPTION
Replaces broken PR #389 with clean version.

## Includes
- Stripe webhook endpoint only
- Supabase entitlement table
- No UI / no pricing changes

Safe and mergeable.
