### PR TITLE
Add chatbot skills v2 from uploaded Agent OS bundle

### DIFF
--- a/app/api/agent-chat-v2/route.ts
+++ b/app/api/agent-chat-v2/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../lib/authz';
+import type { ChatbotSkillContext } from '../../../lib/agent-v2/skills';
+import { planChatbotSkills } from '../../../lib/agent-v2/skills';
+
+function sseData(payload: unknown) {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+export async function POST(request: Request) {
+  const access = await requireOrgRole(['operator', 'org_admin']);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const body = await request.json().catch(() => null);
+  const message = String(body?.message || '').trim();
+  if (!message) {
+    return NextResponse.json({ error: 'message is required' }, { status: 400 });
+  }
+
+  const context: ChatbotSkillContext = {
+    orgId: access.orgId,
+    origin: new URL(request.url).origin,
+    authHeader: request.headers.get('authorization') || '',
+    cookieHeader: request.headers.get('cookie') || '',
+  };
+
+  const plan = planChatbotSkills(message);
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        controller.enqueue(
+          encoder.encode(
+            sseData({
+              type: 'assistant_reply',
+              reply: 'DSG Agent v2 พร้อมใช้งานจาก skills bundle',
+              model: 'skills-v2',
+            }),
+          ),
+        );
+
+        controller.enqueue(
+          encoder.encode(
+            sseData({
+              type: 'plan',
+              steps: plan.map((step) => ({ id: step.id, toolId: step.toolId })),
+            }),
+          ),
+        );
+
+        for (const step of plan) {
+          controller.enqueue(encoder.encode(sseData({ type: 'step_start', step: step.id, tool: step.toolName })));
+
+          try {
+            const result = await step.run(context);
+            controller.enqueue(encoder.encode(sseData({ type: 'step_result', step: step.id, result })));
+          } catch (error) {
+            controller.enqueue(
+              encoder.encode(
+                sseData({
+                  type: 'step_error',
+                  step: step.id,
+                  error: error instanceof Error ? error.message : 'Internal server error',
+                }),
+              ),
+            );
+          }
+        }
+
+        controller.enqueue(encoder.encode(sseData({ type: 'done' })));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/components/AgentChatWidget.tsx
+++ b/components/AgentChatWidget.tsx
@@ -12,12 +12,14 @@ type ChatLine = {
 
 const STORAGE_KEY = 'dsg_chat_history';
 const MAX_HISTORY = 100;
+const AGENT_CHAT_ENDPOINT = '/api/agent-chat-v2';
 
 const PAGE_SUGGESTIONS: Record<string, { label: string; prompt: string }[]> = {
   '/dashboard': [{ label: 'Check readiness', prompt: 'check readiness' }],
   '/dashboard/agents': [
     { label: 'Create agent', prompt: 'create agent' },
     { label: 'List agents', prompt: 'list agents' },
+    { label: 'Create chatbot', prompt: 'create chatbot "Support Bot"' },
   ],
   '/dashboard/policies': [{ label: 'List policies', prompt: 'list policies' }],
   '/dashboard/executions': [{ label: 'Check audit', prompt: 'audit lineage' }],
@@ -41,7 +43,7 @@ export default function AgentChatWidget() {
   const [draft, setDraft] = useState('');
   const [busy, setBusy] = useState(false);
   const [lines, setLines] = useState<ChatLine[]>([
-    makeLine('system', 'DSG Agent พร้อมช่วย — พิมพ์คำสั่งหรือกดปุ่มลัดตามหน้าที่ใช้งาน'),
+    makeLine('system', 'DSG Agent v2 พร้อมช่วย — ใช้ skills bundle ใหม่สำหรับ chatbot/agent runtime'),
   ]);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -81,7 +83,7 @@ export default function AgentChatWidget() {
     setDraft('');
 
     try {
-      const res = await fetch('/api/agent-chat', {
+      const res = await fetch(AGENT_CHAT_ENDPOINT, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ message, pageContext: pathname }),
@@ -144,7 +146,7 @@ export default function AgentChatWidget() {
     <div className="fixed bottom-6 right-6 z-50 flex h-[520px] w-[380px] flex-col rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
       <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
         <div>
-          <p className="text-sm font-semibold text-slate-100">DSG Agent</p>
+          <p className="text-sm font-semibold text-slate-100">DSG Agent v2</p>
           <p className="text-[10px] text-slate-400">{pathname}</p>
         </div>
         <button onClick={() => setOpen(false)} className="text-slate-400 hover:text-white" aria-label="Close agent chat">

--- a/lib/agent-v2/skills.ts
+++ b/lib/agent-v2/skills.ts
@@ -1,0 +1,239 @@
+export type ChatbotSkillContext = {
+  origin: string;
+  orgId: string;
+  authHeader: string;
+  cookieHeader: string;
+};
+
+export type ChatbotSkillStep = {
+  id: string;
+  toolId: string;
+  toolName: string;
+  run: (context: ChatbotSkillContext) => Promise<unknown>;
+};
+
+export function extractAgentId(text: string) {
+  const uuid = text.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  if (uuid) return uuid[0];
+
+  const prefixed = text.match(/agt_[a-zA-Z0-9_-]+/);
+  return prefixed ? prefixed[0] : '';
+}
+
+export function extractQuotedText(text: string) {
+  const match = text.match(/["“”']([^"“”']{1,200})["“”']/);
+  return match ? match[1].trim() : '';
+}
+
+export function cleanChatMessage(text: string) {
+  const quoted = extractQuotedText(text);
+  if (quoted) return quoted;
+
+  const cleaned = text
+    .replace(/chatbot|chat bot|แชทบอท|แชตบอท|ถามบอท|คุยกับบอท/gi, '')
+    .trim();
+
+  return cleaned || text.trim();
+}
+
+async function callJson(context: ChatbotSkillContext, path: string, init?: RequestInit) {
+  const response = await fetch(`${context.origin}${path}`, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      authorization: context.authHeader,
+      cookie: context.cookieHeader,
+    },
+    cache: 'no-store',
+  });
+
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = typeof json === 'object' && json && 'error' in json
+      ? String((json as { error?: unknown }).error)
+      : `Tool call failed (${path})`;
+    throw new Error(error);
+  }
+
+  return json;
+}
+
+function postJson(context: ChatbotSkillContext, path: string, body?: unknown) {
+  return callJson(context, path, {
+    method: 'POST',
+    body: JSON.stringify(body || {}),
+  });
+}
+
+export const chatbotSkills = {
+  readiness(): ChatbotSkillStep {
+    return {
+      id: 's1',
+      toolId: 'readiness_v2',
+      toolName: 'Check System Readiness',
+      run: (context) => callJson(context, '/api/readiness'),
+    };
+  },
+
+  listAgents(id = 's1'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'list_agents_v2',
+      toolName: 'List Agents',
+      run: (context) => callJson(context, '/api/agents'),
+    };
+  },
+
+  listPolicies(id = 's1'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'list_policies_v2',
+      toolName: 'List Policies',
+      run: (context) => callJson(context, '/api/policies'),
+    };
+  },
+
+  listExecutions(id = 's1', limit = 10): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'list_executions_v2',
+      toolName: 'List Executions',
+      run: (context) => callJson(context, `/api/executions?limit=${encodeURIComponent(String(limit))}`),
+    };
+  },
+
+  auditEvents(id = 's1', limit = 20): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'audit_events_v2',
+      toolName: 'Get Audit Events',
+      run: (context) => callJson(context, `/api/audit?limit=${encodeURIComponent(String(limit))}`),
+    };
+  },
+
+  runtimeSummary(agentId: string, id = 's1'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'runtime_summary_v2',
+      toolName: 'Get Runtime Audit Summary',
+      run: (context) =>
+        callJson(
+          context,
+          `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(agentId)}`,
+        ),
+    };
+  },
+
+  runtimeRecovery(agentId: string, id = 's2'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'runtime_recovery_v2',
+      toolName: 'Validate Runtime Recovery',
+      run: (context) =>
+        postJson(context, '/api/runtime-recovery', {
+          org_id: context.orgId,
+          agent_id: agentId,
+        }),
+    };
+  },
+
+  createAgent(name: string, monthlyLimit = 10000, id = 's1'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'create_agent_v2',
+      toolName: 'Create New Agent',
+      run: (context) =>
+        postJson(context, '/api/agents', {
+          name: name || 'New Agent',
+          monthly_limit: monthlyLimit,
+        }),
+    };
+  },
+
+  createChatbotAgent(name: string, monthlyLimit = 50000, id = 's2'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'create_chatbot_agent_v2',
+      toolName: 'Create Chatbot Agent',
+      run: (context) =>
+        postJson(context, '/api/agents', {
+          name: name || 'Chatbot Agent',
+          monthly_limit: monthlyLimit,
+        }),
+    };
+  },
+
+  chatbotMessage(agentId: string, message: string, id = 's1'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'chatbot_message_v2',
+      toolName: 'Chat with Chatbot Agent',
+      run: (context) =>
+        postJson(context, '/api/mcp/call', {
+          agent_id: agentId,
+          action: 'chatbot.message',
+          payload: { message },
+          tool_name: 'chatbot_message_v2',
+        }),
+    };
+  },
+
+  autoSetup(id = 's2'): ChatbotSkillStep {
+    return {
+      id,
+      toolId: 'auto_setup_v2',
+      toolName: 'Run Org Auto Setup',
+      run: (context) => postJson(context, '/api/setup/auto'),
+    };
+  },
+};
+
+export function planChatbotSkills(message: string): ChatbotSkillStep[] {
+  const text = message.trim();
+  const lower = text.toLowerCase();
+  const agentId = extractAgentId(text);
+
+  if (/readiness|health|status|สถานะ/.test(lower)) {
+    return [chatbotSkills.readiness()];
+  }
+
+  if (/audit|lineage|ตรวจสอบ/.test(lower)) {
+    if (agentId) {
+      return [
+        chatbotSkills.runtimeSummary(agentId, 's1'),
+        chatbotSkills.runtimeRecovery(agentId, 's2'),
+      ];
+    }
+
+    return [
+      chatbotSkills.auditEvents('s1'),
+      chatbotSkills.listExecutions('s2'),
+    ];
+  }
+
+  if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
+    if (/create|สร้าง|new|เพิ่ม/.test(lower) || !agentId) {
+      return [
+        chatbotSkills.listPolicies('s1'),
+        chatbotSkills.createChatbotAgent(extractQuotedText(text) || 'Chatbot Agent', 50000, 's2'),
+        chatbotSkills.listAgents('s3'),
+      ];
+    }
+
+    return [chatbotSkills.chatbotMessage(agentId, cleanChatMessage(text), 's1')];
+  }
+
+  if (/create agent|สร้างเอเจนต์|new agent/.test(lower)) {
+    return [chatbotSkills.createAgent(extractQuotedText(text) || 'New Agent')];
+  }
+
+  if (/agent|เอเจนต์|api เอเจ้น|api agent/.test(lower)) {
+    return [chatbotSkills.listAgents()];
+  }
+
+  if (/auto_setup|auto setup|setup|ติดตั้ง/.test(lower)) {
+    return [chatbotSkills.readiness(), chatbotSkills.autoSetup('s2')];
+  }
+
+  return [chatbotSkills.readiness(), chatbotSkills.listAgents('s2')];
+}


### PR DESCRIPTION
## Summary

Integrates the latest uploaded Agent OS/chatbot bundle as a clean v2 skill layer instead of modifying the legacy `lib/agent/tools.ts` / `lib/agent/planner.ts` files.

### What this PR adds

- `lib/agent-v2/skills.ts`
  - self-contained chatbot skills
  - readiness
  - list agents
  - list policies
  - audit lineage fallback
  - runtime summary/recovery when agent id is present
  - create agent
  - create chatbot agent
  - chatbot message via `/api/mcp/call`
  - auto setup

- `app/api/agent-chat-v2/route.ts`
  - SSE endpoint wired to the v2 skills
  - no import from legacy `planner/tools/executor`
  - keeps route logic thin and deterministic

- `components/AgentChatWidget.tsx`
  - points the dashboard widget to `/api/agent-chat-v2`
  - adds Create chatbot quick action

### Why this shape

Previous attempts changed the legacy agent tool registry and caused Vercel build failures. This PR isolates the new chatbot implementation so the legacy agent runtime remains untouched.

### Uploaded bundle used

Pulled the shape from the latest provided Agent OS bundle (`dsg-agent-os-portable-deploy.zip`) and merged it as a safer v2 skills layer.