### PR TITLE
Add deterministic governance claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ It provides:
 - comparison benchmark rubric for adjacent market tools
 - public vendor-baseline comparison derived from official/public market documentation
 
+## Deterministic governance claims
+
+DSG is a deterministic AI Action Governance Gateway that checks policy, risk, approval, and mathematical invariants before tool execution.
+
+DSG uses deterministic control logic for high-risk tool calls, reducing reliance on probabilistic model judgment at the execution boundary.
+
+DSG is designed to reduce hallucination-driven actions by preventing AI outputs from directly executing tools unless they satisfy predefined policy and invariant checks.
+
+DSG enforces mathematical safety invariants over tool-execution requests and turns AI tool execution into an auditable state transition with request hashes, record hashes, and exportable evidence.
+
+Boundary:
+
+```text
+DSG does not claim to make language models hallucination-free. Instead, it controls whether AI-proposed actions can affect business systems by requiring deterministic policy and invariant checks at the execution boundary.
+
+Cost reduction claims are design goals and risk-reduction mechanisms unless supported by customer production studies.
+```
+
 ## Formal Verification & Deterministic Control
 
 DSG includes a published formal verification artifact:

--- a/app/marketplace/production-evidence/page.tsx
+++ b/app/marketplace/production-evidence/page.tsx
@@ -21,6 +21,25 @@ const checks = [
   "Audit export API",
 ];
 
+const claimCards = [
+  {
+    title: "Deterministic control",
+    body: "DSG uses deterministic control logic for high-risk tool calls, reducing reliance on probabilistic model judgment at the execution boundary.",
+  },
+  {
+    title: "Action-layer hallucination risk reduction",
+    body: "DSG is designed to reduce hallucination-driven actions by preventing AI outputs from directly executing tools unless they satisfy policy and invariant checks.",
+  },
+  {
+    title: "Mathematical invariants",
+    body: "DSG enforces runtime safety invariants over organization identity, actor identity, registered tool/action matching, approval requirements, entitlement checks, and evidence writability.",
+  },
+  {
+    title: "Audit-proof state transitions",
+    body: "DSG turns AI tool execution into an auditable state transition with request hashes, record hashes, and exportable evidence.",
+  },
+];
+
 const publicBaselines = ["Zapier", "n8n", "Make", "Workato", "Temporal"];
 
 export default function MarketplaceProductionEvidencePage() {
@@ -33,9 +52,9 @@ export default function MarketplaceProductionEvidencePage() {
             DSG Gateway evidence: 6/6 passed, 95% rubric score
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            Latest internal production benchmark evidence verified the public DSG Gateway flow end-to-end: connector registration,
-            Gateway Mode execution, Monitor Mode plan-check, audit commit, audit events, and audit export. DSG is also measured
-            against a public vendor-baseline rubric derived from official/public market-leader documentation.
+            DSG is a deterministic AI Action Governance Gateway for high-risk tool execution. It places a verified control
+            layer between AI intent and production systems, checking policy, entitlement, risk, approval, and mathematical
+            invariants before an action can execute.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/gateway/monitor?orgId=org-smoke" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">
@@ -57,6 +76,18 @@ export default function MarketplaceProductionEvidencePage() {
               <p className="mt-2 text-3xl font-bold text-white">{metric.value}</p>
             </div>
           ))}
