### PR TITLE
Fix Vercel build by forcing auth-gated pages to dynamic rendering

### DIFF
--- a/app/app-shell/page.tsx
+++ b/app/app-shell/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from 'next/navigation';
 import AppShellClient from '../../components/AppShellClient';
 import { createClient } from '../../lib/supabase/server';
 
+export const dynamic = 'force-dynamic';
+
 export default async function AppShellPage() {
   const supabase = await createClient();
   const {

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,6 +3,8 @@ import { createClient } from '../../lib/supabase/server';
 import Link from 'next/link';
 import AgentChatWidget from '../../components/AgentChatWidget';
 
+export const dynamic = 'force-dynamic';
+
 const NAV = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/dashboard/command-center', label: 'Command Center' },


### PR DESCRIPTION
### Motivation
- Prevent Vercel build-time prerendering from initializing the Supabase server client and failing due to missing public env vars by making auth-gated pages dynamic.

### Description
- Added `export const dynamic = 'force-dynamic'` to `app/app-shell/page.tsx` and `app/dashboard/layout.tsx` so these auth-gated surfaces are server-rendered at request time and no longer prerendered during the build.

### Testing
- Ran `npm run build` locally and the build completes successfully; prior to the change the build failed while prerendering `/app-shell` and `/dashboard/agents` with missing `NEXT_PUBLIC_SUPABASE_*` env var errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3acba253483288fe4ef878e830eb7)