### PR TITLE
Map Z3 deterministic proof module into DSG backend

### DIFF
--- a/app/api/dsg/v1/gates/evaluate/route.ts
+++ b/app/api/dsg/v1/gates/evaluate/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { evaluateDeterministicGate } from '../../../../../../lib/dsg/deterministic/gate-engine';
+import type { DeterministicProofRequest } from '../../../../../../lib/dsg/deterministic/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null) as Partial<DeterministicProofRequest> | null;
+
+  if (!body || !body.context || typeof body.context !== 'object') {
+    return NextResponse.json({ ok: false, error: 'missing_context' }, { status: 400 });
+  }
+
+  const result = evaluateDeterministicGate({
+    planId: body.planId,
+    policyRef: body.policyRef,
+    policyVersion: body.policyVersion,
+    riskLevel: body.riskLevel,
+    previousProofHash: body.previousProofHash,
+    context: body.context,
+  });
+
+  return NextResponse.json({
+    ok: result.ok,
+    type: 'dsg-deterministic-gate-decision',
+    gateStatus: result.gateStatus,
+    proofStatus: result.proofStatus,
+    riskLevel: result.riskLevel,
+    reason: result.reason ?? null,
+    proof: result.proof,
+    boundary: {
+      statement: 'DSG-native deterministic gate adapter. UNSUPPORTED is never PASS. External Z3 solver is not invoked by this route.',
+      externalSolverInvoked: false,
+      productionReadyClaim: false,
+    },
+  });
+}

--- a/app/api/dsg/v1/proofs/prove/route.ts
+++ b/app/api/dsg/v1/proofs/prove/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { proveDeterministicPlan } from '../../../../../../lib/dsg/deterministic/proof-engine';
+import type { DeterministicProofRequest } from '../../../../../../lib/dsg/deterministic/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null) as Partial<DeterministicProofRequest> | null;
+
+  if (!body || !body.context || typeof body.context !== 'object') {
+    return NextResponse.json({ ok: false, error: 'missing_context' }, { status: 400 });
+  }
+
+  const proof = proveDeterministicPlan({
+    planId: body.planId,
+    policyRef: body.policyRef,
+    policyVersion: body.policyVersion,
+    riskLevel: body.riskLevel,
+    previousProofHash: body.previousProofHash,
+    context: body.context,
+  });
+
+  return NextResponse.json({
+    ok: proof.status === 'PASS',
+    type: 'dsg-deterministic-proof',
+    proof,
+    boundary: {
+      statement: 'DSG-native deterministic proof adapter. External Z3 solver is not invoked by this route.',
+      externalSolverInvoked: false,
+      productionReadyClaim: false,
+    },
+  });
+}

