### PR TITLE
Document DSG governance gateway SaaS positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,347 @@
-# tdealer01-crypto-dsg-control-plane
+# DSG Finance Governance Control Plane
 
-Production-ready control plane for DSG runtime operations, built with Next.js App Router + Supabase.
+DSG Finance Governance Control Plane is the first production surface of the broader **DSG Governance Gateway**: a governance, invariant, and audit layer for high-risk AI agent actions.
 
-This repository is structured to cover end-to-end runtime governance: Auth/SSO, Spine execution, DSG core integration, agent lifecycle, billing, enterprise proof, dashboards, and operational APIs.
+This repository is not only a finance approval app. It is a SaaS control plane that lets existing agents keep their runtime while DSG governs risky tool execution before it reaches external apps.
+
+```text
+DSG = Governance / Invariant / Audit Gateway
+Zapier = Universal Connector to external apps
+Agent = Existing runtime that must submit plans/tool calls through DSG first
+```
+
+Core gateway flow:
+
+```text
+Agent
+→ DSG Plan Check
+→ Policy / Invariant / Risk
+→ DSG Connector
+→ Zapier / Make / n8n / MCP / REST
+→ App destination
+→ Result back to DSG
+→ Audit Ledger / Proof Export
+```
+
+DSG does not replace customer agents or apps. DSG governs high-risk AI actions before they execute, then records proof after execution.
+
+## Current production status
+
+Live deployment:
+
+- https://tdealer01-crypto-dsg-control-plane.vercel.app
+
+Verified runtime status:
+
+- Vercel deployment: READY
+- Finance readiness endpoint: HTTP 200
+- Supabase env: configured
+- Finance governance tables: reachable
+- RBAC-gated approve API: HTTP 200
+- Audit proof write path: verified
+- `request_hash` and `record_hash`: generated and stored
+
+Smoke-tested approval:
+
+```text
+org_id: org-smoke
+transaction_id: TX-SMOKE-001
+approval_id: APR-SMOKE-001
+action: approve
+result: ok
+next_status: approved
+```
+
+Stored audit proof:
+
+```text
+request_hash: 5c1a727def56cf684cc5282f5c95e90d45a27809ec35e7da705804e5f459d5e9
+record_hash: 36bbe8fc4594abc9159868a22f6eb6a185c4e80220848f8be2008d1506b45179
+```
+
+## Product purpose
+
+DSG prevents high-risk finance and AI-agent actions from becoming ungoverned workflow outputs.
+
+It provides:
+
+- deterministic approval decisions
+- finance action gating before execution
+- role and plan entitlement enforcement
+- immutable audit evidence
+- request and record hashing
+- readiness checks for production deployment
+- proof export and verification APIs
+- a path to universal connector governance through Zapier, Make, n8n, MCP, REST, and custom APIs
+
+## Product boundary
+
+This repository is the DSG Finance Governance Control Plane backend and SaaS surface.
+
+It includes:
+
+- production readiness checks
+- Supabase-backed finance workflow records
+- RBAC-gated finance actions
+- deterministic audit proof storage
+- runtime hash verification APIs
+- gateway-oriented documentation for connector/provider expansion
+
+Finance Governance is the first product surface. The broader platform direction is DSG as a universal governance gateway for AI actions.
+
+See:
+
+- `docs/dsg-governance-gateway.md`
+- `docs/zapier-provider-roadmap.md`
+- `docs/finance-governance-audit-ledger.md`
+- `docs/finance-governance-access-gate.md`
+- `docs/production-readiness-gate.md`
 
 ---
 
