### PR TITLE
Add DSG gateway tool execution provider

### DIFF
--- a/app/api/gateway/tools/execute/route.ts
+++ b/app/api/gateway/tools/execute/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { executeGatewayTool, normalizeGatewayToolRequest } from '../../../../../lib/gateway/executor';
+
+export const dynamic = 'force-dynamic';
+
+function statusForDecision(result: Awaited<ReturnType<typeof executeGatewayTool>>) {
+  if (result.ok) {
+    return 200;
+  }
+
+  if (result.decision === 'review' || result.decision === 'ask_more_info') {
+    return 202;
+  }
+
+  if (result.reason === 'plan_not_entitled') {
+    return 402;
+  }
+
+  if (result.reason === 'missing_org_id' || result.reason === 'missing_actor_id' || result.reason === 'missing_actor_role' || result.reason === 'missing_org_plan') {
+    return 400;
+  }
+
+  if (result.reason === 'role_not_allowed') {
+    return 403;
+  }
+
+  if (result.reason === 'tool_not_registered' || result.reason === 'tool_action_mismatch') {
+    return 404;
+  }
+
+  return 502;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const gatewayRequest = normalizeGatewayToolRequest(body, request.headers);
+    const result = await executeGatewayTool(gatewayRequest);
+
+    return NextResponse.json(result, { status: statusForDecision(result) });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        decision: 'block',
+        reason: error instanceof Error ? error.message : 'gateway_execution_error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/gateway-tool-execution-api.md
+++ b/docs/gateway-tool-execution-api.md
@@ -1,0 +1,151 @@
+# Gateway Tool Execution API
+
+This API is the production entry point for DSG-governed connector execution.
+
+It is designed for real provider calls, starting with Zapier webhooks, while failing closed when policy, risk, approval, or provider configuration is missing.
+
+## Endpoint
+
+```http
+POST /api/gateway/tools/execute
+```
+
+## Required headers
+
+```http
+x-org-id: <organization-id>
+x-actor-id: <user-or-agent-id>
+x-actor-role: agent_operator
+x-org-plan: enterprise
+```
+
+For approved high-risk or critical tools:
+
+```http
+x-approval-token: <approval-token>
+```
+
+The same values can also be provided in the JSON body, but headers are preferred for runtime gateway calls.
+
+## Request body
+
+```json
+{
+  "toolName": "zapier.gmail.send_email",
+  "action": "send_email",
+  "planId": "PLAN-123",
+  "input": {
+    "to": "customer@example.com",
+    "subject": "Approved message",
+    "body": "Message generated after DSG approval."
+  }
+}
+```
+
+## Production behavior
+
+The gateway performs these steps:
+
+```text
+normalize request
+→ find tool registry entry
+→ evaluate org/actor/plan/risk policy
+→ require approval token for high-risk/critical tools
+→ execute provider only if allowed
+→ return provider result
+→ return requestHash and recordHash
+```
+
+## Zapier provider configuration
+
+The Zapier provider uses a fail-closed env lookup.
+
+Per-tool env key:
+
+```text
+ZAPIER_WEBHOOK_ZAPIER_GMAIL_SEND_EMAIL
+ZAPIER_WEBHOOK_ZAPIER_SLACK_POST_MESSAGE
+ZAPIER_WEBHOOK_ZAPIER_HUBSPOT_UPDATE_DEAL
+```
+
+Fallback env key:
+
+```text
+ZAPIER_WEBHOOK_URL
+```
+
+If no webhook URL is configured, the request does not execute and returns `provider_not_configured`.
+
+## Example: real Zapier Gmail execution
+
+```bash
+curl -i -X POST "https://<host>/api/gateway/tools/execute" \
+  -H "content-type: application/json" \
+  -H "x-org-id: org-smoke" \
+  -H "x-actor-id: agent-001" \
+  -H "x-actor-role: agent_operator" \
+  -H "x-org-plan: enterprise" \
+  -H "x-approval-token: APPROVED-001" \
+  -d '{
+    "toolName": "zapier.gmail.send_email",
+    "action": "send_email",
+    "planId": "PLAN-001",
+    "input": {
+      "to": "customer@example.com",
+      "subject": "Approved DSG message",
+      "body": "This action passed DSG governance before Zapier execution."
+    }
+  }'
+```
+
+Expected allowed response shape:
+
+```json
+{
+  "ok": true,
+  "decision": "allow",
+  "providerResult": {
+    "ok": true,
+    "provider": "zapier",
+    "toolName": "zapier.gmail.send_email",
+    "action": "send_email"
+  },
+  "audit": {
+    "committed": true,
+    "requestHash": "...",
+    "recordHash": "..."
+  }
+}
+```
+
+## Example: high-risk tool without approval
+
+```bash
+curl -i -X POST "https://<host>/api/gateway/tools/execute" \
+  -H "content-type: application/json" \
+  -H "x-org-id: org-smoke" \
+  -H "x-actor-id: agent-001" \
+  -H "x-actor-role: agent_operator" \
+  -H "x-org-plan: enterprise" \
+  -d '{
+    "toolName": "zapier.gmail.send_email",
+    "action": "send_email",
+    "input": {"to":"customer@example.com"}
+  }'
+```
+
+Expected result:
+
+```json
+{
+  "ok": false,
+  "decision": "review",
+  "reason": "approval_required"
+}
+```
+
+## Smoke-only tool
+
+`mock.safe.echo` exists only for zero-risk gateway smoke tests. It should not be treated as a product connector.
+
+Production connector paths should use `zapier.*`, `custom_http.*`, or future DB-backed tool registry entries.

--- a/lib/gateway/executor.ts
+++ b/lib/gateway/executor.ts
@@ -1,0 +1,79 @@
+import { buildGatewayAuditProof } from './audit';
+import { executeGatewayProvider } from './providers';
+import { evaluateGatewayToolRequest } from './policy';
+import { findGatewayTool } from './tool-registry';
+import type { GatewayToolExecutionResult, GatewayToolProviderResult, GatewayToolRequest } from './types';
+
+function sanitizeInput(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return {};
+  }
+
+  return input as Record<string, unknown>;
+}
+
+export function normalizeGatewayToolRequest(raw: unknown, headers: Headers): GatewayToolRequest {
+  const body = raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+
+  const header = (name: string) => headers.get(name)?.trim() ?? '';
+  const stringField = (name: string) => (typeof body[name] === 'string' ? (body[name] as string).trim() : '');
+
+  return {
+    orgId: stringField('orgId') || header('x-org-id'),
+    actorId: stringField('actorId') || header('x-actor-id') || header('x-user-id'),
+    actorRole: stringField('actorRole') || header('x-actor-role') || header('x-user-role'),
+    orgPlan: stringField('orgPlan') || header('x-org-plan') || header('x-plan'),
+    planId: stringField('planId') || undefined,
+    toolName: stringField('toolName'),
+    action: stringField('action'),
+    input: sanitizeInput(body.input),
+    approvalToken: stringField('approvalToken') || header('x-approval-token') || undefined,
+  };
+}
+
+export async function executeGatewayTool(request: GatewayToolRequest): Promise<GatewayToolExecutionResult> {
+  const registryEntry = findGatewayTool(request.toolName);
+  const policy = evaluateGatewayToolRequest(request, registryEntry);
+
+  if (policy.decision !== 'allow') {
+    const audit = buildGatewayAuditProof(request, null, policy.decision, policy.reason);
+    return {
+      ok: false,
+      decision: policy.decision,
+      reason: policy.reason,
+      registryEntry: registryEntry ?? undefined,
+      audit,
+    };
+  }
+
+  let providerResult: GatewayToolProviderResult;
+
+  try {
+    providerResult = await executeGatewayProvider(request);
+  } catch (error) {
+    providerResult = {
+      ok: false,
+      provider: registryEntry?.provider ?? 'unknown',
+      toolName: request.toolName,
+      action: request.action,
+      target: request.toolName,
+      error: error instanceof Error ? error.message : 'provider_error',
+    };
+  }
+
+  const audit = buildGatewayAuditProof(
+    request,
+    providerResult,
+    providerResult.ok ? 'allow' : 'block',
+    providerResult.error
+  );
+
+  return {
+    ok: providerResult.ok,
+    decision: providerResult.ok ? 'allow' : 'block',
+    reason: providerResult.error,
+    registryEntry: registryEntry ?? undefined,
+    providerResult,
+    audit,
+  };
+}

