### PR TITLE
Complete consult toolkit and commercial hardening pack

### DIFF
--- a/app/consult/page.tsx
+++ b/app/consult/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+
+const assets = [
+  { href: "/docs/consult-toolkit/audit-readiness-checklist", title: "Audit Readiness Checklist", body: "Structured consultant checklist for pilot, buyer, and governance review." },
+  { href: "/evidence-pack", title: "Evidence Pack", body: "Exportable evidence bundle with hashes and portable proof." },
+  { href: "/controls", title: "Control Templates", body: "Reusable governance controls mapped to operational risk." },
+  { href: "/approvals?orgId=org-smoke", title: "Approval Workflow", body: "Review queue and reviewer-decision governance flow." },
+  { href: "/marketplace/production-evidence", title: "Production Evidence", body: "Benchmark, baseline, and deterministic production claims boundary." },
+];
+
+export default function ConsultPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
+      <div className="mx-auto max-w-6xl">
+        <section className="rounded-3xl border border-violet-500/30 bg-violet-500/10 p-8 md:p-12">
+          <p className="text-sm uppercase tracking-[0.25em] text-violet-300">Consult & Audit Toolkit</p>
+          <h1 className="mt-4 text-4xl font-black md:text-6xl">Operational governance toolkit for consultants, auditors, and enterprise buyers</h1>
+          <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
+            DSG provides working governance flows, evidence exports, deterministic controls, and audit-readiness frameworks for AI action deployment reviews.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Link href="/evidence-pack" className="rounded-xl bg-violet-400 px-5 py-3 font-bold text-black">Open evidence pack</Link>
+            <Link href="/controls" className="rounded-xl border border-violet-300/40 px-5 py-3 font-bold text-violet-100">Open controls</Link>
+            <Link href="/approvals?orgId=org-smoke" className="rounded-xl border border-violet-300/40 px-5 py-3 font-bold text-violet-100">Open approval queue</Link>
+          </div>
+        </section>
+        <section className="mt-8 grid gap-4 md:grid-cols-2">
+          {assets.map((asset) => (
+            <Link key={asset.href} href={asset.href} className="rounded-2xl border border-slate-800 bg-slate-900 p-6 hover:border-violet-400/50">
+              <h2 className="text-2xl font-bold">{asset.title}</h2>
+              <p className="mt-3 leading-7 text-slate-300">{asset.body}</p>
+              <p className="mt-4 font-bold text-violet-300">Open →</p>
+            </Link>
+          ))}
+        </section>
+        <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
+          <h2 className="text-2xl font-bold">Boundary</h2>
+          <p className="mt-3 leading-7 text-slate-300">
+            DSG consult and audit assets support governance and readiness assessment. They are not independent certification or legal compliance guarantees.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/consult-toolkit/audit-readiness-checklist.md
+++ b/docs/consult-toolkit/audit-readiness-checklist.md
@@ -1,0 +1,47 @@
+# DSG Audit Readiness Checklist
+
+Purpose: help a consultant or buyer verify that an AI action governance flow produces usable evidence before a pilot is considered complete.
+
+Boundary: this is an audit-readiness aid. It is not an independent audit, legal opinion, or certification report.
+
+## Completion rule
+
+A DSG consult/audit flow is complete only when all four questions can be answered:
+
+1. What benefit does the user get?
+2. Where does the user click or what command/API does the user run?
+3. What evidence proves the flow worked?
+4. Where is the tangible output?
+
+## Checklist
+
+| Area | Required evidence | Pass criteria | Status |
+|---|---|---|---|
+| Workflow scope | Workflow name, owner, tool/action | Workflow is clearly identified | Required |
+| Risk classification | Risk level and rationale | Low/medium/high/critical recorded | Required |
+| Pre-execution decision | DSG decision | allow/block/review visible | Required |
+| Approval workflow | approvalHash or rejection evidence | High-risk actions have reviewer evidence | Required for high/critical |
+| Request proof | requestHash | Hash exists before execution/audit commit | Required |
+| Result proof | recordHash | Hash exists after execution/audit commit | Required |
+| Evidence export | JSON export or bundle | Export can be downloaded/opened | Required |
+| Signed/hash bundle | bundleHash, eventHashes, signature metadata | Portable evidence package exists | Required |
+| Control mapping | DSG controls mapped to need | At least one control mapped per risk | Required |
+| Boundary statement | No certification overclaim | Page/report says support/aligned, not certified | Required |
+
+## Output package
+
+A completed pilot should produce:
+
+```text
+workflow-inventory.md
+risk-classification.md
+evidence-bundle.json
+approvalHash or review decision
+requestHash
+recordHash
+client-readiness-report.md
+```
+
+## Safe wording
+
+DSG provides audit-ready evidence for governed AI/tool execution workflows. It does not provide independent certification by itself.

