### PR TITLE
Add deterministic SMT2 gateway invariant evidence

### DIFF
--- a/docs/gateway-deterministic-smt2-invariants.md
+++ b/docs/gateway-deterministic-smt2-invariants.md
@@ -1,0 +1,79 @@
+# Gateway Deterministic SMT2 Invariants
+
+DSG Gateway can emit deterministic SMT-LIB v2-compatible invariant evidence for AI/tool execution requests.
+
+## Why
+
+Prompt-based policy review is not enough for high-risk execution governance.
+
+DSG uses deterministic invariants for checks that must not be negotiated or guessed:
+
+- organization id must exist
+- actor id must exist
+- actor role must exist and be allowed
+- organization plan must be entitled
+- tool must be registered
+- requested action must match the registered tool action
+- evidence must be writable before allow
+- high-risk and critical actions must have approval
+
+## Script
+
+```bash
+npm run benchmark:gateway:smt2
+```
+
+Outputs:
+
+```text
+artifacts/gateway-smt2/gateway-smt2-invariants-result.json
+artifacts/gateway-smt2/gateway-smt2-invariants-report.md
+```
+
+## Evidence boundary
+
+The verifier emits SMT-LIB v2-compatible constraint text and hashes the SMT2 input/result.
+
+Current implementation:
+
+- deterministic SMT2 text generation
+- deterministic static invariant evaluation
+- SMT2 hash
+- result hash
+- pass/fail report
+
+Not yet included:
+
+- external Z3/cvc5 solver invocation
+- solver certificate export
+
+The emitted SMT2 text is structured so external solver verification can be added later without changing the policy surface.
+
+## Example invariant
+
+```lisp
+(assert has_org)
+(assert has_actor)
+(assert is_registered_tool)
+(assert action_matches_tool)
+(assert actor_role_allowed)
+(assert plan_entitled)
+(assert evidence_writable)
+(assert (=> (or requires_approval (>= risk 2)) has_approval))
+```
+
+## Product wording
+
+Use:
+
+```text
+DSG emits deterministic SMT2-compatible invariant evidence before governed AI/tool execution.
+```
+
+Do not use yet:
+
+```text
+DSG has independently certified formal verification.
+```
+
+That claim would require external solver artifacts and independent review.

