### PR TITLE
Fix DSG Agent chatbot functions and runtime tool routing

### DIFF
--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -1,8 +1,11 @@
 import type { AgentPlan, AgentPlanStep } from './context';
 
 function extractAgentId(message: string) {
-  const match = message.match(/agt_[a-zA-Z0-9_-]+/);
-  return match ? match[0] : '';
+  const explicit = message.match(/agt_[a-zA-Z0-9_-]+/);
+  if (explicit) return explicit[0];
+
+  const uuid = message.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  return uuid ? uuid[0] : '';
 }
 
 function extractEffectId(message: string) {
@@ -20,6 +23,12 @@ function extractUrl(message: string) {
   return match ? match[0] : '';
 }
 
+function extractChatMessage(message: string) {
+  const quoted = extractQuotedName(message);
+  if (quoted) return quoted;
+  return message.replace(/chatbot|chat bot|แชทบอท|แชตบอท|ถามบอท|คุยกับบอท/gi, '').trim() || message.trim();
+}
+
 function nextStep(id: number, toolId: string, params: Record<string, unknown>): AgentPlanStep {
   return { id: `s${id}`, toolId, params };
 }
@@ -28,7 +37,6 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
   const text = message.trim();
   const lower = text.toLowerCase();
   const agentId = extractAgentId(text);
-
 
   if (/^(ช่วย|help|แนะนำ|suggest)$/i.test(lower)) {
     switch (pageContext) {
@@ -41,12 +49,19 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
         return { steps: [nextStep(1, 'capacity', {})] };
       case '/dashboard/executions':
       case '/dashboard/operations':
-        return {
-          steps: [
-            nextStep(1, 'audit_summary', { agent_id: agentId }),
-            nextStep(2, 'recovery_validate', { agent_id: agentId }),
-          ],
-        };
+        return agentId
+          ? {
+              steps: [
+                nextStep(1, 'audit_summary', { agent_id: agentId }),
+                nextStep(2, 'recovery_validate', { agent_id: agentId }),
+              ],
+            }
+          : {
+              steps: [
+                nextStep(1, 'get_audit', {}),
+                nextStep(2, 'list_executions', { limit: 10 }),
+              ],
+            };
       default:
         return { steps: [nextStep(1, 'readiness', {})] };
     }
@@ -54,6 +69,40 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
 
   if (/readiness|health|status|สถานะ/.test(lower)) {
     return { steps: [nextStep(1, 'readiness', {})] };
+  }
+
+  if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
+    if (/create|สร้าง|new|เพิ่ม/.test(lower)) {
+      return {
+        steps: [
+          nextStep(1, 'list_policies', {}),
+          nextStep(2, 'create_chatbot_agent', {
+            name: extractQuotedName(text) || 'Chatbot Agent',
+            monthly_limit: 50000,
+          }),
+          nextStep(3, 'list_agents', {}),
+        ],
+      };
+    }
+
+    if (agentId) {
+      return {
+        steps: [
+          nextStep(1, 'readiness', {}),
+          nextStep(2, 'chatbot_message', {
+            agent_id: agentId,
+            message: extractChatMessage(text),
+          }),
+        ],
+      };
+    }
+
+    return {
+      steps: [
+        nextStep(1, 'list_agents', {}),
+        nextStep(2, 'list_policies', {}),
+      ],
+    };
   }
 
   if (/execute|run|รัน|ทำงาน/.test(lower)) {
@@ -66,23 +115,31 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
   }
 
   if (/audit|lineage|ตรวจสอบ/.test(lower)) {
-    return {
-      steps: [
-        nextStep(1, 'audit_summary', { agent_id: agentId }),
-        nextStep(2, 'recovery_validate', { agent_id: agentId }),
-      ],
-    };
+    return agentId
+      ? {
+          steps: [
+            nextStep(1, 'audit_summary', { agent_id: agentId }),
+            nextStep(2, 'recovery_validate', { agent_id: agentId }),
+          ],
+        }
+      : {
+          steps: [
+            nextStep(1, 'get_audit', {}),
+            nextStep(2, 'list_executions', { limit: 10 }),
+          ],
+        };
   }
 
   if (/checkpoint|บันทึก/.test(lower)) {
-    return {
-      steps: [
-        nextStep(1, 'recovery_validate', { agent_id: agentId }),
-        nextStep(2, 'checkpoint', { agent_id: agentId }),
-      ],
-    };
+    return agentId
+      ? {
+          steps: [
+            nextStep(1, 'recovery_validate', { agent_id: agentId }),
+            nextStep(2, 'checkpoint', { agent_id: agentId }),
+          ],
+        }
+      : { steps: [nextStep(1, 'list_agents', {})] };
   }
-
 
   if (/execution|executions|proof|replay|หลักฐาน/.test(lower)) {
     const executionId = text.match(/exec_[a-zA-Z0-9_-]+/)?.[0] || '';
@@ -140,7 +197,6 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
     };
   }
 