--- a/docs/deterministic/z3-backend-mapping.md
+++ b/docs/deterministic/z3-backend-mapping.md
@@ -1,0 +1,107 @@
+# DSG Z3 Deterministic Backend Mapping
+
+Purpose: map the uploaded `z3-logic-deterministic.zip` into the existing DSG backend as a controlled deterministic proof and gate module.
+
+## Integration position
+
+```text
+Agent / Operator Action
+→ DSG Intake & Validation
+→ DSG Policy Engine
+→ DSG Deterministic Proof Engine
+→ DSG Gate Decision
+→ DSG Execution Orchestrator
+→ DSG Audit Ledger / Evidence Export
+```
+
+## What was added
+
+```text
+lib/dsg/deterministic/types.ts
+lib/dsg/deterministic/proof-hash.ts
+lib/dsg/deterministic/proof-engine.ts
+lib/dsg/deterministic/gate-engine.ts
+app/api/dsg/v1/proofs/prove/route.ts
+app/api/dsg/v1/gates/evaluate/route.ts
+```
+
+## API routes
+
+Create a deterministic proof:
+
+```text
+POST /api/dsg/v1/proofs/prove
+```
+
+Evaluate a deterministic gate:
+
+```text
+POST /api/dsg/v1/gates/evaluate
+```
+
+## Example request
+
+```bash
+curl -X POST https://your-domain.example.com/api/dsg/v1/gates/evaluate \
+  -H "content-type: application/json" \
+  -d '{
+    "planId": "PLAN-Z3-001",
+    "riskLevel": "high",
+    "context": {
+      "requirement_clear": true,
+      "tool_available": true,
+      "permission_granted": true,
+      "secret_bound": true,
+      "dependency_resolved": true,
+      "testable": true,
+      "deploy_target_ready": true,
+      "audit_hook_available": true
+    }
+  }'
+```
+
+Expected pass result:
+
+```text
+gateStatus: PASS
+proofStatus: PASS
+proofHash: present
+inputHash: present
+constraintSetHash: present
+```
+
+## Critical invariant
+
+```text
+UNSUPPORTED is never PASS.
+```
+
+## Boundary
+
+This is a DSG-native TypeScript static-check adapter mapped from the uploaded Z3 module. It does not invoke an external Z3 solver yet.
+
+Do not claim:
+
+```text
+external Z3 solver invoked
+enterprise-ready proof system
+third-party certified evidence system
+```
+
+Allowed wording:
+
+```text
+DSG has a deterministic proof/gate backend scaffold mapped from the Z3 module, with proofHash, inputHash, constraintSetHash, structured failures, and gate decision API.
+```
+
+## Production hardening still required
+
+```text
+real Ed25519/ECDSA signing
+Postgres append-only or WORM evidence storage
+policy manifest storage
+actual solver adapter and solver version detection
+JWT/JWKS auth
+replay protection with nonce/requestHash/idempotency key
+CI gates for lint/typecheck/unit/API/chain verification
+```

--- a/lib/dsg/deterministic/gate-engine.ts
+++ b/lib/dsg/deterministic/gate-engine.ts
@@ -1,0 +1,31 @@
+import type { DeterministicGateDecision, DeterministicProof, DeterministicProofStatus, DeterministicRiskLevel } from './types';
+import { proveDeterministicPlan } from './proof-engine';
+import type { DeterministicProofRequest } from './types';
+
+export function proofToGateStatus(
+  proofStatus: DeterministicProofStatus,
+  riskLevel: DeterministicRiskLevel
+): 'PASS' | 'BLOCK' | 'REVIEW' {
+  if (proofStatus === 'PASS') return 'PASS';
+  if (proofStatus === 'BLOCK') return 'BLOCK';
+  if (proofStatus === 'REVIEW') return 'REVIEW';
+  if (proofStatus === 'UNSUPPORTED') {
+    return riskLevel === 'low' ? 'REVIEW' : 'BLOCK';
+  }
+  return 'BLOCK';
+}
+
+export function evaluateDeterministicGate(request: DeterministicProofRequest): DeterministicGateDecision {
+  const riskLevel = request.riskLevel ?? 'medium';
+  const proof: DeterministicProof = proveDeterministicPlan(request);
+  const gateStatus = proofToGateStatus(proof.status, riskLevel);
+
+  return {
+    ok: gateStatus === 'PASS',
+    gateStatus,
+    proofStatus: proof.status,
+    riskLevel,
+    reason: gateStatus === 'PASS' ? undefined : proof.failureReasons[0]?.code ?? 'deterministic_gate_not_passed',
+    proof,
+  };
+}

