### PR TITLE
Add finance governance RBAC entitlement access gate

### DIFF
--- a/app/api/finance-governance/approvals/[id]/approve/route.ts
+++ b/app/api/finance-governance/approvals/[id]/approve/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
+import { requireFinanceGovernanceAccess } from '../../../../../../lib/finance-governance/access-gate';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 
@@ -12,6 +13,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 export async function POST(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
+    requireFinanceGovernanceAccess(request, orgId, 'approve');
     const { id } = await context.params;
     const result = await repository.applyAction(orgId, id, 'approve');
     return NextResponse.json(result, { status: 200 });

--- a/app/api/finance-governance/approvals/[id]/escalate/route.ts
+++ b/app/api/finance-governance/approvals/[id]/escalate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
+import { requireFinanceGovernanceAccess } from '../../../../../../lib/finance-governance/access-gate';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 
@@ -12,6 +13,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 export async function POST(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
+    requireFinanceGovernanceAccess(request, orgId, 'escalate');
     const { id } = await context.params;
     const result = await repository.applyAction(orgId, id, 'escalate');
     return NextResponse.json(result, { status: 200 });

--- a/app/api/finance-governance/approvals/[id]/reject/route.ts
+++ b/app/api/finance-governance/approvals/[id]/reject/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../../../lib/finance-governance/api-error';
+import { requireFinanceGovernanceAccess } from '../../../../../../lib/finance-governance/access-gate';
 import { FinanceGovernanceRepository } from '../../../../../../lib/finance-governance/repository';
 import { resolveOrgId } from '../../../../../../lib/finance-governance/org-scope';
 
@@ -12,6 +13,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 export async function POST(request: Request, context: RouteContext) {
   try {
     const orgId = resolveOrgId(request);
+    requireFinanceGovernanceAccess(request, orgId, 'reject');
     const { id } = await context.params;
     const result = await repository.applyAction(orgId, id, 'reject');
     return NextResponse.json(result, { status: 200 });

--- a/docs/finance-governance-access-gate.md
+++ b/docs/finance-governance-access-gate.md
@@ -1,0 +1,100 @@
+# Finance Governance Access Gate
+
+This document describes the backend RBAC and entitlement gate for Finance Governance actions.
+
+## Protected write actions
+
+The following routes require the finance governance access gate:
+
+```http
+POST /api/finance-governance/approvals/<id>/approve
+POST /api/finance-governance/approvals/<id>/reject
+POST /api/finance-governance/approvals/<id>/escalate
+```
+
+## Required headers
+
+```http
+x-org-id: <organization-id>
+x-actor-id: <user-or-agent-id>
+x-actor-role: <role>
+x-org-plan: <plan>
+```
+
+Accepted role headers:
+
+- `x-actor-role`
+- `x-user-role`
+
+Accepted actor headers:
+
+- `x-actor-id`
+- `x-user-id`
+
+Accepted plan headers:
+
+- `x-org-plan`
+- `x-plan`
+
+## Write roles
+
+Write actions are allowed only for:
+
+- `owner`
+- `admin`
+- `finance_admin`
+- `finance_approver`
+
+## Write plans
+
+Write actions are allowed only for:
+
+- `enterprise`
+- `business`
+- `pro`
+
+## Deny reasons
+
+The gate can deny with:
+
+- `missing_actor_role` -> HTTP 403
+- `missing_org_plan` -> HTTP 403
+- `role_not_allowed` -> HTTP 403
+- `plan_not_entitled` -> HTTP 402
+- `finance_governance_access_denied` -> HTTP 403
+
+## Smoke checks
+
+Allowed request:
+
+```bash
+curl -i -X POST "https://<host>/api/finance-governance/approvals/<id>/approve" \
+  -H "x-org-id: <org-id>" \
+  -H "x-actor-id: user_123" \
+  -H "x-actor-role: finance_approver" \
+  -H "x-org-plan: enterprise"
+```
+
+Denied by role:
+
+```bash
+curl -i -X POST "https://<host>/api/finance-governance/approvals/<id>/approve" \
+  -H "x-org-id: <org-id>" \
+  -H "x-actor-id: user_123" \
+  -H "x-actor-role: viewer" \
+  -H "x-org-plan: enterprise"
+```
+
+Denied by entitlement:
+
+```bash
+curl -i -X POST "https://<host>/api/finance-governance/approvals/<id>/approve" \
+  -H "x-org-id: <org-id>" \
+  -H "x-actor-id: user_123" \
+  -H "x-actor-role: finance_approver" \
+  -H "x-org-plan: free"
+```
+
+## Production note
+
+This gate is the server-side enforcement layer for finance action routes. It should later be replaced or backed by persisted organization membership, plan, and entitlement tables when billing and identity data are fully DB-backed.

--- a/lib/finance-governance/access-gate.ts
+++ b/lib/finance-governance/access-gate.ts
@@ -1,0 +1,80 @@
+export type FinanceGovernanceAccessAction = 'approve' | 'reject' | 'escalate' | 'read';
+
+export type FinanceGovernanceAccessDecision = {
+  ok: boolean;
+  orgId: string;
+  actor: string;
+  role: string;
+  plan: string;
+  action: FinanceGovernanceAccessAction;
+  reason?: string;
+};
+
+const WRITE_ROLES = new Set(['owner', 'admin', 'finance_admin', 'finance_approver']);
+const READ_ROLES = new Set([...WRITE_ROLES, 'finance_viewer', 'viewer', 'auditor']);
+const WRITE_PLANS = new Set(['enterprise', 'business', 'pro']);
+const READ_PLANS = new Set([...WRITE_PLANS, 'free', 'trial']);
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+function deny(
+  orgId: string,
+  actor: string,
+  role: string,
+  plan: string,
+  action: FinanceGovernanceAccessAction,
+  reason: string
+): FinanceGovernanceAccessDecision {
+  return { ok: false, orgId, actor, role, plan, action, reason };
+}
+
+export function evaluateFinanceGovernanceAccess(
+  request: Request,
+  orgId: string,
+  action: FinanceGovernanceAccessAction
+): FinanceGovernanceAccessDecision {
+  const actor = header(request, 'x-actor-id') || header(request, 'x-user-id') || 'anonymous';
+  const role = (header(request, 'x-actor-role') || header(request, 'x-user-role') || '').toLowerCase();
+  const plan = (header(request, 'x-org-plan') || header(request, 'x-plan') || '').toLowerCase();
+
+  if (!orgId) {
+    return deny(orgId, actor, role, plan, action, 'missing_org_id');
+  }
+
+  if (!role) {
+    return deny(orgId, actor, role, plan, action, 'missing_actor_role');
+  }
+
+  if (!plan) {
+    return deny(orgId, actor, role, plan, action, 'missing_org_plan');
+  }
+
+  const allowedRoles = action === 'read' ? READ_ROLES : WRITE_ROLES;
+  const allowedPlans = action === 'read' ? READ_PLANS : WRITE_PLANS;
+
+  if (!allowedRoles.has(role)) {
+    return deny(orgId, actor, role, plan, action, 'role_not_allowed');
+  }
+
+  if (!allowedPlans.has(plan)) {
+    return deny(orgId, actor, role, plan, action, 'plan_not_entitled');
+  }
+
+  return { ok: true, orgId, actor, role, plan, action };
+}
+
+export function requireFinanceGovernanceAccess(
+  request: Request,
+  orgId: string,
+  action: FinanceGovernanceAccessAction
+): FinanceGovernanceAccessDecision {
+  const decision = evaluateFinanceGovernanceAccess(request, orgId, action);
+
+  if (!decision.ok) {
+    throw new Error(decision.reason ?? 'finance_governance_access_denied');
+  }
+
+  return decision;
+}

--- a/lib/finance-governance/api-error.ts
+++ b/lib/finance-governance/api-error.ts
@@ -7,6 +7,11 @@ const KNOWN_FINANCE_GOVERNANCE_ERRORS: Record<string, number> = {
   case_not_found: 404,
   approval_not_found: 404,
   audit_record_not_found: 404,
+  missing_actor_role: 403,
+  missing_org_plan: 403,
+  role_not_allowed: 403,
+  plan_not_entitled: 402,
+  finance_governance_access_denied: 403,
 };
 
 export function handleFinanceGovernanceApiError(route: string, error: unknown) {


### PR DESCRIPTION
## Summary

Continues backend hardening after #418 by adding a server-side RBAC/entitlement gate for finance governance write actions.

This PR adds:

- `lib/finance-governance/access-gate.ts`
- access checks for approve/reject/escalate routes
- finance governance error mapping for access denials
- docs for required headers, roles, plans, and smoke checks

## Protected routes

- `POST /api/finance-governance/approvals/[id]/approve`
- `POST /api/finance-governance/approvals/[id]/reject`
- `POST /api/finance-governance/approvals/[id]/escalate`

## Required headers

```http
x-org-id: <organization-id>
x-actor-id: <user-or-agent-id>
x-actor-role: <role>
x-org-plan: <plan>
```

Allowed write roles:

- `owner`
- `admin`
- `finance_admin`
- `finance_approver`

Allowed write plans:

- `enterprise`
- `business`
- `pro`

## Validation

Smoke checks after deploy:

```bash
curl -i -X POST "https://<host>/api/finance-governance/approvals/<id>/approve" \
  -H "x-org-id: <org-id>" \
  -H "x-actor-id: user_123" \
  -H "x-actor-role: finance_approver" \
  -H "x-org-plan: enterprise"
```

Denied by role/plan should return `403` or `402`.

I could not run local CI here. Termux local installs can fail because Supabase postinstall does not support Android arm64.

## GO / NO-GO

This adds a server-side access gate, but production remains **NO-GO** until CI/build/readiness and end-to-end route smoke checks are green.