### PR TITLE
Correct evidence bundle wording and clarify signing behavior boundaries

### DIFF
--- a/app/evidence-pack/page.tsx
+++ b/app/evidence-pack/page.tsx
@@ -6,7 +6,7 @@ const evidence = [
   ["Comparison Rubric", "190/200, 95% internal rubric score", "Implemented"],
   ["Public Vendor Baseline", "5 public documentation baselines, vendorRuntimeTested=0", "Implemented"],
   ["Audit Export API", "Exportable JSON audit evidence", "Implemented"],
-  ["Signed Evidence Bundle", "Portable bundle with bundleHash, eventHashes, and signature metadata", "Implemented"],
+  ["Evidence Bundle with Hash/Signature Metadata", "Portable bundle with bundleHash, eventHashes, and signature metadata", "Implemented"],
   ["GitHub Secure Deploy Gate Action", "CI/CD gate evidence with verdict and evidence hash", "Implemented"],
   ["PDF Evidence Report", "Human-readable reviewer report", "Planned"],
 ];
@@ -21,11 +21,11 @@ export default function EvidencePackPage() {
             Audit evidence for governed AI execution
           </h1>
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">
-            DSG ONE produces structured AI action governance evidence with runtime decisions, request hashes, record hashes, benchmark evidence, invariant checks, signed evidence bundle metadata, and exportable audit records.
+            DSG ONE produces structured AI action governance evidence with runtime decisions, request hashes, record hashes, benchmark evidence, invariant checks, evidence bundle hash/signature metadata, and exportable audit records.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
             <Link href="/ai-compliance" className="rounded-xl bg-emerald-400 px-5 py-3 font-bold text-black">Back to AI compliance</Link>
-            <Link href="/api/gateway/evidence/bundle?orgId=org-smoke" className="rounded-xl border border-emerald-300/50 px-5 py-3 font-bold text-emerald-100">Download signed evidence bundle</Link>
+            <Link href="/api/gateway/evidence/bundle?orgId=org-smoke" className="rounded-xl border border-emerald-300/50 px-5 py-3 font-bold text-emerald-100">Download evidence bundle</Link>
             <Link href="/api/gateway/audit/export?orgId=org-smoke" className="rounded-xl border border-emerald-300/50 px-5 py-3 font-bold text-emerald-100">Open audit export JSON</Link>
             <Link href="/marketplace/production-evidence" className="rounded-xl border border-slate-700 px-5 py-3 font-bold text-slate-200">View production evidence</Link>
           </div>
@@ -45,7 +45,7 @@ export default function EvidencePackPage() {
         </section>
 
         <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-2xl font-bold">Sample signed bundle structure</h2>
+          <h2 className="text-2xl font-bold">Sample evidence bundle structure</h2>
           <pre className="mt-5 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-200">{`{
   "type": "dsg-gateway-signed-evidence-bundle",
   "version": "1.0",
@@ -74,7 +74,10 @@ export default function EvidencePackPage() {
         <section className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-6">
           <h2 className="text-2xl font-bold">Boundary</h2>
           <p className="mt-3 leading-7 text-slate-300">
-            This page shows sample and internal production evidence. The signed evidence bundle is DSG ONE-generated audit evidence, not an independent third-party audit report. If no signing secret is configured, DSG ONE returns hash-only signature metadata instead of HMAC metadata.
+            This page shows sample and internal production evidence. DSG ONE returns HMAC signature metadata when DSG_EVIDENCE_SIGNING_SECRET is configured. If the signing secret is not configured, DSG ONE returns hash-only signature metadata.
+          </p>
+          <p className="mt-3 leading-7 text-slate-300">
+            This page does not claim WORM storage, external attestation, third-party audit, or guaranteed compliance.
           </p>
         </section>
       </div>

--- a/artifacts/ux-route-map/ux-route-map-result.json
+++ b/artifacts/ux-route-map/ux-route-map-result.json
@@ -1,7 +1,7 @@
 {
   "ok": true,
   "type": "dsg-ux-route-map-verification",
-  "checkedAt": "2026-05-02T10:22:50.035Z",
+  "checkedAt": "2026-05-02T10:31:26.426Z",
   "routeChecks": 12,
   "flowOutcomeChecks": 3,
   "failures": [],
@@ -42,7 +42,7 @@
     {
       "id": "signed-evidence-bundle",
       "benefit": "User can export portable audit evidence for buyer, auditor, or consultant review.",
-      "action": "Open /evidence-pack and click Download signed evidence bundle.",
+      "action": "Open /evidence-pack and click Download evidence bundle.",
       "evidence": "Evidence bundle API returns bundleHash, eventHashes, and signature metadata.",
       "output": "/api/gateway/evidence/bundle?orgId=org-smoke",
       "files": [
@@ -51,7 +51,7 @@
         "lib/gateway/evidence-bundle.ts"
       ],
       "requiredText": [
-        "Download signed evidence bundle",
+        "Download evidence bundle",
         "bundleHash",
         "signature"
       ]

--- a/docs/evidence/signed-evidence-bundle.md
+++ b/docs/evidence/signed-evidence-bundle.md
@@ -1,4 +1,4 @@
-# DSG Signed Evidence Bundle
+# DSG Evidence Bundle with Hash/Signature Metadata
 
 Purpose: provide a portable JSON evidence package for governed AI/tool execution.
 
@@ -40,6 +40,8 @@ DSG_EVIDENCE_SIGNING_KEY_ID
 
 If no signing secret is configured, DSG still returns a deterministic `bundleHash` and `eventHashes`, but `signatureMode` is `hash-only`.
 
+Implementation boundary: DSG ONE returns HMAC signature metadata when `DSG_EVIDENCE_SIGNING_SECRET` is configured. If the signing secret is not configured, DSG ONE returns hash-only signature metadata.
+
 ## Sample
 
 ```json
@@ -67,7 +69,7 @@ If no signing secret is configured, DSG still returns a deterministic `bundleHas
 
 ## Safe wording
 
-DSG provides portable signed evidence bundles for governed AI/tool execution, including bundle hashes, event hashes, and signing metadata.
+DSG provides portable evidence bundles for governed AI/tool execution, including bundle hashes, event hashes, and hash/signature metadata.
 
 ## Not claimed
 
@@ -75,3 +77,6 @@ DSG provides portable signed evidence bundles for governed AI/tool execution, in
 - ISO certification
 - NIST certification
 - Guaranteed compliance
+- WORM storage
+- External attestation
+- Third-party audit

--- a/scripts/verify-ux-route-map.mjs
+++ b/scripts/verify-ux-route-map.mjs
@@ -54,11 +54,11 @@ const flowOutcomes = [
   {
     id: 'signed-evidence-bundle',
     benefit: 'User can export portable audit evidence for buyer, auditor, or consultant review.',
-    action: 'Open /evidence-pack and click Download signed evidence bundle.',
+    action: 'Open /evidence-pack and click Download evidence bundle.',
     evidence: 'Evidence bundle API returns bundleHash, eventHashes, and signature metadata.',
     output: '/api/gateway/evidence/bundle?orgId=org-smoke',
     files: ['app/evidence-pack/page.tsx', 'app/api/gateway/evidence/bundle/route.ts', 'lib/gateway/evidence-bundle.ts'],
-    requiredText: ['Download signed evidence bundle', 'bundleHash', 'signature'],
+    requiredText: ['Download evidence bundle', 'bundleHash', 'signature'],
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Remove UI and documentation language that implies HMAC signing is always active and instead reflect the actual implementation behavior.
- Make the evidence bundle wording safer and aligned with runtime behavior so users are not misled about signing or compliance guarantees.
- Ensure UX route verification continues to pass after the wording change by updating verifier expectations.

### Description
- Updated `app/evidence-pack/page.tsx` to replace user-facing strings (`Signed Evidence Bundle` → `Evidence Bundle with Hash/Signature Metadata`, `Download signed evidence bundle` → `Download evidence bundle`, `Sample signed bundle structure` → `Sample evidence bundle structure`) and added implementation and prohibited-claim boundary text noting `DSG_EVIDENCE_SIGNING_SECRET` controls HMAC metadata and that the page does not claim WORM storage, external attestation, third-party audit, or guaranteed compliance.
- Updated `docs/evidence/signed-evidence-bundle.md` to use safer wording, add the implementation boundary that HMAC metadata is returned only when `DSG_EVIDENCE_SIGNING_SECRET` is configured, and expand the list of explicit "not claimed" items.
- Updated `scripts/verify-ux-route-map.mjs` to align the UX verification expected text (`Download evidence bundle`) so `npm run ux:routes` still validates the flow, and regenerated `artifacts/ux-route-map/ux-route-map-result.json` accordingly. 
- No API behavior, environment files, package versions, database/schema/auth/deployment config, or tests were changed.

### Testing
- Ran `npm run ux:routes`, which passed and produced an updated UX route artifact confirming no flow failures. ✅
- Ran `npm run build`, which completed successfully; the build emitted an existing non-blocking webpack warning originating from a Prisma/OpenTelemetry dependency. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d24d6a688328a7967e9b75b7780e)