--- a/lib/dsg/deterministic/proof-engine.ts
+++ b/lib/dsg/deterministic/proof-engine.ts
@@ -1,0 +1,158 @@
+import crypto from 'node:crypto';
+import type {
+  DeterministicConstraintResult,
+  DeterministicFailureReason,
+  DeterministicProof,
+  DeterministicProofRequest,
+  DeterministicProofStatus,
+  DeterministicRiskLevel,
+} from './types';
+import { buildConstraintSetHash, buildProofHash, hashDeterministicValue } from './proof-hash';
+
+const CONSTRAINTS = [
+  {
+    constraintId: 'requirement_clear',
+    name: 'Requirement must be clear',
+    severity: 'high' as DeterministicRiskLevel,
+    evidenceKey: 'requirement_clear',
+    message: 'Requirement is missing or ambiguous.',
+  },
+  {
+    constraintId: 'tool_available',
+    name: 'Tool must be available',
+    severity: 'critical' as DeterministicRiskLevel,
+    evidenceKey: 'tool_available',
+    message: 'Requested tool is not available.',
+  },
+  {
+    constraintId: 'permission_granted',
+    name: 'Permission must be granted',
+    severity: 'critical' as DeterministicRiskLevel,
+    evidenceKey: 'permission_granted',
+    message: 'Actor does not have permission.',
+  },
+  {
+    constraintId: 'secret_bound',
+    name: 'Secret boundary must be satisfied',
+    severity: 'critical' as DeterministicRiskLevel,
+    evidenceKey: 'secret_bound',
+    message: 'Secret binding is missing.',
+  },
+  {
+    constraintId: 'dependency_resolved',
+    name: 'Dependencies must be resolved',
+    severity: 'high' as DeterministicRiskLevel,
+    evidenceKey: 'dependency_resolved',
+    message: 'Dependencies are unresolved.',
+  },
+  {
+    constraintId: 'testable',
+    name: 'Action must be testable',
+    severity: 'medium' as DeterministicRiskLevel,
+    evidenceKey: 'testable',
+    message: 'Action has no testable path.',
+  },
+  {
+    constraintId: 'deploy_target_ready',
+    name: 'Deploy target must be ready',
+    severity: 'high' as DeterministicRiskLevel,
+    evidenceKey: 'deploy_target_ready',
+    message: 'Deploy target is not ready.',
+  },
+  {
+    constraintId: 'audit_hook_available',
+    name: 'Audit hook must be available',
+    severity: 'critical' as DeterministicRiskLevel,
+    evidenceKey: 'audit_hook_available',
+    message: 'Audit hook is unavailable.',
+  },
+];
+
+function boolValue(context: Record<string, unknown>, key: string) {
+  return context[key] === true;
+}
+
+function statusFromFailures(failures: DeterministicFailureReason[]): DeterministicProofStatus {
+  if (failures.some((failure) => failure.severity === 'critical')) return 'BLOCK';
+  if (failures.some((failure) => failure.severity === 'high')) return 'REVIEW';
+  if (failures.length > 0) return 'REVIEW';
+  return 'PASS';
+}
+
+export function proveDeterministicPlan(request: DeterministicProofRequest): DeterministicProof {
+  const timestamp = new Date().toISOString();
+  const proofId = `dpf_${crypto.randomBytes(16).toString('hex')}`;
+  const policyRef = request.policyRef ?? 'dsg.deterministic.default';
+  const policyVersion = request.policyVersion ?? '1.0';
+  const context = request.context ?? {};
+
+  const constraints: DeterministicConstraintResult[] = CONSTRAINTS.map((constraint) => {
+    const passed = boolValue(context, constraint.evidenceKey);
+    return {
+      ...constraint,
+      passed,
+    };
+  });
+
+  const failureReasons = constraints
+    .filter((constraint) => !constraint.passed)
+    .map((constraint) => ({
+      code: constraint.constraintId,
+      message: constraint.message,
+      constraintId: constraint.constraintId,
+      severity: constraint.severity,
+    }));
+
+  const status = statusFromFailures(failureReasons);
+  const inputHash = hashDeterministicValue({
+    planId: request.planId ?? null,
+    context,
+    policyRef,
+    policyVersion,
+    riskLevel: request.riskLevel ?? 'medium',
+  });
+  const constraintSetHash = buildConstraintSetHash(CONSTRAINTS.map((constraint) => constraint.constraintId));
+  const proofHash = buildProofHash({
+    proofId,
+    status,
+    timestamp,
+    solver: { name: 'static_check', version: 'dsg-deterministic-ts-1.0' },
+    policyRef,
+    policyVersion,
+    constraintsChecked: constraints.length,
+    inputHash,
+    constraintSetHash,
+    previousProofHash: request.previousProofHash,
+    failureReasons,
+    constraints,
+  });
+
+  return {
+    proofId,
+    status,
+    timestamp,
+    solver: {
+      name: 'static_check',
+      version: 'dsg-deterministic-ts-1.0',
+    },
+    policyRef,
+    policyVersion,
+    constraintsChecked: constraints.length,
+    inputHash,
+    constraintSetHash,
+    proofHash,
+    previousProofHash: request.previousProofHash,
+    model: {
+      planId: request.planId ?? null,
+      riskLevel: request.riskLevel ?? 'medium',
+    },
+    failureReasons,
+    constraints,
+    evidenceBoundary: {
+      statement:
+        'This DSG-native deterministic proof is a TypeScript static-check adapter mapped from the Z3 module. It does not claim that an external Z3 solver was invoked.',
+      externalSolverInvoked: false,
+      productionReadyClaim: false,
+    },
+  };
+}

