### PR TITLE
Fix gateway connectors import path

### DIFF
--- a/app/api/gateway/connectors/route.ts
+++ b/app/api/gateway/connectors/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
 


### PR DESCRIPTION
## Summary

Fixes the relative import path in `app/api/gateway/connectors/route.ts`.

## Why

The route is located at:

```text
app/api/gateway/connectors/route.ts
```

So importing `lib/supabase-server` requires four `..` segments, not three.

## Change

```diff
- import { getSupabaseAdmin } from '../../../lib/supabase-server';
+ import { getSupabaseAdmin } from '../../../../lib/supabase-server';
```

## Validation

Hotfix for the production build failure after PR #425. No runtime behavior changed.