### PR TITLE
Add gateway webhook inbox receiver

### DIFF
--- a/app/api/gateway/webhook/inbox/route.ts
+++ b/app/api/gateway/webhook/inbox/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+function sanitizeHeaders(request: Request) {
+  return {
+    orgId: header(request, 'x-dsg-org-id') || header(request, 'x-org-id'),
+    actorId: header(request, 'x-dsg-actor-id') || header(request, 'x-actor-id'),
+    toolName: header(request, 'x-dsg-tool-name'),
+    action: header(request, 'x-dsg-action'),
+    contentType: header(request, 'content-type'),
+  };
+}
+
+export async function POST(request: Request) {
+  const receivedAt = new Date().toISOString();
+  const body = await request.json().catch(() => ({}));
+  const headers = sanitizeHeaders(request);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      service: 'gateway-webhook-inbox',
+      receivedAt,
+      headers,
+      payload: body,
+    },
+    { status: 200 }
+  );
+}
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      ok: true,
+      service: 'gateway-webhook-inbox',
+      accepts: ['POST'],
+    },
+    { status: 200 }
+  );
+}

--- a/docs/gateway-webhook-inbox.md
+++ b/docs/gateway-webhook-inbox.md
@@ -1,0 +1,56 @@
+# Gateway Webhook Inbox
+
+`POST /api/gateway/webhook/inbox` is an internal smoke receiver and customer webhook template.
+
+It exists so DSG managed connector execution can be tested end-to-end without depending on Zapier paid Webhooks or a third-party endpoint.
+
+## Endpoint
+
+```http
+POST /api/gateway/webhook/inbox
+```
+
+## Behavior
+
+The endpoint accepts JSON POST payloads and returns:
+
+- `ok: true`
+- `service: gateway-webhook-inbox`
+- sanitized DSG headers
+- echoed payload
+- `receivedAt` timestamp
+
+## Smoke flow
+
+Register this endpoint as a custom HTTP connector:
+
+```text
+https://<host>/api/gateway/webhook/inbox
+```
+
+Then execute through:
+
+```http
+POST /api/gateway/tools/execute
+```
+
+Expected result:
+
+```text
+Gateway policy passes
+→ custom_http provider POSTs to inbox
+→ inbox returns HTTP 200
+→ gateway returns ok:true
+→ requestHash and recordHash are returned
+```
+
+## Purpose
+
+This endpoint is not a replacement for customer infrastructure.
+
+It is a production-safe receiver for:
+
+- smoke testing DSG managed connectors
+- documenting payload format
+- proving POST execution path
+- giving customers a template for their own webhook endpoint


### PR DESCRIPTION
## Summary

Adds a POST-capable gateway webhook inbox so the managed connector flow can be tested end-to-end without Zapier paid Webhooks or an external customer endpoint.

## What this adds

- `POST /api/gateway/webhook/inbox`
- `GET /api/gateway/webhook/inbox` health/info response
- docs for the gateway webhook inbox receiver

## Why

The managed connector path already executes custom HTTP providers, but `/api/health` only supports GET and returns 405 when used as a POST target.

This gives DSG a safe internal smoke receiver:

```text
/api/gateway/connectors
→ endpointUrl = /api/gateway/webhook/inbox
→ /api/gateway/tools/execute
→ custom_http provider POST
→ inbox returns HTTP 200
→ gateway returns requestHash / recordHash
```

## Validation

Additive route + docs only. Existing finance and gateway execution code is not changed.