--- a/lib/gateway/policy.ts
+++ b/lib/gateway/policy.ts
@@ -1,0 +1,60 @@
+import type { GatewayDecision, GatewayToolRegistryEntry, GatewayToolRequest } from './types';
+
+const WRITE_ROLES = new Set(['owner', 'admin', 'finance_admin', 'finance_approver', 'agent_operator']);
+const EXECUTION_PLANS = new Set(['enterprise', 'business', 'pro']);
+
+export type GatewayPolicyDecision = {
+  decision: GatewayDecision;
+  reason?: string;
+};
+
+export function evaluateGatewayToolRequest(
+  request: GatewayToolRequest,
+  tool: GatewayToolRegistryEntry | null
+): GatewayPolicyDecision {
+  if (!request.orgId) {
+    return { decision: 'block', reason: 'missing_org_id' };
+  }
+
+  if (!request.actorId) {
+    return { decision: 'block', reason: 'missing_actor_id' };
+  }
+
+  if (!request.actorRole) {
+    return { decision: 'block', reason: 'missing_actor_role' };
+  }
+
+  if (!request.orgPlan) {
+    return { decision: 'block', reason: 'missing_org_plan' };
+  }
+
+  if (!tool) {
+    return { decision: 'block', reason: 'tool_not_registered' };
+  }
+
+  if (tool.action !== request.action) {
+    return { decision: 'block', reason: 'tool_action_mismatch' };
+  }
+
+  if (!WRITE_ROLES.has(request.actorRole.toLowerCase())) {
+    return { decision: 'block', reason: 'role_not_allowed' };
+  }
+
+  if (!EXECUTION_PLANS.has(request.orgPlan.toLowerCase())) {
+    return { decision: 'block', reason: 'plan_not_entitled' };
+  }
+
+  if (tool.risk === 'critical') {
+    return { decision: 'review', reason: 'critical_risk_requires_human_review' };
+  }
+
+  if (tool.requiresApproval && !request.approvalToken) {
+    return { decision: 'review', reason: 'approval_required' };
+  }
+
+  if (tool.executionMode === 'critical' && !request.approvalToken) {
+    return { decision: 'review', reason: 'critical_mode_requires_approval' };
+  }
+
+  return { decision: 'allow' };
+}

