### PR TITLE
Add runtime-governed OpenRouter provider with customer BYOK

### DIFF
--- a/app/api/agent-chat-v2/route.ts
+++ b/app/api/agent-chat-v2/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireOrgRole } from '../../../lib/authz';
+import { generateRuntimeGovernedModelReply } from '../../../lib/agent-v2/openrouter-provider';
 import type { ChatbotSkillContext } from '../../../lib/agent-v2/skills';
 import { planChatbotSkills } from '../../../lib/agent-v2/skills';
 
@@ -15,6 +16,7 @@ export async function POST(request: Request) {
 
   const body = await request.json().catch(() => null);
   const message = String(body?.message || '').trim();
+  const pageContext = String(body?.pageContext || '').trim();
   if (!message) {
     return NextResponse.json({ error: 'message is required' }, { status: 400 });
   }
@@ -32,12 +34,26 @@ export async function POST(request: Request) {
   const stream = new ReadableStream({
     async start(controller) {
       try {
+        let modelReply = null as Awaited<ReturnType<typeof generateRuntimeGovernedModelReply>>;
+        try {
+          modelReply = await generateRuntimeGovernedModelReply({
+            orgId: access.orgId,
+            message,
+            pageContext,
+          });
+        } catch {
+          modelReply = null;
+        }
+
         controller.enqueue(
           encoder.encode(
             sseData({
               type: 'assistant_reply',
-              reply: 'DSG Agent v2 พร้อมใช้งานจาก skills bundle',
-              model: 'skills-v2',
+              reply: modelReply?.reply || 'DSG Agent v2 พร้อมใช้งานจาก skills bundle',
+              model: modelReply?.modelUsed || 'skills-v2',
+              provider: modelReply?.provider || 'internal-skills',
+              providerSource: modelReply?.providerSource || 'runtime',
+              runtimeGoverned: true,
             }),
           ),
         );
@@ -47,6 +63,7 @@ export async function POST(request: Request) {
             sseData({
               type: 'plan',
               steps: plan.map((step) => ({ id: step.id, toolId: step.toolId })),
+              runtimeGoverned: true,
             }),
           ),
         );

--- a/app/api/model-provider/openrouter/route.ts
+++ b/app/api/model-provider/openrouter/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../lib/authz';
+import {
+  disableOpenRouterProviderKey,
+  getOpenRouterProviderStatus,
+  saveOpenRouterProviderKey,
+} from '../../../../lib/agent-v2/openrouter-provider';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const access = await requireOrgRole(['org_admin', 'operator']);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  try {
+    const status = await getOpenRouterProviderStatus(access.orgId);
+    return NextResponse.json(status);
+  } catch {
+    return NextResponse.json({ error: 'model_provider_status_failed' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const body = await request.json().catch(() => null);
+  const apiKey = String(body?.api_key || '').trim();
+  if (!apiKey) {
+    return NextResponse.json({ error: 'api_key is required' }, { status: 400 });
+  }
+
+  try {
+    const result = await saveOpenRouterProviderKey(access.orgId, access.userId, apiKey);
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'model_provider_save_failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  try {
+    const result = await disableOpenRouterProviderKey(access.orgId);
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json({ error: 'model_provider_disable_failed' }, { status: 500 });
+  }
+}

--- a/lib/agent-v2/openrouter-provider.ts
+++ b/lib/agent-v2/openrouter-provider.ts
@@ -1,0 +1,207 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+import { getSupabaseAdmin } from '../supabase-server';
+
+export type ModelProviderSource = 'customer_byok' | 'system_runtime';
+export type ModelIntent = 'planning' | 'reasoning' | 'chat' | 'code';
+
+export type RuntimeGovernedModelReply = {
+  reply: string;
+  provider: 'openrouter';
+  providerSource: ModelProviderSource;
+  modelUsed: string;
+  intent: ModelIntent;
+};
+
+type Credential = {
+  apiKey: string;
+  source: ModelProviderSource;
+};
+
+const MODEL_BY_INTENT: Record<ModelIntent, { id: string; model: string; maxTokens: number }> = {
+  planning: { id: 'qwen-planner', model: process.env.OPENROUTER_MODEL_PLANNING || 'qwen/qwen-2.5-7b-instruct:free', maxTokens: 1200 },
+  reasoning: { id: 'deepseek-reasoner', model: process.env.OPENROUTER_MODEL_REASONING || 'deepseek/deepseek-r1-0528:free', maxTokens: 1800 },
+  chat: { id: 'llama-chat', model: process.env.OPENROUTER_MODEL_CHAT || 'meta-llama/llama-4-scout:free', maxTokens: 1200 },
+  code: { id: 'qwen-coder', model: process.env.OPENROUTER_MODEL_CODE || 'qwen/qwen-2.5-coder-7b-instruct:free', maxTokens: 1200 },
+};
+
+const PROVIDER_TABLE = 'agent_model_provider_keys';
+const KEY_VERSION = 'v1';
+const TIMEOUT_MS = 12_000;
+
+function classifyIntent(message: string): ModelIntent {
+  const lower = message.toLowerCase();
+  if (/json|config|schema|sql|code|โค้ด|สคริปต์|debug|build|typescript|route/.test(lower)) return 'code';
+  if (/why|ทำไม|วิเคราะห์|analyze|audit|proof|compare|เปรียบเทียบ|อธิบาย|explain|lineage/.test(lower)) return 'reasoning';
+  if (/^(hi|hello|สวัสดี|ช่วย|help|แนะนำ|อะไร|what|how|ยังไง|เล่า|tell)/.test(lower)) return 'chat';
+  return 'planning';
+}
+
+function secretKey() {
+  const secret = process.env.MODEL_PROVIDER_SECRET || process.env.NEXTAUTH_SECRET || '';
+  return secret ? createHash('sha256').update(secret).digest() : null;
+}
+
+function encrypt(value: string) {
+  const key = secretKey();
+  if (!key) throw new Error('MODEL_PROVIDER_SECRET is required');
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [KEY_VERSION, iv.toString('base64'), tag.toString('base64'), encrypted.toString('base64')].join(':');
+}
+
+function decrypt(value: string) {
+  const key = secretKey();
+  if (!key) return null;
+  const [version, iv, tag, encrypted] = value.split(':');
+  if (version !== KEY_VERSION || !iv || !tag || !encrypted) return null;
+  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(iv, 'base64'));
+  decipher.setAuthTag(Buffer.from(tag, 'base64'));
+  const plain = Buffer.concat([decipher.update(Buffer.from(encrypted, 'base64')), decipher.final()]);
+  return plain.toString('utf8');
+}
+
+function previewKey(apiKey: string) {
+  const trimmed = apiKey.trim();
+  return trimmed.length > 10 ? `${trimmed.slice(0, 6)}…${trimmed.slice(-4)}` : 'hidden';
+}
+
+function isMissingTable(error: unknown) {
+  const item = error as { code?: string; message?: string } | null;
+  const message = String(item?.message || '').toLowerCase();
+  return item?.code === 'PGRST205' || (message.includes(PROVIDER_TABLE) && (message.includes('does not exist') || message.includes('schema cache') || message.includes('could not find')));
+}
+
+async function customerCredential(orgId: string): Promise<Credential | null> {
+  const { data, error } = await getSupabaseAdmin()
+    .from(PROVIDER_TABLE)
+    .select('encrypted_api_key')
+    .eq('org_id', orgId)
+    .eq('provider', 'openrouter')
+    .eq('status', 'active')
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    if (isMissingTable(error)) return null;
+    throw error;
+  }
+
+  const apiKey = data?.encrypted_api_key ? decrypt(String(data.encrypted_api_key)) : null;
+  return apiKey ? { apiKey, source: 'customer_byok' } : null;
+}
+
+async function resolveCredential(orgId: string): Promise<Credential | null> {
+  const customer = await customerCredential(orgId);
+  if (customer) return customer;
+  return process.env.OPENROUTER_API_KEY ? { apiKey: process.env.OPENROUTER_API_KEY, source: 'system_runtime' } : null;
+}
+
+export async function getOpenRouterProviderStatus(orgId: string) {
+  const systemConfigured = Boolean(process.env.OPENROUTER_API_KEY);
+  const { data, error } = await getSupabaseAdmin()
+    .from(PROVIDER_TABLE)
+    .select('api_key_preview, updated_at')
+    .eq('org_id', orgId)
+    .eq('provider', 'openrouter')
+    .eq('status', 'active')
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    if (isMissingTable(error)) return { ok: true, provider: 'openrouter', customerConfigured: false, systemConfigured, missingTable: true };
+    throw error;
+  }
+
+  return { ok: true, provider: 'openrouter', customerConfigured: Boolean(data), systemConfigured, missingTable: false, api_key_preview: data?.api_key_preview || null, updated_at: data?.updated_at || null };
+}
+
+export async function saveOpenRouterProviderKey(orgId: string, userId: string, apiKey: string) {
+  const trimmed = apiKey.trim();
+  if (!trimmed) throw new Error('api_key is required');
+  const supabase = getSupabaseAdmin();
+  const now = new Date().toISOString();
+
+  await supabase
+    .from(PROVIDER_TABLE)
+    .update({ status: 'replaced', updated_at: now })
+    .eq('org_id', orgId)
+    .eq('provider', 'openrouter')
+    .eq('status', 'active');
+
+  const { error } = await supabase.from(PROVIDER_TABLE).insert({
+    org_id: orgId,
+    provider: 'openrouter',
+    encrypted_api_key: encrypt(trimmed),
+    api_key_preview: previewKey(trimmed),
+    status: 'active',
+    created_by: userId,
+    updated_at: now,
+  });
+  if (error) throw error;
+  return { ok: true, provider: 'openrouter', api_key_preview: previewKey(trimmed) };
+}
+
+export async function disableOpenRouterProviderKey(orgId: string) {
+  const { error } = await getSupabaseAdmin()
+    .from(PROVIDER_TABLE)
+    .update({ status: 'disabled', updated_at: new Date().toISOString() })
+    .eq('org_id', orgId)
+    .eq('provider', 'openrouter')
+    .eq('status', 'active');
+  if (error) throw error;
+  return { ok: true, provider: 'openrouter', customerConfigured: false };
+}
+
+function systemPrompt(pageContext?: string) {
+  return `You are DSG Agent v2. You can explain and propose safe next steps, but real system changes must be executed only through DSG runtime tools. Never claim an action was executed unless the runtime result confirms it. Match the user's language. Current page: ${pageContext || 'unknown'}.`;
+}
+
+export async function generateRuntimeGovernedModelReply(params: {
+  orgId: string;
+  message: string;
+  pageContext?: string;
+}): Promise<RuntimeGovernedModelReply | null> {
+  const credential = await resolveCredential(params.orgId);
+  if (!credential) return null;
+
+  const intent = classifyIntent(params.message);
+  const model = MODEL_BY_INTENT[intent];
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${credential.apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+        'X-Title': 'DSG Runtime Governed Chatbot',
+      },
+      body: JSON.stringify({
+        model: model.model,
+        messages: [
+          { role: 'system', content: systemPrompt(params.pageContext) },
+          { role: 'user', content: params.message },
+        ],
+        max_tokens: model.maxTokens,
+        temperature: 0.2,
+      }),
+    });
+
+    if (!response.ok) throw new Error(`OpenRouter error ${response.status}`);
+
+    const json = (await response.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    const reply = String(json.choices?.[0]?.message?.content || '').trim();
+    if (!reply) return null;
+
+    return { reply, provider: 'openrouter', providerSource: credential.source, modelUsed: model.id, intent };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/supabase/migrations/202604261825_agent_model_provider_keys.sql
+++ b/supabase/migrations/202604261825_agent_model_provider_keys.sql
@@ -1,0 +1,23 @@
+create table if not exists public.agent_model_provider_keys (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  provider text not null check (provider in ('openrouter')),
+  encrypted_api_key text not null,
+  api_key_preview text not null default 'hidden',
+  status text not null default 'active' check (status in ('active', 'disabled', 'replaced')),
+  created_by uuid references public.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_agent_model_provider_keys_org_provider_status
+  on public.agent_model_provider_keys(org_id, provider, status, updated_at desc);
+
+alter table public.agent_model_provider_keys enable row level security;
+
+drop policy if exists agent_model_provider_keys_no_client_access on public.agent_model_provider_keys;
+create policy agent_model_provider_keys_no_client_access
+  on public.agent_model_provider_keys
+  for all
+  using (false)
+  with check (false);


### PR DESCRIPTION
## Summary

Adds OpenRouter back in a safer runtime-governed shape.

### Design

Chatbot remains separated from execution authority:

- OpenRouter/BYOK is only used for assistant wording and planning context.
- Real actions still run through the DSG runtime path.
- Execution still goes through skills -> `/api/mcp/call` -> spine runtime -> policy/quota/approval/audit/ledger/invariants.

### Added

- `lib/agent-v2/openrouter-provider.ts`
  - system runtime OpenRouter key fallback via `OPENROUTER_API_KEY`
  - customer BYOK resolver from Supabase table
  - encrypted customer key storage using `MODEL_PROVIDER_SECRET` or `NEXTAUTH_SECRET`
  - free model routing defaults for planning/reasoning/chat/code
  - timeout guard

- `app/api/model-provider/openrouter/route.ts`
  - `GET` status
  - `POST` save org OpenRouter key
  - `DELETE` disable org OpenRouter key

- `supabase/migrations/202604261825_agent_model_provider_keys.sql`
  - org-scoped provider key table
  - encrypted key column
  - preview only for display
  - RLS blocks direct client access

- `app/api/agent-chat-v2/route.ts`
  - optionally calls OpenRouter for natural-language answer
  - always continues to run planned skills through runtime-governed path
  - falls back to internal skills if no provider/key or OpenRouter fails

### Required env

- `OPENROUTER_API_KEY` for shared system runtime provider, optional if using customer BYOK only
- `MODEL_PROVIDER_SECRET` recommended for customer key encryption

### Safety invariant

The model provider does not directly execute side effects. Runtime remains the only execution authority.