### PR TITLE
Add vendor benchmark harness scaffold

### DIFF
--- a/benchmarks/vendor-comparison/vendors.json
+++ b/benchmarks/vendor-comparison/vendors.json
@@ -1,0 +1,48 @@
+{
+  "suiteId": "dsg-vendor-comparison-harness-v1",
+  "evidenceBoundary": "Vendor results are valid only when status is tested and evidence artifacts are present. not_configured/skipped vendors must not receive a comparative score.",
+  "vendors": [
+    {
+      "id": "dsg",
+      "name": "DSG Gateway",
+      "type": "native",
+      "enabledByDefault": true,
+      "requiredEnv": []
+    },
+    {
+      "id": "zapier",
+      "name": "Zapier",
+      "type": "webhook_or_platform",
+      "enabledByDefault": false,
+      "requiredEnv": ["ZAPIER_BENCHMARK_WEBHOOK_URL"]
+    },
+    {
+      "id": "make",
+      "name": "Make",
+      "type": "webhook_or_platform",
+      "enabledByDefault": false,
+      "requiredEnv": ["MAKE_BENCHMARK_WEBHOOK_URL"]
+    },
+    {
+      "id": "n8n",
+      "name": "n8n",
+      "type": "self_host_or_cloud_webhook",
+      "enabledByDefault": false,
+      "requiredEnv": ["N8N_BENCHMARK_WEBHOOK_URL"]
+    },
+    {
+      "id": "workato",
+      "name": "Workato",
+      "type": "enterprise_webhook_or_api_recipe",
+      "enabledByDefault": false,
+      "requiredEnv": ["WORKATO_BENCHMARK_WEBHOOK_URL"]
+    },
+    {
+      "id": "temporal",
+      "name": "Temporal",
+      "type": "durable_execution_endpoint",
+      "enabledByDefault": false,
+      "requiredEnv": ["TEMPORAL_BENCHMARK_ENDPOINT"]
+    }
+  ]
+}

--- a/docs/vendor-benchmark-harness.md
+++ b/docs/vendor-benchmark-harness.md
@@ -1,0 +1,58 @@
+# Vendor Benchmark Harness
+
+This harness creates a fair test surface for DSG and adjacent vendors.
+
+## Command
+
+```bash
+npm run benchmark:vendors
+```
+
+## Default behavior
+
+By default, only DSG is tested because DSG has a native benchmark suite inside this repository.
+
+Other vendors are marked `not_configured` until their endpoint/credential environment variables are provided.
+
+## Vendor environment variables
+
+```bash
+export ZAPIER_BENCHMARK_WEBHOOK_URL="https://hooks.zapier.com/..."
+export MAKE_BENCHMARK_WEBHOOK_URL="https://hook.make.com/..."
+export N8N_BENCHMARK_WEBHOOK_URL="https://your-n8n.example.com/webhook/..."
+export WORKATO_BENCHMARK_WEBHOOK_URL="https://www.workato.com/webhooks/..."
+export TEMPORAL_BENCHMARK_ENDPOINT="https://your-temporal-wrapper.example.com/benchmark"
+```
+
+Then rerun:
+
+```bash
+npm run benchmark:vendors
+```
+
+## Outputs
+
+```text
+artifacts/vendor-comparison/vendor-comparison-result.json
+artifacts/vendor-comparison/vendor-comparison-report.md
+```
+
+## Evidence boundary
+
+Only vendors with status `tested` and `scoreEligible: true` should be scored in a same-suite comparison.
+
+Vendors marked `not_configured` or `skipped` must not receive comparative scores.
+
+This harness does not claim DSG beats another vendor unless that vendor has been tested with the same workload and evidence requirements.
+
+## Workload
+
+The current cross-vendor smoke workload sends a governed-action payload and records:
+
+- HTTP status
+- latency
+- payload hash
+- response hash
+- configured endpoint state
+
+This is the first layer. Deeper vendor-specific harnesses can add approval, audit export, retry, replay, and policy evidence when a vendor account supports those features.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "benchmark:gateway:compare": "node scripts/score-gateway-comparison.mjs",
     "benchmark:gateway:smt2": "node scripts/verify-gateway-smt2-invariants.mjs",
     "benchmark:evidence": "node scripts/benchmark-full-evidence.mjs",
+    "benchmark:vendors": "node scripts/benchmark-vendors.mjs",
     "benchmark:site": "node scripts/render-benchmark-site.mjs",
     "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs",
     "ops:runtime-rpc-fix": "./scripts/apply-runtime-rpc-fix.sh",

