### PR TITLE
Add public vendor baseline comparison pack

### DIFF
--- a/benchmarks/vendor-baseline/public-doc-baselines.json
+++ b/benchmarks/vendor-baseline/public-doc-baselines.json
@@ -1,0 +1,107 @@
+{
+  "suiteId": "dsg-public-vendor-baseline-v1",
+  "generatedFrom": "public documentation / official docs baseline",
+  "evidenceBoundary": "These vendor baselines are derived from public documentation and are not runtime benchmark results for those vendors. DSG evidence is production-tested separately. Do not claim DSG beat a vendor unless that vendor has been runtime-tested with the same suite.",
+  "dsgTestedEvidence": {
+    "command": "npm run benchmark:evidence",
+    "status": "tested",
+    "latestObserved": {
+      "fullEvidencePass": true,
+      "productionGatewayPassed": "6/6",
+      "smt2RuntimeInvariantPassed": "6/6",
+      "comparisonScore": "190/200",
+      "comparisonPercent": "95%"
+    }
+  },
+  "vendors": [
+    {
+      "id": "zapier",
+      "name": "Zapier",
+      "baselineType": "public_docs",
+      "runtimeTested": false,
+      "scoreEligible": false,
+      "category": "automation connector platform",
+      "sourceUrls": [
+        "https://help.zapier.com/hc/en-us/articles/8496288690317-Trigger-Zaps-from-webhooks",
+        "https://help.zapier.com/hc/en-us/articles/21986957116301-Easily-find-Zaps-by-the-URL-used-in-Webhooks-by-Zapier-steps"
+      ],
+      "capabilities": {
+        "webhookTrigger": "Catch Hook / Catch Raw Hook can trigger Zaps from webhooks.",
+        "httpMethods": "Catch Hook is documented for GET, PUT, or POST API endpoints.",
+        "endpointModel": "Webhook URL is provided in the Zap editor for that Zap.",
+        "runtimeEndpointRequired": true
+      }
+    },
+    {
+      "id": "n8n",
+      "name": "n8n",
+      "baselineType": "public_docs",
+      "runtimeTested": false,
+      "scoreEligible": false,
+      "category": "workflow automation platform",
+      "sourceUrls": [
+        "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/"
+      ],
+      "capabilities": {
+        "webhookTrigger": "Webhook node receives requests and can trigger workflows.",
+        "testAndProductionUrls": "Webhook node has Test URL and Production URL.",
+        "productionExecutionHistory": "Production execution data can be viewed in the Executions tab.",
+        "runtimeEndpointRequired": true
+      }
+    },
+    {
+      "id": "make",
+      "name": "Make",
+      "baselineType": "public_docs",
+      "runtimeTested": false,
+      "scoreEligible": false,
+      "category": "automation connector platform",
+      "sourceUrls": [
+        "https://help.make.com/webhooks",
+        "https://apps.make.com/gateway"
+      ],
+      "capabilities": {
+        "customWebhook": "Custom webhooks create a URL that external apps or services can call.",
+        "scenarioExecution": "Webhooks can trigger scenario execution when the URL receives a request.",
+        "defaultResponses": "Documented default responses include 200 accepted, 400 queue full, and 429 rate limit.",
+        "runtimeEndpointRequired": true
+      }
+    },
+    {
+      "id": "workato",
+      "name": "Workato",
+      "baselineType": "public_docs",
+      "runtimeTested": false,
+      "scoreEligible": false,
+      "category": "enterprise automation / API platform",
+      "sourceUrls": [
+        "https://docs.workato.com/workato-api/api-platform",
+        "https://docs.workato.com/en/limits.html"
+      ],
+      "capabilities": {
+        "apiPlatform": "API Platform APIs manage endpoints, collections, clients, and access profiles.",
+        "rateLimit": "API platform endpoints are documented at up to 10 requests per second.",
+        "limits": "API platform limits include synchronous job timeout, payload, header, cache, and response/cache constraints.",
+        "runtimeEndpointRequired": true
+      }
+    },
+    {
+      "id": "temporal",
+      "name": "Temporal",
+      "baselineType": "public_docs",
+      "runtimeTested": false,
+      "scoreEligible": false,
+      "category": "durable execution / workflow orchestration",
+      "sourceUrls": [
+        "https://temporal.io/",
+        "https://docs.temporal.io/"
+      ],
+      "capabilities": {
+        "durableExecution": "Temporal Workflows capture state and can resume after failures.",
+        "workflowOrchestration": "Temporal is positioned as a reliable application / durable execution platform.",
+        "webhookModel": "Temporal is not a public webhook endpoint by default; HTTP benchmark requires a wrapper endpoint.",
+        "runtimeEndpointRequired": true
+      }
+    }
+  ]
+}