--- a/docs/market-segments/segment-packaging.md
+++ b/docs/market-segments/segment-packaging.md
@@ -1,0 +1,61 @@
+# DSG Market Segment Packaging
+
+## Primary segments
+
+### 1. Enterprise AI Governance
+- Buyer: CIO, CISO, governance lead
+- Need: deterministic control layer before AI execution
+- Core assets:
+  - AI compliance page
+  - approval workflow
+  - evidence bundle
+  - deploy gate
+
+### 2. Compliance Consulting
+- Buyer: consultant, auditor, transformation partner
+- Need: repeatable audit-readiness toolkit
+- Core assets:
+  - consult toolkit
+  - audit checklist
+  - control templates
+  - evidence exports
+
+### 3. DevSecOps / CI-CD Governance
+- Buyer: engineering/security teams
+- Need: deterministic deploy blocking
+- Core assets:
+  - GitHub Marketplace action
+  - production gateway benchmark
+  - SMT2 invariants
+
+### 4. SaaS Governance Platform
+- Buyer: SMB to enterprise
+- Need: operational governance SaaS
+- Core assets:
+  - landing pages
+  - marketplace funnel
+  - pricing
+  - onboarding
+
+## Packaging rule
+
+Each segment must answer:
+
+```text
+What problem is solved?
+What route/product is used?
+What evidence proves value?
+What commercial artifact is sold?
+```
+
+## External validation roadmap
+
+Required next:
+
+- pilot case studies
+- customer testimonials
+- consultant deployment reports
+- benchmark reproducibility reports
+- optional third-party assessments
+
+Boundary: external validation assets increase trust but do not replace actual certification unless independently performed.

--- a/docs/trust/roadmap.md
+++ b/docs/trust/roadmap.md
@@ -1,0 +1,44 @@
+# DSG Buyer Trust Roadmap
+
+Purpose: define assets that make DSG easier to evaluate, pilot, and buy.
+
+## Current assets
+
+- benchmark reports
+- baseline comparison
+- runtime invariant evidence
+- production gateway evidence
+- consult toolkit
+- audit readiness checklist
+
+## Next assets
+
+- reproducibility report
+- pilot summary
+- partner deployment summary
+- signed benchmark bundle
+- operational controls summary
+- review summary
+- governance whitepaper
+
+## Completion rule
+
+Every trust asset must show:
+
+1. user benefit
+2. user action
+3. evidence produced
+4. tangible output
+
+## Claim boundary
+
+Use evidence-ready and governance-enabling language. Do not claim formal certification unless completed by the proper process.
+
+## Output packs
+
+```text
+case-study-pack
+reproducibility-report
+customer-reference-pack
+security-review-pack
+```


### PR DESCRIPTION
Builds out missing Phase 3 and Phase 4 foundation assets.

Included:
- /consult landing page for consultants, auditors, and enterprise buyers
- audit readiness checklist with flow-completion and evidence requirements
- market segment packaging for enterprise, consulting, DevSecOps, and SaaS
- buyer trust roadmap for stronger commercial validation assets

User outcome:
- Benefit: converts DSG from technical governance demo into consult-ready and commercial-ready product packaging.
- Action: users can open /consult and use packaged audit/commercial assets.
- Evidence: checklist, segment docs, and trust roadmap create repeatable buyer and deployment artifacts.
- Tangible output: working consult route plus reusable documentation packs.