### PR TITLE
Normalize public UX to “DSG ONE” identity; add /sync-center compatibility page

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,92 +1,47 @@
 import Link from 'next/link';
 
-const quickstart = [
-  'Create an agent inside your workspace.',
-  'Save your API key.',
-  'Call POST /api/execute.',
-  'Review usage, audit, and policy outcomes in your workspace.',
-];
-
-const afterExecution = [
-  'The runtime returns a decision and execution output.',
-  'Your workspace records usage and governance signals.',
-  'Operators can review execution outcomes through workspace-scoped views.',
-];
+const flow = [
+  ['GET /api/dsg/v1/policies/manifest', 'Fetch deterministic policy manifest metadata before execution.'],
+  ['POST /api/dsg/v1/gates/evaluate', 'Run gate evaluation for an action request and receive structured constraint outcomes.'],
+  ['POST /api/dsg/v1/proofs/prove', 'Generate deterministic proof scaffold output for the evaluated request.'],
+  ['POST /api/execute', 'Protected execution entry for governed runtime actions.'],
+  ['POST /api/spine/execute', 'Runtime-native execution path for deeper integration scenarios.'],
+  ['GET /api/health', 'Public availability probe for service baseline checks.'],
+] as const;
 
 export default function DocsPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-16 text-white">
       <div className="mx-auto max-w-5xl">
-        <h1 className="text-4xl font-bold md:text-5xl">Run your first authenticated execution</h1>
-        <p className="mt-4 max-w-4xl text-lg text-slate-300">
-          Use DSG when you need a stable execution entry, authenticated agents, and workspace-visible runtime outcomes.
-        </p>
-        <p className="mt-4 text-slate-300">
-          This guide shows how to create your first agent, call the stable execution route, and review the result inside
-          your workspace.
-        </p>
+        <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">DSG ONE — AI Runtime Control Plane</p>
+        <h1 className="mt-3 text-4xl font-bold md:text-5xl">Developer docs: deterministic gate API flow</h1>
+        <p className="mt-4 text-lg text-slate-300">Use this page to understand runtime governance flow, endpoint purpose, evidence boundary, and next integration action.</p>
 
