### PR TITLE
Add GitHub Marketplace Action link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Live deployment:
 
 - https://tdealer01-crypto-dsg-control-plane.vercel.app
 
+Published GitHub Marketplace Action:
+
+- https://github.com/marketplace/actions/dsg-secure-deploy-gate
+- Release: https://github.com/tdealer01-crypto/dsg-secure-deploy-gate-action/releases/tag/v1.0.2
+
+```yaml
+- name: DSG Secure Deploy Gate
+  uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1.0.2
+```
+
 Published formal verification artifact:
 
 - https://doi.org/10.5281/zenodo.18225586
@@ -35,6 +45,7 @@ Verified production surfaces:
 - Monitor Mode audit commit: verified
 - Audit events API: verified
 - Audit export API: verified
+- GitHub Marketplace Action: published as `dsg-secure-deploy-gate-action@v1.0.2`
 - `requestHash` / `recordHash`: generated and returned
 - Production gateway benchmark: 6/6 passed
 - Comparison rubric score: 190/200, 95%
@@ -82,6 +93,7 @@ It provides:
 - Monitor Mode for customer-owned runtime execution
 - request and record hashing
 - audit event history and export APIs
+- published GitHub Marketplace Action for deterministic CI/CD deployment gating
 - published formal verification evidence
 - deterministic SMT2-compatible runtime invariant evidence
 - production benchmark evidence
@@ -132,6 +144,7 @@ Repository runtime evidence complements the published formal verification artifa
 - requestHash and recordHash audit evidence
 - deterministic SMT2-compatible gateway invariant evidence
 - production benchmark reports
+- DSG Secure Deploy Gate GitHub Marketplace Action for CI/CD gating
 
 Correct wording:
 
