### PR TITLE
Add DSG multi governance orchestrator skill

### DIFF
--- a/.agents/skills/dsg-multi-governance-orchestrator/README.md
+++ b/.agents/skills/dsg-multi-governance-orchestrator/README.md
@@ -1,0 +1,22 @@
+# DSG Multi Governance Orchestrator Skill
+
+Reusable DSG skill for the SaaS control-plane repo. It merges the 5 uploaded sources plus the deterministic/marketplace patch into one operating standard for architecture pages, launch readiness, M1/M2 production cutover, action-layer permission gates, audit evidence, and deterministic execution.
+
+## Use cases
+
+- Add `/dsg-architecture` without replacing the existing finance/promo landing page.
+- Convert architecture concepts into copy/paste Next.js route code.
+- Run GO/NO-GO launch checks before public or marketplace release.
+- Plan deterministic multi-agent execution and merge work safely.
+- Keep production work focused on M1 Production Cutover and M2 Hardening + Launch.
+
+## Quick helper
+
+```bash
+bash .agents/skills/dsg-multi-governance-orchestrator/scripts/apply-architecture-page.sh .
+```
+
+The helper supports:
+
+- portable SaaS layout: `app/dsg-architecture/page.tsx`
+- DSG ONE dashboard layout: `frontend/app/dashboard/architecture/page.tsx`

