### PR TITLE
chore: add redeploy-trigger.txt to force Vercel redeploy

### DIFF
--- a/redeploy-trigger.txt
+++ b/redeploy-trigger.txt
@@ -1,0 +1,3 @@
+Redeploy trigger after empty commit dbf80da7b4775fb08c0900cd098e3c6854497c04
+Timestamp (UTC): 2026-04-30T19:17:57Z
+Reason: create a real file change so Vercel/Git detects a new deployable diff.


### PR DESCRIPTION
### Motivation
- Provide a real repository diff so Vercel/Git reliably detects a deployable change and avoids empty-commit redeploy failures.

### Description
- Add `redeploy-trigger.txt` containing an audit line, UTC timestamp, and a short reason to act as an explicit redeploy trigger; no other code or behavior changes were made.
- Skills: no skill was used because this is a trivial repository artifact fix.

### Testing
- No automated tests were run for this low-risk repository artifact change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aa8f8e3c83289124f19239ccfed8)