### PR TITLE
Add finance governance audit ledger verification APIs

### DIFF
--- a/app/api/finance-governance/audit-ledger/[recordHash]/verify/route.ts
+++ b/app/api/finance-governance/audit-ledger/[recordHash]/verify/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
+import { FinanceGovernanceAuditLedgerRepository } from '../../../../../../lib/finance-governance/audit-ledger-repository';
+import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
+
+export const dynamic = 'force-dynamic';
+
+const repository = new FinanceGovernanceAuditLedgerRepository();
+
+type RouteContext = { params: Promise<{ recordHash: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    const orgId = resolveOrgId(request);
+    const { recordHash } = await context.params;
+    const result = await repository.verify(orgId, recordHash);
+
+    return NextResponse.json({ ok: result.verification.ok, ...result });
+  } catch (error) {
+    return handleFinanceGovernanceApiError('api/finance-governance/audit-ledger/verify', error);
+  }
+}

--- a/app/api/finance-governance/audit-ledger/route.ts
+++ b/app/api/finance-governance/audit-ledger/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
+import { FinanceGovernanceAuditLedgerRepository } from '../../../../lib/finance-governance/audit-ledger-repository';
+import { resolveOrgId } from '../../../../lib/finance-governance/org-scope';
+
+export const dynamic = 'force-dynamic';
+
+const repository = new FinanceGovernanceAuditLedgerRepository();
+
+export async function GET(request: Request) {
+  try {
+    const orgId = resolveOrgId(request);
+    const url = new URL(request.url);
+    const limit = Number(url.searchParams.get('limit') ?? 50);
+    const records = await repository.list(orgId, limit);
+
+    return NextResponse.json({ ok: true, records });
+  } catch (error) {
+    return handleFinanceGovernanceApiError('api/finance-governance/audit-ledger', error);
+  }
+}

--- a/docs/finance-governance-audit-ledger.md
+++ b/docs/finance-governance-audit-ledger.md
@@ -4,15 +4,17 @@ This document tracks the backend cutover for the Finance Governance control plan
 
 ## Status
 
-This branch adds a dedicated audit ledger path for finance governance actions.
+The backend now has a dedicated audit ledger write path and verification API for finance governance actions.
 
-Implemented in this cutover:
+Implemented:
 
 - `finance_governance_audit_ledger` migration
 - stable SHA-256 request hash
 - stable SHA-256 record hash
 - repository-level audit ledger writer
 - workflow action payload now includes audit proof metadata
+- audit ledger list API
+- audit ledger verify API
 - unit coverage for audit ledger inserts and proof hashes
 
 ## Dataset / benchmark reference
@@ -77,12 +79,59 @@ Hashes are generated from stable JSON serialization with sorted object keys.
 - `request_hash`: hash of the normalized finance governance action event
 - `record_hash`: hash of the database ledger record payload including `request_hash`
 
+## API
+
+List audit ledger records for an organization:
+
+```http
+GET /api/finance-governance/audit-ledger?limit=50
+x-org-id: <org-id>
+```
+
+Verify one ledger record by hash:
+
+```http
+GET /api/finance-governance/audit-ledger/<recordHash>/verify
+x-org-id: <org-id>
+```
+
+Successful verification response shape:
+
+```json
+{
+  "ok": true,
+  "record": {
+    "record_hash": "<stored-record-hash>"
+  },
+  "verification": {
+    "ok": true,
+    "expectedRequestHash": "<sha256>",
+    "expectedRecordHash": "<sha256>",
+    "storedRequestHash": "<sha256>",
+    "storedRecordHash": "<sha256>",
+    "mismatches": []
+  }
+}
+```
+
+If data is tampered, `verification.ok` becomes `false` and `mismatches` identifies which hash failed.
+
 ## Validation
 
 Run the targeted unit test:
 
 ```bash
 npm run test:unit -- tests/unit/finance-governance-repository.test.ts
+```
+
+API smoke checks after deploying with migrations applied:
+
+```bash
+curl -H "x-org-id: <org-id>" \
+  "https://<host>/api/finance-governance/audit-ledger?limit=10"
+
+curl -H "x-org-id: <org-id>" \
+  "https://<host>/api/finance-governance/audit-ledger/<recordHash>/verify"
 ```
 
 On Android/Termux, `npm install` may fail because the Supabase package postinstall does not support Android arm64. Validate this PR in GitHub Actions, Vercel, or a Linux/macOS development environment instead of relying only on local Termux install.

