### PR TITLE
Route public chatbot demo requests to proof demo

### DIFF
--- a/app/api/public-chat/route.ts
+++ b/app/api/public-chat/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server';
 
+const DEMO_URL = '/enterprise-proof/demo';
+const REQUEST_ACCESS_URL = '/request-access';
+const PRICING_URL = '/pricing';
+
 const SUGGESTIONS = [
+  'ดูเดโม่ระบบ',
   'ดู pricing และเลือกแพ็กเกจ',
   'ขอ demo หรือ request access',
   'อธิบาย DSG Agent และ runtime approval',
@@ -10,23 +15,27 @@ const SUGGESTIONS = [
 function publicReply(message: string) {
   const lower = message.toLowerCase();
 
-  if (/price|pricing|ราคา|แพ็ก|แพค|plan/.test(lower)) {
-    return 'ดูราคาและแพ็กเกจได้ที่ /pricing ครับ ถ้าต้องการใช้งานจริง แนะนำเริ่มจาก request access แล้วค่อยเปิด dashboard หลังล็อกอิน';
+  if (/demo|เดโม|เดโม่|proof|พิสูจน์|ตัวอย่าง/.test(lower)) {
+    return `ดูหน้าเดโม่และ proof สำหรับ buyer ได้ที่ ${DEMO_URL} ครับ ถ้าต้องการทดลองแบบมีสิทธิ์ใช้งานจริง ให้ไปที่ ${REQUEST_ACCESS_URL}`;
   }
 
-  if (/demo|access|สมัคร|เริ่ม|start|signup|sign up/.test(lower)) {
-    return 'เริ่มได้ที่ /request-access หรือ /signup ครับ ถ้าคุณมีบัญชีแล้วให้เข้า /login เพื่อเปิด dashboard และใช้ DSG Agent แบบมี audit/approval';
+  if (/price|pricing|ราคา|แพ็ก|แพค|plan/.test(lower)) {
+    return `ดูราคาและแพ็กเกจได้ที่ ${PRICING_URL} ครับ ถ้าต้องการใช้งานจริง แนะนำเริ่มจาก ${REQUEST_ACCESS_URL} แล้วค่อยเปิด dashboard หลังล็อกอิน`;
+  }
+
+  if (/access|สมัคร|เริ่ม|start|signup|sign up/.test(lower)) {
+    return `เริ่มได้ที่ ${REQUEST_ACCESS_URL} หรือ /signup ครับ ถ้าคุณมีบัญชีแล้วให้เข้า /login เพื่อเปิด dashboard และใช้ DSG Agent แบบมี audit/approval`;
   }
 
   if (/agent|chatbot|bot|แชท|บอท|เอเจนต์/.test(lower)) {
-    return 'DSG Agent ช่วยวางแผน ตรวจ readiness และจัดการ agent workflow ได้ แต่ action จริง เช่น สร้าง agent หรือ execute runtime ต้องล็อกอินและผ่าน approval gate ก่อน เพื่อมี audit/ledger ครบ';
+    return `DSG Agent ช่วยวางแผน ตรวจ readiness และจัดการ agent workflow ได้ ดูเดโม่ที่ ${DEMO_URL} ได้เลย แต่ action จริง เช่น สร้าง agent หรือ execute runtime ต้องล็อกอินและผ่าน approval gate ก่อน เพื่อมี audit/ledger ครบ`;
   }
 
   if (/readiness|health|status|สถานะ/.test(lower)) {
     return 'หน้า public ตรวจ health/readiness พื้นฐานได้ แต่ข้อมูล runtime ลึก ๆ ต้องล็อกอิน dashboard ก่อน เพื่อป้องกันข้อมูลภายในและรักษา audit trail';
   }
 
-  return 'สวัสดีครับ ผมคือ DSG public assistant ถามเรื่อง DSG Agent, pricing, demo, request access หรือวิธีเข้า dashboard ได้เลยครับ';
+  return `สวัสดีครับ ผมคือ DSG public assistant ถามเรื่อง DSG Agent, pricing, demo, request access หรือวิธีเข้า dashboard ได้เลยครับ ถ้าอยากดูเดโม่ตอนนี้ เปิด ${DEMO_URL}`;
 }
 
 export async function POST(request: Request) {
@@ -41,6 +50,12 @@ export async function POST(request: Request) {
     ok: true,
     mode: 'public_chat',
     reply: publicReply(message),
+    links: {
+      demo: DEMO_URL,
+      requestAccess: REQUEST_ACCESS_URL,
+      pricing: PRICING_URL,
+      login: '/login',
+    },
     safety: {
       authenticated_actions: false,
       execution_allowed: false,

--- a/components/PublicChatWidget.tsx
+++ b/components/PublicChatWidget.tsx
@@ -16,6 +16,8 @@ function makeLine(role: ChatLine['role'], content: string): ChatLine {
   };
 }
 
+const quickPrompts = ['ดูเดโม่', 'ราคา', 'ขอ demo', 'DSG Agent คืออะไร', 'เริ่มใช้งาน'];
+
 export default function PublicChatWidget() {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState('');
@@ -66,7 +68,7 @@ export default function PublicChatWidget() {
   }
 
   return (
-    <div className="fixed bottom-5 right-5 z-[80] flex h-[480px] w-[min(380px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
+    <div className="fixed bottom-5 right-5 z-[80] flex h-[500px] w-[min(390px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
       <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
         <div>
           <p className="text-sm font-semibold text-slate-100">DSG Public Assistant</p>
@@ -75,6 +77,21 @@ export default function PublicChatWidget() {
         <button onClick={() => setOpen(false)} className="text-slate-400 hover:text-white" aria-label="Close public chat">
           ✕
         </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 border-b border-slate-800 px-4 py-3">
+        <a
+          href="/enterprise-proof/demo"
+          className="rounded-xl bg-emerald-400 px-3 py-2 text-center text-xs font-bold text-black hover:bg-emerald-300"
+        >
+          ดูเดโม่
+        </a>
+        <a
+          href="/request-access"
+          className="rounded-xl border border-emerald-400/40 px-3 py-2 text-center text-xs font-bold text-emerald-100 hover:bg-emerald-400/10"
+        >
+          ขอสิทธิ์ทดลอง
+        </a>
       </div>
 
       <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
@@ -95,7 +112,7 @@ export default function PublicChatWidget() {
       </div>
 
       <div className="flex flex-wrap gap-2 border-t border-slate-800 px-4 py-2">
-        {['ราคา', 'ขอ demo', 'DSG Agent คืออะไร', 'เริ่มใช้งาน'].map((item) => (
+        {quickPrompts.map((item) => (
           <button
             key={item}
             onClick={() => submit(item)}


### PR DESCRIPTION
## Summary

Connects the public chatbot directly to the existing enterprise proof demo page.

### Changed
- Public chat now answers demo/proof questions with `/enterprise-proof/demo`.
- Public chat response includes structured links for demo, request access, pricing, and login.
- Public chat widget adds top CTAs:
  - `ดูเดโม่` -> `/enterprise-proof/demo`
  - `ขอสิทธิ์ทดลอง` -> `/request-access`
- Adds `ดูเดโม่` to quick prompts.

### Safety boundary
- Public chat remains non-executing.
- Runtime/agent actions still require login + approval gate.

## Validation needed

```bash
npm ci
npm run typecheck
npm run test
npm run build
npm run verify:production-manifest
```
