### PR TITLE
Rollback Agent runtime changes to restore production build

### DIFF
--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -1,11 +1,8 @@
 import type { AgentPlan, AgentPlanStep } from './context';
 
 function extractAgentId(message: string) {
-  const explicit = message.match(/agt_[a-zA-Z0-9_-]+/);
-  if (explicit) return explicit[0];
-
-  const uuid = message.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
-  return uuid ? uuid[0] : '';
+  const match = message.match(/agt_[a-zA-Z0-9_-]+/);
+  return match ? match[0] : '';
 }
 
 function extractEffectId(message: string) {
@@ -23,12 +20,6 @@ function extractUrl(message: string) {
   return match ? match[0] : '';
 }
 
-function extractChatMessage(message: string) {
-  const quoted = extractQuotedName(message);
-  if (quoted) return quoted;
-  return message.replace(/chatbot|chat bot|แชทบอท|แชตบอท|ถามบอท|คุยกับบอท/gi, '').trim() || message.trim();
-}
-
 function nextStep(id: number, toolId: string, params: Record<string, unknown>): AgentPlanStep {
   return { id: `s${id}`, toolId, params };
 }
@@ -37,6 +28,7 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
   const text = message.trim();
   const lower = text.toLowerCase();
   const agentId = extractAgentId(text);
+
 
   if (/^(ช่วย|help|แนะนำ|suggest)$/i.test(lower)) {
     switch (pageContext) {
@@ -49,19 +41,12 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
         return { steps: [nextStep(1, 'capacity', {})] };
       case '/dashboard/executions':
       case '/dashboard/operations':
-        return agentId
-          ? {
-              steps: [
-                nextStep(1, 'audit_summary', { agent_id: agentId }),
-                nextStep(2, 'recovery_validate', { agent_id: agentId }),
-              ],
-            }
-          : {
-              steps: [
-                nextStep(1, 'get_audit', {}),
-                nextStep(2, 'list_executions', { limit: 10 }),
-              ],
-            };
+        return {
+          steps: [
+            nextStep(1, 'audit_summary', { agent_id: agentId }),
+            nextStep(2, 'recovery_validate', { agent_id: agentId }),
+          ],
+        };
       default:
         return { steps: [nextStep(1, 'readiness', {})] };
     }
@@ -69,40 +54,6 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
 
   if (/readiness|health|status|สถานะ/.test(lower)) {
     return { steps: [nextStep(1, 'readiness', {})] };
-  }
-
-  if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
-    if (/create|สร้าง|new|เพิ่ม/.test(lower)) {
-      return {
-        steps: [
-          nextStep(1, 'list_policies', {}),
-          nextStep(2, 'create_chatbot_agent', {
-            name: extractQuotedName(text) || 'Chatbot Agent',
-            monthly_limit: 50000,
-          }),
-          nextStep(3, 'list_agents', {}),
-        ],
-      };
-    }
-
-    if (agentId) {
-      return {
-        steps: [
-          nextStep(1, 'readiness', {}),
-          nextStep(2, 'chatbot_message', {
-            agent_id: agentId,
-            message: extractChatMessage(text),
-          }),
-        ],
-      };
-    }
-
-    return {
-      steps: [
-        nextStep(1, 'list_agents', {}),
-        nextStep(2, 'list_policies', {}),
-      ],
-    };
   }
 
   if (/execute|run|รัน|ทำงาน/.test(lower)) {
@@ -115,31 +66,23 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
   }
 
   if (/audit|lineage|ตรวจสอบ/.test(lower)) {
-    return agentId
-      ? {
-          steps: [
-            nextStep(1, 'audit_summary', { agent_id: agentId }),
-            nextStep(2, 'recovery_validate', { agent_id: agentId }),
-          ],
-        }
-      : {
-          steps: [
-            nextStep(1, 'get_audit', {}),
-            nextStep(2, 'list_executions', { limit: 10 }),
-          ],
-        };
+    return {
+      steps: [
+        nextStep(1, 'audit_summary', { agent_id: agentId }),
+        nextStep(2, 'recovery_validate', { agent_id: agentId }),
+      ],
+    };
   }
 
   if (/checkpoint|บันทึก/.test(lower)) {
-    return agentId
-      ? {
-          steps: [
-            nextStep(1, 'recovery_validate', { agent_id: agentId }),
-            nextStep(2, 'checkpoint', { agent_id: agentId }),
-          ],
-        }
-      : { steps: [nextStep(1, 'list_agents', {})] };
+    return {
+      steps: [
+        nextStep(1, 'recovery_validate', { agent_id: agentId }),
+        nextStep(2, 'checkpoint', { agent_id: agentId }),
+      ],
+    };
   }
+
 
   if (/execution|executions|proof|replay|หลักฐาน/.test(lower)) {
     const executionId = text.match(/exec_[a-zA-Z0-9_-]+/)?.[0] || '';
@@ -197,6 +140,7 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
     };
   }
 
