### PR TITLE
Fix Vercel deploy for public homepage CTAs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,12 +81,12 @@ export default function HomePage() {
                 >
                   ดูเดโม่ / View demo
                 </Link>
-                <a
+                <Link
                   href="#public-chat"
                   className="rounded-2xl border border-emerald-200/40 bg-black/20 px-5 py-3 text-sm font-bold text-emerald-100 transition hover:border-emerald-100"
                 >
                   ถาม DSG
-                </a>
+                </Link>
               </div>
             </div>
 

--- a/components/PublicChatWidget.tsx
+++ b/components/PublicChatWidget.tsx
@@ -59,7 +59,7 @@ export default function PublicChatWidget() {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="fixed bottom-5 right-5 z-[9999] rounded-full border border-emerald-300/50 bg-emerald-300 px-5 py-4 text-sm font-extrabold text-black shadow-2xl shadow-emerald-500/40 ring-2 ring-black/50 transition hover:scale-105 focus:outline-none focus:ring-4 focus:ring-emerald-200"
+        className="fixed bottom-5 right-5 z-50 rounded-full border border-emerald-300/50 bg-emerald-300 px-5 py-4 text-sm font-extrabold text-black shadow-2xl shadow-emerald-500/40 ring-2 ring-black/50 transition hover:scale-105 focus:outline-none focus:ring-4 focus:ring-emerald-200"
         aria-label="Open public DSG chat"
       >
         ถาม DSG
@@ -68,7 +68,7 @@ export default function PublicChatWidget() {
   }
 
   return (
-    <div className="fixed bottom-5 right-5 z-[9999] flex h-[500px] w-[min(390px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
+    <div className="fixed bottom-5 right-5 z-50 flex h-[500px] w-[min(390px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
       <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
         <div>
           <p className="text-sm font-semibold text-slate-100">DSG Public Assistant</p>


### PR DESCRIPTION
## Summary

UI-only fix for the public homepage CTA deploy.

### Changed
- Replace internal `#public-chat` anchor with Next `Link` in `app/page.tsx`.
- Replace arbitrary `z-[9999]` with stable Tailwind `z-50` in `components/PublicChatWidget.tsx`.

### Safety
- No auth changes.
- No billing changes.
- No database changes.
- No runtime gate changes.
- No env/deploy config changes.

### Validation needed

```bash
npm ci
npm run typecheck
npm run test
npm run verify:production-manifest
npm run build
```

Manual production check after deploy:

```bash
BASE=https://tdealer01-crypto-dsg-control-plane.vercel.app
curl -I "$BASE"
curl -I "$BASE/enterprise-proof/demo"
curl -I "$BASE/api/health"
curl -I "$BASE/api/readiness"
```

Logged-out homepage must show:
- Try before login
- ดูเดโม่ / View demo
- ถาม DSG
- floating public chat launcher
