### PR TITLE
Fix missing gateway audit helper

### DIFF
--- a/lib/gateway/audit.ts
+++ b/lib/gateway/audit.ts
@@ -1,0 +1,50 @@
+import crypto from 'node:crypto';
+import type { GatewayToolProviderResult, GatewayToolRequest } from './types';
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`).join(',')}}`;
+}
+
+export function hashGatewayValue(value: unknown) {
+  return crypto.createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+export function buildGatewayAuditProof(
+  request: GatewayToolRequest,
+  providerResult: GatewayToolProviderResult | null,
+  decision: string,
+  reason?: string
+) {
+  const requestHash = hashGatewayValue({
+    orgId: request.orgId,
+    actorId: request.actorId,
+    actorRole: request.actorRole,
+    orgPlan: request.orgPlan,
+    planId: request.planId,
+    toolName: request.toolName,
+    action: request.action,
+    input: request.input,
+  });
+
+  const recordHash = hashGatewayValue({
+    requestHash,
+    decision,
+    reason: reason ?? null,
+    providerResult: providerResult ?? null,
+  });
+
+  return {
+    committed: Boolean(providerResult?.ok || decision !== 'allow'),
+    requestHash,
+    recordHash,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the missing `lib/gateway/audit.ts` helper imported by `lib/gateway/executor.ts`.

## Why

The production deploy after PR #423 failed during `npm run build` because `executor.ts` imports `./audit`, but the audit helper file was not included in the merged PR.

## Fix

- Adds deterministic stable stringify
- Adds SHA-256 request hash generation
- Adds SHA-256 record hash generation
- Exports `buildGatewayAuditProof` used by the gateway executor

## Validation

This is the missing module required for the gateway tool execution build path. No existing routes are changed.