### PR TITLE
Fix DSG agent readiness gate and approval-safe execution

### DIFF
--- a/app/api/agent-chat-v2/route.ts
+++ b/app/api/agent-chat-v2/route.ts
@@ -8,6 +8,10 @@ function sseData(payload: unknown) {
   return `data: ${JSON.stringify(payload)}\n\n`;
 }
 
+function hasApprovalToken(value: unknown) {
+  return typeof value === 'string' && value.trim().length >= 8;
+}
+
 export async function POST(request: Request) {
   const access = await requireOrgRole(['operator', 'org_admin']);
   if (!access.ok) {
@@ -17,6 +21,8 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   const message = String(body?.message || '').trim();
   const pageContext = String(body?.pageContext || '').trim();
+  const executeApprovedPlan = body?.executeApprovedPlan === true;
+  const approvalToken = body?.approvalToken;
   if (!message) {
     return NextResponse.json({ error: 'message is required' }, { status: 400 });
   }
@@ -49,11 +55,12 @@ export async function POST(request: Request) {
           encoder.encode(
             sseData({
               type: 'assistant_reply',
-              reply: modelReply?.reply || 'DSG Agent v2 พร้อมใช้งานจาก skills bundle',
+              reply: modelReply?.reply || 'DSG Agent v2 สร้างแผนแล้ว โปรดตรวจและอนุมัติก่อน execution',
               model: modelReply?.modelUsed || 'skills-v2',
               provider: modelReply?.provider || 'internal-skills',
               providerSource: modelReply?.providerSource || 'runtime',
               runtimeGoverned: true,
+              approval: { required_for_execution: true, runtime_gate: true },
             }),
           ),
         );
@@ -62,11 +69,30 @@ export async function POST(request: Request) {
           encoder.encode(
             sseData({
               type: 'plan',
-              steps: plan.map((step) => ({ id: step.id, toolId: step.toolId })),
+              steps: plan.map((step) => ({ id: step.id, toolId: step.toolId, toolName: step.toolName })),
+              executionMode: executeApprovedPlan ? 'approved_execution_requested' : 'plan_only',
               runtimeGoverned: true,
+              definitionOfSuccess: [
+                'User reviews the plan',
+                'Execution request includes executeApprovedPlan=true and approvalToken',
+                'Runtime tool result confirms the action outcome',
+              ],
             }),
           ),
         );
+
+        if (!executeApprovedPlan || !hasApprovalToken(approvalToken)) {
+          controller.enqueue(
+            encoder.encode(
+              sseData({
+                type: 'approval_required',
+                message: 'Plan only. Send executeApprovedPlan=true with approvalToken to run planned steps.',
+              }),
+            ),
+          );
+          controller.enqueue(encoder.encode(sseData({ type: 'done' })));
+          return;
+        }
 
         for (const step of plan) {
           controller.enqueue(encoder.encode(sseData({ type: 'step_start', step: step.id, tool: step.toolName })));

--- a/lib/agent/context.ts
+++ b/lib/agent/context.ts
@@ -4,6 +4,7 @@ export type AgentContext = {
   origin: string;
   authHeader: string;
   cookieHeader: string;
+  approvalToken?: string;
 };
 
 export type AgentPlanStep = {

--- a/lib/agent/executor.ts
+++ b/lib/agent/executor.ts
@@ -2,6 +2,10 @@ import { resolveGate } from '../gate';
 import type { AgentContext } from './context';
 import type { AgentTool } from './tools';
 
+function hasExplicitApproval(context: AgentContext) {
+  return typeof context.approvalToken === 'string' && context.approvalToken.trim().length >= 8;
+}
+
 export async function executeToolSafely(
   tool: AgentTool,
   params: Record<string, unknown>,
@@ -11,9 +15,28 @@ export async function executeToolSafely(
     return tool.execute(params, context);
   }
 
+  if (!hasExplicitApproval(context)) {
+    return {
+      requiresApproval: true,
+      blocked: true,
+      reason: 'Plan generated. User approval is required before write or critical agent execution.',
+      tool: tool.id,
+      params,
+    };
+  }
+
+  const agentId = String(params.agent_id || '').trim();
+  if (!agentId) {
+    return {
+      blocked: true,
+      reason: 'agent_id is required for write or critical runtime tools; empty agent_id is not sent to runtime APIs.',
+      tool: tool.id,
+    };
+  }
+
   const gate = resolveGate();
   const gateResult = await gate.evaluate({
-    agent_id: String(params.agent_id || 'operator-console'),
+    agent_id: agentId,
     action: `tool:${tool.id}`,
     payload: {
       params,

--- a/lib/agent/planner.ts
+++ b/lib/agent/planner.ts
@@ -1,7 +1,9 @@
 import type { AgentPlan, AgentPlanStep } from './context';
 
-function extractAgentId(message: string) {
-  const match = message.match(/agt_[a-zA-Z0-9_-]+/);
+const UUID_PATTERN = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}';
+
+export function extractAgentId(message: string) {
+  const match = message.match(new RegExp(`\\b(?:agt_[a-zA-Z0-9_-]+|${UUID_PATTERN})\\b`));
   return match ? match[0] : '';
 }
 
@@ -24,11 +26,26 @@ function nextStep(id: number, toolId: string, params: Record<string, unknown>): 
   return { id: `s${id}`, toolId, params };
 }
 
+function missingAgentPlan(): AgentPlan {
+  return {
+    steps: [
+      nextStep(1, 'readiness', {}),
+      nextStep(2, 'list_agents', {}),
+    ],
+  };
+}
+
+function withAgentId(agentId: string, build: (agentId: string) => AgentPlan): AgentPlan {
+  if (!agentId) {
+    return missingAgentPlan();
+  }
+  return build(agentId);
+}
+
 export function planGoal(message: string, pageContext?: string): AgentPlan {
   const text = message.trim();
   const lower = text.toLowerCase();
   const agentId = extractAgentId(text);
-
 
   if (/^(ช่วย|help|แนะนำ|suggest)$/i.test(lower)) {
     switch (pageContext) {
@@ -41,12 +58,12 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
         return { steps: [nextStep(1, 'capacity', {})] };
       case '/dashboard/executions':
       case '/dashboard/operations':
-        return {
+        return withAgentId(agentId, (id) => ({
           steps: [
-            nextStep(1, 'audit_summary', { agent_id: agentId }),
-            nextStep(2, 'recovery_validate', { agent_id: agentId }),
+            nextStep(1, 'audit_summary', { agent_id: id }),
+            nextStep(2, 'recovery_validate', { agent_id: id }),
           ],
-        };
+        }));
       default:
         return { steps: [nextStep(1, 'readiness', {})] };
     }
@@ -57,32 +74,31 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
   }
 
   if (/execute|run|รัน|ทำงาน/.test(lower)) {
-    return {
+    return withAgentId(agentId, (id) => ({
       steps: [
         nextStep(1, 'readiness', {}),
-        nextStep(2, 'execute_action', { agent_id: agentId, action: 'operator-request', payload: { message: text } }),
+        nextStep(2, 'execute_action', { agent_id: id, action: 'operator-request', payload: { message: text } }),
       ],
-    };
+    }));
   }
 
   if (/audit|lineage|ตรวจสอบ/.test(lower)) {
-    return {
+    return withAgentId(agentId, (id) => ({
       steps: [
-        nextStep(1, 'audit_summary', { agent_id: agentId }),
-        nextStep(2, 'recovery_validate', { agent_id: agentId }),
+        nextStep(1, 'audit_summary', { agent_id: id }),
+        nextStep(2, 'recovery_validate', { agent_id: id }),
       ],
-    };
+    }));
   }
 
   if (/checkpoint|บันทึก/.test(lower)) {
-    return {
+    return withAgentId(agentId, (id) => ({
       steps: [
-        nextStep(1, 'recovery_validate', { agent_id: agentId }),
-        nextStep(2, 'checkpoint', { agent_id: agentId }),
+        nextStep(1, 'recovery_validate', { agent_id: id }),
+        nextStep(2, 'checkpoint', { agent_id: id }),
       ],
-    };
+    }));
   }
-
 
   if (/execution|executions|proof|replay|หลักฐาน/.test(lower)) {
     const executionId = text.match(/exec_[a-zA-Z0-9_-]+/)?.[0] || '';
@@ -123,15 +139,15 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
   }
 
   if (/browser|navigate|open url|เปิดเว็บ|เปิดลิงก์|เข้าเว็บ/.test(lower)) {
-    return {
+    return withAgentId(agentId, (id) => ({
       steps: [
         nextStep(1, 'browser_navigate', {
-          agent_id: agentId,
+          agent_id: id,
           url: extractUrl(text),
           extract: '',
         }),
       ],
-    };
+    }));
   }
 
   if (/search|ค้นหา|ออนไลน์|online|เว็บ|web/.test(lower)) {
@@ -139,7 +155,6 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
       steps: [nextStep(1, 'realtime_web_search', { query: text })],
     };
   }
-
 
   if (/list agents|show agents|agents|เอเจนต์ทั้งหมด/.test(lower)) {
     return { steps: [nextStep(1, 'list_agents', {})] };
@@ -164,24 +179,23 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
     return {
       steps: [
         nextStep(1, 'create_agent', {
-          name: 'New Agent',
-          policy_id: 'default',
+          name: extractQuotedName(text) || 'New Agent',
+          policy_id: null,
         }),
       ],
     };
   }
 
-
-  if (/agent detail|รายละเอียดเอเจนต์/.test(lower) && agentId) {
-    return { steps: [nextStep(1, 'get_agent_detail', { agent_id: agentId })] };
+  if (/agent detail|รายละเอียดเอเจนต์/.test(lower)) {
+    return withAgentId(agentId, (id) => ({ steps: [nextStep(1, 'get_agent_detail', { agent_id: id })] }));
   }
 
-  if (/rotate key|rotate api key/.test(lower) && agentId) {
-    return { steps: [nextStep(1, 'rotate_agent_key', { agent_id: agentId })] };
+  if (/rotate key|rotate api key/.test(lower)) {
+    return withAgentId(agentId, (id) => ({ steps: [nextStep(1, 'rotate_agent_key', { agent_id: id })] }));
   }
 
-  if (/delete agent|disable agent|ลบเอเจนต์/.test(lower) && agentId) {
-    return { steps: [nextStep(1, 'delete_agent', { agent_id: agentId })] };
+  if (/delete agent|disable agent|ลบเอเจนต์/.test(lower)) {
+    return withAgentId(agentId, (id) => ({ steps: [nextStep(1, 'delete_agent', { agent_id: id })] }));
   }
 
   if (/chatbot|chat bot|แชทบอท|แชตบอท/.test(lower)) {
@@ -190,6 +204,7 @@ export function planGoal(message: string, pageContext?: string): AgentPlan {
         nextStep(1, 'list_policies', {}),
         nextStep(2, 'create_chatbot_agent', {
           name: extractQuotedName(text) || 'Chatbot Agent',
+          policy_id: null,
           monthly_limit: 50000,
         }),
         nextStep(3, 'list_agents', {}),

--- a/lib/agent/tools.ts
+++ b/lib/agent/tools.ts
@@ -28,21 +28,44 @@ async function callJson(
 
   const json = await response.json().catch(() => ({}));
   if (!response.ok) {
+    if (path === '/api/readiness' && response.status >= 500) {
+      return {
+        ready: false,
+        status: 'deployment_error',
+        warning: 'Readiness returned 500. Please inspect the deployment and Vercel logs before executing agents.',
+        error: String(json.error || 'readiness failed'),
+      };
+    }
     throw new Error(String(json.error || `Tool call failed (${path})`));
   }
 
   return json;
 }
 
+function requiredAgentId(params: Record<string, unknown>) {
+  const agentId = String(params.agent_id || '').trim();
+  if (!agentId) {
+    throw new Error('agent_id is required and cannot be empty');
+  }
+  return agentId;
+}
+
+function omitEmptyPolicy<T extends Record<string, unknown>>(payload: T) {
+  if (payload.policy_id === '' || payload.policy_id === 'default' || payload.policy_id === undefined) {
+    delete payload.policy_id;
+  }
+  return payload;
+}
+
 export const DSG_TOOLS: AgentTool[] = [
   {
     id: 'readiness',
     name: 'Check System Readiness',
-    description: 'Fetch readiness, health, entropy, alerts, and billing state.',
+    description: 'Fetch deployment readiness from /api/readiness with a safe warning fallback on server errors.',
     parameters: {},
     riskLevel: 'read',
     requiredRole: 'monitor',
-    execute: async (_params, context) => callJson(context, '/api/core/monitor', { method: 'GET' }),
+    execute: async (_params, context) => callJson(context, '/api/readiness', { method: 'GET' }),
   },
   {
     id: 'execute_action',
@@ -59,7 +82,7 @@ export const DSG_TOOLS: AgentTool[] = [
       callJson(context, '/api/mcp/call', {
         method: 'POST',
         body: JSON.stringify({
-          agent_id: params.agent_id,
+          agent_id: requiredAgentId(params),
           action: params.action,
           payload: params.payload || {},
           tool_name: 'agent-chat',
@@ -81,7 +104,7 @@ export const DSG_TOOLS: AgentTool[] = [
       callJson(context, '/api/mcp/call', {
         method: 'POST',
         body: JSON.stringify({
-          agent_id: params.agent_id,
+          agent_id: requiredAgentId(params),
           action: 'browser.navigate',
           payload: {
             url: params.url,
@@ -106,7 +129,7 @@ export const DSG_TOOLS: AgentTool[] = [
       callJson(context, '/api/mcp/call', {
         method: 'POST',
         body: JSON.stringify({
-          agent_id: params.agent_id,
+          agent_id: requiredAgentId(params),
           action: 'social.telegram.send',
           payload: {
             chat_id: params.chat_id,
@@ -126,7 +149,7 @@ export const DSG_TOOLS: AgentTool[] = [
     riskLevel: 'read',
     requiredRole: 'runtime_summary',
     execute: async (params, context) =>
-      callJson(context, `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(String(params.agent_id || ''))}`, {
+      callJson(context, `/api/runtime-summary?org_id=${encodeURIComponent(context.orgId)}&agent_id=${encodeURIComponent(requiredAgentId(params))}`, {
         method: 'GET',
       }),
   },
@@ -142,7 +165,7 @@ export const DSG_TOOLS: AgentTool[] = [
     execute: async (params, context) =>
       callJson(context, '/api/checkpoint', {
         method: 'POST',
-        body: JSON.stringify({ org_id: context.orgId, agent_id: params.agent_id }),
+        body: JSON.stringify({ org_id: context.orgId, agent_id: requiredAgentId(params) }),
       }),
   },
   {
@@ -157,7 +180,7 @@ export const DSG_TOOLS: AgentTool[] = [
     execute: async (params, context) =>
       callJson(context, '/api/runtime-recovery', {
         method: 'POST',
-        body: JSON.stringify({ org_id: context.orgId, agent_id: params.agent_id }),
+        body: JSON.stringify({ org_id: context.orgId, agent_id: requiredAgentId(params) }),
       }),
   },
   {
@@ -200,7 +223,7 @@ export const DSG_TOOLS: AgentTool[] = [
     description: 'Create a new agent with one-time API key return.',
     parameters: {
       name: { type: 'string', required: true, description: 'Agent name' },
-      policy_id: { type: 'string', required: true, description: 'Policy ID' },
+      policy_id: { type: 'string', required: false, description: 'Policy ID; omit/null for backend default' },
       monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit' },
     },
     riskLevel: 'write',
@@ -208,7 +231,7 @@ export const DSG_TOOLS: AgentTool[] = [
     execute: async (params, context) =>
       callJson(context, '/api/agents', {
         method: 'POST',
-        body: JSON.stringify(params),
+        body: JSON.stringify(omitEmptyPolicy({ ...params })),
       }),
   },
   {
@@ -217,7 +240,7 @@ export const DSG_TOOLS: AgentTool[] = [
     description: 'Create a chatbot-ready agent with safe defaults for interactive usage.',
     parameters: {
       name: { type: 'string', required: false, description: 'Agent name (default: Chatbot Agent)' },
-      policy_id: { type: 'string', required: false, description: 'Policy ID (default policy if omitted)' },
+      policy_id: { type: 'string', required: false, description: 'Policy ID; omit/null for backend default' },
       monthly_limit: { type: 'number', required: false, description: 'Monthly execution limit (default: 50000)' },
     },
     riskLevel: 'write',
@@ -225,11 +248,11 @@ export const DSG_TOOLS: AgentTool[] = [
     execute: async (params, context) =>
       callJson(context, '/api/agents', {
         method: 'POST',
-        body: JSON.stringify({
+        body: JSON.stringify(omitEmptyPolicy({
           name: String(params.name || 'Chatbot Agent'),
-          policy_id: params.policy_id ? String(params.policy_id) : undefined,
+          policy_id: params.policy_id ? String(params.policy_id) : null,
           monthly_limit: Number(params.monthly_limit || 50000),
-        }),
+        })),
       }),
   },
   {
@@ -355,7 +378,7 @@ export const DSG_TOOLS: AgentTool[] = [
     riskLevel: 'read',
     requiredRole: 'execute',
     execute: async (params, context) =>
-      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, { method: 'GET' }),
+      callJson(context, `/api/agents/${encodeURIComponent(requiredAgentId(params))}`, { method: 'GET' }),
   },
   {
     id: 'update_agent',
@@ -365,21 +388,18 @@ export const DSG_TOOLS: AgentTool[] = [
       agent_id: { type: 'string', required: true, description: 'Agent ID' },
       name: { type: 'string', required: false, description: 'New name' },
       status: { type: 'string', required: false, description: 'active or disabled' },
-      policy_id: { type: 'string', required: false, description: 'New policy ID' },
+      policy_id: { type: 'string', required: false, description: 'New policy ID; omit/null for backend default' },
       monthly_limit: { type: 'number', required: false, description: 'New monthly limit' },
     },
     riskLevel: 'write',
     requiredRole: 'execute',
-    execute: async (params, context) =>
-      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, {
+    execute: async (params, context) => {
+      const { agent_id: _agentId, ...patch } = params;
+      return callJson(context, `/api/agents/${encodeURIComponent(requiredAgentId(params))}`, {
         method: 'PATCH',
-        body: JSON.stringify({
-          name: params.name,
-          status: params.status,
-          policy_id: params.policy_id,
-          monthly_limit: params.monthly_limit,
-        }),
-      }),
+        body: JSON.stringify(omitEmptyPolicy(patch)),
+      });
+    },
   },
   {
     id: 'rotate_agent_key',
@@ -391,7 +411,7 @@ export const DSG_TOOLS: AgentTool[] = [
     riskLevel: 'critical',
     requiredRole: 'execute',
     execute: async (params, context) =>
-      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}/rotate-key`, {
+      callJson(context, `/api/agents/${encodeURIComponent(requiredAgentId(params))}/rotate-key`, {
         method: 'POST',
       }),
   },
@@ -405,7 +425,7 @@ export const DSG_TOOLS: AgentTool[] = [
     riskLevel: 'critical',
     requiredRole: 'execute',
     execute: async (params, context) =>
-      callJson(context, `/api/agents/${encodeURIComponent(String(params.agent_id || ''))}`, {
+      callJson(context, `/api/agents/${encodeURIComponent(requiredAgentId(params))}`, {
         method: 'DELETE',
       }),
   },

--- a/lib/model-provider/openrouter.ts
+++ b/lib/model-provider/openrouter.ts
@@ -1,0 +1,109 @@
+import type { AgentPlan, AgentPlanStep } from '../agent/context';
+
+export type ModelProviderRequest = {
+  orgId: string;
+  sessionKey: string;
+  message: string;
+  pageContext?: string;
+  customerApiKey?: string | null;
+};
+
+export type ModelProviderResult = {
+  reply: string;
+  plan: AgentPlan;
+  modelUsed: string;
+  provider: 'openrouter' | 'fallback-skills-planner';
+  keySource: 'customer' | 'system' | 'none';
+};
+
+function toPlanSteps(value: unknown): AgentPlanStep[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((step, index) => {
+    const item = step && typeof step === 'object' ? (step as Record<string, unknown>) : {};
+    const params = item.params && typeof item.params === 'object' ? (item.params as Record<string, unknown>) : {};
+
+    return {
+      id: typeof item.id === 'string' && item.id ? item.id : `s${index + 1}`,
+      toolId: typeof item.toolId === 'string' ? item.toolId : '',
+      params,
+    };
+  });
+}
+
+function systemPrompt(pageContext?: string) {
+  return `You are the DSG Agent planning brain.
+Return JSON only with this shape:
+{
+  "reply": "brief Thai or English response matching the user",
+  "plan": { "steps": [{ "id": "s1", "toolId": "readiness", "params": {} }] }
+}
+Never claim that an action has executed. Write/critical actions are only proposed and must be approved through the runtime gate.
+Current page: ${pageContext || 'unknown'}`;
+}
+
+export async function callOpenRouterProvider(request: ModelProviderRequest): Promise<ModelProviderResult> {
+  const customerApiKey = request.customerApiKey?.trim();
+  const systemApiKey = process.env.OPENROUTER_API_KEY?.trim();
+  const apiKey = customerApiKey || systemApiKey;
+
+  if (!apiKey) {
+    return {
+      reply: 'ไม่มี model key ที่ใช้งานได้ จึงใช้ fallback skills planner แทน',
+      plan: { steps: [] },
+      modelUsed: 'fallback-skills-planner',
+      provider: 'fallback-skills-planner',
+      keySource: 'none',
+    };
+  }
+
+  const model = process.env.OPENROUTER_MODEL || 'qwen/qwen-2.5-7b-instruct:free';
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': process.env.APP_URL || 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+        'X-Title': 'DSG Control Plane',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: systemPrompt(request.pageContext) },
+          { role: 'user', content: request.message },
+        ],
+        max_tokens: 2048,
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text().catch(() => '');
+      throw new Error(`OpenRouter provider error: ${response.status} ${err}`);
+    }
+
+    const json = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = json.choices?.[0]?.message?.content || '';
+    const parsed = JSON.parse(content) as { reply?: unknown; plan?: { steps?: unknown } };
+
+    return {
+      reply: String(parsed.reply || ''),
+      plan: { steps: toPlanSteps(parsed.plan?.steps) },
+      modelUsed: model,
+      provider: 'openrouter',
+      keySource: customerApiKey ? 'customer' : 'system',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/scripts/go-no-go-gate.sh
+++ b/scripts/go-no-go-gate.sh
@@ -15,7 +15,7 @@ if [[ -z "$TMP_ROOT" || ! -d "$TMP_ROOT" || ! -w "$TMP_ROOT" ]]; then
 fi
 
 response_file="${TMP_ROOT%/}/go-no-go-response.json"
-monitor_file="${TMP_ROOT%/}/go-no-go-monitor.json"
+readiness_file="${TMP_ROOT%/}/go-no-go-readiness.json"
 
 http_code() {
   local url="$1"
@@ -46,23 +46,21 @@ check_endpoint "/support"
 
 echo "== Runtime baseline checks =="
 check_endpoint "/api/health"
-check_endpoint "/api/readiness"
 
-monitor_code=$(http_code "${BASE_URL%/}/api/core/monitor" "$monitor_file")
-if [[ "$monitor_code" == "200" ]]; then
-  status=$(jq -r '.readiness.status // .readiness_status // "unknown"' "$monitor_file" 2>/dev/null || echo "unknown")
-  if [[ "$status" == "ready" ]]; then
-    echo "✅ /api/core/monitor readiness=$status"
-  else
-    echo "❌ /api/core/monitor readiness=$status"
-    failures=$((failures + 1))
-  fi
-elif [[ "$monitor_code" == "401" || "$monitor_code" == "403" ]]; then
-  echo "⚠️ /api/core/monitor requires auth (HTTP ${monitor_code})"
+readiness_code=$(http_code "${BASE_URL%/}/api/readiness" "$readiness_file")
+if [[ "$readiness_code" =~ ^(2|3)[0-9][0-9]$ ]]; then
+  readiness_status=$(jq -r '.status // .readiness.status // .readiness_status // "ready"' "$readiness_file" 2>/dev/null || echo "ready")
+  echo "✅ /api/readiness -> HTTP ${readiness_code} status=${readiness_status}"
+elif [[ "$readiness_code" == "500" ]]; then
+  echo "❌ /api/readiness -> HTTP 500"
+  echo "   Deployment readiness endpoint returned an internal server error. Inspect Vercel deployment logs before any agent execution."
+  failures=$((failures + 1))
 else
-  echo "❌ /api/core/monitor -> HTTP ${monitor_code}"
+  echo "❌ /api/readiness -> HTTP ${readiness_code}"
   failures=$((failures + 1))
 fi
+
+# /api/core/monitor is intentionally no longer a release dependency. /api/readiness is the source of truth.
 
 # NEW: enforce user-flow audit via Playwright
 if command -v npx >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

This PR implements the approved deterministic release/agent safety patch from the DSG action-layer skill workflow.

### Changed
- Make agent readiness use `/api/readiness` instead of `/api/core/monitor`.
- Add readiness `500` fallback warning so operators inspect deployment logs before agent execution.
- Support UUID `agent_id` in the planner in addition to `agt_...` IDs.
- Prevent plans from sending `agent_id: ""` into runtime APIs.
- Replace planner-created `policy_id: "default"` with `null`/omitted policy behavior.
- Add explicit approval context and block write/critical tool execution until approval is present.
- Make `agent-chat-v2` plan-only by default; execution requires `executeApprovedPlan=true` and an `approvalToken`.
- Make `go-no-go-gate.sh` readiness-first and remove `/api/core/monitor` as a release dependency.
- Add a BYOK model-provider helper for customer/system/fallback routing without logging keys.

## Evidence / go-no-go notes

- Branch is based on current `main` commit `280fc6d49e628a7de416b4e7aadea2a0ece3aed2`.
- Compare status: ahead by 7, behind by 0.
- Changed files:
  - `app/api/agent-chat-v2/route.ts`
  - `lib/agent/context.ts`
  - `lib/agent/executor.ts`
  - `lib/agent/planner.ts`
  - `lib/agent/tools.ts`
  - `lib/model-provider/openrouter.ts`
  - `scripts/go-no-go-gate.sh`

## Required validation before marking ready

```bash
npm ci
npm run typecheck
npm run test
npm run build
npm run verify:production-manifest
./scripts/go-no-go-gate.sh <preview-url>
```

## Release policy

Do not merge or deploy production until CI and preview go/no-go evidence are green. This PR is draft intentionally.
