### PR TITLE
Add finance governance audit ledger backend cutover

### DIFF
--- a/docs/finance-governance-audit-ledger.md
+++ b/docs/finance-governance-audit-ledger.md
@@ -1,0 +1,100 @@
+# Finance Governance Audit Ledger Cutover
+
+This document tracks the backend cutover for the Finance Governance control plane from UI-only proof to DB-backed audit evidence.
+
+## Status
+
+This branch adds a dedicated audit ledger path for finance governance actions.
+
+Implemented in this cutover:
+
+- `finance_governance_audit_ledger` migration
+- stable SHA-256 request hash
+- stable SHA-256 record hash
+- repository-level audit ledger writer
+- workflow action payload now includes audit proof metadata
+- unit coverage for audit ledger inserts and proof hashes
+
+## Dataset / benchmark reference
+
+External dataset reference provided for DSG Finance Governance Control Plane evidence:
+
+- DOI: https://doi.org/10.34740/kaggle/dsv/16000593
+
+The referenced Kaggle dataset is used as supporting evidence context for DSG finance governance benchmark/provenance materials. The backend audit ledger in this repo is the runtime persistence layer; the dataset reference is not treated as a replacement for live production audit logs.
+
+## Runtime write path
+
+For finance governance actions, the repository now writes:
+
+1. Control-layer records where available:
+   - `finance_approval_decisions`
+   - `finance_approval_requests`
+   - `finance_transactions`
+   - `finance_exceptions`
+   - `finance_evidence_bundles`
+2. Legacy compatibility records where legacy workflow tables exist:
+   - `finance_workflow_approvals`
+   - `finance_workflow_cases`
+   - `finance_workflow_action_events`
+3. Dedicated audit ledger:
+   - `finance_governance_audit_ledger`
+
+## Audit proof fields
+
+Each audit ledger row includes:
+
+- `org_id`
+- `case_id`
+- `approval_id`
+- `action`
+- `actor`
+- `result`
+- `target`
+- `message`
+- `next_status`
+- `request_hash`
+- `record_hash`
+- `payload`
+- `created_at`
+
+The repository also stores the audit proof in the legacy workflow action event payload:
+
+```json
+{
+  "audit": {
+    "requestHash": "<sha256>",
+    "recordHash": "<sha256>",
+    "stored": true
+  }
+}
+```
+
+## Hashing rule
+
+Hashes are generated from stable JSON serialization with sorted object keys.
+
+- `request_hash`: hash of the normalized finance governance action event
+- `record_hash`: hash of the database ledger record payload including `request_hash`
+
+## Validation
+
+Run the targeted unit test:
+
+```bash
+npm run test:unit -- tests/unit/finance-governance-repository.test.ts
+```
+
+On Android/Termux, `npm install` may fail because the Supabase package postinstall does not support Android arm64. Validate this PR in GitHub Actions, Vercel, or a Linux/macOS development environment instead of relying only on local Termux install.
+
+## GO / NO-GO
+
+This change moves backend audit evidence forward, but production is still **NO-GO** until:
+
+- migrations are applied in the target Supabase project
+- CI test/build is green
+- `/api/health` is green
+- `/api/readiness` is green
+- production env vars are configured
+- RBAC/org enforcement is verified end-to-end
+- entitlement/billing gates are verified if the route is exposed to paid plans