--- a/.agents/skills/dsg-multi-governance-orchestrator/SKILL.md
+++ b/.agents/skills/dsg-multi-governance-orchestrator/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: dsg-multi-governance-orchestrator
+description: Use this skill for DSG multi-source governance work that combines UI trust upgrades, action-layer permission gates, deterministic execution, marketplace/enterprise cutover, portable SaaS architecture pages, DSG ONE architecture pages, Termux/Codex/Multica bootstrap planning, and production GO/NO-GO validation. Trigger when the user says DSG multi, 5 files, ผสานมัลติ, ทำเป็นสกิว, architecture page, action layer gate, marketplace cutover, M1/M2, deterministic execution, or launch readiness.
+---
+
+# DSG Multi Governance Orchestrator
+
+This skill merges the five DSG uploaded sources plus the user-supplied deterministic/marketplace patch into one reusable SaaS operating standard.
+
+## Source map
+
+1. `skill.zip` -> DSG UI / visual system / trust-first product posture.
+2. `skill_archive.zip` -> DSG Action Layer GED: plan pane, execution pane, permission gate, audit model, runtime state machine, starter app direction.
+3. `dsg-agent-os-portable-deploy.zip` -> portable SaaS/control-plane Next.js app surface.
+4. `dsg-one-agent-ready-autonomy-v3.zip` -> DSG ONE dashboard/backend app surface.
+5. `dsg_action_layer_gate_debug_report_2026-04-25.md` -> NO-GO launch gate evidence: production build/readiness/lockfile must be green.
+6. `ข้อความที่วาง (1).txt` -> deterministic 10x execution protocol, marketplace acceptance, M1/M2 cutover, and Termux/Codex/Multica bootstrap scripts.
+
+## Core rule
+
+Be direct. Protect production. Do not mix demo-only changes with launch readiness.
+
+Default release posture:
+
+- **NO-GO** when build, lockfile, health, readiness, manifest, or trust pages are missing/failing.
+- **GO** only when all gates are green with current evidence.
+- Never claim production readiness from static UI alone.
+
+## Deterministic execution protocol
+
+Use this sequence for multi-agent or parallel work:
+
+1. **T0 Input Lock**: freeze schema, code, config, tests, constraints, and desired output.
+2. **T1 Dependency Graph Build**: parse work into a DAG and classify independent/dependent/write-conflict domains.
+3. **T2 Parallel Execute**: run independent read-only or partitioned-write tasks in isolated scopes.
+4. **T3 Deterministic Merge**: normalize outputs, sort by `(stage, topo_index, task_id)`, merge with explicit conflict log.
+5. **T4 Verification Gate**: replay merge, compare hashes, validate dependency order, run correctness checks.
+
+Fail fast if replay hash differs.
+
+## Permission and action-layer model
+
+Always separate major work into:
+
+1. user-facing plan,
+2. explicit approval,
+3. live execution with evidence.
+
+Only checkpoint the user for external login, new app connections, privileged external settings, destructive actions, publishing, sending, payment, booking, billing, or equivalent public actions.
+
+Use only these permission verdicts:
+
+- `allow`
+- `needs user takeover`
+- `deny`
+
+## Production cutover standard
+
+Use only two production milestones:
+
+- `M1: Production Cutover`
+- `M2: Hardening + Launch`
+
+Reject mock routes, server-memory source of truth, localStorage persistence, demo-only workflows/actions/pages, and work unrelated to marketplace readiness.
+
+Production acceptance requires DB-backed submit/approve/reject/escalate, server-side org/RBAC, DB-backed dashboard state, complete audit trails, entitlement gates, trust pages, and green health/readiness/smoke checks.
+
+## Launch GO/NO-GO gate
+
+For any launch claim, verify in this order:
+
+```bash
+npm install --package-lock-only
+npm ci
+npm run typecheck || true
+npm run test || true
+npm run build
+npm run verify:production-manifest || true
+./scripts/go-no-go-gate.sh <base-url> || true
+```
+
+Required runtime checks:
+
+- `/api/health` returns HTTP 200 and `ok: true`.
+- `/api/readiness` returns HTTP 200 and `ok: true`.
+- `/terms`, `/privacy`, `/security`, `/support` are reachable.
+- Protected routes return expected `401` or `403` when unauthenticated.
+
+## Architecture page generation
+
+When asked to add the architecture page without replacing existing pages:
+
+### Portable SaaS Next.js app
+
+Create `app/dsg-architecture/page.tsx`. Do not replace `app/page.tsx`.
+
+Route: `/dsg-architecture`
+
+### DSG ONE dashboard app
+
+Create `frontend/app/dashboard/architecture/page.tsx`.
+
+Patch nav in `frontend/app/dashboard/layout.tsx` with a new Architecture item using `Workflow` from `lucide-react`.
+
+Route: `/dashboard/architecture`
+
+## UI/UX trust standard
+
+Use references in `references/multi-source-ui-action-reference.md` and launch gates in `references/launch-gate-debug-report-2026-04-25.md`.
+
+Design direction: premium, credible, enterprise-safe, futuristic control-room/NASA energy, readable on mobile and desktop, trust-first, task-first, low-friction.
+
+Avoid touching auth, billing, DB, runtime gates, production env, or deployment config unless explicitly requested.
+
+## Output format
+
+```markdown
+## What I changed / would add
+[direct summary]
+
+## Files
+[file paths]
+
+## Code
+[copy/paste code or commands]
+
+## Validation
+[commands]
+
+## GO/NO-GO
+[current verdict]
+```
+
+## Included references and assets
+
+- `references/source-inventory.md` maps the 5 uploaded files plus the patch file.
+- `references/multi-source-ui-action-reference.md` contains the UI, action-layer, deterministic, marketplace, and cutover operating standards.
+- `references/launch-gate-debug-report-2026-04-25.md` contains launch readiness evidence and blocker rules.
+- `scripts/apply-architecture-page.sh` contains a copy/paste helper for adding architecture pages to supported repo layouts.