@@ -146,6 +159,37 @@ The published DOI artifact is the formal verification evidence. The current repo
 ```
 
 Do not collapse the two layers into a single unsupported claim. The DOI artifact and the runtime gateway SMT2 evidence are related assurance layers, but they are not the same artifact.
+
+## GitHub Marketplace Action
+
+DSG Secure Deploy Gate is published on GitHub Marketplace:
+
+```text
+https://github.com/marketplace/actions/dsg-secure-deploy-gate
+```
+
+Latest release:
+
+```text
+https://github.com/tdealer01-crypto/dsg-secure-deploy-gate-action/releases/tag/v1.0.2
+```
+
+Usage:
+
+```yaml
+- name: DSG Secure Deploy Gate
+  uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1.0.2
+```
+
+Action purpose:
+
+- deterministic deploy gate for GitHub Actions
+- fail-closed behavior for unsafe deploy conditions
+- CI/CD policy enforcement before production deployment
+- evidence-oriented deployment control
+- designed for regulated, high-assurance, and AI-assisted software delivery workflows
+
+Evidence boundary: this Action provides a deployment gate. It does not claim independent third-party certification.
 
 ## Core modes
 
@@ -570,6 +614,7 @@ Current status:
 Finance governance backend smoke path: GO
 Gateway Mode production benchmark: GO
 Monitor Mode production benchmark: GO
+GitHub Marketplace Action: published at v1.0.2
 Production Gateway Benchmark: 6/6 passed, 100%
 SMT2 Runtime Invariants: 6/6 passed, 100%
 Comparison Rubric: 190/200, 95%
@@ -594,6 +639,7 @@ It includes:
 - deterministic audit proof storage
 - runtime hash verification APIs
 - audit export APIs
+- GitHub Marketplace Action for deterministic deploy gating
 - production benchmark evidence
 - published formal verification evidence
 - deterministic SMT2-compatible runtime invariant evidence

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
 
+const actionMarketplaceUrl = "https://github.com/marketplace/actions/dsg-secure-deploy-gate";
+const actionReleaseUrl = "https://github.com/tdealer01-crypto/dsg-secure-deploy-gate-action/releases/tag/v1.0.2";
+
 const reviewerChecks = [
   {
     title: "Product home",
@@ -12,6 +15,12 @@ const reviewerChecks = [
     note: "Public baseline probe for control-plane and DSG core health status.",
   },
   {
+    title: "GitHub Marketplace Action",
+    href: actionMarketplaceUrl,
+    note: "Published DSG Secure Deploy Gate Action for deterministic CI/CD deployment gating.",
+    external: true,
+  },
+  {
     title: "Login",
     href: "/login",
     note: "Entry into authenticated operator workspace routes.",
@@ -22,12 +31,14 @@ const capabilities = [
   "Deterministic policy gate with ALLOW / STABILIZE / BLOCK decisions.",
   "Audit-oriented execution records and usage tracking.",
   "Authenticated operator surfaces for dashboard, audit, policy, and billing review.",
+  "Published GitHub Marketplace Action for deterministic CI/CD deployment gating.",
   "Stable execution entry via /api/execute with deeper runtime handled behind the current execution layer.",
 ];
 
 const reviewSteps = [
   "Open the product home and confirm the public landing page is reachable.",
   "Open /api/health and confirm the JSON baseline probe is returned.",
+  "Open the GitHub Marketplace Action and confirm v1.0.2 usage is visible.",
   "Use /login or /password-login to enter authenticated operator routes.",
   "Use protected execution and operator APIs only with valid credentials and organization-scoped access.",
 ];
@@ -44,7 +55,7 @@ export default function MarketplacePage() {
             DSG — Deterministic Safety Gate
           </h1>
           <p className="mt-6 max-w-3xl text-lg text-slate-300">
-            DSG Control Plane exposes a public product surface, a public baseline health probe, and authenticated operator routes for governed AI execution. This page is designed to help marketplace reviewers distinguish public checks from protected runtime workflows.
+            DSG Control Plane exposes a public product surface, a public baseline health probe, a published GitHub Marketplace Action, and authenticated operator routes for governed AI execution. This page is designed to help marketplace reviewers distinguish public checks from protected runtime workflows.
           </p>
 
           <div className="mt-10 flex flex-wrap gap-4">
@@ -53,6 +64,12 @@ export default function MarketplacePage() {
               className="rounded-xl bg-emerald-500 px-5 py-3 font-semibold text-black"
             >
               Open Product Home
+            </Link>
+            <Link
+              href={actionMarketplaceUrl}
+              className="rounded-xl bg-blue-500 px-5 py-3 font-semibold text-white"
+            >
+              Open GitHub Marketplace Action
             </Link>
             <Link
               href="/login"
@@ -68,6 +85,23 @@ export default function MarketplacePage() {
             </Link>
           </div>
         </div>
+
+        <section className="mt-8 rounded-2xl border border-blue-500/30 bg-blue-500/10 p-6">
+          <h2 className="text-2xl font-semibold">GitHub Marketplace Action</h2>
+          <p className="mt-3 max-w-4xl text-slate-300">
+            DSG Secure Deploy Gate is published on GitHub Marketplace as a deterministic deployment gate for CI/CD workflows. Use it as a required gate before production deployment jobs.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-4">
+            <Link href={actionMarketplaceUrl} className="rounded-xl bg-blue-400 px-5 py-3 font-bold text-black">
+              View Marketplace listing
+            </Link>
+            <Link href={actionReleaseUrl} className="rounded-xl border border-blue-300/50 px-5 py-3 font-bold text-blue-100">
+              View v1.0.2 release
+            </Link>
+          </div>
+          <pre className="mt-5 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`- name: DSG Secure Deploy Gate
+  uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1.0.2`}</pre>
+        </section>
 
         <section className="mt-8 grid gap-6 md:grid-cols-2">
           <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
@@ -95,7 +129,7 @@ export default function MarketplacePage() {
                       <p className="mt-1 text-sm text-slate-400">{item.note}</p>
                     </div>
                     <Link href={item.href} className="text-sm font-semibold text-emerald-400">
-                      Open
+                      Open{item.external ? " ↗" : ""}
                     </Link>
                   </div>
                 </div>
@@ -139,7 +173,7 @@ export default function MarketplacePage() {
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
           <h2 className="text-2xl font-semibold">Protected Execute API</h2>
           <p className="mt-3 text-slate-300">
-            Execution requests use a bearer token and agent identifier. Reviewers should validate the public product surface with the landing page and health endpoint first, then use authenticated operator access for protected execution and workspace flows.
+            Execution requests use a bearer token and agent identifier. Reviewers should validate the public product surface with the landing page, GitHub Marketplace Action, and health endpoint first, then use authenticated operator access for protected execution and workspace flows.
           </p>
           <pre className="mt-4 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`curl -X POST https://your-domain.com/api/execute \\
   -H "Authorization: Bearer DSG_API_KEY" \\


### PR DESCRIPTION
## Summary

Adds the published DSG Secure Deploy Gate GitHub Marketplace Action to the DSG control-plane README and marketplace reviewer page.

## Published Action

- Marketplace: https://github.com/marketplace/actions/dsg-secure-deploy-gate
- Release: https://github.com/tdealer01-crypto/dsg-secure-deploy-gate-action/releases/tag/v1.0.2

## Usage

```yaml
- name: DSG Secure Deploy Gate
  uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1.0.2
```

## What changed

- README now lists the published GitHub Marketplace Action near the top.
- README production status includes the Action as published at `v1.0.2`.
- `/marketplace` now has a GitHub Marketplace Action section, link, release link, and usage snippet.
- Reviewer checks include opening the GitHub Marketplace Action.

## Evidence boundary

This Action provides a deterministic deployment gate for CI/CD. It does not claim independent third-party certification.

## Runtime impact

Docs and marketplace page only.