--- a/lib/finance-governance/audit-ledger.ts
+++ b/lib/finance-governance/audit-ledger.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'crypto';
+import type { FinanceGovernanceActionResult } from './actions';
+
+export type FinanceGovernanceAuditEvent = {
+  orgId: string;
+  caseId: string | null;
+  approvalId: string | null;
+  action: FinanceGovernanceActionResult['action'];
+  actor: string;
+  result: 'ok' | 'error' | 'denied';
+  target: string | null;
+  message: string;
+  nextStatus: string;
+  payload: FinanceGovernanceActionResult;
+};
+
+export type FinanceGovernanceAuditProof = {
+  requestHash: string;
+  recordHash: string;
+  stored: boolean;
+};
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+function isMissingRelation(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String((error as { message?: string })?.message ?? '');
+  return /relation .* does not exist|relation not found|does not exist/i.test(message);
+}
+
+export async function writeFinanceGovernanceAuditLedger(
+  supabase: any,
+  event: FinanceGovernanceAuditEvent
+): Promise<FinanceGovernanceAuditProof> {
+  const requestHash = sha256(event);
+  const record = {
+    org_id: event.orgId,
+    case_id: event.caseId,
+    approval_id: event.approvalId,
+    action: event.action,
+    actor: event.actor,
+    result: event.result,
+    target: event.target,
+    message: event.message,
+    next_status: event.nextStatus,
+    request_hash: requestHash,
+    payload: event.payload,
+  };
+  const recordHash = sha256(record);
+
+  const { error } = await supabase.from('finance_governance_audit_ledger').insert({
+    ...record,
+    record_hash: recordHash,
+  });
+
+  if (error) {
+    if (isMissingRelation(error)) {
+      return { requestHash, recordHash, stored: false };
+    }
+
+    throw new Error(`failed_to_write_audit_ledger:${error.message}`);
+  }
+
+  return { requestHash, recordHash, stored: true };
+}

--- a/lib/finance-governance/repository.ts
+++ b/lib/finance-governance/repository.ts
@@ -4,6 +4,7 @@ import {
   type FinanceGovernanceActionName,
   type FinanceGovernanceActionResult,
 } from './actions';
+import { writeFinanceGovernanceAuditLedger } from './audit-ledger';
 import type {
   FinanceGovernanceApprovalItem,
   FinanceGovernanceCaseDetail,
@@ -350,6 +351,21 @@ export class FinanceGovernanceRepository {
       }
     }
 
+    const auditEvent = {
+      orgId,
+      caseId,
+      approvalId,
+      action: result.action,
+      actor: 'api',
+      result: result.ok ? 'ok' as const : 'error' as const,
+      target: approvalId ?? caseId,
+      message: result.message,
+      nextStatus: result.nextStatus,
+      payload: result,
+    };
+
+    const auditProof = await writeFinanceGovernanceAuditLedger(supabase, auditEvent);
+
     const { error } = await supabase.from('finance_workflow_action_events').insert({
       org_id: orgId,
       case_id: caseId,
@@ -360,7 +376,10 @@ export class FinanceGovernanceRepository {
       target: approvalId ?? caseId,
       message: result.message,
       next_status: result.nextStatus,
-      payload: result,
+      payload: {
+        ...result,
+        audit: auditProof,
+      },
     });
 
     if (error) {

--- a/supabase/migrations/20260429060000_finance_governance_audit_ledger.sql
+++ b/supabase/migrations/20260429060000_finance_governance_audit_ledger.sql
@@ -1,0 +1,38 @@
+create table if not exists public.finance_governance_audit_ledger (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  case_id text,
+  approval_id text,
+  action text not null,
+  actor text not null default 'api',
+  result text not null default 'ok',
+  target text,
+  message text not null,
+  next_status text not null,
+  request_hash text not null,
+  record_hash text not null unique,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint finance_governance_audit_ledger_action_chk
+    check (action in ('submit', 'approve', 'reject', 'escalate')),
+  constraint finance_governance_audit_ledger_result_chk
+    check (result in ('ok', 'error', 'denied'))
+);
+
+create index if not exists idx_finance_governance_audit_ledger_org_created
+  on public.finance_governance_audit_ledger (org_id, created_at desc);
+
+create index if not exists idx_finance_governance_audit_ledger_org_action
+  on public.finance_governance_audit_ledger (org_id, action, created_at desc);
+
+create index if not exists idx_finance_governance_audit_ledger_org_approval
+  on public.finance_governance_audit_ledger (org_id, approval_id, created_at desc);
+
+alter table public.finance_governance_audit_ledger enable row level security;
+
+drop policy if exists finance_governance_audit_ledger_org_select on public.finance_governance_audit_ledger;
+create policy finance_governance_audit_ledger_org_select
+on public.finance_governance_audit_ledger
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));

--- a/tests/unit/finance-governance-repository.test.ts
+++ b/tests/unit/finance-governance-repository.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FinanceGovernanceRepository } from '../../lib/finance-governance/repository';
 
-const calls: Array<{ table: string; op: string; payload?: unknown }> = [];
+const calls: Array<{ table: string; op: string; payload?: any }> = [];
 let caseExists = true;
 let legacyWorkflowExists = true;
 