--- a/lib/dsg/deterministic/proof-hash.ts
+++ b/lib/dsg/deterministic/proof-hash.ts
@@ -1,0 +1,34 @@
+import { hashGatewayValue } from '../../gateway/audit';
+
+export function hashDeterministicValue(value: unknown) {
+  return hashGatewayValue(value);
+}
+
+export function buildConstraintSetHash(constraintIds: string[]) {
+  return hashDeterministicValue({
+    type: 'dsg-deterministic-constraint-set',
+    version: '1.0',
+    constraintIds: [...constraintIds].sort(),
+  });
+}
+
+export function buildProofHash(input: {
+  proofId: string;
+  status: string;
+  timestamp: string;
+  solver: unknown;
+  policyRef: string;
+  policyVersion: string;
+  constraintsChecked: number;
+  inputHash: string;
+  constraintSetHash: string;
+  previousProofHash?: string;
+  failureReasons: unknown[];
+  constraints: unknown[];
+}) {
+  return hashDeterministicValue({
+    type: 'dsg-deterministic-proof',
+    version: '1.0',
+    ...input,
+  });
+}

--- a/lib/dsg/deterministic/types.ts
+++ b/lib/dsg/deterministic/types.ts
@@ -1,0 +1,63 @@
+export type DeterministicProofStatus = 'PASS' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED';
+export type DeterministicSolverName = 'z3' | 'rule_engine' | 'static_check' | 'none';
+export type DeterministicGateStatus = 'PASS' | 'BLOCK' | 'REVIEW';
+export type DeterministicRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export type DeterministicFailureReason = {
+  code: string;
+  message: string;
+  constraintId?: string;
+  severity: DeterministicRiskLevel;
+};
+
+export type DeterministicConstraintResult = {
+  constraintId: string;
+  name: string;
+  passed: boolean;
+  severity: DeterministicRiskLevel;
+  evidenceKey: string;
+  message: string;
+};
+
+export type DeterministicProof = {
+  proofId: string;
+  status: DeterministicProofStatus;
+  timestamp: string;
+  solver: {
+    name: DeterministicSolverName;
+    version: string;
+  };
+  policyRef: string;
+  policyVersion: string;
+  constraintsChecked: number;
+  inputHash: string;
+  constraintSetHash: string;
+  proofHash: string;
+  previousProofHash?: string;
+  model?: Record<string, unknown>;
+  failureReasons: DeterministicFailureReason[];
+  constraints: DeterministicConstraintResult[];
+  evidenceBoundary: {
+    statement: string;
+    externalSolverInvoked: boolean;
+    productionReadyClaim: boolean;
+  };
+};
+
+export type DeterministicProofRequest = {
+  planId?: string;
+  policyRef?: string;
+  policyVersion?: string;
+  riskLevel?: DeterministicRiskLevel;
+  previousProofHash?: string;
+  context: Record<string, unknown>;
+};
+
+export type DeterministicGateDecision = {
+  ok: boolean;
+  gateStatus: DeterministicGateStatus;
+  proofStatus: DeterministicProofStatus;
+  riskLevel: DeterministicRiskLevel;
+  reason?: string;
+  proof: DeterministicProof;
+};

