### PR TITLE
Wire finance governance UI to live backend data

### DIFF
--- a/app/finance-governance/app/approvals/page.tsx
+++ b/app/finance-governance/app/approvals/page.tsx
@@ -1,35 +1,18 @@
-const approvals = [
-  {
-    id: 'APR-1001',
-    vendor: 'Northwind Supply',
-    amount: 'US$14,250',
-    status: 'Needs approver',
-    risk: 'Threshold exceeded',
-  },
-  {
-    id: 'APR-1002',
-    vendor: 'Contoso Services',
-    amount: 'US$2,480',
-    status: 'Exception open',
-    risk: 'Missing document',
-  },
-  {
-    id: 'APR-1003',
-    vendor: 'Blue Ocean Partners',
-    amount: 'US$31,900',
-    status: 'Compliance review',
-    risk: 'High-risk vendor',
-  },
-];
+import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/repository';
+import { getOrg } from '../../../../lib/server/getOrg';
 
-export default function FinanceGovernanceApprovalsPage() {
+const repository = new FinanceGovernanceRepository();
+
+export default async function FinanceGovernanceApprovalsPage() {
+  const orgId = await getOrg();
+  const approvals = await repository.getApprovals(orgId);
   return (
     <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
       <div className="max-w-3xl">
         <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Approval queue</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Pending finance approvals</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
-          This queue is the skeleton for role-aware approvals, filtering, and action handling across governed finance workflows.
+          Real-time governed approval queue mapped to the DSG backend for policy-aware decisioning and compliance operations.
         </p>
       </div>
 

--- a/app/finance-governance/app/cases/[id]/page.tsx
+++ b/app/finance-governance/app/cases/[id]/page.tsx
@@ -1,19 +1,18 @@
+import { FinanceGovernanceRepository } from '../../../../../lib/finance-governance/repository';
+import { getOrg } from '../../../../../lib/server/getOrg';
+
 type CaseDetailPageProps = {
   params: Promise<{
     id: string;
   }>;
 };
 
-const timeline = [
-  'Submission created by finance maker',
-  'Policy route resolved for threshold-based approval',
-  'Exception opened for missing supporting document',
-  'Compliance review requested',
-  'Evidence bundle marked ready for export',
-];
+const repository = new FinanceGovernanceRepository();
 
 export default async function FinanceGovernanceCaseDetailPage({ params }: CaseDetailPageProps) {
   const { id } = await params;
+  const orgId = await getOrg();
+  const detail = await repository.getCaseDetail(orgId, id);
 
   return (
     <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
@@ -28,11 +27,11 @@ export default async function FinanceGovernanceCaseDetailPage({ params }: CaseDe
           <div className="mt-8 grid gap-4 md:grid-cols-2">
             <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
               <p className="text-sm text-slate-400">Status</p>
-              <p className="mt-2 text-xl font-semibold text-emerald-100">Compliance review</p>
+              <p className="mt-2 text-xl font-semibold text-emerald-100">{detail.status}</p>
             </div>
             <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5">
               <p className="text-sm text-slate-400">Evidence export</p>
-              <p className="mt-2 text-xl font-semibold text-emerald-100">Ready</p>
+              <p className="mt-2 text-xl font-semibold text-emerald-100">{detail.exportStatus}</p>
             </div>
           </div>
         </section>
@@ -40,7 +39,7 @@ export default async function FinanceGovernanceCaseDetailPage({ params }: CaseDe
         <section className="rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
           <h2 className="text-2xl font-semibold">Case timeline</h2>
           <div className="mt-6 grid gap-4">
-            {timeline.map((item, index) => (
+            {detail.timeline.map((item, index) => (
               <div key={item} className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4">
                 <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300/20 font-semibold text-cyan-100">
                   {index + 1}

--- a/app/finance-governance/app/onboarding/page.tsx
+++ b/app/finance-governance/app/onboarding/page.tsx
@@ -1,29 +1,55 @@
-const steps = [
-  'Create or confirm the workspace',
-  'Invite finance, approver, audit, and admin roles',
-  'Select invoice or payment approval template',
-  'Publish the first policy version',
-  'Submit the first governed item',
-];
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { getOrg } from '../../../../lib/server/getOrg';
 
-export default function FinanceGovernanceOnboardingPage() {
+type ChecklistPayload = {
+  steps?: Array<string | { id?: string; label?: string; status?: 'todo' | 'in_progress' | 'done' }>;
+} | null;
+
+function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: string | null | undefined) {
+  const rawSteps = Array.isArray(checklist?.steps) ? checklist.steps : [];
+  return rawSteps.map((step, index) => {
+    if (typeof step === 'string') {
+      return {
+        id: `step-${index + 1}`,
+        label: step,
+        status: bootstrapStatus === 'completed' ? 'done' : index === 0 ? 'in_progress' : 'todo',
+      };
+    }
+    return {
+      id: step.id || `step-${index + 1}`,
+      label: step.label || `Step ${index + 1}`,
+      status: step.status || (bootstrapStatus === 'completed' ? 'done' : index === 0 ? 'in_progress' : 'todo'),
+    };
+  });
+}
+
+export default async function FinanceGovernanceOnboardingPage() {
+  const orgId = await getOrg();
+  const admin = getSupabaseAdmin() as any;
+  const { data } = await admin
+    .from('org_onboarding_states')
+    .select('bootstrap_status, checklist')
+    .eq('org_id', orgId)
+    .maybeSingle();
+  const steps = mapChecklistToSteps(data?.checklist ?? null, data?.bootstrap_status);
+
   return (
     <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
       <div className="max-w-3xl">
         <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Onboarding</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance workflow onboarding template</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
-          This page is the skeleton for the first-run setup flow that turns a new organization into a configured finance-governance workspace.
+          Automated onboarding flow synced from backend checklist state so compliance setup progress is always live.
         </p>
       </div>
 
       <div className="mt-10 grid gap-4">
         {steps.map((step, index) => (
-          <section key={step} className="flex items-center gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
+          <section key={step.id} className="flex items-center gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
             <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-300/20 font-semibold text-emerald-100">
               {index + 1}
             </div>
-            <p className="text-base text-slate-100">{step}</p>
+            <p className="text-base text-slate-100">{step.label}</p>
           </section>
         ))}
       </div>

--- a/app/finance-governance/app/page.tsx
+++ b/app/finance-governance/app/page.tsx
@@ -1,30 +1,29 @@
 import Link from 'next/link';
+import { FinanceGovernanceRepository } from '../../../lib/finance-governance/repository';
+import { getOrg } from '../../../lib/server/getOrg';
 
-const quickLinks = [
-  { href: '/finance-governance/app/onboarding', label: 'Onboarding template' },
-  { href: '/finance-governance/app/approvals', label: 'Approval queue' },
-  { href: '/finance-governance/app/cases/sample-case', label: 'Sample case detail' },
-];
+const repository = new FinanceGovernanceRepository();
 
-const cards = [
-  {
-    title: 'Pending approvals',
-    value: '12',
-    text: 'Items waiting for reviewer action in the current workspace.',
-  },
-  {
-    title: 'Open exceptions',
-    value: '3',
-    text: 'Cases that require exception review, waiver, or follow-up.',
-  },
-  {
-    title: 'Ready exports',
-    value: '5',
-    text: 'Evidence bundles available for internal or external review.',
-  },
-];
-
-export default function FinanceGovernanceAppHomePage() {
+export default async function FinanceGovernanceAppHomePage() {
+  const orgId = await getOrg();
+  const workspace = await repository.getWorkspaceSummary(orgId);
+  const cards = [
+    {
+      title: 'Pending approvals',
+      value: String(workspace.counts.pendingApprovals),
+      text: 'Items waiting for reviewer action in the current workspace.',
+    },
+    {
+      title: 'Open exceptions',
+      value: String(workspace.counts.openExceptions),
+      text: 'Cases that require exception review, waiver, or follow-up.',
+    },
+    {
+      title: 'Ready exports',
+      value: String(workspace.counts.readyExports),
+      text: 'Evidence bundles available for internal or external review.',
+    },
+  ];
   return (
     <main className="mx-auto min-h-screen max-w-7xl px-6 py-16 text-white">
       <div className="max-w-3xl">
@@ -48,7 +47,7 @@ export default function FinanceGovernanceAppHomePage() {
       <div className="mt-10 rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
         <h2 className="text-2xl font-semibold">Quick links</h2>
         <div className="mt-5 flex flex-wrap gap-4">
-          {quickLinks.map((link) => (
+          {workspace.quickLinks.map((link) => (
             <Link key={link.href} href={link.href} className="rounded-2xl border border-white/20 bg-white/5 px-6 py-3 text-base font-semibold text-white">
               {link.label}
             </Link>


### PR DESCRIPTION
### Motivation
- Replace hardcoded/mock UI placeholders with real backend-backed data so the finance governance pages reflect live compliance and audit state.

### Description
- Wire the workspace home to `FinanceGovernanceRepository` and `getOrg` and render `workspace.counts` and `workspace.quickLinks` instead of static values by updating `app/finance-governance/app/page.tsx`.
- Load approvals from the backend via `repository.getApprovals(orgId)` and replace the hardcoded approvals list in `app/finance-governance/app/approvals/page.tsx`.
- Read onboarding checklist state from `org_onboarding_states` using the Supabase admin client, map it to step objects, and render dynamic steps in `app/finance-governance/app/onboarding/page.tsx`.
- Fetch case detail via `repository.getCaseDetail(orgId, id)` and show `status`, `exportStatus`, and `timeline` in `app/finance-governance/app/cases/[id]/page.tsx`.

### Testing
- Ran static type checks with `npm run typecheck` and the final run completed successfully after fixing a type mismatch in onboarding list rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ea2546348328a301a2d89628fbba)