@@ -65,14 +65,25 @@ describe('FinanceGovernanceRepository', () => {
     legacyWorkflowExists = true;
   });
 
-  it('writes submit action to DB tables', async () => {
+  it('writes submit action to DB tables and audit ledger', async () => {
     const repository = new FinanceGovernanceRepository();
     await repository.submit('org-test', 'case-123');
 
     expect(calls.some((c) => c.table === 'finance_workflow_cases' && c.op === 'update')).toBe(true);
     expect(calls.some((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert')).toBe(true);
+    expect(calls.some((c) => c.table === 'finance_governance_audit_ledger' && c.op === 'insert')).toBe(true);
   });
 
+  it('stores audit proof hashes in the workflow action event payload', async () => {
+    const repository = new FinanceGovernanceRepository();
+    await repository.submit('org-test', 'case-123');
+
+    const eventInsert = calls.find((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert');
+
+    expect(eventInsert?.payload?.payload?.audit?.requestHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(eventInsert?.payload?.payload?.audit?.recordHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(eventInsert?.payload?.payload?.audit?.stored).toBe(true);
+  });
 
   it('does not write action event when submit case does not exist', async () => {
     caseExists = false;
@@ -81,8 +92,8 @@ describe('FinanceGovernanceRepository', () => {
     await expect(repository.submit('org-test', 'case-404')).rejects.toThrow('case_not_found');
 
     expect(calls.some((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert')).toBe(false);
+    expect(calls.some((c) => c.table === 'finance_governance_audit_ledger' && c.op === 'insert')).toBe(false);
   });
-
 
   it('skips legacy approval table updates when runtime backend runs only control-layer tables', async () => {
     legacyWorkflowExists = false;
@@ -91,6 +102,7 @@ describe('FinanceGovernanceRepository', () => {
 
     expect(calls.some((c) => c.table === 'finance_workflow_approvals' && c.op === 'update')).toBe(false);
     expect(calls.some((c) => c.table === 'finance_approval_requests' && c.op === 'update')).toBe(true);
+    expect(calls.some((c) => c.table === 'finance_governance_audit_ledger' && c.op === 'insert')).toBe(true);
   });
 
   it('updates approval status and logs action events', async () => {
@@ -99,5 +111,6 @@ describe('FinanceGovernanceRepository', () => {
 
     expect(calls.some((c) => c.table === 'finance_workflow_approvals' && c.op === 'update')).toBe(true);
     expect(calls.some((c) => c.table === 'finance_workflow_action_events' && c.op === 'insert')).toBe(true);
+    expect(calls.some((c) => c.table === 'finance_governance_audit_ledger' && c.op === 'insert')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Continues the backend production cutover after #415 by adding a real audit-ledger write path for finance governance actions.

This PR adds:

- `finance_governance_audit_ledger` Supabase migration
- stable SHA-256 request hash and record hash generation
- repository-level audit ledger writer
- `FinanceGovernanceRepository.writeAction()` integration with the new ledger
- workflow action payload audit proof metadata
- unit coverage for audit ledger inserts and proof hashes
- README/documentation with the provided Kaggle DOI reference

## Files

- `lib/finance-governance/audit-ledger.ts`
- `lib/finance-governance/repository.ts`
- `supabase/migrations/20260429060000_finance_governance_audit_ledger.sql`
- `tests/unit/finance-governance-repository.test.ts`
- `docs/finance-governance-audit-ledger.md`

## Dataset / benchmark reference

Added the user-provided DSG Finance Governance Control Plane dataset reference:

- https://doi.org/10.34740/kaggle/dsv/16000593

Note: this is documented as supporting benchmark/provenance context, not as a replacement for live production audit logs.

## Validation

Targeted test:

```bash
npm run test:unit -- tests/unit/finance-governance-repository.test.ts
```

I could not run local CI from this environment. The user's Termux screenshot showed `supabase` postinstall failing on Android arm64, which prevents `vitest`/`next` from installing locally there. Please validate in GitHub Actions, Vercel, or a Linux/macOS dev environment.

## GO / NO-GO

This improves backend audit evidence, but production is still **NO-GO** until migrations are applied and CI/build/readiness are green.