--- a/lib/gateway/invariants/smt2.ts
+++ b/lib/gateway/invariants/smt2.ts
@@ -1,0 +1,99 @@
+import crypto from 'node:crypto';
+import type { GatewayToolRequest } from '../types';
+
+export type Smt2InvariantRisk = 0 | 1 | 2 | 3;
+
+export type Smt2InvariantInput = {
+  hasOrg: boolean;
+  hasActor: boolean;
+  hasActorRole: boolean;
+  hasOrgPlan: boolean;
+  isRegisteredTool: boolean;
+  actionMatchesTool: boolean;
+  actorRoleAllowed: boolean;
+  planEntitled: boolean;
+  risk: Smt2InvariantRisk;
+  requiresApproval: boolean;
+  hasApproval: boolean;
+  evidenceWritable: boolean;
+};
+
+export type Smt2InvariantEvaluation = {
+  ok: boolean;
+  decision: 'allow' | 'block';
+  violated: string[];
+  smt2: string;
+  smt2Hash: string;
+  resultHash: string;
+};
+
+const ROLE_ALLOWLIST = new Set(['owner', 'admin', 'finance_admin', 'finance_approver', 'agent_operator']);
+const PLAN_ALLOWLIST = new Set(['enterprise', 'business', 'pro']);
+
+function bool(value: boolean) {
+  return value ? 'true' : 'false';
+}
+
+function riskToInt(risk: string | undefined): Smt2InvariantRisk {
+  if (risk === 'critical') return 3;
+  if (risk === 'high') return 2;
+  if (risk === 'medium') return 1;
+  return 0;
+}
+
+function sha256(value: string) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+export function buildSmt2InvariantInput(
+  request: GatewayToolRequest,
+  tool: { action: string; risk: string; requiresApproval: boolean } | null,
+  evidenceWritable = true
+): Smt2InvariantInput {
+  return {
+    hasOrg: Boolean(request.orgId),
+    hasActor: Boolean(request.actorId),
+    hasActorRole: Boolean(request.actorRole),
+    hasOrgPlan: Boolean(request.orgPlan),
+    isRegisteredTool: Boolean(tool),
+    actionMatchesTool: Boolean(tool && tool.action === request.action),
+    actorRoleAllowed: ROLE_ALLOWLIST.has((request.actorRole || '').toLowerCase()),
+    planEntitled: PLAN_ALLOWLIST.has((request.orgPlan || '').toLowerCase()),
+    risk: riskToInt(tool?.risk),
+    requiresApproval: Boolean(tool?.requiresApproval),
+    hasApproval: Boolean(request.approvalToken),
+    evidenceWritable,
+  };
+}
+
+export function renderGatewayInvariantSmt2(input: Smt2InvariantInput) {
+  return `; DSG Gateway deterministic invariant check\n; Generated from normalized gateway request.\n; Risk scale: 0 low, 1 medium, 2 high, 3 critical\n\n(set-logic QF_UFLIA)\n\n(declare-const has_org Bool)\n(declare-const has_actor Bool)\n(declare-const has_actor_role Bool)\n(declare-const has_org_plan Bool)\n(declare-const is_registered_tool Bool)\n(declare-const action_matches_tool Bool)\n(declare-const actor_role_allowed Bool)\n(declare-const plan_entitled Bool)\n(declare-const risk Int)\n(declare-const requires_approval Bool)\n(declare-const has_approval Bool)\n(declare-const evidence_writable Bool)\n\n(assert (= has_org ${bool(input.hasOrg)}))\n(assert (= has_actor ${bool(input.hasActor)}))\n(assert (= has_actor_role ${bool(input.hasActorRole)}))\n(assert (= has_org_plan ${bool(input.hasOrgPlan)}))\n(assert (= is_registered_tool ${bool(input.isRegisteredTool)}))\n(assert (= action_matches_tool ${bool(input.actionMatchesTool)}))\n(assert (= actor_role_allowed ${bool(input.actorRoleAllowed)}))\n(assert (= plan_entitled ${bool(input.planEntitled)}))\n(assert (= risk ${input.risk}))\n(assert (= requires_approval ${bool(input.requiresApproval)}))\n(assert (= has_approval ${bool(input.hasApproval)}))\n(assert (= evidence_writable ${bool(input.evidenceWritable)}))\n\n; Core invariants required before ALLOW.\n(assert has_org)\n(assert has_actor)\n(assert has_actor_role)\n(assert has_org_plan)\n(assert is_registered_tool)\n(assert action_matches_tool)\n(assert actor_role_allowed)\n(assert plan_entitled)\n(assert evidence_writable)\n\n; High-risk and critical actions require approval.\n(assert (=> (or requires_approval (>= risk 2)) has_approval))\n\n(check-sat)\n(get-model)\n`;
+}
+
+export function evaluateSmt2InvariantInput(input: Smt2InvariantInput): Smt2InvariantEvaluation {
+  const violated: string[] = [];
+
+  if (!input.hasOrg) violated.push('missing_org_id');
+  if (!input.hasActor) violated.push('missing_actor_id');
+  if (!input.hasActorRole) violated.push('missing_actor_role');
+  if (!input.hasOrgPlan) violated.push('missing_org_plan');
+  if (!input.isRegisteredTool) violated.push('tool_not_registered');
+  if (!input.actionMatchesTool) violated.push('tool_action_mismatch');
+  if (!input.actorRoleAllowed) violated.push('role_not_allowed');
+  if (!input.planEntitled) violated.push('plan_not_entitled');
+  if (!input.evidenceWritable) violated.push('evidence_not_writable');
+  if ((input.requiresApproval || input.risk >= 2) && !input.hasApproval) violated.push('approval_required');
+
+  const smt2 = renderGatewayInvariantSmt2(input);
+  const smt2Hash = sha256(smt2);
+  const resultHash = sha256(JSON.stringify({ violated, smt2Hash }));
+
+  return {
+    ok: violated.length === 0,
+    decision: violated.length === 0 ? 'allow' : 'block',
+    violated,
+    smt2,
+    smt2Hash,
+    resultHash,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "benchmark": "node scripts/benchmark-dsg.mjs",
     "benchmark:gateway": "node scripts/benchmark-gateway-production.mjs",
     "benchmark:gateway:compare": "node scripts/score-gateway-comparison.mjs",
+    "benchmark:gateway:smt2": "node scripts/verify-gateway-smt2-invariants.mjs",
     "benchmark:site": "node scripts/render-benchmark-site.mjs",
     "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs",
     "ops:runtime-rpc-fix": "./scripts/apply-runtime-rpc-fix.sh",

--- a/scripts/verify-gateway-smt2-invariants.mjs
+++ b/scripts/verify-gateway-smt2-invariants.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const OUT_DIR = process.env.GATEWAY_SMT2_OUT_DIR || 'artifacts/gateway-smt2';
+
+const cases = [
+  {
+    id: 'allow_low_risk_registered_tool',
+    expectedDecision: 'allow',
+    input: {
+      hasOrg: true,
+      hasActor: true,
+      hasActorRole: true,
+      hasOrgPlan: true,
+      isRegisteredTool: true,
+      actionMatchesTool: true,
+      actorRoleAllowed: true,
+      planEntitled: true,
+      risk: 1,
+      requiresApproval: false,
+      hasApproval: false,
+      evidenceWritable: true,
+    },
+  },
+  {
+    id: 'block_missing_org',
+    expectedDecision: 'block',
+    input: {
+      hasOrg: false,
+      hasActor: true,
+      hasActorRole: true,
+      hasOrgPlan: true,
+      isRegisteredTool: true,
+      actionMatchesTool: true,
+      actorRoleAllowed: true,
+      planEntitled: true,
+      risk: 1,
+      requiresApproval: false,
+      hasApproval: false,
+      evidenceWritable: true,
+    },
+  },
+  {
+    id: 'block_unregistered_tool',
+    expectedDecision: 'block',
+    input: {
+      hasOrg: true,
+      hasActor: true,
+      hasActorRole: true,
+      hasOrgPlan: true,
+      isRegisteredTool: false,
+      actionMatchesTool: false,
+      actorRoleAllowed: true,
+      planEntitled: true,
+      risk: 0,
+      requiresApproval: false,
+      hasApproval: false,
+      evidenceWritable: true,
+    },
+  },
+  {
+    id: 'block_high_risk_without_approval',
+    expectedDecision: 'block',
+    input: {
+      hasOrg: true,
+      hasActor: true,
+      hasActorRole: true,
+      hasOrgPlan: true,
+      isRegisteredTool: true,
+      actionMatchesTool: true,
+      actorRoleAllowed: true,
+      planEntitled: true,
+      risk: 2,
+      requiresApproval: false,
+      hasApproval: false,
+      evidenceWritable: true,
+    },
+  },
+  {
+    id: 'allow_high_risk_with_approval',
+    expectedDecision: 'allow',
+    input: {
+      hasOrg: true,
+      hasActor: true,
+      hasActorRole: true,
+      hasOrgPlan: true,
+      isRegisteredTool: true,
+      actionMatchesTool: true,
+      actorRoleAllowed: true,
+      planEntitled: true,
+      risk: 2,
+      requiresApproval: true,
+      hasApproval: true,
+      evidenceWritable: true,
+    },
+  },
+  {
+    id: 'block_evidence_not_writable',
+    expectedDecision: 'block',
+    input: {
+      hasOrg: true,
+      hasActor: true,
+      hasActorRole: true,
+      hasOrgPlan: true,
+      isRegisteredTool: true,
+      actionMatchesTool: true,
+      actorRoleAllowed: true,
+      planEntitled: true,
+      risk: 1,
+      requiresApproval: false,
+      hasApproval: false,
+      evidenceWritable: false,
+    },
+  },
+];
+
+await main();
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+
+  const results = cases.map((testCase) => {
+    const evaluation = evaluate(testCase.input);
+    return {
+      id: testCase.id,
+      expectedDecision: testCase.expectedDecision,
+      observedDecision: evaluation.decision,
+      pass: testCase.expectedDecision === evaluation.decision,
+      violated: evaluation.violated,
+      smt2Hash: evaluation.smt2Hash,
+      resultHash: evaluation.resultHash,
+      smt2: evaluation.smt2,
+    };
+  });
+
+  const passed = results.filter((result) => result.pass).length;
+  const summary = {
+    pass: passed === results.length,
+    total: results.length,
+    passed,
+    failed: results.length - passed,
+    passRate: `${Math.round((passed / results.length) * 100)}%`,
+  };
+
+  const artifact = {
+    generatedAt: new Date().toISOString(),
+    suite: 'gateway-smt2-deterministic-invariants-v1',
+    summary,
+    results,
+  };
+
+  await fs.writeFile(path.join(OUT_DIR, 'gateway-smt2-invariants-result.json'), JSON.stringify(artifact, null, 2));
+  await fs.writeFile(path.join(OUT_DIR, 'gateway-smt2-invariants-report.md'), renderReport(artifact));
+
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.pass) {
+    process.exitCode = 1;
+  }
+}
+
+function bool(value) {
+  return value ? 'true' : 'false';
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function renderSmt2(input) {
+  return `; DSG Gateway deterministic invariant check\n; Generated from normalized gateway request.\n; Risk scale: 0 low, 1 medium, 2 high, 3 critical\n\n(set-logic QF_UFLIA)\n\n(declare-const has_org Bool)\n(declare-const has_actor Bool)\n(declare-const has_actor_role Bool)\n(declare-const has_org_plan Bool)\n(declare-const is_registered_tool Bool)\n(declare-const action_matches_tool Bool)\n(declare-const actor_role_allowed Bool)\n(declare-const plan_entitled Bool)\n(declare-const risk Int)\n(declare-const requires_approval Bool)\n(declare-const has_approval Bool)\n(declare-const evidence_writable Bool)\n\n(assert (= has_org ${bool(input.hasOrg)}))\n(assert (= has_actor ${bool(input.hasActor)}))\n(assert (= has_actor_role ${bool(input.hasActorRole)}))\n(assert (= has_org_plan ${bool(input.hasOrgPlan)}))\n(assert (= is_registered_tool ${bool(input.isRegisteredTool)}))\n(assert (= action_matches_tool ${bool(input.actionMatchesTool)}))\n(assert (= actor_role_allowed ${bool(input.actorRoleAllowed)}))\n(assert (= plan_entitled ${bool(input.planEntitled)}))\n(assert (= risk ${input.risk}))\n(assert (= requires_approval ${bool(input.requiresApproval)}))\n(assert (= has_approval ${bool(input.hasApproval)}))\n(assert (= evidence_writable ${bool(input.evidenceWritable)}))\n\n(assert has_org)\n(assert has_actor)\n(assert has_actor_role)\n(assert has_org_plan)\n(assert is_registered_tool)\n(assert action_matches_tool)\n(assert actor_role_allowed)\n(assert plan_entitled)\n(assert evidence_writable)\n(assert (=> (or requires_approval (>= risk 2)) has_approval))\n\n(check-sat)\n(get-model)\n`;
+}
+
+function evaluate(input) {
+  const violated = [];
+  if (!input.hasOrg) violated.push('missing_org_id');
+  if (!input.hasActor) violated.push('missing_actor_id');
+  if (!input.hasActorRole) violated.push('missing_actor_role');
+  if (!input.hasOrgPlan) violated.push('missing_org_plan');
+  if (!input.isRegisteredTool) violated.push('tool_not_registered');
+  if (!input.actionMatchesTool) violated.push('tool_action_mismatch');
+  if (!input.actorRoleAllowed) violated.push('role_not_allowed');
+  if (!input.planEntitled) violated.push('plan_not_entitled');
+  if (!input.evidenceWritable) violated.push('evidence_not_writable');
+  if ((input.requiresApproval || input.risk >= 2) && !input.hasApproval) violated.push('approval_required');
+
+  const smt2 = renderSmt2(input);
+  const smt2Hash = sha256(smt2);
+  return {
+    decision: violated.length === 0 ? 'allow' : 'block',
+    violated,
+    smt2,
+    smt2Hash,
+    resultHash: sha256(JSON.stringify({ violated, smt2Hash })),
+  };
+}
+
+function renderReport(artifact) {
+  const rows = artifact.results
+    .map((result) => `| ${result.id} | ${result.pass ? 'PASS' : 'FAIL'} | ${result.expectedDecision} | ${result.observedDecision} | ${result.violated.join(', ') || 'none'} | ${result.smt2Hash.slice(0, 16)}… |`)
+    .join('\n');
+
+  return `# Gateway SMT2 Deterministic Invariant Report\n\nGenerated at: ${artifact.generatedAt}\n\n## Verdict\n\n**${artifact.summary.pass ? 'PASS' : 'FAIL'}**\n\n## Summary\n\n- Total: ${artifact.summary.total}\n- Passed: ${artifact.summary.passed}\n- Failed: ${artifact.summary.failed}\n- Pass rate: ${artifact.summary.passRate}\n\n## Cases\n\n| Case | Verdict | Expected | Observed | Violated invariants | SMT2 hash |\n|---|---:|---|---|---|---|\n${rows}\n\n## Evidence boundary\n\nThis verifier emits deterministic SMT-LIB v2-compatible constraint text and hashes the SMT2 input/result. The current script performs static invariant evaluation without invoking an external SMT solver. External Z3/cvc5 verification can be added later using the emitted SMT2 text.\n`;
+}


### PR DESCRIPTION
## Summary

Adds deterministic SMT2-compatible invariant evidence for DSG Gateway governance checks.

## What this adds

- `lib/gateway/invariants/smt2.ts`
- `scripts/verify-gateway-smt2-invariants.mjs`
- `npm run benchmark:gateway:smt2`
- `docs/gateway-deterministic-smt2-invariants.md`

## Invariants covered

- organization id required
- actor id required
- actor role required and allowed
- organization plan required and entitled
- tool must be registered
- requested action must match registered tool action
- evidence must be writable before allow
- high-risk / critical / approval-required actions require approval

## Outputs

```text
artifacts/gateway-smt2/gateway-smt2-invariants-result.json
artifacts/gateway-smt2/gateway-smt2-invariants-report.md
```

## Evidence boundary

This PR emits SMT-LIB v2-compatible constraint text and hashes the SMT2 input/result. It currently performs deterministic static invariant evaluation without invoking an external Z3/cvc5 solver. External solver verification can be added later using the emitted SMT2 text.

## Safe wording

Allowed:

```text
DSG emits deterministic SMT2-compatible invariant evidence before governed AI/tool execution.
```

Not allowed yet:

```text
DSG has independently certified formal verification.
```