### PR TITLE
Add DSG governance gateway roadmap docs

### DIFF
--- a/docs/dsg-governance-gateway.md
+++ b/docs/dsg-governance-gateway.md
@@ -1,0 +1,84 @@
+# DSG Governance Gateway
+
+DSG is a governance, invariant, and audit gateway for AI agents.
+
+It does not replace the agent runtime. It sits between existing agents and high-risk tool execution, enforcing policy checks before execution and writing audit-grade proof after execution.
+
+## Positioning
+
+```text
+DSG = Governance / Invariant / Audit Gateway
+Zapier = Universal Connector to external apps
+Agent = Existing runtime that must submit plans/tool calls through DSG first
+```
+
+## Core flow
+
+```text
+Agent
+→ DSG Plan Check
+→ Policy / Invariant / Risk
+→ DSG Connector
+→ Zapier / Make / n8n / MCP / REST
+→ App destination
+→ Result back to DSG
+→ Audit Ledger / Proof Export
+```
+
+## Lock points
+
+The DSG gateway locks the critical points around high-risk execution:
+
+1. Tool Registry
+2. Risk Classification
+3. Gateway Execution
+4. Audit Commit
+5. Proof Export
+
+## Execution modes
+
+```text
+Monitor Mode  = agent executes after DSG allow, then commits result
+Gateway Mode  = DSG executes tool call directly
+Critical Mode = human approval required before execution
+```
+
+## Current first surface
+
+Finance Governance is the first production surface.
+
+Verified backend capabilities:
+
+```text
+Readiness endpoint          OK
+Supabase runtime tables     OK
+RBAC / entitlement gate     OK
+Approve action smoke test   OK
+Audit ledger proof write    OK
+Request hash / record hash  OK
+```
+
+## SaaS expansion path
+
+Near-term connector targets:
+
+```text
+Zapier
+Make
+n8n
+Stripe
+Gmail
+Slack
+HubSpot
+Shopify
+Bank API
+Custom HTTP API
+MCP tools
+```
+
+## Product claim
+
+```text
+DSG does not replace your agents or apps.
+DSG governs high-risk AI actions before they execute, then records proof after execution.
+```

--- a/docs/zapier-provider-roadmap.md
+++ b/docs/zapier-provider-roadmap.md
@@ -1,0 +1,118 @@
+# Zapier Provider Roadmap
+
+Zapier should be integrated as a connector/provider behind the DSG Governance Gateway.
+
+The goal is not to rebuild every app connector inside DSG. The goal is to govern access to Zapier-powered actions.
+
+## Positioning
+
+```text
+DSG = Governance / Invariant / Audit Gateway
+Zapier = Universal Connector
+Agent = Existing runtime
+```
+
+## Target flow
+
+```text
+Agent submits plan + requested tool call
+→ DSG Plan Check
+→ Policy / Invariant / Risk decision
+→ DSG Connector Provider
+→ Zapier webhook/action
+→ App destination
+→ Result returns to DSG
+→ Audit Commit
+→ Evidence Export
+```
+
+## Provider interface
+
+A DSG connector provider should expose a stable interface:
+
+```ts
+export type GatewayToolRequest = {
+  orgId: string;
+  actorId: string;
+  actorRole: string;
+  planId?: string;
+  toolName: string;
+  action: string;
+  risk: 'low' | 'medium' | 'high' | 'critical';
+  input: Record<string, unknown>;
+};
+
+export type GatewayToolResult = {
+  ok: boolean;
+  provider: string;
+  toolName: string;
+  action: string;
+  target?: string;
+  result?: Record<string, unknown>;
+  error?: string;
+};
+```
+
+## Required DSG checks before Zapier execution
+
+```text
+org entitlement
+actor role
+tool registry allowlist
+risk classification
+policy decision
+invariant check
+approval requirement
+payload validation
+```
+
+## Implementation phases
+
+### Phase 1: Webhook provider
+
+- Add `lib/gateway/providers/zapier-webhook-provider.ts`
+- Support one configured Zapier webhook URL per tool
+- Require DSG access gate before provider execution
+- Commit result to audit ledger
+
+### Phase 2: Tool Registry
+
+- Add DB-backed tool registry
+- Add risk classification
+- Add allowlist/denylist
+- Add per-org provider configuration
+
+### Phase 3: Gateway Execution API
+
+- Add `POST /api/gateway/tools/execute`
+- Validate request
+- Run plan/policy/risk checks
+- Call provider if allowed
+- Commit result
+
+### Phase 4: Customer-facing SaaS controls
+
+- Tool registry UI
+- Connector setup UI
+- Risk policy UI
+- Audit proof export UI
+
+## Non-goals
+
+Do not replace Zapier.
+
+Do not rebuild every app connector.
+
+Do not force customers to migrate their agents.
+
+Do not let agents bypass DSG for high-risk actions.
+
+## SaaS claim
+
+```text
+Use your existing agents.
+Use your existing apps.
+Route high-risk actions through DSG.
+Execute through Zapier.
+Export proof when auditors ask.
+```


### PR DESCRIPTION
## Summary

Add docs-only gateway roadmap without touching README or runtime code.

This avoids conflicts with the Codex README work while keeping the product direction documented:

- DSG as Governance / Invariant / Audit Gateway
- Zapier as Universal Connector path
- Existing agents keep their runtime and submit plan/tool calls through DSG first
- Finance Governance remains the first production surface

## Added docs

- `docs/dsg-governance-gateway.md`
- `docs/zapier-provider-roadmap.md`

## Product flow documented

```text
Agent
→ DSG Plan Check
→ Policy / Invariant / Risk
→ DSG Connector
→ Zapier / Make / n8n / MCP / REST
→ App destination
→ Result back to DSG
→ Audit Ledger / Proof Export
```

## Validation

Docs-only change. No runtime code modified. README deliberately not touched to avoid conflict with Codex changes.