--- a/docs/public-vendor-baseline-comparison.md
+++ b/docs/public-vendor-baseline-comparison.md
@@ -1,0 +1,61 @@
+# Public Vendor Baseline Comparison
+
+This pack compares DSG tested evidence against public vendor baselines derived from official/public documentation.
+
+## Command
+
+```bash
+npm run benchmark:vendors:baseline
+```
+
+## Outputs
+
+```text
+artifacts/public-vendor-baseline/public-vendor-baseline-result.json
+artifacts/public-vendor-baseline/public-vendor-baseline-report.md
+```
+
+## Evidence model
+
+```text
+DSG = tested production evidence
+Vendors = public documentation baseline only
+```
+
+This is intentionally not a claim that the vendor runtimes were tested.
+
+## Included public baselines
+
+- Zapier
+- n8n
+- Make
+- Workato
+- Temporal
+
+## Safe wording
+
+Use:
+
+```text
+DSG has production-tested evidence against a public vendor-baseline rubric derived from official/public market-leader documentation.
+```
+
+Do not use:
+
+```text
+DSG runtime-tested and beat every vendor listed here.
+```
+
+## Runtime benchmark requirement
+
+To claim a true runtime vendor comparison, each vendor must have:
+
+- a real endpoint or account-owned workflow
+- the same benchmark payload
+- recorded HTTP status
+- latency measurement
+- payload hash
+- response hash
+- evidence artifact
+- status `tested`
+- `scoreEligible: true`

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "benchmark:gateway:smt2": "node scripts/verify-gateway-smt2-invariants.mjs",
     "benchmark:evidence": "node scripts/benchmark-full-evidence.mjs",
     "benchmark:vendors": "node scripts/benchmark-vendors.mjs",
+    "benchmark:vendors:baseline": "node scripts/benchmark-public-baselines.mjs",
     "benchmark:site": "node scripts/render-benchmark-site.mjs",
     "benchmark:full": "node scripts/benchmark-dsg.mjs && node scripts/render-benchmark-site.mjs",
     "ops:runtime-rpc-fix": "./scripts/apply-runtime-rpc-fix.sh",