--- a/lib/finance-governance/api-error.ts
+++ b/lib/finance-governance/api-error.ts
@@ -6,6 +6,7 @@ const KNOWN_FINANCE_GOVERNANCE_ERRORS: Record<string, number> = {
   missing_org_id: 400,
   case_not_found: 404,
   approval_not_found: 404,
+  audit_record_not_found: 404,
 };
 
 export function handleFinanceGovernanceApiError(route: string, error: unknown) {

--- a/lib/finance-governance/audit-ledger-repository.ts
+++ b/lib/finance-governance/audit-ledger-repository.ts
@@ -1,0 +1,51 @@
+import { getSupabaseAdmin } from '../supabase-server';
+import {
+  verifyFinanceGovernanceAuditLedgerRow,
+  type FinanceGovernanceAuditLedgerRow,
+} from './audit-ledger';
+
+export class FinanceGovernanceAuditLedgerRepository {
+  async list(orgId: string, limit = 50) {
+    const supabase = getSupabaseAdmin() as any;
+    const safeLimit = Math.min(Math.max(limit, 1), 200);
+
+    const { data, error } = await supabase
+      .from('finance_governance_audit_ledger')
+      .select('id,org_id,case_id,approval_id,action,actor,result,target,message,next_status,request_hash,record_hash,payload,created_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+      .limit(safeLimit);
+
+    if (error) {
+      throw new Error(`failed_to_read_audit_ledger:${error.message}`);
+    }
+
+    return data ?? [];
+  }
+
+  async verify(orgId: string, recordHash: string) {
+    const supabase = getSupabaseAdmin() as any;
+
+    const { data, error } = await supabase
+      .from('finance_governance_audit_ledger')
+      .select('id,org_id,case_id,approval_id,action,actor,result,target,message,next_status,request_hash,record_hash,payload,created_at')
+      .eq('org_id', orgId)
+      .eq('record_hash', recordHash)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`failed_to_read_audit_ledger:${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error('audit_record_not_found');
+    }
+
+    const row = data as FinanceGovernanceAuditLedgerRow;
+
+    return {
+      record: row,
+      verification: verifyFinanceGovernanceAuditLedgerRow(row),
+    };
+  }
+}

--- a/lib/finance-governance/audit-ledger.ts
+++ b/lib/finance-governance/audit-ledger.ts
@@ -20,6 +20,32 @@ export type FinanceGovernanceAuditProof = {
   stored: boolean;
 };
 
+export type FinanceGovernanceAuditLedgerRow = {
+  id?: string;
+  org_id: string;
+  case_id: string | null;
+  approval_id: string | null;
+  action: FinanceGovernanceActionResult['action'];
+  actor: string;
+  result: 'ok' | 'error' | 'denied';
+  target: string | null;
+  message: string;
+  next_status: string;
+  request_hash: string;
+  record_hash: string;
+  payload: FinanceGovernanceActionResult;
+  created_at?: string;
+};
+
+export type FinanceGovernanceAuditVerification = {
+  ok: boolean;
+  expectedRequestHash: string;
+  expectedRecordHash: string;
+  storedRequestHash: string;
+  storedRecordHash: string;
+  mismatches: string[];
+};
+
 function stableJson(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map((item) => stableJson(item)).join(',')}]`;
@@ -42,6 +68,62 @@ function sha256(value: unknown): string {
 function isMissingRelation(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String((error as { message?: string })?.message ?? '');
   return /relation .* does not exist|relation not found|does not exist/i.test(message);
+}
+
+function toAuditEvent(row: FinanceGovernanceAuditLedgerRow): FinanceGovernanceAuditEvent {
+  return {
+    orgId: row.org_id,
+    caseId: row.case_id,
+    approvalId: row.approval_id,
+    action: row.action,
+    actor: row.actor,
+    result: row.result,
+    target: row.target,
+    message: row.message,
+    nextStatus: row.next_status,
+    payload: row.payload,
+  };
+}
+
+function toRecord(row: FinanceGovernanceAuditLedgerRow) {
+  return {
+    org_id: row.org_id,
+    case_id: row.case_id,
+    approval_id: row.approval_id,
+    action: row.action,
+    actor: row.actor,
+    result: row.result,
+    target: row.target,
+    message: row.message,
+    next_status: row.next_status,
+    request_hash: row.request_hash,
+    payload: row.payload,
+  };
+}
+
+export function verifyFinanceGovernanceAuditLedgerRow(
+  row: FinanceGovernanceAuditLedgerRow
+): FinanceGovernanceAuditVerification {
+  const expectedRequestHash = sha256(toAuditEvent(row));
+  const expectedRecordHash = sha256(toRecord(row));
+  const mismatches: string[] = [];
+
+  if (row.request_hash !== expectedRequestHash) {
+    mismatches.push('request_hash');
+  }
+
+  if (row.record_hash !== expectedRecordHash) {
+    mismatches.push('record_hash');
+  }
+
+  return {
+    ok: mismatches.length === 0,
+    expectedRequestHash,
+    expectedRecordHash,
+    storedRequestHash: row.request_hash,
+    storedRecordHash: row.record_hash,
+    mismatches,
+  };
 }
 
 export async function writeFinanceGovernanceAuditLedger(

--- a/tests/unit/finance-governance-audit-ledger.test.ts
+++ b/tests/unit/finance-governance-audit-ledger.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  verifyFinanceGovernanceAuditLedgerRow,
+  type FinanceGovernanceAuditLedgerRow,
+} from '../../lib/finance-governance/audit-ledger';
+
+const row: FinanceGovernanceAuditLedgerRow = {
+  org_id: 'org-test',
+  case_id: 'case-123',
+  approval_id: null,
+  action: 'submit',
+  actor: 'api',
+  result: 'ok',
+  target: 'case-123',
+  message: 'Finance workflow item submitted',
+  next_status: 'pending',
+  request_hash: '',
+  record_hash: '',
+  payload: {
+    ok: true,
+    action: 'submit',
+    message: 'Finance workflow item submitted',
+    nextStatus: 'pending',
+    caseId: 'case-123',
+  },
+};
+
+describe('finance governance audit ledger verification', () => {
+  it('detects matching request and record hashes', () => {
+    const firstPass = verifyFinanceGovernanceAuditLedgerRow(row);
+    const completeRow = {
+      ...row,
+      request_hash: firstPass.expectedRequestHash,
+      record_hash: firstPass.expectedRecordHash,
+    };
+
+    const verification = verifyFinanceGovernanceAuditLedgerRow(completeRow);
+
+    expect(verification.ok).toBe(true);
+    expect(verification.mismatches).toEqual([]);
+  });
+
+  it('detects tampered ledger records', () => {
+    const firstPass = verifyFinanceGovernanceAuditLedgerRow(row);
+    const completeRow = {
+      ...row,
+      request_hash: firstPass.expectedRequestHash,
+      record_hash: firstPass.expectedRecordHash,
+      message: 'tampered message',
+    };
+
+    const verification = verifyFinanceGovernanceAuditLedgerRow(completeRow);
+
+    expect(verification.ok).toBe(false);
+    expect(verification.mismatches).toContain('request_hash');
+    expect(verification.mismatches).toContain('record_hash');
+  });
+});


### PR DESCRIPTION
## Summary

Continues the backend cutover after #416 by making finance governance audit evidence readable and verifiable through backend APIs.

This PR adds:

- audit ledger row verification helpers
- audit ledger repository for list/verify reads
- `GET /api/finance-governance/audit-ledger?limit=50`
- `GET /api/finance-governance/audit-ledger/[recordHash]/verify`
- 404 mapping for `audit_record_not_found`
- docs for list/verify API usage
- unit tests for valid and tampered ledger rows

## Files

- `app/api/finance-governance/audit-ledger/route.ts`
- `app/api/finance-governance/audit-ledger/[recordHash]/verify/route.ts`
- `lib/finance-governance/audit-ledger.ts`
- `lib/finance-governance/audit-ledger-repository.ts`
- `lib/finance-governance/api-error.ts`
- `tests/unit/finance-governance-audit-ledger.test.ts`
- `docs/finance-governance-audit-ledger.md`

## Validation

Targeted tests:

```bash
npm run test:unit -- tests/unit/finance-governance-audit-ledger.test.ts tests/unit/finance-governance-repository.test.ts
```

API smoke after deploy/migrations:

```bash
curl -H "x-org-id: <org-id>" "https://<host>/api/finance-governance/audit-ledger?limit=10"
curl -H "x-org-id: <org-id>" "https://<host>/api/finance-governance/audit-ledger/<recordHash>/verify"
```

I could not run local CI here. Termux local installs can fail because Supabase postinstall does not support Android arm64.

## GO / NO-GO

This adds runtime audit verification APIs, but production remains **NO-GO** until CI/build/readiness and the Supabase migration are green in the target environment.