### PR TITLE
Fix release gate plans import for Vercel build

### DIFF
--- a/app/release-gate/page.tsx
+++ b/app/release-gate/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { releaseGatePlans } from '@/lib/release-gate/plans';
+import { releaseGatePlans } from '../../lib/release-gate/plans';
 
 export default function ReleaseGatePage() {
   const [url, setUrl] = useState('');

--- a/lib/release-gate/plans.ts
+++ b/lib/release-gate/plans.ts
@@ -11,7 +11,7 @@ export const releaseGatePlans: ReleaseGatePlan[] = [
     id: 'free',
     name: 'Free',
     price: '$0',
-    description: 'Basic launch readiness check for a single public URL.',
+    description: 'Basic launch readiness check for one public URL.',
     features: [
       'Health and readiness URL guidance',
       'Trust page checklist',


### PR DESCRIPTION
Ensures lib/release-gate/plans.ts exists and switches release-gate page to a relative import so Vercel build can resolve it.