### PR TITLE
Phase 2: add DSG ONE reusable UX governance components

### DIFF
--- a/components/ActionPathGraph.tsx
+++ b/components/ActionPathGraph.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { GateStatus } from "./StatusBadge";
+
+type ActionPathNode = {
+  id: string;
+  title: string;
+  subtitle: string;
+};
+
+type ActionPathGraphProps = {
+  actor: ActionPathNode;
+  action: ActionPathNode;
+  policies: ActionPathNode[];
+  gateResult: GateStatus;
+  finalDecision: string;
+  demoLabel?: string;
+};
+
+export function ActionPathGraph({ actor, action, policies, gateResult, finalDecision, demoLabel }: ActionPathGraphProps) {
+  return (
+    <section className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-slate-100">Action path graph</h3>
+        {demoLabel ? <span className="text-xs text-slate-300">Demo data: {demoLabel}</span> : null}
+      </div>
+      <div className="grid grid-cols-1 gap-2 text-xs text-slate-200 md:grid-cols-4">
+        <Node label="Actor" node={actor} />
+        <Node label="Requested action" node={action} />
+        <div className="rounded border border-slate-700 p-2">
+          <p className="mb-1 text-[11px] uppercase tracking-wide text-slate-400">Policy checks</p>
+          <ul className="space-y-1">
+            {policies.map((policy) => (
+              <li key={policy.id}>{policy.title}: {policy.subtitle}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded border border-slate-700 p-2">
+          <p className="mb-1 text-[11px] uppercase tracking-wide text-slate-400">Gate outcome</p>
+          <p>{gateResult}</p>
+          <p className="text-slate-400">Final decision: {finalDecision}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Node({ label, node }: { label: string; node: ActionPathNode }) {
+  return (
+    <div className="rounded border border-slate-700 p-2">
+      <p className="mb-1 text-[11px] uppercase tracking-wide text-slate-400">{label}</p>
+      <p>{node.title}</p>
+      <p className="text-slate-400">{node.subtitle}</p>
+    </div>
+  );
+}

--- a/components/AuditExportPanel.tsx
+++ b/components/AuditExportPanel.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+type AuditExportFormat = "JSON" | "CSV" | "PDF";
+
+type AuditExportPanelProps = {
+  availableFormats: AuditExportFormat[];
+  bundleLabel: string;
+  exportTimestamp: string;
+  packHash?: string;
+  demoLabel?: string;
+};
+
+export function AuditExportPanel({ availableFormats, bundleLabel, exportTimestamp, packHash, demoLabel }: AuditExportPanelProps) {
+  return (
+    <section className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-slate-100">Audit evidence export</h3>
+        {demoLabel ? <span className="text-xs text-slate-300">Demo data: {demoLabel}</span> : null}
+      </div>
+      <p className="text-sm text-slate-200">Bundle: {bundleLabel}</p>
+      <p className="mt-1 text-xs text-slate-400">Export timestamp: {exportTimestamp}</p>
+      <p className="mt-1 text-xs text-slate-400">Pack hash: {packHash ?? "missing"}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {availableFormats.map((format) => (
+          <button
+            type="button"
+            key={format}
+            className="rounded border border-slate-600 px-3 py-1 text-xs text-slate-200"
+            aria-label={`Export ${bundleLabel} as ${format}`}
+          >
+            Export {format}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/ConstraintChecklist.tsx
+++ b/components/ConstraintChecklist.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export type ConstraintState = "pass" | "fail" | "review";
+
+type ConstraintItem = {
+  id: string;
+  label: string;
+  detail: string;
+  state: ConstraintState;
+};
+
+type ConstraintChecklistProps = {
+  items: ConstraintItem[];
+  demoLabel?: string;
+};
+
+const stateLabel: Record<ConstraintState, string> = {
+  pass: "PASS",
+  fail: "BLOCK",
+  review: "REVIEW"
+};
+
+export function ConstraintChecklist({ items, demoLabel }: ConstraintChecklistProps) {
+  return (
+    <section className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-slate-100">Constraints checked</h3>
+        {demoLabel ? <span className="text-xs text-slate-300">Demo data: {demoLabel}</span> : null}
+      </div>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id} className="rounded border border-slate-700 p-2">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm text-slate-100">{item.label}</p>
+              <span className="text-xs font-semibold text-slate-300">{stateLabel[item.state]}</span>
+            </div>
+            <p className="mt-1 text-xs text-slate-400">{item.detail}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/components/EvidenceDrawer.tsx
+++ b/components/EvidenceDrawer.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+export type EvidenceAvailability = "present" | "missing" | "planned" | "unsupported";
+
+type EvidenceField = {
+  key: string;
+  label: string;
+  availability: EvidenceAvailability;
+  detail: string;
+};
+
+type EvidenceDrawerProps = {
+  title?: string;
+  fields: EvidenceField[];
+  demoLabel?: string;
+};
+
+const availabilityClass: Record<EvidenceAvailability, string> = {
+  present: "text-emerald-300",
+  missing: "text-rose-300",
+  planned: "text-amber-300",
+  unsupported: "text-slate-300"
+};
+
+export function EvidenceDrawer({ title = "Evidence", fields, demoLabel }: EvidenceDrawerProps) {
+  return (
+    <aside className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-slate-100">{title}</h3>
+        {demoLabel ? <span className="text-xs text-slate-300">Demo data: {demoLabel}</span> : null}
+      </div>
+      <ul className="space-y-2">
+        {fields.map((field) => (
+          <li key={field.key} className="rounded border border-slate-700 p-2">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm text-slate-100">{field.label}</p>
+              <span className={`text-xs uppercase ${availabilityClass[field.availability]}`}>{field.availability}</span>
+            </div>
+            <p className="mt-1 text-xs text-slate-400">{field.detail}</p>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/components/GateResultCard.tsx
+++ b/components/GateResultCard.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { GateStatus, StatusBadge } from "./StatusBadge";
+
+type GateResultCardProps = {
+  status: GateStatus;
+  summary: string;
+  reason?: string;
+  nextReviewerOrAction?: string;
+  ruleRefs?: string[];
+  demoLabel?: string;
+};
+
+export function GateResultCard({
+  status,
+  summary,
+  reason,
+  nextReviewerOrAction,
+  ruleRefs = [],
+  demoLabel
+}: GateResultCardProps) {
+  const statusExplanation =
+    status === "PASS"
+      ? `Passed because ${summary}`
+      : status === "BLOCK"
+        ? `Blocked because ${reason ?? summary}`
+        : status === "REVIEW"
+          ? `Review required: ${nextReviewerOrAction ?? "next reviewer not specified"}`
+          : `Unsupported because ${reason ?? "required connector or policy capability is unavailable"}`;
+
+  return (
+    <article className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <StatusBadge status={status} explanation={statusExplanation} />
+        {demoLabel ? <span className="rounded border border-slate-600 px-2 py-1 text-xs text-slate-300">Demo: {demoLabel}</span> : null}
+      </div>
+      <p className="text-sm text-slate-100">{summary}</p>
+      {reason ? <p className="mt-2 text-sm text-slate-300">Reason: {reason}</p> : null}
+      {status === "REVIEW" ? (
+        <p className="mt-2 text-sm text-amber-200">Next reviewer/action required: {nextReviewerOrAction ?? "TBD"}</p>
+      ) : null}
+      {ruleRefs.length > 0 ? (
+        <div className="mt-3">
+          <p className="text-xs uppercase tracking-wide text-slate-400">Rule references</p>
+          <ul className="mt-1 list-inside list-disc text-sm text-slate-300">
+            {ruleRefs.map((ruleRef) => (
+              <li key={ruleRef}>{ruleRef}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+export type GateStatus = "PASS" | "BLOCK" | "REVIEW" | "UNSUPPORTED";
+
+type StatusBadgeProps = {
+  status: GateStatus;
+  explanation: string;
+  className?: string;
+};
+
+const STYLES: Record<GateStatus, string> = {
+  PASS: "border-emerald-400/50 bg-emerald-900/30 text-emerald-100",
+  BLOCK: "border-rose-400/60 bg-rose-900/30 text-rose-100",
+  REVIEW: "border-amber-400/60 bg-amber-900/30 text-amber-100",
+  UNSUPPORTED: "border-slate-500/60 bg-slate-800 text-slate-200"
+};
+
+export function StatusBadge({ status, explanation, className }: StatusBadgeProps) {
+  return (
+    <div className={`inline-flex items-start gap-2 rounded-md border px-3 py-2 ${STYLES[status]} ${className ?? ""}`}>
+      <span className="text-xs font-semibold tracking-wide">{status}</span>
+      <span className="text-xs leading-5">{explanation}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Implement the Phase 2 UX foundation to provide reusable UI building blocks for the DSG ONE runtime governance gateway.
- Use `docs/product/DSG_ONE_UI_UX_BLUEPRINT.md` as the source of truth to ensure decision semantics and evidence-first posture are enforced.
- Add front-end components only and avoid any backend, route, env, package, or schema changes per the Phase 2 constraints.

### Description
- Added six shared components under `components/`: `StatusBadge`, `GateResultCard`, `ConstraintChecklist`, `ActionPathGraph`, `EvidenceDrawer`, and `AuditExportPanel`. 
- Enforced status semantics so `PASS` displays label + explanation, `BLOCK` shows label + reason, `REVIEW` surfaces next reviewer/action, and `UNSUPPORTED` uses neutral/low-emphasis styling and never success visuals. 
- Implemented evidence availability states (`present`, `missing`, `planned`, `unsupported`) and added an optional `demoLabel` prop on components to clearly mark demo/static usage. 
- Respected scope rules by not modifying API behavior, routes, environment, package versions, database/schema/auth/deployment configuration, or removing tests.

### Testing
- Ran `npm run ux:routes` which passed route verification with no failures. 
- Ran `npm run build` which completed successfully producing static/dynamic pages, with a non-blocking third-party instrumentation warning from Prisma/OpenTelemetry observed but not affecting the build outcome. 
- No existing tests were removed or changed as part of this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c0f6c21483289de9f20bfb3a98f4)