-## Production Launch Checkpoint — 2026-04-25
+## Core backend capabilities
+
+### Finance readiness
+
+```http
+GET /api/finance-governance/readiness
+```
+
+Expected healthy response:
+
+```json
+{
+  "ok": true,
+  "service": "finance-governance"
+}
+```
+
+The readiness gate checks:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `finance_transactions`
+- `finance_approval_requests`
+- `finance_approval_decisions`
+- `finance_governance_audit_ledger`
+- `finance_workflow_action_events`
+
+### RBAC / entitlement gate
+
+Protected write routes:
+
+```http
+POST /api/finance-governance/approvals/:id/approve
+POST /api/finance-governance/approvals/:id/reject
+POST /api/finance-governance/approvals/:id/escalate
+```
+
+Required headers:
+
+```http
+x-org-id: <organization-id>
+x-actor-id: <user-or-agent-id>
+x-actor-role: finance_approver
+x-org-plan: enterprise
+```
+
+Allowed write roles:
+
+- `owner`
+- `admin`
+- `finance_admin`
+- `finance_approver`
+
+Allowed write plans:
+
+- `enterprise`
+- `business`
+- `pro`
+
+Denied requests return:
+
+- `403` for role/access failures
+- `402` for entitlement/plan failures
+
+### Audit ledger
+
+Audit ledger records are written to:
+
+```text
+finance_governance_audit_ledger
+```
+
+Each audit record stores:
+
+- `org_id`
+- `case_id`
+- `approval_id`
+- `action`
+- `actor`
+- `result`
+- `target`
+- `message`
+- `next_status`
+- `request_hash`
+- `record_hash`
+- `payload`
+- `created_at`
+
+Read audit records:
+
+```http
+GET /api/finance-governance/audit-ledger?limit=50
+x-org-id: <org-id>
+```
+
+Verify one audit record:
+
+```http
+GET /api/finance-governance/audit-ledger/:recordHash/verify
+x-org-id: <org-id>
+```
+
+## Production database tables
+
+Required Supabase tables:
+
+```text
+finance_transactions
+finance_approval_requests
+finance_approval_decisions
+finance_governance_audit_ledger
+finance_workflow_action_events
+```
+
+Verified schema status:
+
+```text
+finance_transactions              OK
+finance_approval_requests         OK
+finance_approval_decisions        OK
+finance_governance_audit_ledger   OK
+finance_workflow_action_events    OK
+```
+
+RLS is enabled on all five tables.
+
+## Smoke test
+
+Readiness:
+
+```bash
+curl -i https://tdealer01-crypto-dsg-control-plane.vercel.app/api/finance-governance/readiness
+```
+
+Approve action:
+
+```bash
+curl -i -X POST "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/finance-governance/approvals/APR-SMOKE-001/approve" \
+  -H "x-org-id: org-smoke" \
+  -H "x-actor-id: smoke-user" \
+  -H "x-actor-role: finance_approver" \
+  -H "x-org-plan: enterprise"
+```
+
+Expected response:
+
+```json
+{
+  "ok": true,
+  "action": "approve",
+  "message": "Approval marked as approved",
+  "nextStatus": "approved"
+}
+```
+
+## Gateway expansion roadmap
+
+The next SaaS layer should add connector/provider execution behind DSG governance.
+
+Priority lock points:
+
+```text
+Tool Registry
+Risk Classification
+Gateway Execution
+Audit Commit
+Proof Export
+```
+
+Target connector/provider flow:
+
+```text
+Agent submits plan + requested tool call
+→ DSG Plan Check
+→ Policy / Invariant / Risk decision
+→ DSG Connector Provider
+→ Zapier webhook/action
+→ App destination
+→ Result returns to DSG
+→ Audit Commit
+→ Evidence Export
+```
+
+Near-term targets:
+
+- Zapier webhook provider
+- DB-backed tool registry
+- risk classification table
+- `POST /api/gateway/tools/execute`
+- customer-facing connector setup UI
+- audit proof export UI
+
+## Deployment
+
+The app is deployed on Vercel and uses Supabase as the runtime database.
+
+Required environment variables:
+
+```text
+NEXT_PUBLIC_SUPABASE_URL
+SUPABASE_SERVICE_ROLE_KEY
+DSG_CORE_MODE
+NEXTAUTH_SECRET
+DSG_FINANCE_GOVERNANCE_ENABLED=true
+```
+
+## GO / NO-GO
+
+Production GO requires:
+
+- Vercel deployment is READY
+- `/api/finance-governance/readiness` returns HTTP 200
+- Supabase tables exist and are reachable
+- RLS is enabled
+- approve/reject/escalate routes require RBAC headers
+- audit ledger writes `request_hash` and `record_hash`
+- smoke test action returns HTTP 200
+
+Current status:
+
+```text
+GO for finance governance backend smoke path.
+UI/UX still needs to send RBAC headers consistently.
+Gateway provider expansion is documented but not yet implemented.
+```
+
+---
+
+## Historical production checkpoint
+
+The previous DSG Action Layer production checkpoint remains useful as the baseline for the wider runtime control plane.
 
 **DSG Action Layer Gate: GO**
 
-This checkpoint records the validated production launch baseline for the DSG control plane after the lockfile, manifest, runtime readiness, and Termux go/no-go gate fixes were merged.
-
 | Area | Status | Evidence |
 |---|---:|---|