-
   if (/list agents|show agents|agents|เอเจนต์ทั้งหมด/.test(lower)) {
     return { steps: [nextStep(1, 'list_agents', {})] };
   }
@@ -164,13 +220,12 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
     return {
       steps: [
         nextStep(1, 'create_agent', {
-          name: 'New Agent',
-          policy_id: 'default',
+          name: extractQuotedName(text) || 'New Agent',
+          monthly_limit: 10000,
         }),
       ],
     };
   }
-
 
   if (/agent detail|รายละเอียดเอเจนต์/.test(lower) && agentId) {
     return { steps: [nextStep(1, 'get_agent_detail', { agent_id: agentId })] };
@@ -182,19 +237,6 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
 
   if (/delete agent|disable agent|ลบเอเจนต์/.test(lower) && agentId) {
     return { steps: [nextStep(1, 'delete_agent', { agent_id: agentId })] };
-  }
-
-  if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
-    return {
-      steps: [
-        nextStep(1, 'list_policies', {}),
-        nextStep(2, 'create_chatbot_agent', {
-          name: extractQuotedName(text) || 'Chatbot Agent',
-          monthly_limit: 50000,
-        }),
-        nextStep(3, 'list_agents', {}),
-      ],
-    };
   }
 
   return {

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -34,15 +34,19 @@ async function callJson(
   return json;
 }
 
+function isPresent(value: unknown) {
+  return typeof value === 'string' ? value.trim().length > 0 : value !== undefined && value !== null;
+}
+
 export const DSG_TOOLS: AgentTool[] = [
   {
     id: 'readiness',
     name: 'Check System Readiness',
-    description: 'Fetch readiness, health, entropy, alerts, and billing state.',
+    description: 'Fetch production readiness status.',
     parameters: {},
     riskLevel: 'read',
     requiredRole: 'monitor',
-    execute: async (_params, context) => callJson(context, '/api/core/monitor', { method: 'GET' }),
+    execute: async (_params, context) => callJson(context, '/api/readiness', { method: 'GET' }),
   },
   {
     id: 'execute_action',
@@ -63,6 +67,29 @@ export const DSG_TOOLS: AgentTool[] = [
           action: params.action,
           payload: params.payload || {},
           tool_name: 'agent-chat',
+        }),
+      }),
+  },
+  {
+    id: 'chatbot_message',
+    name: 'Chat with Chatbot Agent',
+    description: 'Send a chatbot message through the governed DSG execution path.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Target chatbot agent ID' },
+      message: { type: 'string', required: true, description: 'Message to send to the chatbot agent' },
+    },
+    riskLevel: 'critical',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, '/api/mcp/call', {
+        method: 'POST',
+        body: JSON.stringify({
+          agent_id: params.agent_id,
+          action: 'chatbot.message',
+          payload: {
+            message: String(params.message || ''),
+          },
+          tool_name: 'chatbot_message',
         }),
       }),
   },
@@ -125,10 +152,14 @@ export const DSG_TOOLS: AgentTool[] = [
     },
     riskLevel: 'read',
     requiredRole: 'runtime_summary',
