### PR TITLE
Add gateway monitor mode APIs and UI

### DIFF
--- a/app/api/gateway/audit/commit/route.ts
+++ b/app/api/gateway/audit/commit/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { commitMonitorAudit } from '../../../../../lib/gateway/monitor';
+
+export const dynamic = 'force-dynamic';
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const orgId = typeof body.orgId === 'string' && body.orgId.trim()
+      ? body.orgId.trim()
+      : header(request, 'x-org-id');
+    const auditToken = typeof body.auditToken === 'string' ? body.auditToken.trim() : '';
+    const result = body.result && typeof body.result === 'object' && !Array.isArray(body.result)
+      ? body.result as Record<string, unknown>
+      : {};
+
+    const commit = await commitMonitorAudit(orgId, auditToken, result);
+    return NextResponse.json(commit, { status: commit.ok ? 200 : 400 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : 'gateway_audit_commit_error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/gateway/audit/events/route.ts
+++ b/app/api/gateway/audit/events/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const orgId = header(request, 'x-org-id') || searchParams.get('orgId')?.trim() || '';
+  const limit = Math.min(Number(searchParams.get('limit') ?? 50) || 50, 100);
+
+  if (!orgId) {
+    return NextResponse.json({ ok: false, error: 'missing_org_id' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  const { data, error } = await supabase
+    .from('gateway_monitor_events')
+    .select('id, org_id, plan_id, tool_name, action, mode, decision, actor_id, actor_role, risk, status, request_hash, decision_hash, record_hash, audit_token, result, created_at, committed_at')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, events: data ?? [] }, { status: 200 });
+}

--- a/app/api/gateway/audit/export/route.ts
+++ b/app/api/gateway/audit/export/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const orgId = header(request, 'x-org-id') || searchParams.get('orgId')?.trim() || '';
+  const auditToken = searchParams.get('auditToken')?.trim() || '';
+
+  if (!orgId) {
+    return NextResponse.json({ ok: false, error: 'missing_org_id' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  let query = supabase
+    .from('gateway_monitor_events')
+    .select('*')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (auditToken) {
+    query = query.eq('audit_token', auditToken).limit(1);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      type: 'gateway-monitor-audit-export',
+      exportedAt: new Date().toISOString(),
+      orgId,
+      count: Array.isArray(data) ? data.length : 0,
+      events: data ?? [],
+    },
+    {
+      status: 200,
+      headers: {
+        'content-disposition': 'attachment; filename="gateway-monitor-audit-export.json"',
+      },
+    }
+  );
+}

--- a/app/api/gateway/plan-check/route.ts
+++ b/app/api/gateway/plan-check/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { createMonitorPlanCheck } from '../../../../lib/gateway/monitor';
+import { normalizeGatewayToolRequest } from '../../../../lib/gateway/executor';
+
+export const dynamic = 'force-dynamic';
+
+function statusForDecision(decision: string) {
+  if (decision === 'allow') {
+    return 200;
+  }
+
+  if (decision === 'review' || decision === 'ask_more_info') {
+    return 202;
+  }
+
+  return 403;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const gatewayRequest = normalizeGatewayToolRequest(body, request.headers);
+    const result = await createMonitorPlanCheck(gatewayRequest);
+
+    return NextResponse.json(result, { status: statusForDecision(result.decision) });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        decision: 'block',
+        reason: error instanceof Error ? error.message : 'gateway_plan_check_error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/gateway/monitor/page.tsx
+++ b/app/gateway/monitor/page.tsx
@@ -1,0 +1,176 @@
+import Link from 'next/link';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+type GatewayMonitorEvent = {
+  id: string;
+  org_id: string;
+  plan_id: string | null;
+  tool_name: string;
+  action: string;
+  mode: string;
+  decision: string;
+  actor_id: string | null;
+  actor_role: string | null;
+  risk: string | null;
+  status: string;
+  request_hash: string;
+  decision_hash: string | null;
+  record_hash: string | null;
+  audit_token: string | null;
+  created_at: string;
+  committed_at: string | null;
+};
+
+async function loadEvents(orgId: string): Promise<GatewayMonitorEvent[]> {
+  try {
+    const supabase = getSupabaseAdmin() as any;
+    const { data, error } = await supabase
+      .from('gateway_monitor_events')
+      .select('id, org_id, plan_id, tool_name, action, mode, decision, actor_id, actor_role, risk, status, request_hash, decision_hash, record_hash, audit_token, created_at, committed_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+      .limit(25);
+
+    if (error) {
+      return [];
+    }
+
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+function shortHash(value?: string | null) {
+  if (!value) {
+    return '—';
+  }
+  return `${value.slice(0, 10)}…${value.slice(-8)}`;
+}
+
+export default async function GatewayMonitorPage({ searchParams }: { searchParams?: { orgId?: string } }) {
+  const orgId = searchParams?.orgId || 'org-smoke';
+  const events = await loadEvents(orgId);
+  const committed = events.filter((event) => event.status === 'committed').length;
+  const allowed = events.filter((event) => event.decision === 'allow').length;
+  const blocked = events.filter((event) => event.decision !== 'allow').length;
+  const exportHref = `/api/gateway/audit/export?orgId=${encodeURIComponent(orgId)}`;
+
+  return (
+    <main className="min-h-screen bg-[#040918] px-6 py-12 text-white">
+      <div className="mx-auto max-w-7xl">
+        <div className="rounded-[2rem] border border-cyan-300/20 bg-cyan-300/10 p-8">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-200">DSG Monitor Mode</p>
+          <h1 className="mt-4 text-4xl font-black tracking-tight md:text-6xl">Realtime gateway audit monitor</h1>
+          <p className="mt-5 max-w-4xl text-lg leading-8 text-slate-200">
+            Monitor Mode lets customer tools execute in their own runtime while DSG returns decision, audit token,
+            request hash, and final record hash for audit proof.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link href={`/gateway/monitor?orgId=${encodeURIComponent(orgId)}`} className="rounded-2xl bg-cyan-300 px-5 py-3 font-bold text-slate-950">
+              Refresh monitor
+            </Link>
+            <Link href={exportHref} className="rounded-2xl border border-cyan-200/40 px-5 py-3 font-bold text-cyan-100">
+              Download audit JSON
+            </Link>
+          </div>
+        </div>
+
+        <section className="mt-8 grid gap-4 md:grid-cols-4">
+          {[
+            ['Org', orgId],
+            ['Events', String(events.length)],
+            ['Allowed', String(allowed)],
+            ['Committed', String(committed)],
+          ].map(([label, value]) => (
+            <div key={label} className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
+              <p className="text-sm text-slate-400">{label}</p>
+              <p className="mt-2 break-all text-2xl font-bold text-white">{value}</p>
+            </div>
+          ))}
+        </section>
+
+        <section className="mt-8 rounded-[1.5rem] border border-white/10 bg-slate-950/70 p-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold">Monitor history</h2>
+              <p className="mt-2 text-sm text-slate-400">Latest plan checks and audit commits for this organization.</p>
+            </div>
+            <form className="flex gap-2" action="/gateway/monitor">
+              <input
+                name="orgId"
+                defaultValue={orgId}
+                className="rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none"
+                aria-label="Organization ID"
+              />
+              <button className="rounded-xl bg-white px-4 py-3 text-sm font-bold text-slate-950">Load</button>
+            </form>
+          </div>
+
+          <div className="mt-6 overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                <tr>
+                  <th className="px-3 py-3">Time</th>
+                  <th className="px-3 py-3">Tool</th>
+                  <th className="px-3 py-3">Decision</th>
+                  <th className="px-3 py-3">Status</th>
+                  <th className="px-3 py-3">Actor</th>
+                  <th className="px-3 py-3">Request hash</th>
+                  <th className="px-3 py-3">Record hash</th>
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((event) => (
+                  <tr key={event.id} className="border-t border-white/10 text-slate-200">
+                    <td className="whitespace-nowrap px-3 py-4">{new Date(event.created_at).toLocaleString()}</td>
+                    <td className="px-3 py-4">
+                      <p className="font-semibold text-white">{event.tool_name}</p>
+                      <p className="text-xs text-slate-500">{event.action} · {event.mode} · {event.risk ?? 'unclassified'}</p>
+                    </td>
+                    <td className="px-3 py-4"><span className="rounded-full border border-cyan-300/25 px-3 py-1 text-xs uppercase text-cyan-100">{event.decision}</span></td>
+                    <td className="px-3 py-4">{event.status}</td>
+                    <td className="px-3 py-4">{event.actor_id ?? '—'}</td>
+                    <td className="px-3 py-4 font-mono text-xs">{shortHash(event.request_hash)}</td>
+                    <td className="px-3 py-4 font-mono text-xs">{shortHash(event.record_hash)}</td>
+                  </tr>
+                ))}
+                {events.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-3 py-8 text-center text-slate-400">
+                      No monitor events yet. Run /api/gateway/plan-check, then /api/gateway/audit/commit.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-5 lg:grid-cols-2">
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
+            <h2 className="text-2xl font-bold">Runtime settings</h2>
+            <pre className="mt-4 overflow-x-auto rounded-2xl bg-black/40 p-4 text-xs leading-6 text-cyan-100">{`POST /api/gateway/plan-check
+x-org-id: ${orgId}
+x-actor-id: agent-001
+x-actor-role: agent_operator
+x-org-plan: enterprise`}</pre>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
+            <h2 className="text-2xl font-bold">Audit commit</h2>
+            <pre className="mt-4 overflow-x-auto rounded-2xl bg-black/40 p-4 text-xs leading-6 text-cyan-100">{`POST /api/gateway/audit/commit
+{
+  "auditToken": "gat_...",
+  "result": {
+    "ok": true,
+    "provider": "customer_runtime"
+  }
+}`}</pre>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/gateway-monitor-mode.md
+++ b/docs/gateway-monitor-mode.md
@@ -1,0 +1,128 @@
+# Gateway Monitor Mode
+
+Monitor Mode lets DSG govern tool execution without taking custody of the customer's API keys.
+
+## Flow
+
+```text
+Customer agent/tool runtime
+→ POST /api/gateway/plan-check
+→ DSG returns decision, audit token, request hash, constraints
+→ Customer executes its own tool
+→ Customer commits result to /api/gateway/audit/commit
+→ DSG records final record hash and evidence event
+```
+
+## APIs
+
+### Plan check
+
+```http
+POST /api/gateway/plan-check
+```
+
+Required headers:
+
+```http
+x-org-id: org-smoke
+x-actor-id: agent-001
+x-actor-role: agent_operator
+x-org-plan: enterprise
+```
+
+Body:
+
+```json
+{
+  "toolName": "custom_http.customer_webhook",
+  "action": "post",
+  "planId": "PLAN-MONITOR-001",
+  "input": {
+    "message": "Customer runtime will execute this after DSG allow"
+  }
+}
+```
+
+Expected allow response:
+
+```json
+{
+  "ok": true,
+  "decision": "allow",
+  "mode": "monitor",
+  "auditToken": "gat_...",
+  "requestHash": "...",
+  "decisionHash": "...",
+  "recordHash": "...",
+  "constraints": {
+    "expiresInSeconds": 300,
+    "allowedTool": "custom_http.customer_webhook",
+    "allowedAction": "post",
+    "decision": "allow"
+  }
+}
+```
+
+### Audit commit
+
+```http
+POST /api/gateway/audit/commit
+```
+
+Body:
+
+```json
+{
+  "auditToken": "gat_...",
+  "result": {
+    "ok": true,
+    "provider": "customer_runtime",
+    "target": "customer.tool",
+    "messageId": "msg_123"
+  }
+}
+```
+
+Expected response:
+
+```json
+{
+  "ok": true,
+  "committed": true,
+  "recordHash": "..."
+}
+```
+
+### Events
+
+```http
+GET /api/gateway/audit/events?orgId=org-smoke
+```
+
+### Export
+
+```http
+GET /api/gateway/audit/export?orgId=org-smoke
+```
+
+## UI
+
+```text
+/gateway/monitor?orgId=org-smoke
+```
+
+The UI shows:
+
+- latest plan checks
+- decision history
+- actor/tool/risk/status
+- request hash
+- record hash
+- audit JSON download link
+- runtime settings snippets
+
+## Product use
+
+Use Monitor Mode when the customer wants governance without giving DSG direct access to production APIs.
+
+Use Gateway Mode when DSG should execute a connector directly.

--- a/lib/gateway/monitor.ts
+++ b/lib/gateway/monitor.ts
@@ -1,0 +1,118 @@
+import crypto from 'node:crypto';
+import { getSupabaseAdmin } from '../supabase-server';
+import { buildGatewayAuditProof, hashGatewayValue } from './audit';
+import { evaluateGatewayToolRequest } from './policy';
+import { findGatewayTool } from './tool-registry';
+import type { GatewayDecision, GatewayToolRequest } from './types';
+
+function createAuditToken() {
+  return `gat_${crypto.randomBytes(24).toString('hex')}`;
+}
+
+function constraintsFor(request: GatewayToolRequest, decision: GatewayDecision) {
+  return {
+    expiresInSeconds: 300,
+    allowedTool: request.toolName,
+    allowedAction: request.action,
+    decision,
+  };
+}
+
+export async function createMonitorPlanCheck(request: GatewayToolRequest) {
+  const registryEntry = await findGatewayTool(request.orgId, request.toolName);
+  const policy = evaluateGatewayToolRequest(request, registryEntry);
+  const audit = buildGatewayAuditProof(request, null, policy.decision, policy.reason);
+  const auditToken = createAuditToken();
+  const constraints = constraintsFor(request, policy.decision);
+  const decisionHash = hashGatewayValue({ requestHash: audit.requestHash, decision: policy.decision, reason: policy.reason ?? null });
+
+  const supabase = getSupabaseAdmin() as any;
+  await supabase.from('gateway_monitor_events').insert({
+    org_id: request.orgId,
+    plan_id: request.planId ?? null,
+    tool_name: request.toolName,
+    action: request.action,
+    mode: 'monitor',
+    decision: policy.decision,
+    actor_id: request.actorId,
+    actor_role: request.actorRole,
+    risk: registryEntry?.risk ?? null,
+    status: policy.decision === 'allow' ? 'recorded' : 'rejected',
+    request_hash: audit.requestHash,
+    decision_hash: decisionHash,
+    record_hash: audit.recordHash,
+    audit_token: auditToken,
+    input: request.input,
+    constraints,
+  });
+
+  return {
+    ok: policy.decision === 'allow',
+    decision: policy.decision,
+    mode: 'monitor',
+    reason: policy.reason,
+    auditToken,
+    requestHash: audit.requestHash,
+    decisionHash,
+    recordHash: audit.recordHash,
+    constraints,
+    registryEntry: registryEntry ?? undefined,
+  };
+}
+
+export async function commitMonitorAudit(orgId: string, auditToken: string, result: Record<string, unknown>) {
+  if (!orgId) {
+    return { ok: false, error: 'missing_org_id' };
+  }
+
+  if (!auditToken) {
+    return { ok: false, error: 'missing_audit_token' };
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  const { data: event, error: readError } = await supabase
+    .from('gateway_monitor_events')
+    .select('id, org_id, request_hash, decision, status')
+    .eq('org_id', orgId)
+    .eq('audit_token', auditToken)
+    .maybeSingle();
+
+  if (readError) {
+    throw new Error(`failed_to_read_monitor_event:${readError.message}`);
+  }
+
+  if (!event) {
+    return { ok: false, error: 'audit_token_not_found' };
+  }
+
+  if (event.decision !== 'allow') {
+    return { ok: false, error: 'decision_not_allowed' };
+  }
+
+  const recordHash = hashGatewayValue({
+    requestHash: event.request_hash,
+    auditToken,
+    result,
+    committedAt: 'committed',
+  });
+
+  const { error: updateError } = await supabase
+    .from('gateway_monitor_events')
+    .update({
+      status: 'committed',
+      result,
+      record_hash: recordHash,
+      committed_at: new Date().toISOString(),
+    })
+    .eq('id', event.id);
+
+  if (updateError) {
+    throw new Error(`failed_to_commit_monitor_event:${updateError.message}`);
+  }
+
+  return {
+    ok: true,
+    committed: true,
+    recordHash,
+  };
+}

--- a/supabase/migrations/20260430_gateway_monitor_events.sql
+++ b/supabase/migrations/20260430_gateway_monitor_events.sql
@@ -1,0 +1,47 @@
+create table if not exists public.gateway_monitor_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  plan_id text,
+  tool_name text not null,
+  action text not null,
+  mode text not null default 'monitor',
+  decision text not null,
+  actor_id text,
+  actor_role text,
+  risk text,
+  status text not null default 'recorded',
+  request_hash text not null,
+  decision_hash text,
+  record_hash text,
+  audit_token text,
+  input jsonb not null default '{}'::jsonb,
+  result jsonb,
+  constraints jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  committed_at timestamptz,
+  constraint gateway_monitor_events_mode_chk
+    check (mode in ('monitor', 'gateway', 'critical')),
+  constraint gateway_monitor_events_decision_chk
+    check (decision in ('allow', 'block', 'review', 'ask_more_info')),
+  constraint gateway_monitor_events_status_chk
+    check (status in ('recorded', 'committed', 'rejected', 'expired'))
+);
+
+create unique index if not exists idx_gateway_monitor_events_audit_token
+  on public.gateway_monitor_events (audit_token)
+  where audit_token is not null;
+
+create index if not exists idx_gateway_monitor_events_org_created
+  on public.gateway_monitor_events (org_id, created_at desc);
+
+create index if not exists idx_gateway_monitor_events_org_tool
+  on public.gateway_monitor_events (org_id, tool_name, created_at desc);
+
+alter table public.gateway_monitor_events enable row level security;
+
+drop policy if exists gateway_monitor_events_org_select on public.gateway_monitor_events;
+create policy gateway_monitor_events_org_select
+on public.gateway_monitor_events
+for select
+to authenticated
+using (auth.uid() is not null and org_id = (auth.jwt() ->> 'org_id'));


### PR DESCRIPTION
## Summary

Adds Monitor Mode product surface for DSG: customers can check policy/risk/approval before executing tools in their own runtime, then commit the execution result back to DSG for audit proof.

## What this adds

- `POST /api/gateway/plan-check`
- `POST /api/gateway/audit/commit`
- `GET /api/gateway/audit/events`
- `GET /api/gateway/audit/export`
- `/gateway/monitor` UI
- `gateway_monitor_events` Supabase migration
- monitor helper library
- docs for Monitor Mode

## Product flow

```text
Customer runtime
→ /api/gateway/plan-check
→ DSG returns allow/block/review + auditToken + requestHash
→ Customer executes its own tool
→ /api/gateway/audit/commit
→ DSG writes final recordHash
→ /gateway/monitor shows history and export
```

## Why

This lets DSG govern high-risk actions without taking custody of customer API keys. It complements Gateway Mode/custom_http execution.

## Validation

Additive API + UI + migration + docs. Existing finance governance and gateway execution routes are not changed.