### PR TITLE
Fix monitor audit event recording

### DIFF
--- a/lib/gateway/monitor.ts
+++ b/lib/gateway/monitor.ts
@@ -27,24 +27,36 @@ export async function createMonitorPlanCheck(request: GatewayToolRequest) {
   const decisionHash = hashGatewayValue({ requestHash: audit.requestHash, decision: policy.decision, reason: policy.reason ?? null });
 
   const supabase = getSupabaseAdmin() as any;
-  await supabase.from('gateway_monitor_events').insert({
-    org_id: request.orgId,
-    plan_id: request.planId ?? null,
-    tool_name: request.toolName,
-    action: request.action,
-    mode: 'monitor',
-    decision: policy.decision,
-    actor_id: request.actorId,
-    actor_role: request.actorRole,
-    risk: registryEntry?.risk ?? null,
-    status: policy.decision === 'allow' ? 'recorded' : 'rejected',
-    request_hash: audit.requestHash,
-    decision_hash: decisionHash,
-    record_hash: audit.recordHash,
-    audit_token: auditToken,
-    input: request.input,
-    constraints,
-  });
+  const { data: insertedEvent, error: insertError } = await supabase
+    .from('gateway_monitor_events')
+    .insert({
+      org_id: request.orgId,
+      plan_id: request.planId ?? null,
+      tool_name: request.toolName,
+      action: request.action,
+      mode: 'monitor',
+      decision: policy.decision,
+      actor_id: request.actorId,
+      actor_role: request.actorRole,
+      risk: registryEntry?.risk ?? null,
+      status: policy.decision === 'allow' ? 'recorded' : 'rejected',
+      request_hash: audit.requestHash,
+      decision_hash: decisionHash,
+      record_hash: audit.recordHash,
+      audit_token: auditToken,
+      input: request.input,
+      constraints,
+    })
+    .select('id, audit_token')
+    .single();
+
+  if (insertError) {
+    throw new Error(`failed_to_record_monitor_event:${insertError.message}`);
+  }
+
+  if (!insertedEvent?.id) {
+    throw new Error('failed_to_record_monitor_event:no_inserted_event');
+  }
 
   return {
     ok: policy.decision === 'allow',


### PR DESCRIPTION
## Summary

Fixes Monitor Mode so `/api/gateway/plan-check` fails closed if the monitor audit event is not actually recorded.

## Why

A plan-check returned an `auditToken`, but `/api/gateway/audit/commit` later returned `audit_token_not_found`. Database inspection showed the token was not present in `gateway_monitor_events`.

The previous implementation did not inspect Supabase insert errors, so it could return allow even when the audit event insert failed.

## Change

- Checks Supabase insert result for `gateway_monitor_events`
- Selects the inserted row id/audit token
- Throws `failed_to_record_monitor_event:*` if insert fails
- Prevents returning `auditToken` unless the event is persisted

## Validation

After this hotfix, any successful plan-check token should be commit-able by `/api/gateway/audit/commit`.