+        </section>
+
+        <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          <h2 className="text-2xl font-bold">Deterministic governance claims</h2>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            {claimCards.map((claim) => (
+              <div key={claim.title} className="rounded-xl border border-emerald-400/20 bg-slate-950 p-5">
+                <h3 className="text-lg font-bold text-emerald-100">{claim.title}</h3>
+                <p className="mt-3 leading-7 text-slate-300">{claim.body}</p>
+              </div>
+            ))}
+          </div>
         </section>
 
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
@@ -88,9 +119,10 @@ export default function MarketplaceProductionEvidencePage() {
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
           <h2 className="text-2xl font-bold">Evidence boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            This page reports an internal production benchmark run for marketplace and demo validation. It is not an
-            independent third-party certification. Vendor runtime benchmark results are not claimed unless vendor endpoints
-            are configured and tested with the same suite.
+            This page reports an internal production benchmark run for marketplace and demo validation. DSG does not claim to make
+            language models hallucination-free. It controls whether AI-proposed actions can affect business systems by requiring
+            deterministic policy and invariant checks at the execution boundary. Cost reduction claims are design goals and
+            risk-reduction mechanisms unless supported by customer production studies.
           </p>
           <pre className="mt-5 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`npm run benchmark:evidence
 npm run benchmark:vendors:baseline

--- a/docs/deterministic-governance-claims.md
+++ b/docs/deterministic-governance-claims.md
@@ -1,0 +1,101 @@
+# Deterministic Governance Claims
+
+This guide defines evidence-aligned claims for DSG's deterministic control, mathematical invariants, audit proof, and risk-reduction positioning.
+
+## Evidence base
+
+DSG combines four assurance layers:
+
+1. Published formal verification evidence
+   - DOI: https://doi.org/10.5281/zenodo.18225586
+   - Z3 theorem prover / SMT-LIB proof artifact scope
+   - deterministic behavior, safety invariance, and constant-time O(1) control primitive claims from the artifact abstract
+
+2. Production Gateway benchmark evidence
+   - 6/6 checks passed
+   - 100% pass rate
+   - avgLatencyMs: 2047
+   - minLatencyMs: 1029
+   - maxLatencyMs: 4254
+
+3. Runtime SMT2-compatible invariant evidence
+   - 6/6 invariant cases passed
+   - 100% pass rate
+   - deterministic static evaluation with SMT-LIB v2-compatible emitted constraints
+
+4. Public vendor-baseline comparison
+   - publicDocVendors: 5
+   - vendorRuntimeTested: 0
+   - used for positioning, not direct vendor runtime victory claims
+
+## Approved claims
+
+```text
+DSG is a deterministic AI Action Governance Gateway that checks policy, risk, approval, and mathematical invariants before tool execution.
+```
+
+```text
+DSG combines published formal verification evidence with runtime audit proof for governed AI and automation workflows.
+```
+
+```text
+DSG uses deterministic control logic for high-risk tool calls, reducing reliance on probabilistic model judgment at the execution boundary.
+```
+
+```text
+DSG is designed to reduce hallucination-driven actions by preventing AI outputs from directly executing tools unless they satisfy predefined policy and invariant checks.
+```
+
+```text
+DSG enforces mathematical safety invariants over tool-execution requests.
+```
+
+```text
+DSG turns AI tool execution into an auditable state transition with request hashes, record hashes, and exportable evidence.
+```
+
+```text
+DSG can reduce downstream remediation and audit-preparation effort by blocking invalid actions before execution and producing structured evidence during normal operation.
+```
+
+## Marketplace copy
+
+```text
+DSG is a deterministic AI Action Governance Gateway for high-risk tool execution.
+
+It places a verified control layer between AI intent and production systems, checking policy, entitlement, risk, approval, and mathematical invariants before an action can execute.
+
+Latest evidence:
+- Production Gateway Benchmark: 6/6 passed, 100%
+- SMT2 Runtime Invariants: 6/6 passed, 100%
+- Comparison Rubric: 190/200, 95%
+- Published formal verification artifact: DOI 10.5281/zenodo.18225586
+
+DSG is designed to reduce hallucination-driven actions, audit preparation effort, and integration risk by turning AI tool execution into deterministic, auditable state transitions.
+```
+
+## Procurement copy
+
+```text
+DSG provides a deterministic control-plane primitive for governed AI tool execution.
+
+The system separates probabilistic AI inference from execution authority. AI systems may propose actions, but DSG evaluates each action against explicit policy, entitlement, approval, and invariant constraints before execution or audit commit.
+
+For regulated environments, DSG provides:
+- deterministic pre-execution decisions
+- runtime invariant checks
+- Monitor Mode for customer-held API keys
+- audit proof with requestHash and recordHash
+- exportable evidence records
+- published formal verification evidence using SMT-LIB/Z3 artifacts
+```
+
+## Boundary statement
+
+```text
+DSG does not claim to make language models hallucination-free. Instead, it controls whether AI-proposed actions can affect business systems by requiring deterministic policy and invariant checks at the execution boundary.
+```
+
+```text
+Cost reduction claims should be stated as design goals and risk-reduction mechanisms unless supported by customer production studies.
+```


### PR DESCRIPTION
## Summary

Adds evidence-aligned deterministic governance claims to README and the marketplace production evidence page.

## What this adds

- Deterministic control claim
- Action-layer hallucination risk reduction wording
- Mathematical invariant positioning
- Audit-proof state transition positioning
- Cost/risk reduction wording with safe boundaries
- `docs/deterministic-governance-claims.md`

## Evidence-backed wording

```text
DSG is a deterministic AI Action Governance Gateway that checks policy, risk, approval, and mathematical invariants before tool execution.
```

```text
DSG is designed to reduce hallucination-driven actions by preventing AI outputs from directly executing tools unless they satisfy predefined policy and invariant checks.
```

```text
DSG turns AI tool execution into an auditable state transition with request hashes, record hashes, and exportable evidence.
```

## Boundary

This PR avoids absolute claims such as zero hallucination, guaranteed cost savings, or independent certification of every deployed runtime. It keeps the wording aligned to published formal verification evidence, production benchmark evidence, and runtime SMT2-compatible invariant evidence.

## Sources used for language boundary

- Z3 is an SMT solver/theorem prover from Microsoft Research used in software verification/program analysis.
- SMT-LIB standardizes SMT solver languages/logics/benchmark libraries.
- NIST AI RMF is a risk management framework, not a product certification.

## Runtime impact

Docs and marketplace copy only.