### PR TITLE
Guard finance repository for control-layer-only backend

### DIFF
--- a/lib/finance-governance/repository.ts
+++ b/lib/finance-governance/repository.ts
@@ -17,6 +17,11 @@ export class FinanceGovernanceRepository {
     return !error;
   }
 
+  private async hasLegacyWorkflowTables(supabase: any) {
+    const { error } = await supabase.from('finance_workflow_approvals').select('id').limit(1);
+    return !error;
+  }
+
   async getWorkspaceSummary(orgId: string): Promise<FinanceGovernanceWorkspaceSummary> {
     const approvals = await this.getApprovals(orgId);
     const pendingApprovals = approvals.filter(
@@ -281,24 +286,28 @@ export class FinanceGovernanceRepository {
       }
     }
 
-    const { data: approval } = await supabase
-      .from('finance_workflow_approvals')
-      .select('case_id')
-      .eq('org_id', orgId)
-      .eq('id', approvalId)
-      .maybeSingle();
+    let legacyApprovalCaseId: string | null = null;
+    if (await this.hasLegacyWorkflowTables(supabase)) {
+      const { data: approval } = await supabase
+        .from('finance_workflow_approvals')
+        .select('case_id')
+        .eq('org_id', orgId)
+        .eq('id', approvalId)
+        .maybeSingle();
+      legacyApprovalCaseId = approval?.case_id ?? null;
 
-    const { error } = await supabase
-      .from('finance_workflow_approvals')
-      .update({ status: result.nextStatus, updated_at: new Date().toISOString() })
-      .eq('org_id', orgId)
-      .eq('id', approvalId);
+      const { error } = await supabase
+        .from('finance_workflow_approvals')
+        .update({ status: result.nextStatus, updated_at: new Date().toISOString() })
+        .eq('org_id', orgId)
+        .eq('id', approvalId);
 
-    if (error) {
-      throw new Error(`failed_to_update_approval:${error.message}`);
+      if (error) {
+        throw new Error(`failed_to_update_approval:${error.message}`);
+      }
     }
 
-    await this.writeAction(orgId, result, approval?.case_id ?? null, approvalId);
+    await this.writeAction(orgId, result, legacyApprovalCaseId, approvalId);
     return result;
   }
 

--- a/tests/unit/finance-governance-repository.test.ts
+++ b/tests/unit/finance-governance-repository.test.ts
@@ -3,6 +3,7 @@ import { FinanceGovernanceRepository } from '../../lib/finance-governance/reposi
 
 const calls: Array<{ table: string; op: string; payload?: unknown }> = [];
 let caseExists = true;
+let legacyWorkflowExists = true;
 
 function buildClient() {
   return {
@@ -16,6 +17,9 @@ function buildClient() {
           return this;
         },
         limit() {
+          if (table === 'finance_workflow_approvals' && !legacyWorkflowExists) {
+            return Promise.resolve({ data: null, error: { message: 'relation not found' } });
+          }
           return Promise.resolve({ data: [] });
         },
         order() {
@@ -58,6 +62,7 @@ describe('FinanceGovernanceRepository', () => {
   beforeEach(() => {
     calls.length = 0;
     caseExists = true;
+    legacyWorkflowExists = true;
   });
 
   it('writes submit action to DB tables', async () => {
@@ -76,6 +81,16 @@ describe('FinanceGovernanceRepository', () => {
     await expect(repository.submit('org-test', 'case-404')).rejects.toThrow('case_not_found');
 
     expect(calls.some((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert')).toBe(false);
+  });
+
+
+  it('skips legacy approval table updates when runtime backend runs only control-layer tables', async () => {
+    legacyWorkflowExists = false;
+    const repository = new FinanceGovernanceRepository();
+    await repository.applyAction('org-test', 'APR-1001', 'approve');
+
+    expect(calls.some((c) => c.table === 'finance_workflow_approvals' && c.op === 'update')).toBe(false);
+    expect(calls.some((c) => c.table === 'finance_approval_requests' && c.op === 'update')).toBe(true);
   });
 
   it('updates approval status and logs action events', async () => {


### PR DESCRIPTION
## Summary

Applies the backend patch for the SaaS finance governance repository:

- adds `hasLegacyWorkflowTables` guard
- skips `finance_workflow_approvals` reads/updates when the runtime backend only has control-layer tables
- still writes action events after control-layer updates
- adds a unit test for control-layer-only runtime behavior

## Why

This supports the real backend cutover path where the production runtime can operate on the newer control-layer tables without requiring legacy workflow tables to exist.

## Validation

Targeted test:

```bash
npm run test:unit -- tests/unit/finance-governance-repository.test.ts
```

I could not run CI from here; this PR only applies the user-provided patch and opens it for repository CI.