--- a/scripts/benchmark-public-baselines.mjs
+++ b/scripts/benchmark-public-baselines.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const BASELINES_FILE = process.env.PUBLIC_VENDOR_BASELINES_FILE || 'benchmarks/vendor-baseline/public-doc-baselines.json';
+const FULL_EVIDENCE_FILE = process.env.DSG_FULL_EVIDENCE_FILE || 'artifacts/full-evidence/dsg-full-evidence-manifest.json';
+const OUT_DIR = process.env.PUBLIC_VENDOR_BASELINE_OUT_DIR || 'artifacts/public-vendor-baseline';
+
+await main();
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const baseline = JSON.parse(await fs.readFile(BASELINES_FILE, 'utf8'));
+  const dsgEvidence = await readJsonIfExists(FULL_EVIDENCE_FILE);
+  const dsgEvidenceHash = await hashFileIfExists(FULL_EVIDENCE_FILE);
+
+  const vendorRows = baseline.vendors.map((vendor) => ({
+    vendorId: vendor.id,
+    vendorName: vendor.name,
+    baselineType: vendor.baselineType,
+    runtimeTested: vendor.runtimeTested,
+    scoreEligible: vendor.scoreEligible,
+    category: vendor.category,
+    sourceCount: vendor.sourceUrls.length,
+    capabilities: Object.keys(vendor.capabilities || {}),
+    status: vendor.runtimeTested ? 'tested' : 'public_docs_only',
+  }));
+
+  const artifact = {
+    generatedAt: new Date().toISOString(),
+    suiteId: baseline.suiteId,
+    evidenceBoundary: baseline.evidenceBoundary,
+    dsg: {
+      baselineType: 'tested_production_evidence',
+      runtimeTested: true,
+      scoreEligible: true,
+      fullEvidencePath: FULL_EVIDENCE_FILE,
+      fullEvidenceExists: Boolean(dsgEvidence),
+      fullEvidenceSha256: dsgEvidenceHash,
+      latestObserved: baseline.dsgTestedEvidence.latestObserved,
+      evidenceSummary: dsgEvidence?.summary ?? null,
+    },
+    vendors: vendorRows,
+    sources: Object.fromEntries(baseline.vendors.map((vendor) => [vendor.id, vendor.sourceUrls])),
+  };
+
+  await fs.writeFile(path.join(OUT_DIR, 'public-vendor-baseline-result.json'), JSON.stringify(artifact, null, 2));
+  await fs.writeFile(path.join(OUT_DIR, 'public-vendor-baseline-report.md'), renderReport(artifact, baseline));
+
+  console.log(JSON.stringify({
+    pass: Boolean(dsgEvidence),
+    dsgRuntimeTested: true,
+    publicDocVendors: vendorRows.length,
+    vendorRuntimeTested: vendorRows.filter((row) => row.runtimeTested).length,
+  }, null, 2));
+
+  if (!dsgEvidence) {
+    process.exitCode = 1;
+  }
+}
+
+async function readJsonIfExists(file) {
+  try {
+    return JSON.parse(await fs.readFile(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+async function hashFileIfExists(file) {
+  try {
+    const content = await fs.readFile(file);
+    return crypto.createHash('sha256').update(content).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function renderReport(artifact, baseline) {
+  const rows = artifact.vendors.map((vendor) => `| ${vendor.vendorName} | ${vendor.category} | ${vendor.status} | ${vendor.scoreEligible ? 'yes' : 'no'} | ${vendor.sourceCount} |`).join('\n');
+  const sourceSections = baseline.vendors.map((vendor) => {
+    const capabilities = Object.entries(vendor.capabilities || {})
+      .map(([key, value]) => `- ${key}: ${value}`)
+      .join('\n');
+    const sources = vendor.sourceUrls.map((url) => `- ${url}`).join('\n');
+    return `### ${vendor.name}\n\nCategory: ${vendor.category}\n\nRuntime tested by this suite: **${vendor.runtimeTested ? 'yes' : 'no'}**\n\nScore eligible: **${vendor.scoreEligible ? 'yes' : 'no'}**\n\nCapabilities from public docs:\n\n${capabilities}\n\nSources:\n\n${sources}\n`;
+  }).join('\n');
+
+  return `# Public Vendor Baseline Comparison\n\nGenerated at: ${artifact.generatedAt}\n\n## Boundary\n\n${artifact.evidenceBoundary}\n\n## DSG tested evidence\n\n- Runtime tested: **yes**\n- Score eligible: **yes**\n- Full evidence artifact: \`${artifact.dsg.fullEvidencePath}\`\n- Full evidence artifact exists: **${artifact.dsg.fullEvidenceExists ? 'yes' : 'no'}**\n- Full evidence SHA-256: \`${artifact.dsg.fullEvidenceSha256 || 'missing'}\`\n- Latest observed full evidence pass: **${artifact.dsg.latestObserved.fullEvidencePass ? 'true' : 'false'}**\n- Production gateway: **${artifact.dsg.latestObserved.productionGatewayPassed}**\n- SMT2 runtime invariants: **${artifact.dsg.latestObserved.smt2RuntimeInvariantPassed}**\n- Comparison score: **${artifact.dsg.latestObserved.comparisonScore} (${artifact.dsg.latestObserved.comparisonPercent})**\n\n## Vendor baseline table\n\n| Vendor | Category | Status | Score eligible | Source count |\n|---|---|---|---:|---:|\n${rows}\n\n## Vendor public-doc baselines\n\n${sourceSections}\n\n## Safe interpretation\n\nUse: DSG has production-tested evidence against a public vendor-baseline rubric derived from official/public market-leader documentation.\n\nDo not use: DSG runtime-tested and beat every vendor listed here.\n`;
+}


### PR DESCRIPTION
## Summary

Adds a public vendor baseline comparison pack that separates public documentation baselines from DSG production-tested evidence.

## What this adds

- `benchmarks/vendor-baseline/public-doc-baselines.json`
- `scripts/benchmark-public-baselines.mjs`
- `npm run benchmark:vendors:baseline`
- `docs/public-vendor-baseline-comparison.md`

## Model

```text
DSG = tested production evidence
Vendors = public documentation baseline only
```

## Vendors included

- Zapier
- n8n
- Make
- Workato
- Temporal

## Evidence boundary

This does not claim that vendor runtimes were tested. It provides a public-doc baseline rubric and shows DSG tested evidence against that rubric.

## Safe wording

Allowed:

```text
DSG has production-tested evidence against a public vendor-baseline rubric derived from official/public market-leader documentation.
```

Not allowed:

```text
DSG runtime-tested and beat every vendor listed here.
```