-| Production deployment | ✅ PASS | Vercel production deployment `dpl_43qqZowFMo7JpsBXgkropG5bLjfb` is `READY` on commit `e4b194b` |
+| Production deployment | ✅ PASS | Vercel production deployment was READY on the validated checkpoint commit |
 | Production URL | ✅ PASS | `https://tdealer01-crypto-dsg-control-plane.vercel.app` |
 | Health endpoint | ✅ PASS | `/api/health` returns HTTP 200 with `ok: true` |
 | Readiness endpoint | ✅ PASS | `/api/readiness` returns HTTP 200 with `ok: true` |
 | Trust pages | ✅ PASS | `/terms`, `/privacy`, `/security`, `/support` return HTTP 200 |
 | Protected monitor endpoint | ✅ PASS | `/api/core/monitor` returns HTTP 401 when unauthenticated, which is expected |
-| Legacy server-store callers | ✅ PASS | No legacy `/api/finance-governance/server-store` callers found |
-| Go/no-go script | ✅ PASS | `GO/NO-GO RESULT: PASS (all scripted checks green)` |
+| Go/no-go script | ✅ PASS | `GO/NO-GO RESULT: PASS` on scripted checks |
 
 ### Re-run the launch gate
 
@@ -36,371 +356,22 @@ Expected result:
 GO/NO-GO RESULT: PASS (all scripted checks green)
 ```
 
-### Runtime readiness requirements
-
-Production readiness depends on these environment-backed checks staying green:
-
-- `NEXTAUTH_SECRET`
-- Supabase service role configuration
-- DSG core configuration
-- DSG core health
-- Finance governance surface
-
-If any readiness check returns `ok: false`, the launch state falls back to **NO-GO** until fixed and redeployed.
-
 ---
 
-## Test Status (Latest Validated Baseline)
+## Repository inventory
 
-Validated local and runtime baseline from the launch repair run:
+This repository covers:
 
-- **199 tests passed**
-- **67 test files passed**
-- **3 tests skipped**
-- **1 test file skipped**
-- **Typecheck passed** with exit code `0`
-- **Production manifest gate passed** with **186 paths present**
-- **Vercel production build passed**
-- **Runtime health/readiness passed**
-- **Go/no-go gate passed**
+- **Auth & SSO**: magic-link, password, SSO, RBAC, JIT provisioning
+- **Spine Execution Engine**: intent → gate → ledger pipeline
+- **DSG Core**: internal + remote safety gate
+- **Agent Management**: CRUD, key rotation, tools, planner
+- **Billing**: Stripe checkout, overage, seat activation
+- **Enterprise Proof**: public + verified runtime proof
+- **Finance Governance**: approval queue, action gates, audit ledger, proof verification
+- **Dashboard**: operational SaaS views
+- **API Routes**: health, readiness, runtime, governance, agent, audit, billing, policy, proof, and spine surfaces
+- **Database**: Supabase migrations + runtime tables
+- **Security**: rate-limit, safe-log, error handling, CSP/security headers
 
-### Breakdown
-
-| Check | Result |
-|---|---:|
-| Vitest test suite | 199 passed / 3 skipped |
-| Test files | 67 passed / 1 skipped |
-| TypeScript typecheck | PASS |
-| Production manifest gate | PASS — 186 paths present |
-| Vercel production deployment | PASS — READY |
-| Runtime smoke | PASS |
-| DSG Action Layer Gate | GO |
-
----
-
-## Production-Ready File Inventory
-
-## 1) Root Config & Entry
-
-| File | Responsibility |
-|---|---|
-| `package.json` | Dependencies & scripts |
-| `package-lock.json` | Locked dependency graph for reproducible Vercel/Linux installs |
-| `tsconfig.json` | TypeScript config |
-| `next.config.js` | Next.js config |
-| `middleware.ts` | Edge middleware (auth/security) |
-| `vitest.config.ts` | Test runner config |
-| `playwright.config.ts` | E2E config |
-| `tailwind.config.js` | Tailwind CSS |
-| `postcss.config.js` | PostCSS |
-| `vercel.json` | Vercel deployment |
-| `.env.example` | Environment template |
-
----
-
-## 2) `app/` — Next.js App Router (Pages & API)
-
-### Pages
-
-| Path | Responsibility |
-|---|---|
-| `app/layout.tsx` | Root layout |
-| `app/page.tsx` | Landing page |
-| `app/login/page.tsx` | Login page |
-| `app/password-login/page.tsx` | Password login |
-| `app/signup/page.tsx` | Signup page |
-| `app/pricing/page.tsx` | Pricing page |
-| `app/quickstart/page.tsx` | Quickstart guide |
-| `app/marketplace/page.tsx` | Marketplace |
-| `app/marketplace-ui/page.tsx` | Marketplace UI |
-| `app/app-shell/page.tsx` | App shell server wrapper |
-| `app/docs/page.tsx` | Docs page |
-| `app/request-access/page.tsx` | Request access |
-| `app/terms/page.tsx` | Terms page |
-| `app/privacy/page.tsx` | Privacy page |
-| `app/security/page.tsx` | Security page |
-| `app/support/page.tsx` | Support page |
-| `app/globals.css` | Global styles |
-
-### Auth Flow (`app/auth/`)
-
-- `app/auth/confirm/`
-- `app/auth/continue/`
-- `app/auth/login/`
-- `app/auth/password-login/`
-- `app/auth/signout/`
-- `app/auth/signup/`
-
-### SSO & Enterprise Proof (`app/sso/`, `app/enterprise-proof/`)
-
-- `app/sso/start/`
-- `app/enterprise-proof/report/`
-- `app/enterprise-proof/start/`
-- `app/enterprise-proof/verified/`
-
-### Dashboard (`app/dashboard/`)
-
-| Path | Responsibility |
-|---|---|
-| `app/dashboard/layout.tsx` | Dashboard layout |
-| `app/dashboard/page.tsx` | Dashboard home |
-| `app/dashboard/error.tsx` | Error boundary |
-| `app/dashboard/agents/` | Agent management |
-| `app/dashboard/audit/` | Audit view |
-| `app/dashboard/billing/` | Billing view |
-| `app/dashboard/capacity/` | Capacity view |
-| `app/dashboard/command-center/` | Command center |
-| `app/dashboard/core-compat/` | Core compat view |
-| `app/dashboard/executions/` | Executions view |
-| `app/dashboard/integration/` | Integration view |
-| `app/dashboard/ledger/` | Ledger view |
-| `app/dashboard/mission/` | Mission view |
-| `app/dashboard/operations/` | Operations view |
-| `app/dashboard/policies/` | Policies view |
-| `app/dashboard/proofs/` | Proofs view |
-| `app/dashboard/replay/` | Replay view |
-| `app/dashboard/settings/` | Settings view |
-| `app/dashboard/skills/` | Skills view |
-
-### API Routes (`app/api/`)
-
-| Path | Responsibility |
-|---|---|
-| `app/api/access/` | Access control |
-| `app/api/adapter-plan/` | Adapter plan |
-| `app/api/agent-chat/` | Agent chat |
-| `app/api/agents/` | Agent CRUD |
-| `app/api/audit/` | Audit API |
-| `app/api/auth/` | Auth API |
-| `app/api/billing/` | Billing/Stripe |
-| `app/api/capacity/` | Capacity API |
-| `app/api/checkpoint/` | Checkpoint API |
-| `app/api/core-compat/` | Core compat |
-| `app/api/core/` | Core API |
-| `app/api/core/monitor/` | Protected core monitor |
-| `app/api/demo/` | Demo API |
-| `app/api/effect-callback/` | Effect callback |
-| `app/api/enterprise-proof/` | Enterprise proof |
-| `app/api/execute/` | **Spine execution** |
-| `app/api/executions/` | Executions list |
-| `app/api/executors/` | Executor dispatch |
-| `app/api/health/` | Health check |
-| `app/api/readiness/` | Production readiness check |
-| `app/api/integration/` | Integration |
-| `app/api/intent/` | **Intent endpoint** |
-| `app/api/ledger/` | Ledger API |
-| `app/api/mcp/` | MCP protocol |
-| `app/api/metrics/` | Metrics |
-| `app/api/onboarding/` | Onboarding |
-| `app/api/policies/` | Policies API |
-| `app/api/proofs/` | Proofs API |
-| `app/api/quickstart/` | Quickstart API |
-| `app/api/replay/` | Replay API |
-| `app/api/runtime-recovery/` | Runtime recovery |
-| `app/api/runtime-summary/` | Runtime summary |
-| `app/api/settings/` | Settings API |
-| `app/api/spine/` | Spine API |
-| `app/api/usage/` | Usage API |
-
----
-
-## 3) `lib/` — Core Business Logic
-
-### Spine Execution Engine (`lib/spine/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/spine/engine.ts` | Spine engine core |
-| `lib/spine/pipeline.ts` | Plugin pipeline |
-| `lib/spine/plugin.ts` | Plugin interface |
-| `lib/spine/register-defaults.ts` | Default plugin registration |
-| `lib/spine/request.ts` | Request types |
-| `lib/spine/types.ts` | Spine types |
-| `lib/spine/plugins/` | Plugin implementations |
-
-### DSG Core Integration (`lib/dsg-core/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/dsg-core/index.ts` | Entry point / mode switch |
-| `lib/dsg-core/internal.ts` | In-process gate |
-| `lib/dsg-core/remote.ts` | Remote gate call |
-| `lib/dsg-core/types.ts` | Core types |
-
-### Gate (`lib/gate/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/gate/index.ts` | Gate entry |
-| `lib/gate/registry.ts` | Gate registry |
-| `lib/gate/types.ts` | Gate types |
-| `lib/gate/plugins/` | Gate plugins |
-
-### Runtime (`lib/runtime/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/runtime/approval.ts` | Approval flow |
-| `lib/runtime/canonical.ts` | Canonical state |
-| `lib/runtime/checkpoint.ts` | Checkpoint logic |
-| `lib/runtime/gate.ts` | Runtime gate |
-| `lib/runtime/makk8-arbiter.ts` | Makk8 arbiter |
-| `lib/runtime/permissions.ts` | Permissions |
-| `lib/runtime/reconcile.ts` | Reconciliation |
-| `lib/runtime/recovery.ts` | Recovery logic |
-
-### Auth & RBAC (`lib/auth/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/auth/access-policy.ts` | Access policy |
-| `lib/auth/directory-sync.ts` | Directory sync |
-| `lib/auth/guest-access.ts` | Guest access |
-| `lib/auth/jit-provisioning.ts` | JIT provisioning |
-| `lib/auth/login-context.ts` | Login context |
-| `lib/auth/preflight.ts` | Auth preflight |
-| `lib/auth/rbac.ts` | RBAC engine |
-| `lib/auth/require-active-profile.ts` | Profile guard |
-| `lib/auth/require-org-permission.ts` | Org permission guard |
-| `lib/auth/safe-next.ts` | Safe Next.js helpers |
-| `lib/auth/sign-in-events.ts` | Sign-in events |
-| `lib/auth/sso-config.ts` | SSO config |
-
-### Billing (`lib/billing/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/billing/overage-config.ts` | Overage config |
-| `lib/billing/seat-activation.ts` | Seat activation |
-
-### Security (`lib/security/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/security/api-error.ts` | API error handling |
-| `lib/security/audit-export.ts` | Audit export |
-| `lib/security/error-response.ts` | Error response |
-| `lib/security/rate-limit.ts` | Rate limiting |
-| `lib/security/safe-log.ts` | Safe logging |
-
-### Agent Tooling (`lib/agent/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/agent/context.ts` | Agent context |
-| `lib/agent/executor.ts` | Agent executor |
-| `lib/agent/planner.ts` | Agent planner |
-| `lib/agent/tools.ts` | Agent tools |
-
-### Enterprise Proof (`lib/enterprise/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/enterprise/proof-access.ts` | Proof access control |
-| `lib/enterprise/proof-public.ts` | Public proof |
-| `lib/enterprise/proof-runtime.ts` | Runtime proof |
-| `lib/enterprise/proof-types.ts` | Proof types |
-| `lib/enterprise/proof.ts` | Proof core |
-
-### Executors (`lib/executors/`)
-
-| File | Responsibility |
-|---|---|
-| `lib/executors/index.ts` | Executor entry |
-| `lib/executors/browserbase.ts` | Browserbase executor |
-| `lib/executors/social.ts` | Social executor |
-| `lib/executors/types.ts` | Executor types |
-
-### Other Lib Files
-
-| File | Responsibility |
-|---|---|
-| `lib/supabase/` | Supabase client |
-| `lib/onboarding/bootstrap.ts` | Onboarding bootstrap |
-| `lib/makk8/action-data.ts` | Makk8 action data |
-| `lib/agent-auth.ts` | Agent auth |
-| `lib/authz.ts` | Authorization |
-| `lib/core-compat.ts` | Core compatibility |
-| `lib/dsg-core.ts` | DSG core entry |
-| `lib/integration-status.ts` | Integration status |
-| `lib/resend.ts` | Email (Resend) |
-| `lib/stripe-products.ts` | Stripe products |
-| `lib/supabase-server.ts` | Supabase server client |
-
----
-
-## 4) `components/` — UI Components
-
-| File | Responsibility |
-|---|---|
-| `components/GlobalNav.tsx` | Global navigation |
-| `components/AppShellClient.tsx` | App shell client UI |
-| `components/LoginForm.tsx` | Login form |
-| `components/audit/entropy-matrix.tsx` | Audit entropy matrix |
-| `components/canvas/EntropyField.tsx` | Canvas entropy field |
-
----
-
-## 5) `supabase/` — Database Schema & Migrations
-
-| File | Responsibility |
-|---|---|
-| `supabase/schema.sql` | Full schema |
-| `supabase/migrations/20260323053000_product_loop_scaffold.sql` | Product loop scaffold |
-| `supabase/migrations/20260323054500_product_loop_rls.sql` | RLS policies |
-| `supabase/migrations/20260323110000_billing_checkout_flow.sql` | Billing checkout |
-| `supabase/migrations/20260323140000_schema_constraints_hardening.sql` | Schema hardening |
-| `supabase/migrations/20260323141000_rls_policy_hardening.sql` | RLS hardening |
-| `supabase/migrations/20260330_monitor_stats.sql` | Monitor stats |
-| `supabase/migrations/20260331_runtime_spine.sql` | Runtime spine tables |
-| `supabase/migrations/20260331_runtime_spine_rpc.sql` | Runtime spine RPC |
-| `supabase/migrations/20260401093000_batch3_enterprise_identity_rollout.sql` | Enterprise identity |
-| `supabase/migrations/20260401120000_enterprise_access_batch2.sql` | Enterprise access |
-| `supabase/migrations/20260401_runtime_rbac.sql` | Runtime RBAC |
-| `supabase/migrations/20260401_schema_policies_table.sql` | Policies table |
-| `supabase/migrations/20260402_billing_quota_in_rpc.sql` | Billing quota RPC |
-| `supabase/migrations/20260404_runtime_spine_rpc_hardening.sql` | Spine RPC hardening |
-
----
-
-## 6) `scripts/` — Deployment & Ops
-
-| File | Responsibility |
-|---|---|
-| `scripts/check-error-handlers.sh` | Error handler check |
-| `scripts/go-no-go-gate.sh` | Launch go/no-go smoke gate |
-| `scripts/verify-production-manifest.mjs` | Production route/file manifest gate |
-| `scripts/stripe-setup.ts` | Stripe setup |
-| `scripts/termux-deploy-all-in-one.sh` | Termux deploy |
-| `apply-billing-checkout-flow.sh` | Apply billing migration |
-| `apply-complete-audit-hotfix.sh` | Apply audit hotfix |
-| `set-vercel-runtime-env.sh` | Set Vercel runtime env |
-| `set-vercel-stripe-env.sh` | Set Vercel Stripe env |
-
----
-
-## 7) `docs/` — Documentation
-
-- `docs/OPERATOR_SETUP_CHECKLIST.md`
-- `docs/PR_REVIEW_PACK_V1_RUNTIME_GAP_2026-03-31.md`
-- `docs/REPO_TRUTH.md`
-- `docs/RUNBOOK_DEPLOY.md`
-
----
-
-## Summary
-
-This is the complete production-ready inventory for `tdealer01-crypto-dsg-control-plane`, covering:
-
-- **Auth & SSO** (magic-link, password, SSO, RBAC, JIT provisioning)
-- **Spine Execution Engine** (intent → gate → ledger pipeline)
-- **DSG Core** (internal + remote safety gate)
-- **Agent Management** (CRUD, key rotation, tools, planner)
-- **Billing** (Stripe checkout, overage, seat activation)
-- **Enterprise Proof** (public + verified runtime proof)
-- **Dashboard** (19 complete views)
-- **API Routes** (health, readiness, runtime, governance, agent, audit, billing, policy, proof, and spine surfaces)
-- **Database** (migrations + schema)
-- **Security** (rate-limit, safe-log, error handling, CSP/security headers)
-
-Latest validated baseline: **DSG Action Layer Gate: GO** after Vercel production build, runtime health/readiness, trust surface checks, and `scripts/go-no-go-gate.sh` all passed.
+Latest validated product posture: **DSG Finance Governance backend smoke path is GO**, and the next product work should extend the gateway model into connector/provider execution.

--- a/docs/dsg-governance-gateway.md
+++ b/docs/dsg-governance-gateway.md
@@ -1,0 +1,176 @@
+# DSG Governance Gateway
+
+DSG is a governance, invariant, and audit gateway for AI agents.
+
+It does not replace the agent runtime. It sits between existing agents and high-risk tool execution, enforcing policy checks before execution and writing audit-grade proof after execution.
+
+## Product positioning
+
+```text
+DSG = Governance / Invariant / Audit Gateway
+Zapier = Universal Connector to external apps
+Agent = Existing runtime that must submit plans/tool calls through DSG first
+```
+
+## Core flow
+
+```text
+Agent
+→ DSG Plan Check
+→ Policy / Invariant / Risk
+→ DSG Connector
+→ Zapier / Make / n8n / MCP / REST
+→ App destination
+→ Result back to DSG
+→ Audit Ledger / Proof Export
+```
+
+## Why this matters
+
+Most AI agent systems can call tools, APIs, webhooks, and business apps.
+
+The problem is not tool access. The problem is governed execution.
+
+DSG adds the missing control layer:
+
+- deterministic policy decisions
+- invariant checks
+- risk classification
+- approval routing
+- gateway execution
+- audit ledger commit
+- request and record hashing
+- proof export for customers and auditors
+
+## Runtime model
+
+Agents keep their own runtime.
+
+Apps keep their own APIs.
+
+DSG controls high-risk action flow.
+
+This avoids forcing customers to migrate their agents or rebuild their app stack before adoption.
+
+## Lock points
+
+The DSG gateway locks the critical points around high-risk execution.
+
+### 1. Tool Registry
+
+A registry of known tools, apps, actions, and connector targets.
+
+Examples:
+
+```text
+stripe.refund
+stripe.invoice.finalize
+gmail.send
+slack.post_message
+bank.transfer
+hubspot.update_deal
+zapier.webhook.invoke
+```
+
+### 2. Risk Classification
+
+Each tool/action is classified by risk.
+
+```text
+low       = read-only or harmless operation
+medium    = write operation with low business impact
+high      = money movement, external communication, customer data mutation
+critical  = irreversible or regulated action
+```
+
+### 3. Gateway Execution
+
+High-risk actions must either:
+
+- pass through DSG before the agent executes; or
+- be executed directly by DSG after approval.
+
+Execution modes:
+
+```text
+Monitor Mode  = agent executes after DSG allow, then commits result
+Gateway Mode  = DSG executes tool call directly
+Critical Mode = human approval required before execution
+```
+
+### 4. Audit Commit
+
+After execution, DSG commits the result into an immutable audit ledger.
+
+The audit record stores:
+
+- org id
+- case id
+- approval id
+- action
+- actor
+- result
+- target
+- message
+- next status
+- request hash
+- record hash
+- payload
+- timestamp
+
+### 5. Proof Export
+
+DSG can export evidence for customers, auditors, and internal governance reviews.
+
+Export forms:
+
+```text
+JSON Evidence Pack
+CSV / Excel
+PDF Report
+Record Hash Verification
+```
+
+## Current first surface: Finance Governance
+
+The first production surface is Finance Governance.
+
+Verified backend capabilities:
+
+```text
+Readiness endpoint          ✅
+Supabase runtime tables     ✅
+RBAC / entitlement gate     ✅
+Approve action smoke test   ✅
+Audit ledger proof write    ✅
+Request hash / record hash  ✅
+```
+
+Finance Governance proves the gateway pattern for controlled approval workflows before expanding into broader connector execution.
+
+## SaaS expansion path
+
+DSG can expand from finance approval governance into a universal AI action governance gateway.
+
+Near-term connector targets:
+
+```text
+Zapier
+Make
+n8n
+Stripe
+Gmail
+Slack
+HubSpot
+Shopify
+Bank API
+Custom HTTP API
+MCP tools
+```
+
+## Product claim
+
+```text
+DSG does not replace your agents or apps.
+DSG governs high-risk AI actions before they execute, then records proof after execution.
+```

--- a/docs/zapier-provider-roadmap.md
+++ b/docs/zapier-provider-roadmap.md
@@ -1,0 +1,195 @@
+# Zapier Provider Roadmap
+
+Zapier should be integrated as a connector/provider behind the DSG Governance Gateway.
+
+The goal is not to rebuild every app connector inside DSG. The goal is to govern access to Zapier-powered actions.
+
+## Positioning
+
+```text
+DSG = Governance / Invariant / Audit Gateway
+Zapier = Universal Connector
+Agent = Existing runtime
+```
+
+Zapier gives DSG broad app coverage.
+
+DSG gives Zapier-triggered actions policy, risk, approval, and audit control.
+
+## Target flow
+
+```text
+Agent submits plan + requested tool call
+→ DSG Plan Check
+→ Policy / Invariant / Risk decision
+→ DSG Connector Provider
+→ Zapier webhook/action
+→ App destination
+→ Result returns to DSG
+→ Audit Commit
+→ Evidence Export
+```
+
+## Provider interface
+
+A DSG connector provider should expose a stable interface:
+
+```ts
+export type GatewayToolRequest = {
+  orgId: string;
+  actorId: string;
+  actorRole: string;
+  planId?: string;
+  toolName: string;
+  action: string;
+  risk: 'low' | 'medium' | 'high' | 'critical';
+  input: Record<string, unknown>;
+};
+
+export type GatewayToolResult = {
+  ok: boolean;
+  provider: string;
+  toolName: string;
+  action: string;
+  target?: string;
+  result?: Record<string, unknown>;
+  error?: string;
+};
+```
+
+## Zapier provider responsibilities
+
+The Zapier provider should:
+
+- accept only DSG-approved actions
+- map DSG tool names to Zapier webhook URLs or Zapier SDK actions
+- forward sanitized payloads
+- capture provider response
+- return result to DSG for audit commit
+- never bypass the DSG policy/risk decision layer
+
+## Tool registry examples
+
+```json
+[
+  {
+    "name": "zapier.gmail.send_email",
+    "provider": "zapier",
+    "risk": "high",
+    "requiresApproval": true
+  },
+  {
+    "name": "zapier.slack.post_message",
+    "provider": "zapier",
+    "risk": "medium",
+    "requiresApproval": false
+  },
+  {
+    "name": "zapier.hubspot.update_deal",
+    "provider": "zapier",
+    "risk": "high",
+    "requiresApproval": true
+  }
+]
+```
+
+## Execution modes
+
+### Monitor Mode
+
+The agent calls Zapier after DSG returns allow.
+
+Then the agent commits result back to DSG.
+
+### Gateway Mode
+
+DSG calls Zapier directly after approval.
+
+This is preferred for high-risk actions.
+
+### Critical Mode
+
+DSG blocks execution until human approval is recorded.
+
+## Required DSG checks before Zapier execution
+
+```text
+org entitlement
+actor role
+tool registry allowlist
+risk classification
+policy decision
+invariant check
+approval requirement
+payload validation
+```
+
+## Audit commit after Zapier result
+
+Every Zapier result must be committed to the DSG audit ledger.
+
+Required fields:
+
+```text
+org_id
+action
+actor
+target
+result
+message
+request_hash
+record_hash
+payload
+created_at
+```
+
+## Implementation phases
+
+### Phase 1: Webhook provider
+
+- Add `lib/gateway/providers/zapier-webhook-provider.ts`
+- Support one configured Zapier webhook URL per tool
+- Require DSG access gate before provider execution
+- Commit result to audit ledger
+
+### Phase 2: Tool Registry
+
+- Add DB-backed tool registry
+- Add risk classification
+- Add allowlist/denylist
+- Add per-org provider configuration
+
+### Phase 3: Gateway Execution API
+
+- Add `POST /api/gateway/tools/execute`
+- Validate request
+- Run plan/policy/risk checks
+- Call provider if allowed
+- Commit result
+
+### Phase 4: Customer-facing SaaS controls
+
+- Tool registry UI
+- Connector setup UI
+- Risk policy UI
+- Audit proof export UI
+
+## Non-goals
+
+Do not replace Zapier.
+
+Do not rebuild every app connector.
+
+Do not force customers to migrate their agents.
+
+Do not let agents bypass DSG for high-risk actions.
+
+## SaaS claim
+
+```text
+Use your existing agents.
+Use your existing apps.
+Route high-risk actions through DSG.
+Execute through Zapier.
+Export proof when auditors ask.
+```


### PR DESCRIPTION
## Summary

Updates product documentation to reflect the current product direction:

- DSG as a Governance / Invariant / Audit Gateway
- Zapier as a Universal Connector path
- Existing agents keep their runtime and route plans/tool calls through DSG first
- Finance Governance as the first production surface of the broader gateway SaaS

## Changes

- Rewrites `README.md` around the verified production posture and gateway positioning
- Adds `docs/dsg-governance-gateway.md`
- Adds `docs/zapier-provider-roadmap.md`

## Current verified status documented

- Finance readiness endpoint: HTTP 200
- Supabase runtime tables reachable
- RBAC-gated approve API: HTTP 200
- Audit ledger proof written with request/record hashes
- Smoke approval `APR-SMOKE-001` verified

## Product flow documented

```text
Agent
→ DSG Plan Check
→ Policy / Invariant / Risk
→ DSG Connector
→ Zapier / Make / n8n / MCP / REST
→ App destination
→ Result back to DSG
→ Audit Ledger / Proof Export
```

## Validation

Docs-only change. No runtime code modified.