+
   if (/list agents|show agents|agents|เอเจนต์ทั้งหมด/.test(lower)) {
     return { steps: [nextStep(1, 'list_agents', {})] };
   }
@@ -220,12 +164,13 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
     return {
       steps: [
         nextStep(1, 'create_agent', {
-          name: extractQuotedName(text) || 'New Agent',
-          monthly_limit: 10000,
+          name: 'New Agent',
+          policy_id: 'default',
         }),
       ],
     };
   }
+
 
   if (/agent detail|รายละเอียดเอเจนต์/.test(lower) && agentId) {
     return { steps: [nextStep(1, 'get_agent_detail', { agent_id: agentId })] };
@@ -237,6 +182,19 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
 
   if (/delete agent|disable agent|ลบเอเจนต์/.test(lower) && agentId) {
     return { steps: [nextStep(1, 'delete_agent', { agent_id: agentId })] };
+  }
+
+  if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
+    return {
+      steps: [
+        nextStep(1, 'list_policies', {}),
+        nextStep(2, 'create_chatbot_agent', {
+          name: extractQuotedName(text) || 'Chatbot Agent',
+          monthly_limit: 50000,
+        }),
+        nextStep(3, 'list_agents', {}),
+      ],
+    };
   }
 
   return {

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -10,50 +10,39 @@ export type AgentTool = {
   execute: (params: Record<string, unknown>, context: AgentContext) => Promise<unknown>;
 };
 
-const noParams: AgentTool['parameters'] = {};
-const agentIdParam = { agent_id: { type: 'string', required: true, description: 'Agent ID' } };
-const limitParam = { limit: { type: 'number', required: false, description: 'Max items' } };
-
-function hasValue(value: unknown) {
-  return typeof value === 'string' ? value.trim().length > 0 : value !== undefined && value !== null;
-}
-
-async function callJson(context: AgentContext, path: string, init?: RequestInit) {
-  const headers: Record<string, string> = { 'content-type': 'application/json' };
-  if (context.authHeader) headers.authorization = context.authHeader;
-  if (context.cookieHeader) headers.cookie = context.cookieHeader;
-
+async function callJson(
+  context: AgentContext,
+  path: string,
+  init?: RequestInit,
+) {
   const response = await fetch(`${context.origin}${path}`, {
     ...init,
-    headers: { ...headers, ...(init?.headers as Record<string, string> | undefined) },
+    headers: {
+      'content-type': 'application/json',
+      authorization: context.authHeader,
+      cookie: context.cookieHeader,
+      ...(init?.headers || {}),
+    },
     cache: 'no-store',
   });
 
   const json = await response.json().catch(() => ({}));
   if (!response.ok) {
-    throw new Error(String((json as { error?: unknown }).error || `Tool call failed (${path})`));
+    throw new Error(String(json.error || `Tool call failed (${path})`));
   }
 
   return json;
-}
-
-function postJson(context: AgentContext, path: string, body?: unknown) {
-  return callJson(context, path, { method: 'POST', body: JSON.stringify(body || {}) });
-}
-
-function mcpCall(context: AgentContext, body: Record<string, unknown>) {
-  return postJson(context, '/api/mcp/call', body);
 }
 
 export const DSG_TOOLS: AgentTool[] = [
   {
     id: 'readiness',
     name: 'Check System Readiness',
-    description: 'Fetch production readiness status.',
-    parameters: noParams,
+    description: 'Fetch readiness, health, entropy, alerts, and billing state.',
+    parameters: {},
     riskLevel: 'read',
     requiredRole: 'monitor',
-    execute: async (_params, context) => callJson(context, '/api/readiness'),
+    execute: async (_params, context) => callJson(context, '/api/core/monitor', { method: 'GET' }),
   },
   {
     id: 'execute_action',
@@ -67,29 +56,14 @@ export const DSG_TOOLS: AgentTool[] = [
     riskLevel: 'critical',
     requiredRole: 'execute',
     execute: async (params, context) =>
-      mcpCall(context, {
-        agent_id: params.agent_id,
-        action: params.action,
-        payload: params.payload || {},
-        tool_name: 'agent-chat',
-      }),
-  },
-  {
-    id: 'chatbot_message',
-    name: 'Chat with Chatbot Agent',
-    description: 'Send a chatbot message through the governed DSG execution path.',
-    parameters: {
-      agent_id: { type: 'string', required: true, description: 'Target chatbot agent ID' },
-      message: { type: 'string', required: true, description: 'Message' },
-    },
-    riskLevel: 'critical',
-    requiredRole: 'execute',
-    execute: async (params, context) =>
-      mcpCall(context, {
-        agent_id: params.agent_id,
-        action: 'chatbot.message',
-        payload: { message: String(params.message || '') },
-        tool_name: 'chatbot_message',
+      callJson(context, '/api/mcp/call', {
+        method: 'POST',
+        body: JSON.stringify({
+          agent_id: params.agent_id,
+          action: params.action,
+          payload: params.payload || {},
+          tool_name: 'agent-chat',
+        }),
       }),
   },
   {
@@ -98,17 +72,23 @@ export const DSG_TOOLS: AgentTool[] = [
     description: 'Navigate to a target URL through Browserbase executor.',
     parameters: {
       agent_id: { type: 'string', required: true, description: 'Target agent ID' },
-      url: { type: 'string', required: true, description: 'Target URL' },
-      extract: { type: 'string', required: false, description: 'Extraction instruction' },
+      url: { type: 'string', required: true, description: 'Target URL to open' },
+      extract: { type: 'string', required: false, description: 'Extraction instruction or selector' },
     },
     riskLevel: 'critical',
     requiredRole: 'execute',
     execute: async (params, context) =>
-      mcpCall(context, {
-        agent_id: params.agent_id,
-        action: 'browser.navigate',
-        payload: { url: params.url, extract: params.extract },
-        tool_name: 'browser_navigate',
+      callJson(context, '/api/mcp/call', {
+        method: 'POST',
+        body: JSON.stringify({
+          agent_id: params.agent_id,
+          action: 'browser.navigate',
+          payload: {
+            url: params.url,
+            extract: params.extract,
+          },
+          tool_name: 'browser_navigate',
+        }),
       }),
   },
   {
@@ -123,45 +103,96 @@ export const DSG_TOOLS: AgentTool[] = [
     riskLevel: 'critical',
     requiredRole: 'execute',
     execute: async (params, context) =>
-      mcpCall(context, {
-        agent_id: params.agent_id,
-        action: 'social.telegram.send',
-        payload: { chat_id: params.chat_id, text: params.text },
-        tool_name: 'telegram_send',
+      callJson(context, '/api/mcp/call', {
+        method: 'POST',
+        body: JSON.stringify({
+          agent_id: params.agent_id,
+          action: 'social.telegram.send',
+          payload: {
+            chat_id: params.chat_id,
+            text: params.text,
+          },
+          tool_name: 'telegram_send',
+        }),
       }),
   },
   {
     id: 'audit_summary',
     name: 'Get Runtime Audit Summary',
     description: 'Fetch runtime truth and latest ledger entries for an agent.',
-    parameters: { agent_id: { type: 'string', required: false, description: 'Agent ID' } },
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
     riskLevel: 'read',
     requiredRole: 'runtime_summary',
-    execute: async (params, context) => {
-      if (!hasValue(params.agent_id)) return callJson(context, '/api/audit?limit=20');
-      return callJson(context, `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(String(params.agent_id))}`);
-    },
-  },
-  {
-    id: 'recovery_validate',
-    name: 'Validate Runtime Recovery',
-    description: 'Validate lineage integrity and missing sequences.',
-    parameters: { agent_id: { type: 'string', required: false, description: 'Agent ID' } },
-    riskLevel: 'read',
-    requiredRole: 'checkpoint',
-    execute: async (params, context) => {
-      if (!hasValue(params.agent_id)) return callJson(context, '/api/executions?limit=10');
-      return postJson(context, '/api/runtime-recovery', { org_id: context.orgId, agent_id: params.agent_id });
-    },
+    execute: async (params, context) =>
+      callJson(context, `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(String(params.agent_id || ''))}`, {
+        method: 'GET',
+      }),
   },
   {
     id: 'checkpoint',
     name: 'Create Runtime Checkpoint',
     description: 'Create a checkpoint hash from latest truth and ledger.',
-    parameters: agentIdParam,
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
     riskLevel: 'write',
     requiredRole: 'checkpoint',
-    execute: async (params, context) => postJson(context, '/api/checkpoint', { org_id: context.orgId, agent_id: params.agent_id }),
+    execute: async (params, context) =>
+      callJson(context, '/api/checkpoint', {
+        method: 'POST',
+        body: JSON.stringify({ org_id: context.orgId, agent_id: params.agent_id }),
+      }),
+  },
+  {
+    id: 'recovery_validate',
+    name: 'Validate Runtime Recovery',
+    description: 'Validate lineage integrity and missing sequences.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'checkpoint',
+    execute: async (params, context) =>
+      callJson(context, '/api/runtime-recovery', {
+        method: 'POST',
+        body: JSON.stringify({ org_id: context.orgId, agent_id: params.agent_id }),
+      }),
+  },
+  {
+    id: 'realtime_web_search',
+    name: 'Real-time Web Search',
+    description: 'Search live online information and return quick references.',
+    parameters: {
+      query: { type: 'string', required: true, description: 'Search query' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(
+        context,
+        `/api/realtime-search?q=${encodeURIComponent(String(params.query || ''))}`,
+        { method: 'GET' },
+      ),
+  },
+  {
+    id: 'capacity',
+    name: 'Check Quota & Capacity',
+    description: 'Fetch quota remaining and utilization.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'usage_read',
+    execute: async (_params, context) => callJson(context, '/api/capacity', { method: 'GET' }),
+  },
+  {
+    id: 'list_agents',
+    name: 'List Agents',
+    description: 'List org agents and current monthly usage.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'execute',
+    execute: async (_params, context) => callJson(context, '/api/agents', { method: 'GET' }),
   },
   {
     id: 'create_agent',
@@ -169,57 +200,234 @@ export const DSG_TOOLS: AgentTool[] = [
     description: 'Create a new agent with one-time API key return.',
     parameters: {
       name: { type: 'string', required: true, description: 'Agent name' },
-      policy_id: { type: 'string', required: false, description: 'Policy ID' },
+      policy_id: { type: 'string', required: true, description: 'Policy ID' },
       monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit' },
     },
     riskLevel: 'write',
     requiredRole: 'execute',
-    execute: async (params, context) => {
-      const body: Record<string, unknown> = {
-        name: String(params.name || 'New Agent'),
-        monthly_limit: Number(params.monthly_limit || 10000),
-      };
-      if (hasValue(params.policy_id)) body.policy_id = String(params.policy_id);
-      return postJson(context, '/api/agents', body);
-    },
+    execute: async (params, context) =>
+      callJson(context, '/api/agents', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      }),
   },
   {
     id: 'create_chatbot_agent',
     name: 'Create Chatbot Agent',
-    description: 'Create a chatbot-ready agent with safe defaults.',
+    description: 'Create a chatbot-ready agent with safe defaults for interactive usage.',
     parameters: {
-      name: { type: 'string', required: false, description: 'Agent name' },
-      policy_id: { type: 'string', required: false, description: 'Policy ID' },
-      monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit' },
+      name: { type: 'string', required: false, description: 'Agent name (default: Chatbot Agent)' },
+      policy_id: { type: 'string', required: false, description: 'Policy ID (default policy if omitted)' },
+      monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit (default: 50000)' },
     },
     riskLevel: 'write',
     requiredRole: 'execute',
-    execute: async (params, context) => {
-      const body: Record<string, unknown> = {
-        name: String(params.name || 'Chatbot Agent'),
-        monthly_limit: Number(params.monthly_limit || 50000),
-      };
-      if (hasValue(params.policy_id)) body.policy_id = String(params.policy_id);
-      return postJson(context, '/api/agents', body);
-    },
+    execute: async (params, context) =>
+      callJson(context, '/api/agents', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: String(params.name || 'Chatbot Agent'),
+          policy_id: params.policy_id ? String(params.policy_id) : undefined,
+          monthly_limit: Number(params.monthly_limit || 50000),
+        }),
+      }),
   },
-  { id: 'list_agents', name: 'List Agents', description: 'List org agents.', parameters: noParams, riskLevel: 'read', requiredRole: 'execute', execute: async (_params, context) => callJson(context, '/api/agents') },
-  { id: 'list_policies', name: 'List Policies', description: 'List available policies.', parameters: noParams, riskLevel: 'read', requiredRole: 'policies_read', execute: async (_params, context) => callJson(context, '/api/policies') },
-  { id: 'capacity', name: 'Check Quota & Capacity', description: 'Fetch quota remaining.', parameters: noParams, riskLevel: 'read', requiredRole: 'usage_read', execute: async (_params, context) => callJson(context, '/api/capacity') },
-  { id: 'get_usage', name: 'Get Usage', description: 'Get plan usage.', parameters: noParams, riskLevel: 'read', requiredRole: 'usage_read', execute: async (_params, context) => callJson(context, '/api/usage') },
-  { id: 'get_metrics', name: 'Get Metrics', description: 'Get metrics.', parameters: noParams, riskLevel: 'read', requiredRole: 'monitor', execute: async (_params, context) => callJson(context, '/api/metrics') },
-  { id: 'get_integration', name: 'Get Integration Status', description: 'Get integration status.', parameters: noParams, riskLevel: 'read', requiredRole: 'monitor', execute: async (_params, context) => callJson(context, '/api/integration') },
-  { id: 'get_enterprise_proof', name: 'Get Enterprise Proof Report', description: 'Get proof report.', parameters: noParams, riskLevel: 'read', requiredRole: 'monitor', execute: async (_params, context) => callJson(context, '/api/enterprise-proof/report') },
-  { id: 'auto_setup', name: 'Run Org Auto Setup', description: 'Auto-configure defaults.', parameters: noParams, riskLevel: 'critical', requiredRole: 'org_admin', execute: async (_params, context) => postJson(context, '/api/setup/auto') },
-  { id: 'realtime_web_search', name: 'Real-time Web Search', description: 'Search live web.', parameters: { query: { type: 'string', required: true, description: 'Search query' } }, riskLevel: 'read', requiredRole: 'monitor', execute: async (params, context) => callJson(context, `/api/realtime-search?q=${encodeURIComponent(String(params.query || ''))}`) },
-  { id: 'list_executions', name: 'List Executions', description: 'List executions.', parameters: limitParam, riskLevel: 'read', requiredRole: 'monitor', execute: async (params, context) => callJson(context, `/api/executions?limit=${encodeURIComponent(String(params.limit || 10))}`) },
-  { id: 'list_proofs', name: 'List Proofs', description: 'List proof artifacts.', parameters: limitParam, riskLevel: 'read', requiredRole: 'monitor', execute: async (params, context) => callJson(context, `/api/proofs?limit=${encodeURIComponent(String(params.limit || 20))}`) },
-  { id: 'get_ledger', name: 'Get Ledger', description: 'Get ledger snapshot.', parameters: limitParam, riskLevel: 'read', requiredRole: 'monitor', execute: async (params, context) => callJson(context, `/api/ledger?limit=${encodeURIComponent(String(params.limit || 20))}`) },
-  { id: 'get_audit', name: 'Get Audit Events', description: 'Get audit events.', parameters: limitParam, riskLevel: 'read', requiredRole: 'monitor', execute: async (params, context) => callJson(context, `/api/audit?limit=${encodeURIComponent(String(params.limit || 20))}`) },
-  { id: 'get_execution_proof', name: 'Get Execution Proof', description: 'Get replay proof.', parameters: { execution_id: { type: 'string', required: true, description: 'Execution ID' } }, riskLevel: 'read', requiredRole: 'monitor', execute: async (params, context) => callJson(context, `/api/replay/${encodeURIComponent(String(params.execution_id || ''))}`) },
-  { id: 'get_agent_detail', name: 'Get Agent Detail', description: 'Get one agent.', parameters: agentIdParam, riskLevel: 'read', requiredRole: 'execute', execute: async (params, context) => callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`) },
-  { id: 'rotate_agent_key', name: 'Rotate Agent API Key', description: 'Rotate API key.', parameters: agentIdParam, riskLevel: 'critical', requiredRole: 'execute', execute: async (params, context) => postJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}/rotate-key`) },
-  { id: 'delete_agent', name: 'Disable Agent', description: 'Disable agent.', parameters: agentIdParam, riskLevel: 'critical', requiredRole: 'execute', execute: async (params, context) => callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, { method: 'DELETE' }) },
-  { id: 'update_agent', name: 'Update Agent', description: 'Update agent.', parameters: agentIdParam, riskLevel: 'write', requiredRole: 'execute', execute: async (params, context) => callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, { method: 'PATCH', body: JSON.stringify(params) }) },
-  { id: 'reconcile_effect', name: 'Reconcile Effect Callback', description: 'Mark effect status.', parameters: { effect_id: { type: 'string', required: true, description: 'Effect ID' }, status: { type: 'string', required: true, description: 'Status' } }, riskLevel: 'write', requiredRole: 'effect_callback', execute: async (params, context) => postJson(context, '/api/effect-callback', params) },
+  {
+    id: 'list_policies',
+    name: 'List Policies',
+    description: 'List available policies.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'policies_read',
+    execute: async (_params, context) => callJson(context, '/api/policies', { method: 'GET' }),
+  },
+  {
+    id: 'reconcile_effect',
+    name: 'Reconcile Effect Callback',
+    description: 'Mark effect status as succeeded or failed.',
+    parameters: {
+      effect_id: { type: 'string', required: true, description: 'Effect ID' },
+      status: { type: 'string', required: true, description: 'succeeded or failed' },
+    },
+    riskLevel: 'write',
+    requiredRole: 'effect_callback',
+    execute: async (params, context) =>
+      callJson(context, '/api/effect-callback', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      }),
+  },
+
+  {
+    id: 'list_executions',
+    name: 'List Executions',
+    description: 'List recent executions for this organization.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 10)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/executions?limit=${encodeURIComponent(String(params.limit || 10))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_execution_proof',
+    name: 'Get Execution Proof',
+    description: 'Get replay details and proof context for one execution.',
+    parameters: {
+      execution_id: { type: 'string', required: true, description: 'Execution ID' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/replay/${encodeURIComponent(String(params.execution_id || ''))}`, { method: 'GET' }),
+  },
+  {
+    id: 'list_proofs',
+    name: 'List Proofs',
+    description: 'List recent proof artifacts from audit logs.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 20)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/proofs?limit=${encodeURIComponent(String(params.limit || 20))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_ledger',
+    name: 'Get Ledger',
+    description: 'Get combined ledger and core-ledger snapshot.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 20)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/ledger?limit=${encodeURIComponent(String(params.limit || 20))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_audit',
+    name: 'Get Audit Events',
+    description: 'Get audit events and determinism checks.',
+    parameters: {
+      limit: { type: 'number', required: false, description: 'Max items (default 20)' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (params, context) =>
+      callJson(context, `/api/audit?limit=${encodeURIComponent(String(params.limit || 20))}`, { method: 'GET' }),
+  },
+  {
+    id: 'get_usage',
+    name: 'Get Usage',
+    description: 'Get current plan usage and projected overage.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'usage_read',
+    execute: async (_params, context) => callJson(context, '/api/usage', { method: 'GET' }),
+  },
+  {
+    id: 'get_metrics',
+    name: 'Get Metrics',
+    description: 'Get current day control-plane performance metrics.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (_params, context) => callJson(context, '/api/metrics', { method: 'GET' }),
+  },
+  {
+    id: 'get_integration',
+    name: 'Get Integration Status',
+    description: 'Fetch integration status and source-of-truth posture.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (_params, context) => callJson(context, '/api/integration', { method: 'GET' }),
+  },
+  {
+    id: 'get_agent_detail',
+    name: 'Get Agent Detail',
+    description: 'Get details and monthly usage for one agent.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'read',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, { method: 'GET' }),
+  },
+  {
+    id: 'update_agent',
+    name: 'Update Agent',
+    description: 'Update agent metadata, status, policy, or monthly limit.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+      name: { type: 'string', required: false, description: 'New name' },
+      status: { type: 'string', required: false, description: 'active or disabled' },
+      policy_id: { type: 'string', required: false, description: 'New policy ID' },
+      monthly_limit: { type: 'number', required: false, description: 'New monthly limit' },
+    },
+    riskLevel: 'write',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          name: params.name,
+          status: params.status,
+          policy_id: params.policy_id,
+          monthly_limit: params.monthly_limit,
+        }),
+      }),
+  },
+  {
+    id: 'rotate_agent_key',
+    name: 'Rotate Agent API Key',
+    description: 'Rotate and return a new one-time API key for an agent.',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'critical',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}/rotate-key`, {
+        method: 'POST',
+      }),
+  },
+  {
+    id: 'delete_agent',
+    name: 'Disable Agent',
+    description: 'Disable an agent (soft delete).',
+    parameters: {
+      agent_id: { type: 'string', required: true, description: 'Agent ID' },
+    },
+    riskLevel: 'critical',
+    requiredRole: 'execute',
+    execute: async (params, context) =>
+      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, {
+        method: 'DELETE',
+      }),
+  },
+  {
+    id: 'get_enterprise_proof',
+    name: 'Get Enterprise Proof Report',
+    description: 'Fetch public enterprise proof and attestation report.',
+    parameters: {},
+    riskLevel: 'read',
+    requiredRole: 'monitor',
+    execute: async (_params, context) => callJson(context, '/api/enterprise-proof/report', { method: 'GET' }),
+  },
+  {
+    id: 'auto_setup',
+    name: 'Run Org Auto Setup',
+    description: 'Auto-configure default policy, agent, seed execution, billing, onboarding, and runtime roles.',
+    parameters: {},
+    riskLevel: 'critical',
+    requiredRole: 'org_admin',
+    execute: async (_params, context) =>
+      callJson(context, '/api/setup/auto', {
+        method: 'POST',
+      }),
+  },
 ];


### PR DESCRIPTION
## Emergency production recovery

The Agent chatbot/runtime changes in #396, #397, and #398 still leave Vercel failing on the current `main`.

This PR rolls back the two touched Agent files to the last known green production baseline from commit `5f666e0`:

- `lib/agent/planner.ts`
- `lib/agent/tools.ts`

Goal: restore deterministic production build first. After production is green, chatbot/Agent improvements should be reintroduced in a smaller branch with a local `npm run build` pass before merge.