-        <section className="mt-10 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-semibold">Quickstart</h2>
-          <ol className="mt-4 list-decimal space-y-2 pl-5 text-slate-300">
-            {quickstart.map((item) => (
-              <li key={item}>{item}</li>
+        <section id="dsg-one-runtime-flow" className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          <h2 className="text-2xl font-semibold">Runtime flow</h2>
+          <ol className="mt-4 space-y-3">
+            {flow.map(([route, detail], index) => (
+              <li key={route} className="rounded-xl border border-slate-800 bg-slate-950 p-4">
+                <p className="font-semibold">{index + 1}. {route}</p>
+                <p className="mt-2 text-sm text-slate-300">{detail}</p>
+              </li>
             ))}
           </ol>
         </section>
 
-        <section className="mt-6 grid gap-4 md:grid-cols-3">
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-            <h3 className="font-semibold">Stable execution route</h3>
-            <p className="mt-2 text-sm text-slate-300">Use /api/execute as the primary stable route for authenticated execution.</p>
-          </div>
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-            <h3 className="font-semibold">Runtime-native route</h3>
-            <p className="mt-2 text-sm text-slate-300">Use /api/spine/execute when you need the runtime-native path.</p>
-          </div>
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-            <h3 className="font-semibold">Public health check</h3>
-            <p className="mt-2 text-sm text-slate-300">Use /api/health to confirm service availability.</p>
-          </div>
-        </section>
-
-        <section className="mt-6 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-semibold">Authenticated production example</h2>
-          <p className="mt-2 text-sm text-slate-300">Replace the token and identifiers below with your workspace values.</p>
-          <pre className="mt-4 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`curl -X POST https://tdealer01-crypto-dsg-control-plane.vercel.app/api/execute \\
-  -H "Authorization: Bearer $DSG_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{
-    "agent_id": "$AGENT_ID",
-    "input": {"prompt": "approve invoice #123"},
-    "context": {"risk_score": 0.12}
-  }'`}</pre>
-        </section>
-
-        <section className="mt-6 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-semibold">What happens after execution?</h2>
-          <ul className="mt-4 space-y-2 text-slate-300">
-            {afterExecution.map((item) => (
-              <li key={item}>• {item}</li>
-            ))}
+        <section className="mt-6 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
+          <h2 className="text-2xl font-semibold">Claim boundary</h2>
+          <ul className="mt-3 space-y-2 text-slate-200">
+            <li>• Verified scaffold: static_check solver, deterministic TypeScript proof/gate outputs, and structured constraint fields.</li>
+            <li>• Not claimed: external Z3 production invocation.</li>
+            <li>• Not yet verified on this page: JWT/JWKS auth completion, WORM storage completion, cryptographic signing completion.</li>
           </ul>
         </section>
 
-        <section className="mt-6 rounded-2xl border border-cyan-400/25 bg-cyan-400/10 p-6">
-          <h2 className="text-2xl font-semibold">Workspace boundary</h2>
-          <p className="mt-2 text-cyan-50">
-            Usage, audit, policy, and execution review routes are workspace-scoped. Public routes are intended for
-            evaluation and service checks only.
-          </p>
-        </section>
-
         <div className="mt-8 flex flex-wrap gap-3">
-          <Link href="/playground" className="rounded-xl border border-white/20 bg-white/5 px-4 py-2 text-sm">
-            Try the Playground
-          </Link>
-          <Link href="/signup" className="rounded-xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-950">
-            Start workspace trial
-          </Link>
+          <Link href="/enterprise-proof/demo" className="rounded-xl bg-cyan-400 px-4 py-2 font-semibold text-black">View live gate evidence</Link>
+          <Link href="/evidence-pack" className="rounded-xl border border-slate-700 px-4 py-2">Open evidence pack</Link>
+          <Link href="/dashboard" className="rounded-xl border border-slate-700 px-4 py-2">Open control plane</Link>
         </div>
       </div>
     </main>

--- a/app/finance-governance/page.tsx
+++ b/app/finance-governance/page.tsx
@@ -64,13 +64,13 @@ export default function FinanceGovernancePage() {
       <section className="mx-auto max-w-7xl px-6 pb-16 pt-20">
         <div className="max-w-4xl">
           <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-sm font-medium text-emerald-200 shadow-glow">
-            Finance Governance Control Plane
+            DSG ONE workflow
           </div>
           <h1 className="mt-8 text-5xl font-bold leading-tight md:text-7xl">
-            Control financial approvals with policy, proof, and audit-ready evidence.
+            Finance Governance is one governed workflow under DSG ONE.
           </h1>
           <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-100">
-            DSG helps finance, compliance, and audit teams govern how transactions and supporting documents are submitted, reviewed, approved, escalated, and exported for audit without replacing the ERP.
+            DSG ONE provides runtime governance for high-risk actions. This Finance Governance surface focuses on transaction approvals, exceptions, and evidence workflows without replacing your ERP.
           </p>
 
           <div className="mt-10 flex flex-wrap gap-4">

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -7,7 +7,7 @@ const reviewerChecks = [
   {
     title: "Product home",
     href: "/",
-    note: "Public landing page and product overview for DSG Control Plane.",
+    note: "Public landing page and product overview for DSG ONE.",
   },
   {
     title: "Health endpoint",
@@ -17,7 +17,7 @@ const reviewerChecks = [
   {
     title: "GitHub Marketplace Action",
     href: actionMarketplaceUrl,
-    note: "Published DSG Secure Deploy Gate Action for deterministic CI/CD deployment gating.",
+    note: "Published GitHub Marketplace Action surface for deterministic CI/CD deployment gating under DSG ONE.",
     external: true,
   },
   {
@@ -52,10 +52,10 @@ export default function MarketplacePage() {
             Marketplace Reviewer Page
           </p>
           <h1 className="mt-4 text-4xl font-bold leading-tight md:text-6xl">
-            DSG — Deterministic Safety Gate
+            DSG ONE Marketplace Surface
           </h1>
           <p className="mt-6 max-w-3xl text-lg text-slate-300">
-            DSG Control Plane exposes a public product surface, a public baseline health probe, a published GitHub Marketplace Action, and authenticated operator routes for governed AI execution. This page is designed to help marketplace reviewers distinguish public checks from protected runtime workflows.
+            DSG ONE exposes a public product surface, a public baseline health probe, a published GitHub Marketplace Action, and authenticated operator routes for governed AI execution. This page is designed to help marketplace reviewers distinguish public checks from protected runtime workflows.
           </p>
 
           <div className="mt-10 flex flex-wrap gap-4">
@@ -105,7 +105,7 @@ export default function MarketplacePage() {
           <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
             <h2 className="text-2xl font-semibold">Product Summary</h2>
             <p className="mt-4 text-slate-300">
-              DSG is a control plane for governed AI execution. The public product surface is available for review, while dashboard, usage, audit, policy, capacity, and execution workflows remain protected operator routes.
+              DSG ONE is an AI Runtime Control Plane for governed AI execution. The public product surface is available for review, while dashboard, usage, audit, policy, capacity, and execution workflows remain protected operator routes.
             </p>
             <ul className="mt-6 space-y-3 text-slate-200">
               {capabilities.map((item) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,7 +99,7 @@ export default function HomePage() {
               <Link href="/enterprise-proof/demo" className="rounded-2xl bg-amber-300 px-6 py-4 text-base font-semibold text-slate-950 transition hover:bg-amber-200">
                 View live gate evidence
               </Link>
-              <Link href="/finance-governance/app" className="rounded-2xl border border-red-300/35 bg-red-500/10 px-6 py-4 font-semibold text-red-100 transition hover:border-red-200/50 hover:bg-red-500/15">
+              <Link href="/dashboard" className="rounded-2xl border border-red-300/35 bg-red-500/10 px-6 py-4 font-semibold text-red-100 transition hover:border-red-200/50 hover:bg-red-500/15">
                 Open control plane
               </Link>
               <Link href="/docs" className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 transition hover:border-amber-300/30">

--- a/app/quickstart/page.tsx
+++ b/app/quickstart/page.tsx
@@ -3,7 +3,5 @@ import { redirect } from 'next/navigation';
 export const dynamic = 'force-dynamic';
 
 export default function QuickstartRedirectPage() {
-  // first-run must use the same production path as real-run
-  // keep /quickstart only as a compatibility URL and send users to Auto-Setup
-  redirect('/dashboard/skills?source=quickstart');
+  redirect('/docs#dsg-one-runtime-flow');
 }

--- a/app/sync-center/page.tsx
+++ b/app/sync-center/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { StatusBadge } from '../../components/StatusBadge';
+
+export default function SyncCenterPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <header className="rounded-2xl border border-slate-800 bg-slate-900 p-8">
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-300">DSG ONE — AI Runtime Control Plane</p>
+          <h1 className="mt-3 text-4xl font-bold">Sync Center</h1>
+          <p className="mt-4 text-slate-300">This page is a sync readiness and integration visibility surface for DSG ONE runtime governance workflows. Live connector orchestration is not yet verified on this public route.</p>
+        </header>
+        <section className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="REVIEW" explanation="Sync posture requires operator review." /><p className="mt-3 text-sm text-slate-300">What this page is: sync readiness overview.</p></div>
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="UNSUPPORTED" explanation="No verified live sync execution on this public surface." /><p className="mt-3 text-sm text-slate-300">Live two-way sync execution is unsupported on this route.</p></div>
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="PASS" explanation="Route exists and links to valid governance surfaces." /><p className="mt-3 text-sm text-slate-300">Next action: review deterministic gate APIs before integration rollout.</p></div>
+        </section>
+        <section className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          <h2 className="text-2xl font-semibold">Next useful actions</h2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link href="/docs" className="rounded-xl bg-cyan-400 px-4 py-2 font-semibold text-black">Open docs</Link>
+            <Link href="/evidence-pack" className="rounded-xl border border-slate-700 px-4 py-2">View evidence pack</Link>
+            <Link href="/dashboard" className="rounded-xl border border-slate-700 px-4 py-2">Open control plane</Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Align public-facing pages to a single, canonical product identity: “DSG ONE — AI Runtime Control Plane” and position the product as a runtime governance gateway rather than a GRC replacement. 
- Ensure every public route communicates job, evidence, claim boundaries, and next useful actions without changing API contracts or backend behavior. 
- Create a minimal compatibility page for a nav-linked route that was missing (`/sync-center`) and reframe finance/marketplace/quickstart UX to follow global identity rules. 

### Description
- Updated public copy, CTAs, and proof boundaries in `app/page.tsx`, `app/docs/page.tsx`, `app/finance-governance/page.tsx`, `app/marketplace/page.tsx`, and `app/quickstart/page.tsx` to use the DSG ONE product name and runtime governance messaging. 
- Rewrote `app/docs/page.tsx` into a deterministic gate API flow that lists the required endpoints (`GET /api/dsg/v1/policies/manifest`, `POST /api/dsg/v1/gates/evaluate`, `POST /api/dsg/v1/proofs/prove`, `POST /api/execute`, `POST /api/spine/execute`, `GET /api/health`) and clearly bounds static_check vs unsupported/not-yet-verified claims. 
- Changed homepage control-plane CTA to link to `/dashboard` (operator entry) and kept the live evidence/demo CTA intact, and changed `/quickstart` to redirect to the docs runtime flow anchor. 
- Added a new compatibility page `app/sync-center/page.tsx` that uses `StatusBadge` to show honest status labels (`REVIEW`, `UNSUPPORTED`, `PASS`) and provides next useful actions linking to Docs/Evidence/Dashboard; all edits are copy/composition-only and TypeScript-safe. 

### Testing
- Ran `npm run ux:routes` and the route verification completed with no failures. (success)
- Ran `npm run build` and Next.js production build completed successfully; a pre-existing webpack warning from a third-party instrumentation package was reported but not introduced by these changes. (success)
- Ran `npm run verify:deterministic` and the deterministic-module checks passed with no failures. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c839d73c8328b50036c608679791)