### PR TITLE
Add DSG managed connector registry

### DIFF
--- a/app/api/gateway/connectors/route.ts
+++ b/app/api/gateway/connectors/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+function isAllowedRole(role: string) {
+  return ['owner', 'admin', 'finance_admin', 'agent_operator'].includes(role.toLowerCase());
+}
+
+function parseUrl(value: unknown) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    if (!['https:', 'http:'].includes(url.protocol)) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: Request) {
+  const orgId = header(request, 'x-org-id');
+  const actorId = header(request, 'x-actor-id') || header(request, 'x-user-id');
+  const actorRole = header(request, 'x-actor-role') || header(request, 'x-user-role');
+
+  if (!orgId) {
+    return NextResponse.json({ ok: false, error: 'missing_org_id' }, { status: 400 });
+  }
+
+  if (!actorId) {
+    return NextResponse.json({ ok: false, error: 'missing_actor_id' }, { status: 400 });
+  }
+
+  if (!isAllowedRole(actorRole)) {
+    return NextResponse.json({ ok: false, error: 'role_not_allowed' }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const endpointUrl = parseUrl(body.endpointUrl);
+  const connectorName = typeof body.name === 'string' && body.name.trim() ? body.name.trim() : 'Customer webhook';
+  const toolName = typeof body.toolName === 'string' && body.toolName.trim()
+    ? body.toolName.trim()
+    : 'custom_http.customer_webhook';
+  const action = typeof body.action === 'string' && body.action.trim() ? body.action.trim() : 'post';
+  const risk = typeof body.risk === 'string' && body.risk.trim() ? body.risk.trim() : 'medium';
+  const requiresApproval = Boolean(body.requiresApproval);
+
+  if (!endpointUrl) {
+    return NextResponse.json({ ok: false, error: 'invalid_endpoint_url' }, { status: 400 });
+  }
+
+  if (!['low', 'medium', 'high', 'critical'].includes(risk)) {
+    return NextResponse.json({ ok: false, error: 'invalid_risk' }, { status: 400 });
+  }
+
+  const executionMode = risk === 'critical' || requiresApproval ? 'critical' : 'gateway';
+  const supabase = getSupabaseAdmin() as any;
+
+  const { data: connector, error: connectorError } = await supabase
+    .from('gateway_connectors')
+    .upsert({
+      org_id: orgId,
+      provider: 'custom_http',
+      status: 'connected',
+      name: connectorName,
+      endpoint_url: endpointUrl,
+      metadata: {
+        created_by: actorId,
+      },
+      connected_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'org_id,provider,name' })
+    .select('id, org_id, provider, name, endpoint_url, status')
+    .single();
+
+  if (connectorError) {
+    return NextResponse.json({ ok: false, error: `failed_to_save_connector:${connectorError.message}` }, { status: 500 });
+  }
+
+  const { data: tool, error: toolError } = await supabase
+    .from('gateway_tools')
+    .upsert({
+      org_id: orgId,
+      connector_id: connector.id,
+      name: toolName,
+      provider: 'custom_http',
+      action,
+      risk,
+      execution_mode: executionMode,
+      requires_approval: requiresApproval,
+      enabled: true,
+      description: typeof body.description === 'string' ? body.description : 'Customer-managed HTTP webhook tool',
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'org_id,name' })
+    .select('id, name, provider, action, risk, execution_mode, requires_approval, enabled')
+    .single();
+
+  if (toolError) {
+    return NextResponse.json({ ok: false, error: `failed_to_save_tool:${toolError.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, connector, tool }, { status: 200 });
+}

--- a/docs/gateway-managed-connectors.md
+++ b/docs/gateway-managed-connectors.md
@@ -1,0 +1,97 @@
+# Gateway Managed Connectors
+
+Phase 1 avoids Zapier paid-plan dependency by letting each customer register a custom HTTP webhook or REST endpoint directly inside DSG.
+
+## Product decision
+
+Zapier remains a future provider path.
+
+The immediate product path is DSG-managed connector registration:
+
+```text
+Customer endpoint / webhook
+→ registered in DSG Connector Registry
+→ mapped to a DSG tool name
+→ governed by policy / risk / approval
+→ executed by /api/gateway/tools/execute
+→ proof hashes returned
+```
+
+## Register connector
+
+```http
+POST /api/gateway/connectors
+```
+
+Required headers:
+
+```http
+x-org-id: <org-id>
+x-actor-id: <actor-id>
+x-actor-role: admin
+```
+
+Body:
+
+```json
+{
+  "name": "Customer webhook",
+  "endpointUrl": "https://customer.example.com/dsg/webhook",
+  "toolName": "custom_http.customer_webhook",
+  "action": "post",
+  "risk": "medium",
+  "requiresApproval": false,
+  "description": "Customer-managed webhook receiver"
+}
+```
+
+## Execute connector
+
+```http
+POST /api/gateway/tools/execute
+```
+
+Example:
+
+```bash
+curl -i -X POST "https://<host>/api/gateway/tools/execute" \
+  -H "content-type: application/json" \
+  -H "x-org-id: org-smoke" \
+  -H "x-actor-id: agent-001" \
+  -H "x-actor-role: agent_operator" \
+  -H "x-org-plan: enterprise" \
+  -d '{
+    "toolName": "custom_http.customer_webhook",
+    "action": "post",
+    "planId": "PLAN-001",
+    "input": {
+      "message": "DSG governed connector execution"
+    }
+  }'
+```
+
+## Database tables
+
+```text
+gateway_connectors
+gateway_tools
+```
+
+`gateway_connectors` stores the customer-managed endpoint.
+
+`gateway_tools` maps a DSG tool name to that connector.
+
+## Safety posture
+
+- No Zapier paid plan required
+- Customer controls their endpoint
+- DSG checks role, plan, risk, and approval before execution
+- High-risk or critical tools can require `x-approval-token`
+- DSG returns `requestHash` and `recordHash`
+- Provider calls fail closed if endpoint is missing or returns an error
+
+## Phase 2
+
+Zapier OAuth / embedded setup can be added later as a provider-specific install flow.
+
+Do not block the Phase 1 product on Zapier paid-plan requirements.

--- a/lib/gateway/executor.ts
+++ b/lib/gateway/executor.ts
@@ -32,7 +32,7 @@ export function normalizeGatewayToolRequest(raw: unknown, headers: Headers): Gat
 }
 
 export async function executeGatewayTool(request: GatewayToolRequest): Promise<GatewayToolExecutionResult> {
-  const registryEntry = findGatewayTool(request.toolName);
+  const registryEntry = await findGatewayTool(request.orgId, request.toolName);
   const policy = evaluateGatewayToolRequest(request, registryEntry);
 
   if (policy.decision !== 'allow') {
@@ -49,7 +49,7 @@ export async function executeGatewayTool(request: GatewayToolRequest): Promise<G
   let providerResult: GatewayToolProviderResult;
 
   try {
-    providerResult = await executeGatewayProvider(request);
+    providerResult = await executeGatewayProvider(request, registryEntry ?? undefined);
   } catch (error) {
     providerResult = {
       ok: false,

--- a/lib/gateway/managed-connectors.ts
+++ b/lib/gateway/managed-connectors.ts
@@ -1,0 +1,46 @@
+import { getSupabaseAdmin } from '../supabase-server';
+import type { GatewayToolRegistryEntry } from './types';
+
+export async function findManagedGatewayTool(orgId: string, toolName: string): Promise<GatewayToolRegistryEntry | null> {
+  if (!orgId || !toolName) {
+    return null;
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  const { data, error } = await supabase
+    .from('gateway_tools')
+    .select('name, provider, action, risk, execution_mode, requires_approval, description, connector_id, gateway_connectors!inner(endpoint_url, status)')
+    .eq('org_id', orgId)
+    .eq('name', toolName)
+    .eq('enabled', true)
+    .maybeSingle();
+
+  if (error) {
+    if (String(error.message || '').toLowerCase().includes('relation')) {
+      return null;
+    }
+    throw new Error(`failed_to_read_gateway_tool:${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const connector = Array.isArray(data.gateway_connectors) ? data.gateway_connectors[0] : data.gateway_connectors;
+
+  if (!connector || connector.status !== 'connected') {
+    return null;
+  }
+
+  return {
+    name: data.name,
+    provider: data.provider,
+    action: data.action,
+    risk: data.risk,
+    executionMode: data.execution_mode,
+    requiresApproval: Boolean(data.requires_approval),
+    description: data.description ?? 'Managed gateway tool',
+    connectorId: data.connector_id,
+    endpointUrl: connector.endpoint_url,
+  };
+}

--- a/lib/gateway/providers.ts
+++ b/lib/gateway/providers.ts
@@ -1,4 +1,4 @@
-import type { GatewayToolProviderResult, GatewayToolRequest } from './types';
+import type { GatewayToolProviderResult, GatewayToolRegistryEntry, GatewayToolRequest } from './types';
 
 function zapierEnvKey(toolName: string) {
   return `ZAPIER_WEBHOOK_${toolName.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
@@ -16,6 +16,19 @@ async function executeMockProvider(request: GatewayToolRequest): Promise<Gateway
       deterministic: true,
     },
   };
+}
+
+async function parseProviderResponse(response: Response) {
+  const text = await response.text();
+  let result: Record<string, unknown> = { raw: text };
+
+  try {
+    result = text ? JSON.parse(text) : {};
+  } catch {
+    result = { raw: text };
+  }
+
+  return result;
 }
 
 async function executeZapierProvider(request: GatewayToolRequest): Promise<GatewayToolProviderResult> {
@@ -53,14 +66,7 @@ async function executeZapierProvider(request: GatewayToolRequest): Promise<Gatew
     }),
   });
 
-  const text = await response.text();
-  let result: Record<string, unknown> = { raw: text };
-
-  try {
-    result = text ? JSON.parse(text) : {};
-  } catch {
-    result = { raw: text };
-  }
+  const result = await parseProviderResponse(response);
 
   return {
     ok: response.ok,
@@ -73,9 +79,66 @@ async function executeZapierProvider(request: GatewayToolRequest): Promise<Gatew
   };
 }
 
-export async function executeGatewayProvider(request: GatewayToolRequest): Promise<GatewayToolProviderResult> {
+async function executeCustomHttpProvider(
+  request: GatewayToolRequest,
+  registryEntry?: GatewayToolRegistryEntry
+): Promise<GatewayToolProviderResult> {
+  const endpointUrl = registryEntry?.endpointUrl || process.env.CUSTOM_HTTP_WEBHOOK_URL;
+
+  if (!endpointUrl) {
+    return {
+      ok: false,
+      provider: 'custom_http',
+      toolName: request.toolName,
+      action: request.action,
+      target: request.toolName,
+      error: 'provider_not_configured',
+    };
+  }
+
+  const response = await fetch(endpointUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-dsg-org-id': request.orgId,
+      'x-dsg-actor-id': request.actorId,
+      'x-dsg-tool-name': request.toolName,
+      'x-dsg-action': request.action,
+    },
+    body: JSON.stringify({
+      orgId: request.orgId,
+      actorId: request.actorId,
+      actorRole: request.actorRole,
+      planId: request.planId ?? null,
+      toolName: request.toolName,
+      action: request.action,
+      input: request.input,
+    }),
+  });
+
+  const result = await parseProviderResponse(response);
+
+  return {
+    ok: response.ok,
+    provider: 'custom_http',
+    toolName: request.toolName,
+    action: request.action,
+    target: endpointUrl,
+    result,
+    error: response.ok ? undefined : `provider_http_${response.status}`,
+  };
+}
+
+export async function executeGatewayProvider(
+  request: GatewayToolRequest,
+  registryEntry?: GatewayToolRegistryEntry
+): Promise<GatewayToolProviderResult> {
   if (request.toolName.startsWith('mock.')) {
     return executeMockProvider(request);
+  }
+
+  if (registryEntry?.provider === 'custom_http' || request.toolName.startsWith('custom_http.')) {
+    return executeCustomHttpProvider(request, registryEntry);
   }
 
   if (request.toolName.startsWith('zapier.')) {

--- a/lib/gateway/tool-registry.ts
+++ b/lib/gateway/tool-registry.ts
@@ -1,3 +1,4 @@
+import { findManagedGatewayTool } from './managed-connectors';
 import type { GatewayToolRegistryEntry } from './types';
 
 export const DEFAULT_GATEWAY_TOOL_REGISTRY: GatewayToolRegistryEntry[] = [
@@ -29,6 +30,15 @@ export const DEFAULT_GATEWAY_TOOL_REGISTRY: GatewayToolRegistryEntry[] = [
     description: 'Update a HubSpot deal through Zapier.',
   },
   {
+    name: 'custom_http.customer_webhook',
+    provider: 'custom_http',
+    action: 'post',
+    risk: 'medium',
+    executionMode: 'gateway',
+    requiresApproval: false,
+    description: 'Customer-managed HTTP webhook connector.',
+  },
+  {
     name: 'mock.safe.echo',
     provider: 'mock',
     action: 'echo',
@@ -39,6 +49,14 @@ export const DEFAULT_GATEWAY_TOOL_REGISTRY: GatewayToolRegistryEntry[] = [
   },
 ];
 
-export function findGatewayTool(name: string) {
+export function findDefaultGatewayTool(name: string) {
   return DEFAULT_GATEWAY_TOOL_REGISTRY.find((tool) => tool.name === name) ?? null;
+}
+
+export async function findGatewayTool(orgId: string, name: string) {
+  const managedTool = await findManagedGatewayTool(orgId, name);
+  if (managedTool) {
+    return managedTool;
+  }
+  return findDefaultGatewayTool(name);
 }

--- a/lib/gateway/types.ts
+++ b/lib/gateway/types.ts
@@ -4,14 +4,19 @@ export type GatewayExecutionMode = 'monitor' | 'gateway' | 'critical';
 
 export type GatewayDecision = 'allow' | 'block' | 'review' | 'ask_more_info';
 
+export type GatewayToolProvider = 'zapier' | 'mock' | 'custom_http';
+
 export type GatewayToolRegistryEntry = {
   name: string;
-  provider: 'zapier' | 'mock' | 'custom_http';
+  provider: GatewayToolProvider;
   action: string;
   risk: GatewayRiskLevel;
   executionMode: GatewayExecutionMode;
   requiresApproval: boolean;
   description: string;
+  connectorId?: string;
+  endpointUrl?: string;
+  authHeaders?: Record<string, string>;
 };
 
 export type GatewayToolRequest = {

--- a/supabase/migrations/20260430_gateway_managed_connectors.sql
+++ b/supabase/migrations/20260430_gateway_managed_connectors.sql
@@ -1,0 +1,68 @@
+create table if not exists public.gateway_connectors (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  provider text not null,
+  status text not null default 'connected',
+  name text not null default 'Customer webhook',
+  endpoint_url text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  connected_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint gateway_connectors_provider_chk
+    check (provider in ('custom_http', 'zapier', 'make', 'n8n')),
+  constraint gateway_connectors_status_chk
+    check (status in ('connected', 'disabled', 'error'))
+);
+
+create unique index if not exists idx_gateway_connectors_org_provider_name
+  on public.gateway_connectors (org_id, provider, name);
+
+create index if not exists idx_gateway_connectors_org_status
+  on public.gateway_connectors (org_id, status, created_at desc);
+
+create table if not exists public.gateway_tools (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  connector_id uuid not null references public.gateway_connectors(id) on delete cascade,
+  name text not null,
+  provider text not null,
+  action text not null,
+  risk text not null default 'medium',
+  execution_mode text not null default 'gateway',
+  requires_approval boolean not null default false,
+  enabled boolean not null default true,
+  description text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint gateway_tools_provider_chk
+    check (provider in ('custom_http', 'zapier', 'make', 'n8n')),
+  constraint gateway_tools_risk_chk
+    check (risk in ('low', 'medium', 'high', 'critical')),
+  constraint gateway_tools_execution_mode_chk
+    check (execution_mode in ('monitor', 'gateway', 'critical'))
+);
+
+create unique index if not exists idx_gateway_tools_org_name
+  on public.gateway_tools (org_id, name);
+
+create index if not exists idx_gateway_tools_org_connector
+  on public.gateway_tools (org_id, connector_id, enabled);
+
+alter table public.gateway_connectors enable row level security;
+alter table public.gateway_tools enable row level security;
+
+drop policy if exists gateway_connectors_org_select on public.gateway_connectors;
+create policy gateway_connectors_org_select
+on public.gateway_connectors
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));
+
+drop policy if exists gateway_tools_org_select on public.gateway_tools;
+create policy gateway_tools_org_select
+on public.gateway_tools
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));


### PR DESCRIPTION
## Summary

Adds Phase 1 DSG-managed connector registry so the product does not depend on Zapier paid Webhooks.

Customers can register their own webhook/REST endpoint in DSG, map it to a tool, and execute it through the existing DSG gateway policy/risk/approval path.

## What this adds

- `POST /api/gateway/connectors`
- `gateway_connectors` Supabase table
- `gateway_tools` Supabase table
- managed connector lookup before default registry fallback
- custom HTTP provider execution path
- docs for customer-managed connectors

## Product flow

```text
Customer webhook / REST API
→ registered in DSG Connector Registry
→ mapped to toolName
→ Agent calls /api/gateway/tools/execute
→ DSG checks role / plan / risk / approval
→ DSG POSTs to customer endpoint
→ requestHash / recordHash returned
```

## Why

Zapier Webhooks are not available on Free plan. This makes DSG usable now for any customer that can provide a webhook or REST endpoint, while leaving Zapier as a future provider path.

## Safety

- role-gated connector registration
- endpoint URL validation
- tool risk classification
- approval requirement support
- provider calls fail closed
- no README changes

## Validation

Additive API + migration + docs. Existing finance governance routes are not changed.