### PR TITLE
Add signed evidence bundle

### DIFF
--- a/app/api/gateway/evidence/bundle/route.ts
+++ b/app/api/gateway/evidence/bundle/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { buildGatewayEvidenceBundle } from '../../../../../lib/gateway/evidence-bundle';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+function header(request: Request, name: string) {
+  return request.headers.get(name)?.trim() ?? '';
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const orgId = header(request, 'x-org-id') || searchParams.get('orgId')?.trim() || '';
+  const auditToken = searchParams.get('auditToken')?.trim() || '';
+
+  if (!orgId) {
+    return NextResponse.json({ ok: false, error: 'missing_org_id' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  let query = supabase
+    .from('gateway_monitor_events')
+    .select('*')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (auditToken) {
+    query = query.eq('audit_token', auditToken).limit(1);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  const bundle = buildGatewayEvidenceBundle({
+    orgId,
+    auditToken: auditToken || undefined,
+    events: data ?? [],
+  });
+
+  return NextResponse.json(bundle, {
+    status: 200,
+    headers: {
+      'content-disposition': 'attachment; filename="dsg-gateway-evidence-bundle.json"',
+    },
+  });
+}

--- a/app/evidence-pack/page.tsx
+++ b/app/evidence-pack/page.tsx
@@ -6,8 +6,8 @@ const evidence = [
   ["Comparison Rubric", "190/200, 95% internal rubric score", "Implemented"],
   ["Public Vendor Baseline", "5 public documentation baselines, vendorRuntimeTested=0", "Implemented"],
   ["Audit Export API", "Exportable JSON audit evidence", "Implemented"],
+  ["Signed Evidence Bundle", "Portable bundle with bundleHash, eventHashes, and signature metadata", "Implemented"],
   ["GitHub Secure Deploy Gate Action", "CI/CD gate evidence with verdict and evidence hash", "Implemented"],
-  ["Signed Evidence Bundle", "Portable signed evidence package", "Planned"],
   ["PDF Evidence Report", "Human-readable reviewer report", "Planned"],
 ];
 
@@ -21,10 +21,11 @@ export default function EvidencePackPage() {
             Audit evidence for governed AI execution
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            DSG produces structured AI action governance evidence with runtime decisions, request hashes, record hashes, benchmark evidence, invariant checks, and exportable audit records.
+            DSG produces structured AI action governance evidence with runtime decisions, request hashes, record hashes, benchmark evidence, invariant checks, signed evidence bundle metadata, and exportable audit records.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/ai-compliance" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Back to AI compliance</Link>
+            <Link href="/api/gateway/evidence/bundle?orgId=org-smoke" className="rounded-xl border border-emerald-300/50 px-5 py-3 font-bold text-emerald-100">Download signed evidence bundle</Link>
             <Link href="/api/gateway/audit/export?orgId=org-smoke" className="rounded-xl border border-emerald-300/50 px-5 py-3 font-bold text-emerald-100">Open audit export JSON</Link>
             <Link href="/marketplace/production-evidence" className="rounded-xl border border-slate-700 px-5 py-3 font-bold text-slate-200">View production evidence</Link>
           </div>
@@ -44,36 +45,36 @@ export default function EvidencePackPage() {
         </section>
 
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-bold">Sample evidence structure</h2>
+          <h2 className="text-2xl font-bold">Sample signed bundle structure</h2>
           <pre className="mt-5 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`{
-  "evidenceType": "dsg-ai-action-governance",
-  "organizationId": "org-smoke",
-  "actorId": "agent-001",
-  "actorRole": "agent_operator",
-  "toolName": "custom_http.customer_webhook",
-  "action": "post",
-  "decision": "allow",
-  "risk": "medium",
-  "approvalRequired": false,
-  "requestHash": "sha256-request-placeholder",
-  "recordHash": "sha256-record-placeholder",
-  "auditToken": "gat_example",
-  "checks": {
-    "organizationIdentity": true,
-    "actorIdentity": true,
-    "roleAllowed": true,
-    "planEntitled": true,
-    "toolRegistered": true,
-    "actionMatchesTool": true,
-    "evidenceWritable": true
-  }
+  "type": "dsg-gateway-signed-evidence-bundle",
+  "version": "1.0",
+  "orgId": "org-smoke",
+  "count": 1,
+  "bundleHash": "sha256-bundle-placeholder",
+  "eventHashes": ["sha256-event-placeholder"],
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "signature": "hmac-signature-placeholder",
+    "signatureMode": "hmac",
+    "keyId": "env:DSG_EVIDENCE_SIGNING_SECRET"
+  },
+  "events": [
+    {
+      "tool_name": "custom_http.customer_webhook",
+      "action": "post",
+      "decision": "allow",
+      "request_hash": "sha256-request-placeholder",
+      "record_hash": "sha256-record-placeholder"
+    }
+  ]
 }`}</pre>
         </section>
 
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            This page shows sample and internal production evidence. It is not an independent audit report. Signed evidence bundles and PDF reports are planned hardening items.
+            This page shows sample and internal production evidence. The signed evidence bundle is DSG-generated audit evidence, not an independent third-party audit report. If no signing secret is configured, DSG returns hash-only signature metadata instead of HMAC metadata.
           </p>
         </section>
       </div>

--- a/docs/evidence/signed-evidence-bundle.md
+++ b/docs/evidence/signed-evidence-bundle.md
@@ -1,0 +1,77 @@
+# DSG Signed Evidence Bundle
+
+Purpose: provide a portable JSON evidence package for governed AI/tool execution.
+
+Boundary: this bundle is DSG-generated audit evidence. It is not an independent third-party certification or audit report.
+
+## Endpoint
+
+```text
+GET /api/gateway/evidence/bundle?orgId=<org-id>
+GET /api/gateway/evidence/bundle?orgId=<org-id>&auditToken=<audit-token>
+```
+
+## Output fields
+
+| Field | Meaning |
+|---|---|
+| `type` | Bundle type: `dsg-gateway-signed-evidence-bundle` |
+| `version` | Bundle schema version |
+| `exportedAt` | Export timestamp |
+| `orgId` | Organization scope |
+| `auditToken` | Optional event filter |
+| `count` | Number of events in the bundle |
+| `bundleHash` | Stable SHA256 hash over bundle content |
+| `eventHashes` | Stable SHA256 hash for each event |
+| `signature.algorithm` | `hmac-sha256` if signing secret exists, otherwise `sha256` |
+| `signature.signatureMode` | `hmac` or `hash-only` |
+| `signature.keyId` | Signing key identifier |
+| `events` | Raw audit events included in the bundle |
+
+## Signing behavior
+
+If `DSG_EVIDENCE_SIGNING_SECRET` is configured, DSG signs the bundle hash using HMAC-SHA256.
+
+Optional key id:
+
+```text
+DSG_EVIDENCE_SIGNING_KEY_ID
+```
+
+If no signing secret is configured, DSG still returns a deterministic `bundleHash` and `eventHashes`, but `signatureMode` is `hash-only`.
+
+## Sample
+
+```json
+{
+  "ok": true,
+  "type": "dsg-gateway-signed-evidence-bundle",
+  "version": "1.0",
+  "orgId": "org-smoke",
+  "count": 1,
+  "bundleHash": "sha256-bundle-placeholder",
+  "eventHashes": ["sha256-event-placeholder"],
+  "signature": {
+    "algorithm": "hmac-sha256",
+    "signature": "hmac-signature-placeholder",
+    "signatureMode": "hmac",
+    "keyId": "env:DSG_EVIDENCE_SIGNING_SECRET"
+  },
+  "evidenceBoundary": {
+    "certificationClaim": false,
+    "independentAuditClaim": false
+  },
+  "events": []
+}
+```
+
+## Safe wording
+
+DSG provides portable signed evidence bundles for governed AI/tool execution, including bundle hashes, event hashes, and signing metadata.
+
+## Not claimed
+
+- Independent third-party certification
+- ISO certification
+- NIST certification
+- Guaranteed compliance

--- a/lib/gateway/evidence-bundle.ts
+++ b/lib/gateway/evidence-bundle.ts
@@ -1,0 +1,71 @@
+import crypto from 'node:crypto';
+import { hashGatewayValue } from './audit';
+
+export type GatewayEvidenceBundleEvent = Record<string, unknown>;
+
+export type GatewayEvidenceBundleInput = {
+  orgId: string;
+  auditToken?: string;
+  exportedAt?: string;
+  events: GatewayEvidenceBundleEvent[];
+};
+
+function signBundle(bundleHash: string) {
+  const secret = process.env.DSG_EVIDENCE_SIGNING_SECRET?.trim();
+
+  if (!secret) {
+    return {
+      algorithm: 'sha256',
+      signature: bundleHash,
+      signatureMode: 'hash-only',
+      keyId: 'none',
+    };
+  }
+
+  const keyId = process.env.DSG_EVIDENCE_SIGNING_KEY_ID?.trim() || 'env:DSG_EVIDENCE_SIGNING_SECRET';
+  const signature = crypto.createHmac('sha256', secret).update(bundleHash).digest('hex');
+
+  return {
+    algorithm: 'hmac-sha256',
+    signature,
+    signatureMode: 'hmac',
+    keyId,
+  };
+}
+
+export function buildGatewayEvidenceBundle(input: GatewayEvidenceBundleInput) {
+  const exportedAt = input.exportedAt ?? new Date().toISOString();
+  const events = Array.isArray(input.events) ? input.events : [];
+  const eventHashes = events.map((event) => hashGatewayValue(event));
+  const bundleHash = hashGatewayValue({
+    type: 'dsg-gateway-signed-evidence-bundle',
+    version: '1.0',
+    orgId: input.orgId,
+    auditToken: input.auditToken ?? null,
+    exportedAt,
+    eventHashes,
+    events,
+  });
+
+  const signature = signBundle(bundleHash);
+
+  return {
+    ok: true,
+    type: 'dsg-gateway-signed-evidence-bundle',
+    version: '1.0',
+    exportedAt,
+    orgId: input.orgId,
+    auditToken: input.auditToken ?? null,
+    count: events.length,
+    bundleHash,
+    eventHashes,
+    signature,
+    evidenceBoundary: {
+      statement:
+        'This bundle is DSG-generated audit evidence for governed AI/tool execution. It is not an independent third-party certification.',
+      certificationClaim: false,
+      independentAuditClaim: false,
+    },
+    events,
+  };
+}


### PR DESCRIPTION
Adds Phase 4 product hardening item: a DSG signed evidence bundle for gateway audit events. Includes bundle builder, API endpoint, evidence-pack page update, and docs. Boundary: DSG-generated audit evidence only; no independent third-party certification claim.