--- a/lib/gateway/policy.ts
+++ b/lib/gateway/policy.ts
@@ -44,16 +44,10 @@ export function evaluateGatewayToolRequest(
     return { decision: 'block', reason: 'plan_not_entitled' };
   }
 
-  if (tool.risk === 'critical') {
-    return { decision: 'review', reason: 'critical_risk_requires_human_review' };
-  }
+  const approvalRequired = tool.requiresApproval || tool.risk === 'critical' || tool.executionMode === 'critical';
 
-  if (tool.requiresApproval && !request.approvalToken) {
+  if (approvalRequired && !request.approvalToken) {
     return { decision: 'review', reason: 'approval_required' };
-  }
-
-  if (tool.executionMode === 'critical' && !request.approvalToken) {
-    return { decision: 'review', reason: 'critical_mode_requires_approval' };
   }
 
   return { decision: 'allow' };

--- a/lib/gateway/providers.ts
+++ b/lib/gateway/providers.ts
@@ -1,0 +1,93 @@
+import type { GatewayToolProviderResult, GatewayToolRequest } from './types';
+
+function zapierEnvKey(toolName: string) {
+  return `ZAPIER_WEBHOOK_${toolName.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
+}
+
+async function executeMockProvider(request: GatewayToolRequest): Promise<GatewayToolProviderResult> {
+  return {
+    ok: true,
+    provider: 'mock',
+    toolName: request.toolName,
+    action: request.action,
+    target: request.toolName,
+    result: {
+      echoed: request.input,
+      deterministic: true,
+    },
+  };
+}
+
+async function executeZapierProvider(request: GatewayToolRequest): Promise<GatewayToolProviderResult> {
+  const envKey = zapierEnvKey(request.toolName);
+  const webhookUrl = process.env[envKey] || process.env.ZAPIER_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    return {
+      ok: false,
+      provider: 'zapier',
+      toolName: request.toolName,
+      action: request.action,
+      target: envKey,
+      error: 'provider_not_configured',
+    };
+  }
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-dsg-org-id': request.orgId,
+      'x-dsg-actor-id': request.actorId,
+      'x-dsg-tool-name': request.toolName,
+      'x-dsg-action': request.action,
+    },
+    body: JSON.stringify({
+      orgId: request.orgId,
+      actorId: request.actorId,
+      actorRole: request.actorRole,
+      planId: request.planId ?? null,
+      toolName: request.toolName,
+      action: request.action,
+      input: request.input,
+    }),
+  });
+
+  const text = await response.text();
+  let result: Record<string, unknown> = { raw: text };
+
+  try {
+    result = text ? JSON.parse(text) : {};
+  } catch {
+    result = { raw: text };
+  }
+
+  return {
+    ok: response.ok,
+    provider: 'zapier',
+    toolName: request.toolName,
+    action: request.action,
+    target: webhookUrl,
+    result,
+    error: response.ok ? undefined : `provider_http_${response.status}`,
+  };
+}
+
+export async function executeGatewayProvider(request: GatewayToolRequest): Promise<GatewayToolProviderResult> {
+  if (request.toolName.startsWith('mock.')) {
+    return executeMockProvider(request);
+  }
+
+  if (request.toolName.startsWith('zapier.')) {
+    return executeZapierProvider(request);
+  }
+
+  return {
+    ok: false,
+    provider: 'unknown',
+    toolName: request.toolName,
+    action: request.action,
+    target: request.toolName,
+    error: 'provider_not_supported',
+  };
+}

--- a/lib/gateway/tool-registry.ts
+++ b/lib/gateway/tool-registry.ts
@@ -1,0 +1,44 @@
+import type { GatewayToolRegistryEntry } from './types';
+
+export const DEFAULT_GATEWAY_TOOL_REGISTRY: GatewayToolRegistryEntry[] = [
+  {
+    name: 'zapier.gmail.send_email',
+    provider: 'zapier',
+    action: 'send_email',
+    risk: 'high',
+    executionMode: 'critical',
+    requiresApproval: true,
+    description: 'Send an email through a Zapier-backed Gmail action.',
+  },
+  {
+    name: 'zapier.slack.post_message',
+    provider: 'zapier',
+    action: 'post_message',
+    risk: 'medium',
+    executionMode: 'gateway',
+    requiresApproval: false,
+    description: 'Post a Slack message through a Zapier-backed action.',
+  },
+  {
+    name: 'zapier.hubspot.update_deal',
+    provider: 'zapier',
+    action: 'update_deal',
+    risk: 'high',
+    executionMode: 'critical',
+    requiresApproval: true,
+    description: 'Update a HubSpot deal through Zapier.',
+  },
+  {
+    name: 'mock.safe.echo',
+    provider: 'mock',
+    action: 'echo',
+    risk: 'low',
+    executionMode: 'gateway',
+    requiresApproval: false,
+    description: 'Deterministic test tool for gateway smoke tests.',
+  },
+];
+
+export function findGatewayTool(name: string) {
+  return DEFAULT_GATEWAY_TOOL_REGISTRY.find((tool) => tool.name === name) ?? null;
+}

--- a/lib/gateway/types.ts
+++ b/lib/gateway/types.ts
@@ -1,0 +1,50 @@
+export type GatewayRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export type GatewayExecutionMode = 'monitor' | 'gateway' | 'critical';
+
+export type GatewayDecision = 'allow' | 'block' | 'review' | 'ask_more_info';
+
+export type GatewayToolRegistryEntry = {
+  name: string;
+  provider: 'zapier' | 'mock' | 'custom_http';
+  action: string;
+  risk: GatewayRiskLevel;
+  executionMode: GatewayExecutionMode;
+  requiresApproval: boolean;
+  description: string;
+};
+
+export type GatewayToolRequest = {
+  orgId: string;
+  actorId: string;
+  actorRole: string;
+  orgPlan: string;
+  planId?: string;
+  toolName: string;
+  action: string;
+  input: Record<string, unknown>;
+  approvalToken?: string;
+};
+
+export type GatewayToolProviderResult = {
+  ok: boolean;
+  provider: string;
+  toolName: string;
+  action: string;
+  target?: string;
+  result?: Record<string, unknown>;
+  error?: string;
+};
+
+export type GatewayToolExecutionResult = {
+  ok: boolean;
+  decision: GatewayDecision;
+  reason?: string;
+  registryEntry?: GatewayToolRegistryEntry;
+  providerResult?: GatewayToolProviderResult;
+  audit: {
+    committed: boolean;
+    requestHash: string;
+    recordHash: string;
+  };
+};


### PR DESCRIPTION
## Summary

Adds a real Gateway Tool Execution API for DSG-governed connector execution.

This is additive and does not touch README, finance governance files, or existing runtime routes.

## What this adds

- `POST /api/gateway/tools/execute`
- Gateway tool registry
- Risk / role / plan / approval policy check
- Zapier webhook provider execution path
- Fail-closed provider behavior when webhook env is missing
- Audit proof hash generation for request/record
- Docs for production execution and Zapier env setup

## Product path

```text
Agent/Client
→ /api/gateway/tools/execute
→ DSG policy / invariant / risk check
→ Zapier webhook provider
→ external app
→ result returns to DSG
→ requestHash / recordHash returned
```

## Real Zapier behavior

Zapier execution uses env mapping:

```text
ZAPIER_WEBHOOK_ZAPIER_GMAIL_SEND_EMAIL
ZAPIER_WEBHOOK_ZAPIER_SLACK_POST_MESSAGE
ZAPIER_WEBHOOK_ZAPIER_HUBSPOT_UPDATE_DEAL
```

Fallback:

```text
ZAPIER_WEBHOOK_URL
```

If no webhook is configured, it returns `provider_not_configured` and does not fake success.

## Safety behavior

- Unregistered tools block
- Role/plan failures block
- high-risk/critical tools require `x-approval-token`
- provider failure returns block/failure result
- no hidden tool execution without DSG allow

## Files

- `app/api/gateway/tools/execute/route.ts`
- `lib/gateway/*`
- `docs/gateway-tool-execution-api.md`

## Validation

Docs + additive API implementation. Existing routes untouched.