### PR TITLE
Add finance governance production readiness gate

### DIFF
--- a/app/api/finance-governance/readiness/route.ts
+++ b/app/api/finance-governance/readiness/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { checkFinanceGovernanceReadiness } from '../../../../lib/finance-governance/readiness';
+import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const readiness = await checkFinanceGovernanceReadiness();
+    return NextResponse.json(readiness, { status: readiness.ok ? 200 : 503 });
+  } catch (error) {
+    return handleFinanceGovernanceApiError('api/finance-governance/readiness', error);
+  }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -40,6 +40,7 @@ function unavailableReadiness(detail: string): ReadinessReport {
       dsgCoreConfig: { ok: false, detail },
       dsgCoreHealth: { ok: false, detail },
       financeGovernanceSurface: UNAVAILABLE_CHECK,
+      financeGovernanceBackend: { ok: false, detail },
     },
     timestamp: new Date().toISOString(),
   };

--- a/docs/production-readiness-gate.md
+++ b/docs/production-readiness-gate.md
@@ -1,0 +1,80 @@
+# Production Readiness Gate
+
+This document defines the backend readiness gate for the DSG control plane and Finance Governance backend.
+
+## Endpoints
+
+Global health:
+
+```http
+GET /api/health
+```
+
+Global deployment readiness:
+
+```http
+GET /api/readiness
+```
+
+Finance governance backend readiness:
+
+```http
+GET /api/finance-governance/readiness
+```
+
+## Finance governance checks
+
+`/api/finance-governance/readiness` checks:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `finance_transactions`
+- `finance_approval_requests`
+- `finance_approval_decisions`
+- `finance_governance_audit_ledger`
+- `finance_workflow_action_events`
+
+The route returns HTTP `200` when all required checks pass and HTTP `503` when any required dependency is missing or unreachable.
+
+## Global readiness integration
+
+`getDeploymentReadiness()` now includes:
+
+```json
+{
+  "checks": {
+    "financeGovernanceBackend": {
+      "ok": true
+    }
+  }
+}
+```
+
+If `DSG_FINANCE_GOVERNANCE_ENABLED=false`, the finance backend check is skipped and marked as enabled for global readiness with detail `skipped:finance_governance_disabled`.
+
+## Smoke checks
+
+```bash
+curl -i https://<host>/api/health
+curl -i https://<host>/api/readiness
+curl -i https://<host>/api/finance-governance/readiness
+```
+
+Expected production gate:
+
+- `/api/health` returns `ok: true`
+- `/api/readiness` returns HTTP 200 and `ok: true`
+- `/api/finance-governance/readiness` returns HTTP 200 and `ok: true`
+
+## GO / NO-GO
+
+Production remains **NO-GO** if any required readiness check fails.
+
+Common blockers:
+
+- missing Supabase env vars
+- Supabase service role cannot query required tables
+- finance governance migrations not applied
+- audit ledger table missing
+- DSG core health failing
+- global readiness returns HTTP 503

--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -1,4 +1,5 @@
 import { getDSGCoreConfig, getDSGCoreHealth } from '../dsg-core';
+import { checkFinanceGovernanceReadiness } from '../finance-governance/readiness';
 import { getSupabaseAdmin } from '../supabase-server';
 
 type CheckResult = {
@@ -15,6 +16,7 @@ export type ReadinessReport = {
     dsgCoreConfig: CheckResult;
     dsgCoreHealth: CheckResult;
     financeGovernanceSurface: CheckResult;
+    financeGovernanceBackend: CheckResult;
   };
   timestamp: string;
 };
@@ -95,6 +97,31 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
     financeGovernanceEnabled ? undefined : 'finance_governance_disabled'
   );
 