--- a/.agents/skills/dsg-multi-governance-orchestrator/references/backend-production-cutover.md
+++ b/.agents/skills/dsg-multi-governance-orchestrator/references/backend-production-cutover.md
@@ -1,0 +1,176 @@
+# Backend Production Cutover Standard
+
+This reference locks the backend direction for the SaaS control-plane repo.
+
+## Non-negotiable backend rule
+
+The SaaS product must not rely on static UI, mock API responses, browser state, localStorage, or server-memory stores as source-of-truth for production flows.
+
+Production state must be DB-backed and audit-backed.
+
+## Backend scope
+
+### 1. DB-backed workflow state
+
+Required state transitions:
+
+- `submit`
+- `approve`
+- `reject`
+- `escalate`
+- `execute`
+- `commit`
+
+Each transition must persist:
+
+- organization / tenant scope
+- actor / agent identity
+- action type
+- previous state
+- next state
+- policy decision
+- request hash
+- decision hash
+- audit record hash
+- timestamp
+
+### 2. Repository layer
+
+All production reads/writes must pass through a server-side repository layer.
+
+Suggested modules:
+
+- `lib/repositories/actions.ts`
+- `lib/repositories/audit.ts`
+- `lib/repositories/organizations.ts`
+- `lib/repositories/entitlements.ts`
+- `lib/repositories/runtime.ts`
+
+Rules:
+
+- no route writes directly to unscoped DB helpers
+- no dashboard reads from local demo state
+- org scope is required for every query
+- RBAC is checked before every critical write/read
+
+### 3. Action API routes
+
+Required production API routes:
+
+- `POST /api/actions/submit`
+- `POST /api/actions/approve`
+- `POST /api/actions/reject`
+- `POST /api/actions/escalate`
+- `POST /api/execute`
+- `POST /api/spine/execute`
+- `POST /api/ledger/commit`
+- `GET /api/audit`
+- `GET /api/ledger/verify`
+- `GET /api/health`
+- `GET /api/readiness`
+
+### 4. Governance decision model
+
+Allowed decision states:
+
+- `ALLOW`
+- `BLOCK`
+- `REVIEW`
+- `ASK_MORE_INFO`
+
+Allowed permission verdicts:
+
+- `allow`
+- `needs user takeover`
+- `deny`
+
+Every decision must include:
+
+- `decision_id`
+- `tenant_id`
+- `agent_id`
+- `tool`
+- `action`
+- `effect`
+- `matched_rule_id`
+- `reason`
+- `input_hash`
+- `decision_hash`
+- `created_at`
+
+### 5. Audit ledger
+
+Every critical route must create an audit record.
+
+Audit record must include:
+
+- previous hash
+- record hash
+- request payload hash
+- decision hash
+- actor identity
+- tenant/org scope
+- route/action name
+- result status
+
+Hashing must use stable JSON with sorted keys.
+
+### 6. Entitlement gate
+
+Before action execution, backend must check:
+
+- plan
+- seat limit
+- quota
+- feature entitlement
+- tool entitlement
+- org active status
+
+Failure must return deterministic error shape.
+
+### 7. Health/readiness
+
+`/api/health` should prove process-level liveness.
+
+`/api/readiness` should prove production dependencies are usable:
+
+- DB reachable
+- required env present
+- migrations compatible
+- audit write/read works or is explicitly disabled in non-prod
+- billing/entitlement config present in production
+
+### 8. Acceptance tests
+
+Minimum tests:
+
+- low-trust agent is blocked
+- critical action requires approval
+- approved action writes DB and audit
+- dashboard read endpoint reflects persisted state
+- cross-org access is denied
+- entitlement quota exceeded is denied
+- audit hash chain verifies
+- readiness fails when required production env is missing
+
+## Stop list
+
+Do not add:
+
+- new mock route
+- new in-memory production store
+- new localStorage source-of-truth
+- demo-only workflow state
+- UI-only launch claim
+
+## GO condition
+
+Backend is considered production-connected only when:
+
+1. critical writes persist to DB,
+2. critical reads come from DB,
+3. audit evidence exists for each state transition,
+4. RBAC/org isolation is enforced server-side,
+5. entitlement gate can deny,
+6. health/readiness are green,
+7. CI build/test passes.