--- a/lib/dsg/deterministic/types.ts
+++ b/lib/dsg/deterministic/types.ts
@@ -1,7 +1,15 @@
 export type DeterministicProofStatus = 'PASS' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED';
 export type DeterministicSolverName = 'z3' | 'rule_engine' | 'static_check' | 'none';
+
+// Canonical DSG gate output intentionally excludes UNSUPPORTED.
+// UNSUPPORTED can appear in a proof, but the gate must convert it to REVIEW or BLOCK.
 export type DeterministicGateStatus = 'PASS' | 'BLOCK' | 'REVIEW';
 export type DeterministicRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+// Compatibility aliases for the uploaded ZIP/UI vocabulary.
+export type ProofStatus = DeterministicProofStatus;
+export type GateStatus = DeterministicGateStatus;
+export type LegacyZipGateStatus = DeterministicProofStatus;
 
 export type DeterministicFailureReason = {
   code: string;
@@ -43,6 +51,73 @@ export type DeterministicProof = {
     productionReadyClaim: boolean;
   };
 };
+
+// Original ZIP proof shape. Kept for adapter/UI migration only.
+// Canonical DSG proof should use DeterministicProof above.
+export interface LegacyZipDeterministicProof {
+  status: ProofStatus;
+  timestamp: string;
+  solverVersion: string;
+  constraintsChecked: number;
+  model?: Record<string, string>;
+  failureReasons: string[];
+  hashChain: string;
+}
+
+export type AuditDecision = 'allow' | 'deny' | 'review' | 'block';
+export type ResourceClassification = 'public' | 'internal' | 'secret' | 'top_secret';
+
+export interface DeterministicAuditEntry {
+  entryId: string;
+  timestamp: string;
+  action: string;
+  actor: {
+    userId: string;
+    sessionId: string;
+    ipAddress: string;
+    deviceFingerprint: string;
+    role: string;
+  };
+  resource: {
+    type: string;
+    id: string;
+    classification: ResourceClassification;
+  };
+  decision: AuditDecision;
+  policyRef: string;
+  policyVersion: string;
+  proofHash: string;
+  previousHash: string;
+  currentHash: string;
+  signature: string;
+  metadata?: Record<string, unknown>;
+}
+
+// Original ZIP audit shape. Kept for adapter/UI migration only.
+// z3ProofHash should be renamed to proofHash when written into DSG evidence.
+export interface LegacyZipAuditEntry {
+  entryId: string;
+  timestamp: string;
+  action: string;
+  actor: {
+    userId: string;
+    sessionId: string;
+    ipAddress: string;
+    deviceFingerprint: string;
+    role: string;
+  };
+  resource: {
+    type: string;
+    id: string;
+    classification: ResourceClassification;
+  };
+  decision: AuditDecision;
+  policyRef: string;
+  z3ProofHash: string;
+  previousHash: string;
+  currentHash: string;
+  signature: string;
+}
 
 export type DeterministicProofRequest = {
   planId?: string;


### PR DESCRIPTION
Maps the uploaded z3-logic-deterministic module into the existing DSG backend as a DSG-native deterministic proof and gate scaffold instead of importing the standalone FastAPI app directly.

Included:
- Deterministic proof types
- Stable proof/input/constraint hash helpers
- Static-check deterministic proof engine
- Gate engine with UNSUPPORTED-is-never-PASS invariant
- POST /api/dsg/v1/proofs/prove
- POST /api/dsg/v1/gates/evaluate
- Backend mapping documentation and production boundary

User outcome:
- Benefit: users can request deterministic proof/gate decisions from the existing DSG backend.
- Action: POST proof/gate context to the new DSG API routes.
- Evidence: response includes proofHash, inputHash, constraintSetHash, structured constraints, and failure reasons.
- Tangible output: JSON proof and gate decision that can be wired into DSG audit/evidence flows.

Boundary:
This is a DSG-native static-check adapter mapped from the Z3 module. It does not claim external Z3 solver invocation or enterprise-ready proof evidence until production hardening is completed.