### PR TITLE
Build Phase 5 trust and external validation routes

### DIFF
--- a/app/reproducibility/page.tsx
+++ b/app/reproducibility/page.tsx
@@ -1,0 +1,28 @@
+export default function ReproducibilityPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
+      <div className="mx-auto max-w-5xl rounded-3xl border border-cyan-500/30 bg-slate-900 p-10">
+        <p className="text-sm uppercase tracking-[0.25em] text-cyan-300">Reproducibility Report</p>
+        <h1 className="mt-4 text-5xl font-black">Reproduce DSG core evidence</h1>
+        <p className="mt-6 text-lg leading-8 text-slate-300">
+          Users can independently reproduce core governance routes, deploy gate checks, and UX route verification.
+        </p>
+
+        <div className="mt-8 rounded-2xl bg-slate-950 p-6 font-mono text-sm leading-7 text-cyan-200">
+          npm run ux:routes{`\n`}
+          curl -I /controls{`\n`}
+          curl -I /approvals?orgId=org-smoke{`\n`}
+          curl -I /evidence-pack{`\n`}
+          verify bundleHash / requestHash / recordHash
+        </div>
+
+        <section className="mt-8 space-y-4 text-slate-300">
+          <p><strong>User benefit:</strong> Buyers and reviewers can verify repeatable governance behavior.</p>
+          <p><strong>Real action:</strong> Run checks and inspect routes.</p>
+          <p><strong>Evidence:</strong> Route verifier output, hashes, signed bundle.</p>
+          <p><strong>Tangible output:</strong> Reproducibility report plus evidence artifacts.</p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/security-review/page.tsx
+++ b/app/security-review/page.tsx
@@ -1,0 +1,19 @@
+export default function SecurityReviewPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
+      <div className="mx-auto max-w-5xl rounded-3xl border border-rose-500/20 bg-slate-900 p-10">
+        <p className="text-sm uppercase tracking-[0.25em] text-rose-300">Security Review</p>
+        <h1 className="mt-4 text-5xl font-black">Security review boundary and hardening roadmap</h1>
+        <ul className="mt-8 space-y-4 text-lg leading-8 text-slate-300">
+          <li>Current deterministic controls</li>
+          <li>Evidence integrity model</li>
+          <li>Protected route behavior</li>
+          <li>Approval governance</li>
+          <li>Deploy gate coverage</li>
+          <li>Future independent review path</li>
+        </ul>
+        <p className="mt-8 text-slate-400">This route documents security posture and review path; it is not itself an outside audit.</p>
+      </div>
+    </main>
+  );
+}

--- a/app/trust/page.tsx
+++ b/app/trust/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+
+const routes = [
+  { href: "/case-studies", title: "Case Studies", body: "Pilot and buyer story structure for external proof." },
+  { href: "/reproducibility", title: "Reproducibility", body: "How to reproduce benchmark, UX, and evidence checks." },
+  { href: "/security-review", title: "Security Review", body: "Security review scope, evidence boundaries, and next trust steps." },
+  { href: "/customer-reference", title: "Customer Reference", body: "Reference-pack structure for pilots, partners, and enterprise buyers." },
+  { href: "/marketplace/production-evidence", title: "Production Evidence", body: "Current benchmark and runtime evidence already published." },
+  { href: "/evidence-pack", title: "Evidence Pack", body: "Signed/hash evidence bundle for audit-ready review." },
+];
+
+export default function TrustPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
+      <div className="mx-auto max-w-6xl">
+        <section className="rounded-3xl border border-emerald-500/30 bg-emerald-500/10 p-8 md:p-12">
+          <p className="text-sm uppercase tracking-[0.25em] text-emerald-300">Phase 5 External Trust</p>
+          <h1 className="mt-4 text-4xl font-black md:text-6xl">Buyer trust and external validation hub</h1>
+          <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
+            DSG trust assets help buyers, consultants, and reviewers verify what exists today, reproduce core evidence, and understand what still requires external validation.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Link href="/reproducibility" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Run reproducibility path</Link>
+            <Link href="/case-studies" className="rounded-xl border border-emerald-300/40 px-5 py-3 font-bold text-emerald-100">Open case-study pack</Link>
+            <Link href="/evidence-pack" className="rounded-xl border border-slate-700 px-5 py-3 font-bold text-slate-200">Open evidence pack</Link>
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-4 md:grid-cols-2">
+          {routes.map((route) => (
+            <Link key={route.href} href={route.href} className="rounded-2xl border border-slate-800 bg-slate-900 p-6 hover:border-emerald-400/50">
+              <h2 className="text-2xl font-bold text-white">{route.title}</h2>
+              <p className="mt-3 leading-7 text-slate-300">{route.body}</p>
+              <p className="mt-4 font-bold text-emerald-300">Open →</p>
+            </Link>
+          ))}
+        </section>
+
+        <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
+          <h2 className="text-2xl font-bold">Boundary</h2>
+          <p className="mt-3 leading-7 text-slate-300">
+            This hub organizes validation assets. It does not claim independent third-party certification, completed outside audit, or guaranteed compliance.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Adds missing external trust infrastructure for roadmap completion.

Included:
- /trust hub
- /reproducibility route
- /security-review route
- links to case-study/customer reference structure

User outcome:
- Benefit: buyers and reviewers can access trust assets directly
- Action: open trust routes and reproduce evidence
- Evidence: trust pages plus reproducibility workflows
- Tangible output: live external validation infrastructure scaffold

Boundary:
No false certification claims; trust assets are structured for real external validation growth.