--- a/.agents/skills/dsg-multi-governance-orchestrator/scripts/apply-architecture-page.sh
+++ b/.agents/skills/dsg-multi-governance-orchestrator/scripts/apply-architecture-page.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+if [ -d "$ROOT/app" ]; then
+  mkdir -p "$ROOT/app/dsg-architecture"
+  cat > "$ROOT/app/dsg-architecture/page.tsx" <<'TSX'
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+type Decision = 'ALLOW' | 'BLOCK' | 'REVIEW' | 'ASK_MORE_INFO';
+type Mode = 'monitor' | 'gateway' | 'critical';
+
+const layers = [
+  ['1. User & Agent Layer', ['Users', 'Existing AI Agents', 'Sales Agent', 'Finance Agent', 'Support Agent', 'DevOps Agent']],
+  ['2. DSG Gateway Protocol', ['API Key Auth', 'Plan Check API', 'Tool Execution Gateway', 'Commit API', 'Webhook Ingress', 'SDK / REST / MCP Adapter']],
+  ['3. Governance Decision Layer', ['Policy Engine', 'Invariant Guard', 'Tool Allowlist', 'Risk Engine', 'Approval Rules', 'Deterministic Engine']],
+  ['4. Audit & Proof Layer', ['Audit Ledger', 'Request Hash', 'Response Hash', 'Execution Proof', 'Plan Token', 'Export Evidence']],
+  ['5. Tool & API Connectors', ['Stripe', 'Shopify', 'HubSpot', 'Slack', 'Gmail', 'LINE', 'Bank API', 'MCP Tools']],
+] as const;
+
+const tools = ['finance.read_balance', 'payment.create', 'treasury.wire', 'gmail.send', 'shopify.refund', 'slack.post_message'];
+
+function stableHash(value: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function evaluate(input: { tool: string; amount: number; trust: string; approval: string; mode: Mode }) {
+  let decision: Decision = 'ALLOW';
+  let rule = 'allow-governed-request';
+  let reason = 'Request is inside policy, invariant, risk, and tool allowlist.';
+  const highRisk = ['payment.create', 'treasury.wire', 'gmail.send', 'shopify.refund'].includes(input.tool) || input.amount >= 5000;
+  const critical = input.tool === 'treasury.wire' || input.amount >= 50000;
+  if (input.trust === 'low') {
+    decision = 'BLOCK';
+    rule = 'block-low-trust-agent';
+    reason = 'Low-trust agent cannot execute governed tools.';
+  } else if (critical && input.approval !== 'approved') {
+    decision = 'REVIEW';
+    rule = 'review-critical-action';
+    reason = 'Critical action requires human approval before execution.';
+  } else if (highRisk && input.approval === 'missing') {
+    decision = 'ASK_MORE_INFO';
+    rule = 'ask-more-info-high-risk';
+    reason = 'High-risk action requires approval context.';
+  }
+  const requestHash = stableHash(JSON.stringify(input));
+  const decisionHash = stableHash(JSON.stringify({ requestHash, decision, rule, reason }));
+  return { decision, rule, reason, requestHash: `req_${requestHash}`, decisionHash: `dec_${decisionHash}` };
+}
+
+export default function DSGArchitecturePage() {
+  const [tool, setTool] = useState('payment.create');
+  const [amount, setAmount] = useState(12000);
+  const [trust, setTrust] = useState('high');
+  const [approval, setApproval] = useState('missing');
+  const [mode, setMode] = useState<Mode>('gateway');
+  const result = useMemo(() => evaluate({ tool, amount, trust, approval, mode }), [tool, amount, trust, approval, mode]);
+  const decisionClass = result.decision === 'ALLOW' ? 'border-emerald-300/40 bg-emerald-400/10 text-emerald-100' : result.decision === 'BLOCK' ? 'border-red-300/40 bg-red-500/10 text-red-100' : result.decision === 'REVIEW' ? 'border-amber-300/40 bg-amber-400/10 text-amber-100' : 'border-violet-300/40 bg-violet-400/10 text-violet-100';
+
+  return (
+    <main className="min-h-screen bg-[#040918] text-white">
+      <section className="mx-auto max-w-[1600px] px-4 py-6 sm:px-8">
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <Link href="/" className="rounded-xl border border-cyan-300/25 bg-white/5 px-4 py-2 text-sm font-semibold text-cyan-100">← Back</Link>
+          <Link href="/finance-governance/app" className="rounded-xl border border-cyan-300/25 bg-cyan-300/10 px-4 py-2 text-sm font-semibold text-cyan-100">Open finance workspace</Link>
+        </div>
+        <header className="text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-300">DSG Architecture</p>
+          <h1 className="mt-3 text-4xl font-black tracking-tight text-cyan-100 sm:text-6xl">DSG Governance Gateway Architecture</h1>
+          <p className="mt-2 text-lg font-semibold text-cyan-300">Use existing APIs. No runtime changes required.</p>
+          <p className="mx-auto mt-4 max-w-5xl rounded-xl border border-cyan-300/30 bg-cyan-300/10 px-5 py-3 text-sm text-cyan-100">DSG decisions are deterministic by policy; AI outputs are governed, constrained, and audited.</p>
+        </header>
+        <div className="mt-6 grid gap-5 xl:grid-cols-[1fr_360px]">
+          <div className="space-y-3 rounded-2xl border border-cyan-400/20 bg-[#061224] p-4">
+            {layers.map(([title, items]) => (
+              <section key={title} className="rounded-2xl border border-white/15 bg-gradient-to-r from-blue-500/20 to-cyan-400/10 p-4">
+                <h3 className="text-xl font-extrabold text-white">{title}</h3>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {items.map((item) => <span key={item} className="rounded-lg border border-white/20 bg-[#0b1a33]/70 px-3 py-2 text-xs font-semibold text-blue-100">{item}</span>)}
+                </div>
+              </section>
+            ))}
+          </div>
+          <aside className="rounded-2xl border border-cyan-400/25 bg-[#07172f] p-4">
+            <h2 className="text-lg font-bold text-cyan-200">Live Gateway Simulator</h2>
+            <div className="mt-4 grid gap-3">
+              <select value={tool} onChange={(e) => setTool(e.target.value)} className="rounded-xl border border-cyan-300/20 bg-slate-950 px-4 py-3 text-sm text-white">{tools.map((item) => <option key={item}>{item}</option>)}</select>
+              <input type="number" value={amount} onChange={(e) => setAmount(Number(e.target.value || 0))} className="rounded-xl border border-cyan-300/20 bg-slate-950 px-4 py-3 text-sm text-white" />
+              <select value={trust} onChange={(e) => setTrust(e.target.value)} className="rounded-xl border border-cyan-300/20 bg-slate-950 px-4 py-3 text-sm text-white"><option>high</option><option>medium</option><option>low</option></select>
+              <select value={approval} onChange={(e) => setApproval(e.target.value)} className="rounded-xl border border-cyan-300/20 bg-slate-950 px-4 py-3 text-sm text-white"><option>approved</option><option>missing</option><option>rejected</option></select>
+              <select value={mode} onChange={(e) => setMode(e.target.value as Mode)} className="rounded-xl border border-cyan-300/20 bg-slate-950 px-4 py-3 text-sm text-white"><option>monitor</option><option>gateway</option><option>critical</option></select>
+            </div>
+            <div className={`mt-5 rounded-2xl border px-5 py-3 text-2xl font-black ${decisionClass}`}>{result.decision}</div>
+            <div className="mt-4 rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-slate-100">{result.reason}</div>
+            <div className="mt-3 font-mono text-xs text-cyan-100">{result.requestHash}<br />{result.decisionHash}</div>
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}
+TSX
+  echo "Created $ROOT/app/dsg-architecture/page.tsx"
+else
+  echo "No supported Next.js app layout found at $ROOT" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a reusable `.agents` skill for the SaaS control-plane repo:

- `dsg-multi-governance-orchestrator` skill
- backend production cutover standard
- launch GO/NO-GO guidance
- architecture-page helper script for adding `/dsg-architecture` without replacing the existing landing page

## Backend direction locked

This PR explicitly sets the next implementation direction to real backend integration, not UI-only work:

- DB-backed action state
- real `submit / approve / reject / escalate / execute / commit` persistence
- server-side org/RBAC enforcement
- audit ledger records and hash chain
- entitlement/billing gate checks
- health/readiness gates
- no mock, memory, or localStorage source-of-truth for production flows

## Files added

- `.agents/skills/dsg-multi-governance-orchestrator/SKILL.md`
- `.agents/skills/dsg-multi-governance-orchestrator/README.md`
- `.agents/skills/dsg-multi-governance-orchestrator/references/backend-production-cutover.md`
- `.agents/skills/dsg-multi-governance-orchestrator/scripts/apply-architecture-page.sh`

## Validation

Docs/skill-only PR. No runtime code changed yet.

Next PR should implement backend production cutover paths described in `references/backend-production-cutover.md`.