--- a/scripts/benchmark-vendors.mjs
+++ b/scripts/benchmark-vendors.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { spawn } from 'node:child_process';
+
+const CONFIG_FILE = process.env.VENDOR_BENCHMARK_CONFIG || 'benchmarks/vendor-comparison/vendors.json';
+const OUT_DIR = process.env.VENDOR_BENCHMARK_OUT_DIR || 'artifacts/vendor-comparison';
+const HTTP_TIMEOUT_MS = Number(process.env.VENDOR_BENCHMARK_TIMEOUT_MS || 15000);
+
+await main();
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const config = JSON.parse(await fs.readFile(CONFIG_FILE, 'utf8'));
+  const results = [];
+
+  for (const vendor of config.vendors) {
+    const result = await runVendor(vendor);
+    results.push(result);
+  }
+
+  const tested = results.filter((result) => result.status === 'tested');
+  const passed = tested.filter((result) => result.pass).length;
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    suiteId: config.suiteId,
+    evidenceBoundary: config.evidenceBoundary,
+    summary: {
+      vendors: results.length,
+      tested: tested.length,
+      passed,
+      failed: tested.length - passed,
+      notConfigured: results.filter((result) => result.status === 'not_configured').length,
+      skipped: results.filter((result) => result.status === 'skipped').length,
+    },
+    results,
+  };
+
+  await fs.writeFile(path.join(OUT_DIR, 'vendor-comparison-result.json'), JSON.stringify(manifest, null, 2));
+  await fs.writeFile(path.join(OUT_DIR, 'vendor-comparison-report.md'), renderReport(manifest));
+
+  console.log(JSON.stringify(manifest.summary, null, 2));
+}
+
+async function runVendor(vendor) {
+  if (vendor.id === 'dsg') {
+    return runDsgBaseline(vendor);
+  }
+
+  const missingEnv = (vendor.requiredEnv || []).filter((name) => !process.env[name]);
+  if (missingEnv.length > 0) {
+    return {
+      vendorId: vendor.id,
+      vendorName: vendor.name,
+      status: 'not_configured',
+      pass: false,
+      reason: `Missing env: ${missingEnv.join(', ')}`,
+      scoreEligible: false,
+    };
+  }
+
+  if (vendor.id === 'temporal') {
+    return runTemporalEndpoint(vendor, process.env.TEMPORAL_BENCHMARK_ENDPOINT);
+  }
+
+  const urlByVendor = {
+    zapier: process.env.ZAPIER_BENCHMARK_WEBHOOK_URL,
+    make: process.env.MAKE_BENCHMARK_WEBHOOK_URL,
+    n8n: process.env.N8N_BENCHMARK_WEBHOOK_URL,
+    workato: process.env.WORKATO_BENCHMARK_WEBHOOK_URL,
+  };
+
+  return runWebhookVendor(vendor, urlByVendor[vendor.id]);
+}
+
+async function runDsgBaseline(vendor) {
+  const startedAt = Date.now();
+  const output = await spawnProcess('npm', ['run', 'benchmark:evidence']);
+  const latencyMs = Date.now() - startedAt;
+  const fullEvidencePath = 'artifacts/full-evidence/dsg-full-evidence-manifest.json';
+  const evidenceHash = await hashFileIfExists(fullEvidencePath);
+
+  return {
+    vendorId: vendor.id,
+    vendorName: vendor.name,
+    status: 'tested',
+    pass: output.status === 0 && Boolean(evidenceHash),
+    scoreEligible: true,
+    mode: 'native_full_evidence',
+    latencyMs,
+    evidence: {
+      command: 'npm run benchmark:evidence',
+      artifact: fullEvidencePath,
+      sha256: evidenceHash,
+    },
+    stdoutTail: tail(output.stdout),
+    stderrTail: tail(output.stderr),
+  };
+}
+
+async function runWebhookVendor(vendor, endpointUrl) {
+  const startedAt = Date.now();
+  const payload = benchmarkPayload(vendor.id);
+  const response = await postJson(endpointUrl, payload);
+  const latencyMs = Date.now() - startedAt;
+
+  const evidence = {
+    endpointConfigured: true,
+    payloadHash: sha256(JSON.stringify(payload)),
+    httpStatus: response.status,
+    responseHash: sha256(JSON.stringify(response.body)),
+  };
+
+  return {
+    vendorId: vendor.id,
+    vendorName: vendor.name,
+    status: 'tested',
+    pass: response.status >= 200 && response.status < 300,
+    scoreEligible: response.status >= 200 && response.status < 300,
+    mode: 'webhook_smoke',
+    latencyMs,
+    evidence,
+    body: response.body,
+  };
+}
+
+async function runTemporalEndpoint(vendor, endpointUrl) {
+  const startedAt = Date.now();
+  const payload = benchmarkPayload(vendor.id);
+  const response = await postJson(endpointUrl, payload);
+  const latencyMs = Date.now() - startedAt;
+
+  return {
+    vendorId: vendor.id,
+    vendorName: vendor.name,
+    status: 'tested',
+    pass: response.status >= 200 && response.status < 300,
+    scoreEligible: response.status >= 200 && response.status < 300,
+    mode: 'durable_execution_endpoint_smoke',
+    latencyMs,
+    evidence: {
+      endpointConfigured: true,
+      payloadHash: sha256(JSON.stringify(payload)),
+      httpStatus: response.status,
+      responseHash: sha256(JSON.stringify(response.body)),
+    },
+    body: response.body,
+  };
+}
+
+function benchmarkPayload(vendorId) {
+  return {
+    suiteId: 'dsg-vendor-comparison-harness-v1',
+    vendorId,
+    timestamp: new Date().toISOString(),
+    workload: {
+      type: 'governed_action_smoke',
+      orgId: 'org-benchmark',
+      actorId: 'benchmark-agent',
+      actorRole: 'agent_operator',
+      toolName: 'benchmark.customer_webhook',
+      action: 'post',
+      risk: 'medium',
+      input: {
+        message: 'Vendor comparison smoke payload',
+      },
+    },
+    requiredEvidence: [
+      'http_2xx_response',
+      'latency_ms',
+      'payload_hash',
+      'response_hash',
+    ],
+  };
+}
+
+async function postJson(url, payload) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let body;
+    try {
+      body = text ? JSON.parse(text) : {};
+    } catch {
+      body = { raw: text };
+    }
+    return { status: response.status, body };
+  } catch (error) {
+    return { status: 0, body: { error: error instanceof Error ? error.message : String(error) } };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function spawnProcess(bin, args) {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { shell: process.platform === 'win32' });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data) => {
+      const text = data.toString();
+      stdout += text;
+      process.stdout.write(text);
+    });
+    child.stderr.on('data', (data) => {
+      const text = data.toString();
+      stderr += text;
+      process.stderr.write(text);
+    });
+    child.on('close', (status) => resolve({ status: status ?? 1, stdout, stderr }));
+  });
+}
+
+async function hashFileIfExists(file) {
+  try {
+    const content = await fs.readFile(file);
+    return sha256(content);
+  } catch {
+    return null;
+  }
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function tail(value, max = 1200) {
+  if (!value) return '';
+  return value.length > max ? value.slice(value.length - max) : value;
+}
+
+function renderReport(manifest) {
+  const rows = manifest.results
+    .map((result) => `| ${result.vendorName} | ${result.status} | ${result.pass ? 'PASS' : '—'} | ${result.scoreEligible ? 'yes' : 'no'} | ${result.latencyMs ?? '—'} | ${result.reason || ''} |`)
+    .join('\n');
+
+  return `# Vendor Comparison Harness Report\n\nGenerated at: ${manifest.generatedAt}\n\n## Evidence boundary\n\n${manifest.evidenceBoundary}\n\n## Summary\n\n- Vendors: ${manifest.summary.vendors}\n- Tested: ${manifest.summary.tested}\n- Passed: ${manifest.summary.passed}\n- Failed: ${manifest.summary.failed}\n- Not configured: ${manifest.summary.notConfigured}\n- Skipped: ${manifest.summary.skipped}\n\n## Results\n\n| Vendor | Status | Result | Score eligible | Latency ms | Note |\n|---|---|---:|---:|---:|---|\n${rows}\n\n## Notes\n\nOnly vendors with status \`tested\` and scoreEligible \`yes\` should be scored in a same-suite comparison. not_configured vendors are placeholders until credentials/endpoints are provided.\n`;
+}


### PR DESCRIPTION
## Summary

Adds a cross-vendor benchmark harness scaffold for DSG vs Zapier, Make, n8n, Workato, and Temporal.

## What this adds

- `benchmarks/vendor-comparison/vendors.json`
- `scripts/benchmark-vendors.mjs`
- `npm run benchmark:vendors`
- `docs/vendor-benchmark-harness.md`

## Behavior

- DSG runs using the native full evidence benchmark.
- Zapier / Make / n8n / Workato / Temporal are marked `not_configured` until their endpoint env vars are provided.
- Vendors without same-suite evidence are not score eligible.

## Vendor env vars

```bash
ZAPIER_BENCHMARK_WEBHOOK_URL
MAKE_BENCHMARK_WEBHOOK_URL
N8N_BENCHMARK_WEBHOOK_URL
WORKATO_BENCHMARK_WEBHOOK_URL
TEMPORAL_BENCHMARK_ENDPOINT
```

## Evidence boundary

Only vendors with status `tested` and `scoreEligible: true` should be scored in a same-suite comparison. `not_configured` vendors must not receive comparative scores.