### PR TITLE
Phase 2.1: tighten DSG ONE UX safety and truth-boundary semantics

### DIFF
--- a/components/ActionPathGraph.tsx
+++ b/components/ActionPathGraph.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GateStatus } from "./StatusBadge";
+import { GateStatus, StatusBadge } from "./StatusBadge";
 
 type ActionPathNode = {
   id: string;
@@ -36,8 +36,7 @@ export function ActionPathGraph({ actor, action, policies, gateResult, finalDeci
         </div>
         <div className="rounded border border-slate-700 p-2">
           <p className="mb-1 text-[11px] uppercase tracking-wide text-slate-400">Gate outcome</p>
-          <p>{gateResult}</p>
-          <p className="text-slate-400">Final decision: {finalDecision}</p>
+          <StatusBadge status={gateResult} explanation={`Final decision: ${finalDecision}`} />
         </div>
       </div>
     </section>

--- a/components/AuditExportPanel.tsx
+++ b/components/AuditExportPanel.tsx
@@ -1,16 +1,23 @@
 import React from "react";
 
 type AuditExportFormat = "JSON" | "CSV" | "PDF";
+type ExportAvailability = "available" | "planned" | "unsupported";
+
+type AvailableFormat = {
+  label: AuditExportFormat;
+  availability: ExportAvailability;
+};
 
 type AuditExportPanelProps = {
-  availableFormats: AuditExportFormat[];
+  availableFormats: AvailableFormat[];
   bundleLabel: string;
   exportTimestamp: string;
   packHash?: string;
   demoLabel?: string;
+  onExport?: (format: AuditExportFormat) => void;
 };
 
-export function AuditExportPanel({ availableFormats, bundleLabel, exportTimestamp, packHash, demoLabel }: AuditExportPanelProps) {
+export function AuditExportPanel({ availableFormats, bundleLabel, exportTimestamp, packHash, demoLabel, onExport }: AuditExportPanelProps) {
   return (
     <section className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
       <div className="mb-3 flex items-center justify-between gap-2">
@@ -19,16 +26,24 @@ export function AuditExportPanel({ availableFormats, bundleLabel, exportTimestam
       </div>
       <p className="text-sm text-slate-200">Bundle: {bundleLabel}</p>
       <p className="mt-1 text-xs text-slate-400">Export timestamp: {exportTimestamp}</p>
-      <p className="mt-1 text-xs text-slate-400">Pack hash: {packHash ?? "missing"}</p>
+      <p className="mt-1 text-xs text-slate-400">
+        Pack hash: {packHash ? `present (${packHash})` : "missing — export evidence is incomplete"}
+      </p>
       <div className="mt-3 flex flex-wrap gap-2">
         {availableFormats.map((format) => (
           <button
             type="button"
-            key={format}
-            className="rounded border border-slate-600 px-3 py-1 text-xs text-slate-200"
-            aria-label={`Export ${bundleLabel} as ${format}`}
+            key={format.label}
+            disabled={format.availability !== "available" || !onExport}
+            className="rounded border border-slate-600 px-3 py-1 text-xs text-slate-200 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label={`Export ${bundleLabel} as ${format.label}`}
+            onClick={() => onExport?.(format.label)}
           >
-            Export {format}
+            {format.availability === "available"
+              ? onExport
+                ? `Export ${format.label}`
+                : `Export ${format.label} (Export not wired)`
+              : `${format.label} (${format.availability})`}
           </button>
         ))}
       </div>

--- a/components/ConstraintChecklist.tsx
+++ b/components/ConstraintChecklist.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export type ConstraintState = "pass" | "fail" | "review";
+export type ConstraintState = "pass" | "fail" | "review" | "unsupported";
 
 type ConstraintItem = {
   id: string;
@@ -17,7 +17,8 @@ type ConstraintChecklistProps = {
 const stateLabel: Record<ConstraintState, string> = {
   pass: "PASS",
   fail: "BLOCK",
-  review: "REVIEW"
+  review: "REVIEW",
+  unsupported: "UNSUPPORTED"
 };
 
 export function ConstraintChecklist({ items, demoLabel }: ConstraintChecklistProps) {

--- a/components/EvidenceDrawer.tsx
+++ b/components/EvidenceDrawer.tsx
@@ -22,6 +22,13 @@ const availabilityClass: Record<EvidenceAvailability, string> = {
   unsupported: "text-slate-300"
 };
 
+const availabilitySymbol: Record<EvidenceAvailability, string> = {
+  present: "✓",
+  missing: "!",
+  planned: "?",
+  unsupported: "—"
+};
+
 export function EvidenceDrawer({ title = "Evidence", fields, demoLabel }: EvidenceDrawerProps) {
   return (
     <aside className="rounded-lg border border-slate-700 bg-slate-900/90 p-4">
@@ -34,7 +41,9 @@ export function EvidenceDrawer({ title = "Evidence", fields, demoLabel }: Eviden
           <li key={field.key} className="rounded border border-slate-700 p-2">
             <div className="flex items-start justify-between gap-3">
               <p className="text-sm text-slate-100">{field.label}</p>
-              <span className={`text-xs uppercase ${availabilityClass[field.availability]}`}>{field.availability}</span>
+              <span className={`text-xs uppercase ${availabilityClass[field.availability]}`}>
+                {availabilitySymbol[field.availability]} {field.availability}
+              </span>
             </div>
             <p className="mt-1 text-xs text-slate-400">{field.detail}</p>
           </li>

--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -15,10 +15,20 @@ const STYLES: Record<GateStatus, string> = {
   UNSUPPORTED: "border-slate-500/60 bg-slate-800 text-slate-200"
 };
 
+const SYMBOLS: Record<GateStatus, string> = {
+  PASS: "✓",
+  BLOCK: "!",
+  REVIEW: "?",
+  UNSUPPORTED: "—"
+};
+
 export function StatusBadge({ status, explanation, className }: StatusBadgeProps) {
   return (
-    <div className={`inline-flex items-start gap-2 rounded-md border px-3 py-2 ${STYLES[status]} ${className ?? ""}`}>
-      <span className="text-xs font-semibold tracking-wide">{status}</span>
+    <div
+      className={`inline-flex items-start gap-2 rounded-md border px-3 py-2 ${STYLES[status]} ${className ?? ""}`}
+      aria-label={`${status}: ${explanation}`}
+    >
+      <span className="text-xs font-semibold tracking-wide">{SYMBOLS[status]} {status}</span>
       <span className="text-xs leading-5">{explanation}</span>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Improve accessibility and non-color status semantics across DSG ONE UX components so status and availability are readable to assistive tech and users who cannot rely on color alone.
- Remove false affordances and surface truth-boundary messaging in export flows so users cannot assume unimplemented formats or incomplete evidence are available.
- Maintain the previously merged component foundation while tightening safety, wording, and wiring checks without changing routes, APIs, envs, packages, or deployment configuration.

### Description
- `components/StatusBadge.tsx`: added non-color symbols (`✓`, `!`, `?`, `—`), visible status text, and an `aria-label` containing the status plus the explanation for improved accessibility and truth-binding.
- `components/ConstraintChecklist.tsx`: added an `unsupported` state to `ConstraintState` and mapped it to the label `UNSUPPORTED` so unsupported constraints are never phrased as success.
- `components/ActionPathGraph.tsx`: replaced plain gateResult text with the `StatusBadge` and bound the explanation to include the `finalDecision` text so explanations are always visible.
- `components/AuditExportPanel.tsx`: changed `availableFormats` from `string[]` to typed objects `{ label, availability }` with `availability` in `available | planned | unsupported`, added optional `onExport` callback, disabled non-available formats and unwired available buttons, and updated pack hash messaging to `Pack hash: missing — export evidence is incomplete` while showing present hashes explicitly.
- `components/EvidenceDrawer.tsx`: added non-color semantic symbols for `present`, `missing`, `planned`, and `unsupported` while keeping explicit availability text labels.

### Testing
- Ran `npm run ux:routes` and the route verification completed successfully with no failures reported (`ok: true`, `failures: []`).
- Ran `npm run build` (Next.js production build) which compiled successfully and generated static pages; build emitted non-blocking telemetry/instrumentation warnings but finished successfully.
- No automated test failures were observed related to these component changes during the build steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c3ed3fec83288008982fb6033ff9)