+  let financeGovernanceBackend = buildCheck(false, 'not_checked');
+  if (financeGovernanceEnabled) {
+    try {
+      const financeReadiness = await withTimeout(
+        checkFinanceGovernanceReadiness(),
+        'finance_governance_backend',
+        7_000
+      );
+      const failedChecks = financeReadiness.checks
+        .filter((check) => check.required && !check.ok)
+        .map((check) => `${check.name}:${check.message ?? 'failed'}`);
+      financeGovernanceBackend = buildCheck(
+        financeReadiness.ok,
+        failedChecks.length ? failedChecks.join(';') : undefined
+      );
+    } catch (error) {
+      financeGovernanceBackend = buildCheck(
+        false,
+        error instanceof Error ? error.message : 'finance_governance_backend_unreachable'
+      );
+    }
+  } else {
+    financeGovernanceBackend = buildCheck(true, 'skipped:finance_governance_disabled');
+  }
+
   const checks = {
     env: envCheck,
     nextAuthSecret,
@@ -102,6 +129,7 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
     dsgCoreConfig,
     dsgCoreHealth,
     financeGovernanceSurface,
+    financeGovernanceBackend,
   };
 
   return {

--- a/lib/finance-governance/readiness.ts
+++ b/lib/finance-governance/readiness.ts
@@ -1,0 +1,82 @@
+import { getSupabaseAdmin } from '../supabase-server';
+
+type ReadinessCheck = {
+  name: string;
+  ok: boolean;
+  required: boolean;
+  message?: string;
+};
+
+type ReadinessResult = {
+  ok: boolean;
+  service: string;
+  checks: ReadinessCheck[];
+  timestamp: string;
+};
+
+const REQUIRED_ENV = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'SUPABASE_SERVICE_ROLE_KEY',
+];
+
+const REQUIRED_TABLES = [
+  'finance_transactions',
+  'finance_approval_requests',
+  'finance_approval_decisions',
+  'finance_governance_audit_ledger',
+  'finance_workflow_action_events',
+];
+
+function envCheck(name: string): ReadinessCheck {
+  return {
+    name: `env:${name}`,
+    ok: Boolean(process.env[name]),
+    required: true,
+    message: process.env[name] ? 'configured' : 'missing',
+  };
+}
+
+async function tableCheck(supabase: any, table: string): Promise<ReadinessCheck> {
+  const { error } = await supabase.from(table).select('id').limit(1);
+
+  return {
+    name: `table:${table}`,
+    ok: !error,
+    required: true,
+    message: error ? error.message : 'reachable',
+  };
+}
+
+export async function checkFinanceGovernanceReadiness(): Promise<ReadinessResult> {
+  const checks: ReadinessCheck[] = REQUIRED_ENV.map(envCheck);
+  const envOk = checks.every((check) => check.ok);
+
+  if (!envOk) {
+    return {
+      ok: false,
+      service: 'finance-governance',
+      checks,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  try {
+    const supabase = getSupabaseAdmin() as any;
+    const tableChecks = await Promise.all(REQUIRED_TABLES.map((table) => tableCheck(supabase, table)));
+    checks.push(...tableChecks);
+  } catch (error) {
+    checks.push({
+      name: 'supabase:admin-client',
+      ok: false,
+      required: true,
+      message: error instanceof Error ? error.message : 'unknown_error',
+    });
+  }
+
+  return {
+    ok: checks.filter((check) => check.required).every((check) => check.ok),
+    service: 'finance-governance',
+    checks,
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

Continues the backend production cutover after #417 by wiring finance governance backend dependencies into readiness/health.

This PR adds:

- `checkFinanceGovernanceReadiness()` dependency checks
- `GET /api/finance-governance/readiness`
- `financeGovernanceBackend` in global `getDeploymentReadiness()`
- health fallback type updated for the new readiness check
- production readiness docs and smoke-check commands

## Finance backend readiness checks

Required:

- `NEXT_PUBLIC_SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`
- `finance_transactions`
- `finance_approval_requests`
- `finance_approval_decisions`
- `finance_governance_audit_ledger`
- `finance_workflow_action_events`

## Validation

API smoke after deploy/migrations:

```bash
curl -i https://<host>/api/health
curl -i https://<host>/api/readiness
curl -i https://<host>/api/finance-governance/readiness
```

Expected:

- HTTP 200 and `ok: true` for readiness in production
- HTTP 503 when a required finance governance backend dependency is missing

I could not run local CI here. Termux local installs can fail because Supabase postinstall does not support Android arm64.

## GO / NO-GO

Production remains **NO-GO** if any required readiness check fails.