-    execute: async (params, context) =>
-      callJson(context, `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(String(params.agent_id || ''))}`, {
+    execute: async (params, context) => {
+      if (!isPresent(params.agent_id)) {
+        return callJson(context, '/api/audit?limit=20', { method: 'GET' });
+      }
+      return callJson(context, `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(String(params.agent_id || ''))}`, {
         method: 'GET',
-      }),
+      });
+    },
   },
   {
     id: 'checkpoint',
@@ -154,11 +185,15 @@ export const DSG_TOOLS: AgentTool[] = [
     },
     riskLevel: 'read',
     requiredRole: 'checkpoint',
-    execute: async (params, context) =>
-      callJson(context, '/api/runtime-recovery', {
+    execute: async (params, context) => {
+      if (!isPresent(params.agent_id)) {
+        return callJson(context, '/api/executions?limit=10', { method: 'GET' });
+      }
+      return callJson(context, '/api/runtime-recovery', {
         method: 'POST',
         body: JSON.stringify({ org_id: context.orgId, agent_id: params.agent_id }),
-      }),
+      });
+    },
   },
   {
     id: 'realtime_web_search',
@@ -200,16 +235,24 @@ export const DSG_TOOLS: AgentTool[] = [
     description: 'Create a new agent with one-time API key return.',
     parameters: {
       name: { type: 'string', required: true, description: 'Agent name' },
-      policy_id: { type: 'string', required: true, description: 'Policy ID' },
+      policy_id: { type: 'string', required: false, description: 'Policy ID' },
       monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit' },
     },
     riskLevel: 'write',
     requiredRole: 'execute',
-    execute: async (params, context) =>
-      callJson(context, '/api/agents', {
+    execute: async (params, context) => {
+      const body: Record<string, unknown> = {
+        name: String(params.name || 'New Agent'),
+        monthly_limit: Number(params.monthly_limit || 10000),
+      };
+      if (isPresent(params.policy_id)) {
+        body.policy_id = params.policy_id;
+      }
+      return callJson(context, '/api/agents', {
         method: 'POST',
-        body: JSON.stringify(params),
-      }),
+        body: JSON.stringify(body),
+      });
+    },
   },
   {
     id: 'create_chatbot_agent',
@@ -222,15 +265,19 @@ export const DSG_TOOLS: AgentTool[] = [
     },
     riskLevel: 'write',
     requiredRole: 'execute',
-    execute: async (params, context) =>
-      callJson(context, '/api/agents', {
+    execute: async (params, context) => {
+      const body: Record<string, unknown> = {
+        name: String(params.name || 'Chatbot Agent'),
+        monthly_limit: Number(params.monthly_limit || 50000),
+      };
+      if (isPresent(params.policy_id)) {
+        body.policy_id = params.policy_id;
+      }
+      return callJson(context, '/api/agents', {
         method: 'POST',
-        body: JSON.stringify({
-          name: String(params.name || 'Chatbot Agent'),
-          policy_id: params.policy_id ? String(params.policy_id) : undefined,
-          monthly_limit: Number(params.monthly_limit || 50000),
-        }),
-      }),
+        body: JSON.stringify(body),
+      });
+    },
   },
   {
     id: 'list_policies',


### PR DESCRIPTION
## Summary

Fixes the failing DSG Agent flows reported from `/dashboard/executions`.

### Fixed
- `readiness` tool now uses `/api/readiness` instead of `/api/core/monitor`, matching the production health/readiness gate that is currently green.
- Agent planner now extracts both `agt_...` ids and UUID agent ids.
- `audit lineage` without an agent id no longer calls runtime-summary/recovery with an empty id; it falls back to audit + executions listing.
- `create agent` no longer sends fake `policy_id: "default"`; it lets backend policy resolution choose the active/default policy.
- Adds `chatbot_message` tool that sends chatbot messages through the governed `/api/mcp/call` path.
- `create_chatbot_agent` safely omits `policy_id` unless explicitly provided.

### Why
The UI logs showed repeated `s1: Internal server error` for readiness/audit/recovery/create-agent, while list_agents and execute_action worked. The issue was routing/parameter shape, not production deploy health.

### Evidence basis
Production `/api/health` and `/api/readiness` are green. This PR keeps those green paths and avoids known empty-agent runtime calls.