### PR TITLE
Polish route identity copy for homepage and sync center

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,9 +5,9 @@ import { EvidenceDrawer } from '../components/EvidenceDrawer';
 import { GateResultCard } from '../components/GateResultCard';
 
 const trustBar = [
-  'Policy-enforced approval routing',
-  'Maker-checker and exception controls',
-  'Exportable audit evidence bundles',
+  'Policy-routed action control',
+  'Deterministic PASS/BLOCK/REVIEW/UNSUPPORTED gates',
+  'Audit-ready proof and replay evidence',
 ];
 
 const painCards = [
@@ -26,10 +26,10 @@ const painCards = [
 ];
 
 const howSteps = [
-  'Submit an invoice, payment, vendor, or finance exception into a governed case.',
-  'DSG resolves the approval route from policy, threshold, role, and maker-checker context.',
-  'Approvers decide with visible policy, exception, and evidence context.',
-  'The system records decisions, exceptions, and evidence bundles for audit review.',
+  'Submit a high-risk AI, workflow, finance, or deployment action.',
+  'DSG ONE resolves policy, entitlement, risk, and approval context.',
+  'The deterministic gate returns PASS, BLOCK, REVIEW, or UNSUPPORTED.',
+  'The system records proof/gate evidence for audit review.',
 ];
 
 const launchLinks = [
@@ -120,8 +120,8 @@ export default function HomePage() {
             <div className="border border-amber-300/20 bg-black/30 p-6 backdrop-blur-sm">
               <div className="flex items-center justify-between border-b border-white/10 pb-5">
                 <div>
-                  <p className="text-[11px] uppercase tracking-[0.3em] text-slate-500">Finance Mission Room</p>
-                  <h2 className="mt-2 text-2xl font-semibold text-white">Approval Control Stack</h2>
+                  <p className="text-[11px] uppercase tracking-[0.3em] text-slate-500">Runtime Control Room</p>
+                  <h2 className="mt-2 text-2xl font-semibold text-white">Governed Action Stack</h2>
                 </div>
                 <span className="rounded-full border border-emerald-300/25 bg-emerald-400/10 px-3 py-1 text-xs uppercase tracking-[0.18em] text-emerald-200">
                   Ready
@@ -142,15 +142,15 @@ export default function HomePage() {
               <div className="mt-6 grid gap-3 md:grid-cols-3">
                 <div className="border border-white/10 bg-[#111317] p-4">
                   <p className="text-[11px] uppercase tracking-[0.22em] text-slate-500">Policy</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-100">Route by threshold</p>
+                  <p className="mt-2 text-lg font-semibold text-slate-100">Route by policy</p>
                 </div>
                 <div className="border border-white/10 bg-[#111317] p-4">
                   <p className="text-[11px] uppercase tracking-[0.22em] text-slate-500">Evidence</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-100">Bundle at decision time</p>
+                  <p className="mt-2 text-lg font-semibold text-slate-100">Evidence at decision time</p>
                 </div>
                 <div className="border border-white/10 bg-[#111317] p-4">
                   <p className="text-[11px] uppercase tracking-[0.22em] text-slate-500">Exceptions</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-100">Escalate with controls</p>
+                  <p className="mt-2 text-lg font-semibold text-slate-100">Review with controls</p>
                 </div>
               </div>
             </div>

--- a/app/sync-center/page.tsx
+++ b/app/sync-center/page.tsx
@@ -13,7 +13,7 @@ export default function SyncCenterPage() {
         <section className="grid gap-4 md:grid-cols-3">
           <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="REVIEW" explanation="Sync posture requires operator review." /><p className="mt-3 text-sm text-slate-300">What this page is: sync readiness overview.</p></div>
           <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="UNSUPPORTED" explanation="No verified live sync execution on this public surface." /><p className="mt-3 text-sm text-slate-300">Live two-way sync execution is unsupported on this route.</p></div>
-          <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="PASS" explanation="Route exists and links to valid governance surfaces." /><p className="mt-3 text-sm text-slate-300">Next action: review deterministic gate APIs before integration rollout.</p></div>
+          <div className="rounded-xl border border-slate-800 bg-slate-900 p-4"><StatusBadge status="REVIEW" explanation="Route available as a compatibility/readiness surface; live sync execution remains unverified." /><p className="mt-3 text-sm text-slate-300">Route available as a compatibility/readiness surface; live sync execution remains unverified.</p></div>
         </section>
         <section className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
           <h2 className="text-2xl font-semibold">Next useful actions</h2>


### PR DESCRIPTION
### Motivation

- Align customer-facing copy with route-wide identity that emphasizes policy-driven routing, deterministic gate outcomes, and audit-ready evidence. 
- Clarify the deterministic gate flow and outcome labels so UI language matches runtime governance semantics (PASS/BLOCK/REVIEW/UNSUPPORTED). 
- Make only copy-level changes without altering API behavior, routes, environment, or deployment/auth/storage claims. 

### Description

- Updated `app/page.tsx` `trustBar` to: `Policy-routed action control`, `Deterministic PASS/BLOCK/REVIEW/UNSUPPORTED gates`, and `Audit-ready proof and replay evidence`. 
- Replaced `app/page.tsx` `howSteps` with the deterministic flow: submit high-risk action, DSG ONE resolves policy/entitlement/risk/approval context, deterministic gate returns PASS/BLOCK/REVIEW/UNSUPPORTED, and system records proof/gate evidence. 
- Replaced homepage labels in `app/page.tsx`: `Finance Mission Room` → `Runtime Control Room`, `Approval Control Stack` → `Governed Action Stack`, `Route by threshold` → `Route by policy`, `Bundle at decision time` → `Evidence at decision time`, and `Escalate with controls` → `Review with controls`; and changed the Sync Center status card in `app/sync-center/page.tsx` to remove PASS-for-existence wording. 
- Files changed: `app/page.tsx`, `app/sync-center/page.tsx`, with all changes limited to UI copy and labels while preserving routes and runtime behavior. 

### Testing

- Ran `npm run ux:routes` which completed successfully and reported no failures. 
- Ran `npm run build` which completed successfully (build emitted an existing upstream webpack warning but did not fail). 
- Ran `npm run verify:deterministic` which completed successfully with no verification failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cdeef89c8328a1c1593461c832df)