### PR TITLE
Clean final monetization: persist subscriptions + DB entitlement check

### DIFF
--- a/app/api/release-gate/check/route.ts
+++ b/app/api/release-gate/check/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { runReleaseGate } from '../../../../lib/release-gate/checker';
+import { hasReleaseGateProAccess } from '../../../../lib/release-gate/entitlements';
 
 export async function GET(req: NextRequest) {
   const url = req.nextUrl.searchParams.get('url');
@@ -10,15 +11,17 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'missing_url' }, { status: 400 });
   }
 
-  // Free mode: allow basic checks
   let isPro = false;
 
   if (sessionId && process.env.STRIPE_SECRET_KEY) {
     try {
       const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
       const session = await stripe.checkout.sessions.retrieve(sessionId);
+      const email = session.customer_details?.email ?? null;
 
-      if (session.payment_status === 'paid') {
+      isPro = await hasReleaseGateProAccess(email);
+
+      if (!isPro && session.payment_status === 'paid') {
         isPro = true;
       }
     } catch (e) {

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,5 +1,52 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+
+async function upsertSubscriptionEntitlement(stripe: Stripe, subscription: Stripe.Subscription) {
+  const supabase = getSupabaseAdmin() as any;
+  const customerId = typeof subscription.customer === 'string'
+    ? subscription.customer
+    : subscription.customer?.id;
+
+  let email: string | null = null;
+
+  if (customerId) {
+    const customer = await stripe.customers.retrieve(customerId);
+    if (!customer.deleted) {
+      email = customer.email ?? null;
+    }
+  }
+
+  const { error } = await supabase
+    .from('release_gate_entitlements')
+    .upsert({
+      email,
+      stripe_customer_id: customerId,
+      stripe_subscription_id: subscription.id,
+      plan: 'pro',
+      status: subscription.status,
+      current_period_end: subscription.current_period_end
+        ? new Date(subscription.current_period_end * 1000).toISOString()
+        : null,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'stripe_subscription_id' });
+
+  if (error) {
+    throw new Error(`failed_to_upsert_release_gate_entitlement:${error.message}`);
+  }
+}
+
+async function markSubscriptionCanceled(subscription: Stripe.Subscription) {
+  const supabase = getSupabaseAdmin() as any;
+  const { error } = await supabase
+    .from('release_gate_entitlements')
+    .update({ status: 'canceled', updated_at: new Date().toISOString() })
+    .eq('stripe_subscription_id', subscription.id);
+
+  if (error) {
+    throw new Error(`failed_to_cancel_release_gate_entitlement:${error.message}`);
+  }
+}
 
 export async function POST(req: NextRequest) {
   const secret = process.env.STRIPE_SECRET_KEY;
@@ -21,19 +68,27 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'invalid_signature' }, { status: 400 });
   }
 
-  if (event.type === 'checkout.session.completed') {
-    const session = event.data.object as Stripe.Checkout.Session;
-    console.log('checkout completed', session.id);
-  }
+  try {
+    if (event.type === 'checkout.session.completed') {
+      const session = event.data.object as Stripe.Checkout.Session;
+      if (typeof session.subscription === 'string') {
+        const subscription = await stripe.subscriptions.retrieve(session.subscription);
+        await upsertSubscriptionEntitlement(stripe, subscription);
+      }
+    }
 
-  if (event.type === 'customer.subscription.updated') {
-    const sub = event.data.object as Stripe.Subscription;
-    console.log('subscription updated', sub.id, sub.status);
-  }
+    if (event.type === 'customer.subscription.updated') {
+      const subscription = event.data.object as Stripe.Subscription;
+      await upsertSubscriptionEntitlement(stripe, subscription);
+    }
 
-  if (event.type === 'customer.subscription.deleted') {
-    const sub = event.data.object as Stripe.Subscription;
-    console.log('subscription deleted', sub.id);
+    if (event.type === 'customer.subscription.deleted') {
+      const subscription = event.data.object as Stripe.Subscription;
+      await markSubscriptionCanceled(subscription);
+    }
+  } catch (err) {
+    console.error('release gate entitlement sync failed', err);
+    return NextResponse.json({ error: 'entitlement_sync_failed' }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });

--- a/lib/release-gate/entitlements.ts
+++ b/lib/release-gate/entitlements.ts
@@ -1,0 +1,21 @@
+import { getSupabaseAdmin } from '../supabase-server';
+
+export async function hasReleaseGateProAccess(email: string | null) {
+  if (!email) {
+    return false;
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  const { data, error } = await supabase
+    .from('release_gate_entitlements')
+    .select('id')
+    .eq('email', email)
+    .in('status', ['active', 'trialing'])
+    .limit(1);
+
+  if (error) {
+    return false;
+  }
+
+  return Array.isArray(data) && data.length > 0;
+}


### PR DESCRIPTION
## Summary

Clean replacement for the stuck/conflicting PRs #392, #393, and #394.

Uses the Production Deterministic Release Architect approach:
- starts from current `main`
- keeps existing free Release Gate behavior working
- persists Stripe subscriptions to `release_gate_entitlements`
- checks Pro access from DB using the verified Stripe Checkout session email
- does not trust arbitrary `email` query params

## What changed

- `app/api/stripe/webhook/route.ts`
  - verifies Stripe signature
  - handles `checkout.session.completed`
  - handles `customer.subscription.updated`
  - handles `customer.subscription.deleted`
  - upserts/cancels `release_gate_entitlements` via Supabase admin client

- `lib/release-gate/entitlements.ts`
  - checks active/trialing entitlement in Supabase

- `app/api/release-gate/check/route.ts`
  - preserves free checks when no session is present
  - verifies `session_id` with Stripe
  - derives customer email from Stripe session, not from caller-supplied query string
  - checks DB entitlement and returns `pro: true` when valid

## Required env vars

- `STRIPE_SECRET_KEY`
- `STRIPE_WEBHOOK_SECRET`
- `NEXT_PUBLIC_SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`

## Replaces

Close #392, #393, #394 after this merges.