### PR TITLE
Align Phase 4 trust/evidence/compliance/support pages to DSG ONE identity

### DIFF
--- a/app/ai-compliance/page.tsx
+++ b/app/ai-compliance/page.tsx
@@ -14,7 +14,7 @@ const controls = [
 const routes = [
   { href: "/iso-42001", title: "ISO/IEC 42001 Alignment", body: "AI Management System workflow support without certification claims." },
   { href: "/nist-ai-rmf", title: "NIST AI RMF Alignment", body: "Govern, Map, Measure, and Manage workflow support for AI risk management." },
-  { href: "/controls", title: "Control Template Library", body: "Reusable DSG controls for identity, runtime invariants, approvals, evidence, and CI/CD gates." },
+  { href: "/controls", title: "Control Template Library", body: "Reusable DSG ONE controls for identity, runtime invariants, approvals, evidence, and CI/CD gates." },
   { href: "/approvals", title: "Approval Workflow", body: "Review queue and decision API for high-risk or approval-required AI actions." },
   { href: "/evidence-pack", title: "Evidence Pack", body: "Sample audit evidence, benchmark summary, signed bundle, requestHash, recordHash, and export structure." },
   { href: "/marketplace/production-evidence", title: "Production Evidence", body: "Gateway benchmark, SMT2 invariant evidence, and public baseline boundary." },
@@ -30,7 +30,7 @@ export default function AICompliancePage() {
             Govern AI actions before they reach production systems
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            DSG helps organizations turn AI-proposed actions into governed, auditable, deterministic state transitions. It sits between AI intent and real-world execution, checking policy, risk, approval, entitlement, and mathematical invariants before action or audit commit.
+            DSG ONE helps organizations turn AI-proposed actions into governed, auditable, deterministic state transitions. It sits between AI intent and real-world execution, checking policy, risk, approval, entitlement, and mathematical invariants before action or audit commit.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/marketplace/production-evidence" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">
@@ -70,7 +70,7 @@ export default function AICompliancePage() {
         </section>
 
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-bold">What DSG controls</h2>
+          <h2 className="text-2xl font-bold">What DSG ONE controls</h2>
           <div className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             {controls.map((item) => (
               <div key={item} className="rounded-xl border border-emerald-400/20 bg-slate-950 p-4 font-semibold text-emerald-100">
@@ -93,7 +93,7 @@ export default function AICompliancePage() {
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            DSG is positioned as a compliance-enabling control layer. It supports ISO/IEC 42001-aligned and NIST AI RMF-style workflows, but this page does not claim ISO certification, NIST certification, independent third-party audit, or guaranteed compliance.
+            DSG ONE is positioned as a compliance-enabling control layer. It supports ISO/IEC 42001-aligned and NIST AI RMF-style workflows, but this page does not claim ISO certification, NIST certification, independent third-party audit, or guaranteed compliance.
           </p>
         </section>
       </div>

--- a/app/controls/page.tsx
+++ b/app/controls/page.tsx
@@ -35,7 +35,7 @@ export default function ControlsPage() {
             Reusable AI action governance controls
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            DSG control templates help compliance teams and consultants operationalize deterministic gates, evidence requirements, approval rules, customer key custody, deploy gating, and signed evidence workflows.
+            DSG ONE control templates help compliance teams and consultants operationalize deterministic gates, evidence requirements, approval rules, customer key custody, deploy gating, and signed evidence workflows.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/ai-compliance" className="rounded-xl bg-cyan-400 px-5 py-3 font-bold text-black">Back to AI compliance</Link>
@@ -128,7 +128,7 @@ export default function ControlsPage() {
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            DSG control templates support governance workflow adoption. They are not certification claims by themselves and do not guarantee compliance without proper implementation, review, and operating controls.
+            DSG ONE control templates support governance workflow adoption. They are not certification claims by themselves and do not guarantee compliance without proper implementation, review, and operating controls.
           </p>
         </section>
       </div>

--- a/app/evidence-pack/page.tsx
+++ b/app/evidence-pack/page.tsx
@@ -21,7 +21,7 @@ export default function EvidencePackPage() {
             Audit evidence for governed AI execution
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            DSG produces structured AI action governance evidence with runtime decisions, request hashes, record hashes, benchmark evidence, invariant checks, signed evidence bundle metadata, and exportable audit records.
+            DSG ONE produces structured AI action governance evidence with runtime decisions, request hashes, record hashes, benchmark evidence, invariant checks, signed evidence bundle metadata, and exportable audit records.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/ai-compliance" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Back to AI compliance</Link>
@@ -74,7 +74,7 @@ export default function EvidencePackPage() {
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            This page shows sample and internal production evidence. The signed evidence bundle is DSG-generated audit evidence, not an independent third-party audit report. If no signing secret is configured, DSG returns hash-only signature metadata instead of HMAC metadata.
+            This page shows sample and internal production evidence. The signed evidence bundle is DSG ONE-generated audit evidence, not an independent third-party audit report. If no signing secret is configured, DSG ONE returns hash-only signature metadata instead of HMAC metadata.
           </p>
         </section>
       </div>

--- a/app/iso-42001/page.tsx
+++ b/app/iso-42001/page.tsx
@@ -5,7 +5,7 @@ const rows = [
   ["Policy and approval checks", "Documented control workflow for sensitive AI actions", "Implemented"],
   ["Invariant checks", "Repeatable required-condition checks before execution", "Implemented"],
   ["requestHash and recordHash", "Traceability for action decision and result evidence", "Implemented"],
-  ["Monitor Mode", "Customer keeps runtime/API keys while DSG records evidence", "Implemented"],
+  ["Monitor Mode", "Customer keeps runtime/API keys while DSG ONE records evidence", "Implemented"],
   ["Audit export", "Reviewable evidence records", "Implemented"],
   ["GitHub Secure Deploy Gate Action", "CI/CD gating evidence", "Implemented"],
   ["Signed evidence bundle", "Portable evidence package", "Planned"],
@@ -22,7 +22,7 @@ export default function ISO42001Page() {
             AI Management System workflow support
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            ISO/IEC 42001:2023 specifies requirements for establishing, implementing, maintaining, and continually improving an Artificial Intelligence Management System for organizations that provide or use AI-based products or services. DSG maps to this direction as a control and evidence layer for governed AI execution.
+            ISO/IEC 42001:2023 specifies requirements for establishing, implementing, maintaining, and continually improving an Artificial Intelligence Management System for organizations that provide or use AI-based products or services. DSG ONE maps to this direction as a control and evidence layer for governed AI execution.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/ai-compliance" className="rounded-xl bg-sky-400 px-5 py-3 font-bold text-black">Back to AI compliance</Link>
@@ -32,7 +32,7 @@ export default function ISO42001Page() {
 
         <section className="mt-8 overflow-hidden rounded-2xl border border-slate-800 bg-slate-900">
           <div className="grid grid-cols-3 border-b border-slate-800 bg-slate-950 p-4 text-sm font-bold uppercase tracking-wide text-slate-300">
-            <div>DSG capability</div><div>AIMS workflow support</div><div>Status</div>
+            <div>DSG ONE capability</div><div>AIMS workflow support</div><div>Status</div>
           </div>
           {rows.map(([capability, support, status]) => (
             <div key={capability} className="grid grid-cols-3 gap-4 border-b border-slate-800 p-4 last:border-b-0">
@@ -46,7 +46,7 @@ export default function ISO42001Page() {
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            DSG supports ISO/IEC 42001-aligned AI governance workflows. This is not a claim that DSG is ISO/IEC 42001 certified.
+            DSG ONE supports ISO/IEC 42001-aligned AI governance workflows. This is not a claim that DSG ONE is ISO/IEC 42001 certified.
           </p>
         </section>
       </div>

--- a/app/nist-ai-rmf/page.tsx
+++ b/app/nist-ai-rmf/page.tsx
@@ -12,7 +12,7 @@ const controls = [
   "Policy/risk/approval checks",
   "Runtime invariant checks",
   "requestHash and recordHash audit proof",
-  "Monitor Mode without DSG custody of customer API keys",
+  "Monitor Mode without DSG ONE custody of customer API keys",
   "GitHub deploy gate for CI/CD risk control",
 ];
 
@@ -26,7 +26,7 @@ export default function NistAiRmfPage() {
             Govern, Map, Measure, and Manage AI action risk
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            NIST AI RMF is a voluntary framework for managing AI risk and improving trustworthy AI. DSG supports NIST AI RMF-style workflows by placing deterministic controls, invariant checks, and audit evidence at the AI action execution boundary.
+            NIST AI RMF is a voluntary framework for managing AI risk and improving trustworthy AI. DSG ONE supports NIST AI RMF-style workflows by placing deterministic controls, invariant checks, and audit evidence at the AI action execution boundary.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/ai-compliance" className="rounded-xl bg-purple-400 px-5 py-3 font-bold text-black">Back to AI compliance</Link>
@@ -45,7 +45,7 @@ export default function NistAiRmfPage() {
         </section>
 
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-bold">DSG controls used in this alignment</h2>
+          <h2 className="text-2xl font-bold">DSG ONE controls used in this alignment</h2>
           <div className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             {controls.map((control) => (
               <div key={control} className="rounded-xl border border-purple-400/20 bg-slate-950 p-4 font-semibold text-purple-100">
@@ -58,7 +58,7 @@ export default function NistAiRmfPage() {
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            DSG helps operationalize NIST AI RMF-style workflows. NIST AI RMF is voluntary and this page does not claim NIST certification.
+            DSG ONE helps operationalize NIST AI RMF-style workflows. NIST AI RMF is voluntary and this page does not claim NIST certification.
           </p>
         </section>
       </div>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -89,13 +89,13 @@ export default function PricingPage() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(181,18,27,0.26),transparent_26%),radial-gradient(circle_at_82%_10%,rgba(245,197,92,0.16),transparent_30%),radial-gradient(circle_at_50%_70%,rgba(16,185,129,0.10),transparent_34%),linear-gradient(180deg,#090a0d_0%,#0b0d10_55%,#07080a_100%)]" />
         <div className="relative mx-auto max-w-7xl px-6 py-16 lg:py-24">
           <p className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
-            DSG Secure Deploy Gate Pricing
+            DSG ONE Secure Deploy Gate Pricing
           </p>
           <h1 className="mt-7 max-w-5xl text-5xl font-bold leading-[1.02] text-white md:text-7xl">
             Sell release confidence with GO / NO-GO evidence.
           </h1>
           <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
-            Start with the free GitHub Action, buy a one-time readiness report, or subscribe to hosted release-governance workflows for teams that need audit-ready production proof.
+            Start with the free GitHub Action, buy a one-time readiness report, or subscribe to hosted DSG ONE release-governance workflows for teams that need evidence-ready production proof.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/readiness-report" className="rounded-2xl bg-amber-300 px-6 py-4 text-base font-bold text-slate-950 transition hover:bg-amber-200">
@@ -174,6 +174,14 @@ export default function PricingPage() {
               </article>
             ))}
           </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-12">
+        <div className="rounded-2xl border border-amber-300/30 bg-amber-300/10 p-6 text-sm leading-7 text-slate-200">
+          <p className="font-semibold text-amber-100">Boundary</p>
+          <p>This pricing page describes DSG ONE products and support alignment. It does not claim certification, external audit completion, or guaranteed compliance outcomes.</p>
+          <p className="mt-2">If an item is demo/scaffold in related evidence pages, treat it as non-production proof until verified.</p>
         </div>
       </section>
     </main>

--- a/app/pro-mode/page.tsx
+++ b/app/pro-mode/page.tsx
@@ -233,7 +233,7 @@ export default function ProModePage() {
               href="/support"
               className="mt-6 inline-block rounded-xl border border-amber-300/35 bg-amber-300/10 px-4 py-2 text-sm font-semibold text-amber-100"
             >
-              Contact the DSG team
+              Contact the DSG ONE team
             </Link>
           </article>
         </section>

--- a/app/reproducibility/page.tsx
+++ b/app/reproducibility/page.tsx
@@ -3,9 +3,9 @@ export default function ReproducibilityPage() {
     <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
       <div className="mx-auto max-w-5xl rounded-3xl border border-cyan-500/30 bg-slate-900 p-10">
         <p className="text-sm uppercase tracking-[0.25em] text-cyan-300">Reproducibility Report</p>
-        <h1 className="mt-4 text-5xl font-black">Reproduce DSG core evidence</h1>
+        <h1 className="mt-4 text-5xl font-black">Reproduce DSG ONE core evidence</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
-          Users can independently reproduce core governance routes, deploy gate checks, and UX route verification.
+          Users can independently reproduce DSG ONE governance routes, deploy gate checks, and UX route verification. Demo/scaffold outputs must be treated as sample evidence unless marked verified.
         </p>
 
         <div className="mt-8 rounded-2xl bg-slate-950 p-6 font-mono text-sm leading-7 text-cyan-200">
@@ -21,6 +21,11 @@ export default function ReproducibilityPage() {
           <p><strong>Real action:</strong> Run checks and inspect routes.</p>
           <p><strong>Evidence:</strong> Route verifier output, hashes, signed bundle.</p>
           <p><strong>Tangible output:</strong> Reproducibility report plus evidence artifacts.</p>
+        </section>
+
+        <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
+          <h2 className="text-2xl font-bold">Boundary</h2>
+          <p className="mt-3 leading-7 text-slate-300">This route is audit-ready reproducibility guidance. It does not claim certification, external attestation, or guaranteed compliance.</p>
         </section>
       </div>
     </main>

--- a/app/security-review/page.tsx
+++ b/app/security-review/page.tsx
@@ -1,18 +1,24 @@
+import Link from "next/link";
+
 export default function SecurityReviewPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
       <div className="mx-auto max-w-5xl rounded-3xl border border-rose-500/20 bg-slate-900 p-10">
-        <p className="text-sm uppercase tracking-[0.25em] text-rose-300">Security Review</p>
+        <p className="text-sm uppercase tracking-[0.25em] text-rose-300">DSG ONE Security Review</p>
         <h1 className="mt-4 text-5xl font-black">Security review boundary and hardening roadmap</h1>
         <ul className="mt-8 space-y-4 text-lg leading-8 text-slate-300">
-          <li>Current deterministic controls</li>
-          <li>Evidence integrity model</li>
-          <li>Protected route behavior</li>
-          <li>Approval governance</li>
-          <li>Deploy gate coverage</li>
-          <li>Future independent review path</li>
+          <li>Current deterministic controls (verified in repository)</li>
+          <li>Evidence integrity model (evidence-ready design)</li>
+          <li>Protected route behavior (verified route behavior)</li>
+          <li>Approval governance (verified workflow path)</li>
+          <li>Deploy gate coverage (alignment/support)</li>
+          <li>Future independent review path (not yet claimed)</li>
         </ul>
-        <p className="mt-8 text-slate-400">This route documents security posture and review path; it is not itself an outside audit.</p>
+        <p className="mt-8 text-slate-300">Boundary: this route documents DSG ONE security posture and review path; it is not an external audit, certification, or formal attestation.</p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link href="/evidence-pack" className="rounded-xl bg-rose-300 px-4 py-2 font-semibold text-black">Review evidence pack</Link>
+          <Link href="/support" className="rounded-xl border border-rose-300/40 px-4 py-2 font-semibold text-rose-100">Contact support</Link>
+        </div>
       </div>
     </main>
   );

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -3,26 +3,32 @@ export default function SupportPage() {
     <main className="min-h-screen bg-slate-950 text-slate-100">
       <section className="mx-auto max-w-5xl px-6 py-16">
         <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Support</p>
-        <h1 className="mt-4 text-4xl font-semibold md:text-5xl">Support and contact</h1>
+        <h1 className="mt-4 text-4xl font-semibold md:text-5xl">DSG ONE support and contact</h1>
 
         <div className="mt-10 grid gap-4">
           <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
             <p className="font-semibold text-white">Support</p>
-            <p className="mt-2 text-sm text-slate-300">Questions about setup, trials, or workspace access? Contact DSG support.</p>
+            <p className="mt-2 text-sm text-slate-300">Questions about setup, trials, or workspace access? Contact DSG ONE support.</p>
           </article>
           <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
             <p className="font-semibold text-white">Security contact</p>
-            <p className="mt-2 text-sm text-slate-300">For security reporting and security-related questions, contact the DSG team directly.</p>
+            <p className="mt-2 text-sm text-slate-300">For security reporting and security-related questions, contact the DSG ONE team directly.</p>
           </article>
           <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
             <p className="font-semibold text-white">Privacy contact</p>
-            <p className="mt-2 text-sm text-slate-300">For privacy and data-handling questions, contact DSG support.</p>
+            <p className="mt-2 text-sm text-slate-300">For privacy and data-handling questions, contact DSG ONE support.</p>
           </article>
           <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
             <p className="font-semibold text-white">Enterprise contact</p>
             <p className="mt-2 text-sm text-slate-300">Need rollout planning or governance onboarding? Request an Enterprise pilot.</p>
           </article>
         </div>
+
+        <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
+          <h2 className="text-2xl font-bold">Claim boundary</h2>
+          <p className="mt-3 text-sm leading-7 text-slate-300">Support responses provide alignment and implementation guidance only. This page does not claim certification, legal attestation, or independent audit conclusions.</p>
+          <p className="mt-3 text-sm leading-7 text-slate-300">Next action: use /evidence-pack for evidence review, then contact support for scope clarification.</p>
+        </section>
       </section>
     </main>
   );

--- a/app/trust/page.tsx
+++ b/app/trust/page.tsx
@@ -17,7 +17,7 @@ export default function TrustPage() {
           <p className="text-sm uppercase tracking-[0.25em] text-emerald-300">Phase 5 External Trust</p>
           <h1 className="mt-4 text-4xl font-black md:text-6xl">Buyer trust and external validation hub</h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            DSG trust assets help buyers, consultants, and reviewers verify what exists today, reproduce core evidence, and understand what still requires external validation.
+            DSG ONE trust assets help buyers, consultants, and reviewers verify what exists today, reproduce core evidence, and understand what still requires external validation.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/reproducibility" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Run reproducibility path</Link>

--- a/artifacts/deterministic-module/verification-result.json
+++ b/artifacts/deterministic-module/verification-result.json
@@ -1,0 +1,9 @@
+{
+  "ok": true,
+  "type": "dsg-deterministic-module-verification",
+  "checkedAt": "2026-05-02T10:24:26.481Z",
+  "requiredFiles": 9,
+  "requiredTextChecks": 13,
+  "failures": [],
+  "userOutcome": "Deterministic module has proof/gate APIs, policy manifest, solver metadata, replay protection, and UNSUPPORTED-is-never-PASS enforcement."
+}

--- a/artifacts/ux-route-map/ux-route-map-result.json
+++ b/artifacts/ux-route-map/ux-route-map-result.json
@@ -1,0 +1,61 @@
+{
+  "ok": true,
+  "type": "dsg-ux-route-map-verification",
+  "checkedAt": "2026-05-02T10:22:50.035Z",
+  "routeChecks": 12,
+  "flowOutcomeChecks": 3,
+  "failures": [],
+  "flowOutcomes": [
+    {
+      "id": "controls-to-evidence",
+      "benefit": "User can turn a governance control into evidence review.",
+      "action": "Open /controls and click Open evidence pack or Open JSON.",
+      "evidence": "The evidence pack page or control templates API returns visible evidence/control data.",
+      "output": "/evidence-pack or /api/gateway/controls/templates",
+      "files": [
+        "app/controls/page.tsx",
+        "app/evidence-pack/page.tsx",
+        "app/api/gateway/controls/templates/route.ts"
+      ],
+      "requiredText": [
+        "Open evidence pack",
+        "Open JSON"
+      ]
+    },
+    {
+      "id": "approval-decision",
+      "benefit": "Reviewer can approve or reject a review-required AI action.",
+      "action": "Open /approvals?orgId=org-smoke and click Approve or Reject on a pending item.",
+      "evidence": "Approval API records approvalHash and redirects with lastDecision.",
+      "output": "/approvals?orgId=org-smoke&lastDecision=...",
+      "files": [
+        "app/approvals/page.tsx",
+        "app/api/gateway/approvals/route.ts"
+      ],
+      "requiredText": [
+        "Approve",
+        "Reject",
+        "approvalHash",
+        "lastDecision"
+      ]
+    },
+    {
+      "id": "signed-evidence-bundle",
+      "benefit": "User can export portable audit evidence for buyer, auditor, or consultant review.",
+      "action": "Open /evidence-pack and click Download signed evidence bundle.",
+      "evidence": "Evidence bundle API returns bundleHash, eventHashes, and signature metadata.",
+      "output": "/api/gateway/evidence/bundle?orgId=org-smoke",
+      "files": [
+        "app/evidence-pack/page.tsx",
+        "app/api/gateway/evidence/bundle/route.ts",
+        "lib/gateway/evidence-bundle.ts"
+      ],
+      "requiredText": [
+        "Download signed evidence bundle",
+        "bundleHash",
+        "signature"
+      ]
+    }
+  ],
+  "userOutcome": "All audited DSG flows expose user benefit, real action, evidence, and tangible output."
+}


### PR DESCRIPTION
### Motivation
- Ensure Phase 4-facing UX surfaces consistently present the product identity as “DSG ONE — AI Runtime Control Plane” and clarify what is verified vs. scaffold/demo versus what is not claimed. 
- Make claim boundaries explicit so pages are framed as alignment/support and evidence-ready guidance rather than certification or third-party attestation. 
- Provide clear next actions (CTAs) to guide reviewers to evidence and support without changing routes or runtime behavior. 

### Description
- Replaced product naming and contextual references with the canonical `DSG ONE` identity across trust, evidence, compliance, pricing, pro-mode, and support pages. 
- Strengthened and added explicit claim/boundary language (alignment/support, not certification) and labeled demo/scaffold outputs where applicable. 
- Added or clarified CTAs that point reviewers to the evidence pack and support contact flows while preserving all existing routes and API behavior. 
- Committed generated verification artifacts for UX route map and deterministic-module checks under `artifacts/ux-route-map/ux-route-map-result.json` and `artifacts/deterministic-module/verification-result.json`. 

### Testing
- Ran `npm run ux:routes` and it passed with no failures (UX route map verification OK). 
- Ran `npm run build` and the site compiled successfully (build completed; noted existing third-party instrumentation warning from Prisma/OpenTelemetry unrelated to content changes). 
- Ran `npm run verify:deterministic` and it passed with no failures (deterministic-module verification OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d03ef5708328bbd927b4c7c6beed)