### PR TITLE
Harden finance governance app pages for live backend data

### DIFF
--- a/app/finance-governance/app/approvals/page.tsx
+++ b/app/finance-governance/app/approvals/page.tsx
@@ -2,6 +2,7 @@ import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/
 import { getOrg } from '../../../../lib/server/getOrg';
 
 const repository = new FinanceGovernanceRepository();
+export const dynamic = 'force-dynamic';
 
 export default async function FinanceGovernanceApprovalsPage() {
   const orgId = await getOrg();
@@ -28,15 +29,23 @@ export default async function FinanceGovernanceApprovalsPage() {
             </tr>
           </thead>
           <tbody>
-            {approvals.map((item) => (
-              <tr key={item.id} className="border-t border-white/10 align-top">
-                <td className="px-5 py-4 font-semibold text-white">{item.id}</td>
-                <td className="px-5 py-4 text-slate-200">{item.vendor}</td>
-                <td className="px-5 py-4 text-slate-200">{item.amount}</td>
-                <td className="px-5 py-4 text-emerald-100">{item.status}</td>
-                <td className="px-5 py-4 text-slate-300">{item.risk}</td>
+            {approvals.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-5 py-8 text-center text-slate-300">
+                  No pending approvals for this workspace.
+                </td>
               </tr>
-            ))}
+            ) : (
+              approvals.map((item) => (
+                <tr key={item.id} className="border-t border-white/10 align-top">
+                  <td className="px-5 py-4 font-semibold text-white">{item.id}</td>
+                  <td className="px-5 py-4 text-slate-200">{item.vendor}</td>
+                  <td className="px-5 py-4 text-slate-200">{item.amount}</td>
+                  <td className="px-5 py-4 text-emerald-100">{item.status}</td>
+                  <td className="px-5 py-4 text-slate-300">{item.risk}</td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/app/finance-governance/app/cases/[id]/page.tsx
+++ b/app/finance-governance/app/cases/[id]/page.tsx
@@ -8,11 +8,13 @@ type CaseDetailPageProps = {
 };
 
 const repository = new FinanceGovernanceRepository();
+export const dynamic = 'force-dynamic';
 
 export default async function FinanceGovernanceCaseDetailPage({ params }: CaseDetailPageProps) {
   const { id } = await params;
   const orgId = await getOrg();
   const detail = await repository.getCaseDetail(orgId, id);
+  const timeline = Array.isArray(detail.timeline) ? detail.timeline : [];
 
   return (
     <main className="mx-auto min-h-screen max-w-6xl px-6 py-16 text-white">
@@ -36,17 +38,21 @@ export default async function FinanceGovernanceCaseDetailPage({ params }: CaseDe
           </div>
         </section>
 
-        <section className="rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
+          <section className="rounded-[1.75rem] border border-white/10 bg-slate-900/70 p-7">
           <h2 className="text-2xl font-semibold">Case timeline</h2>
           <div className="mt-6 grid gap-4">
-            {detail.timeline.map((item, index) => (
-              <div key={item} className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300/20 font-semibold text-cyan-100">
-                  {index + 1}
+            {timeline.length === 0 ? (
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">No timeline events recorded for this case.</div>
+            ) : (
+              timeline.map((item, index) => (
+                <div key={`${item}-${index}`} className="flex items-center gap-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-cyan-300/20 font-semibold text-cyan-100">
+                    {index + 1}
+                  </div>
+                  <p className="text-sm text-slate-100">{item}</p>
                 </div>
-                <p className="text-sm text-slate-100">{item}</p>
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </section>
       </div>

--- a/app/finance-governance/app/onboarding/page.tsx
+++ b/app/finance-governance/app/onboarding/page.tsx
@@ -5,6 +5,13 @@ type ChecklistPayload = {
   steps?: Array<string | { id?: string; label?: string; status?: 'todo' | 'in_progress' | 'done' }>;
 } | null;
 
+function toChecklistPayload(value: unknown): ChecklistPayload {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  return value as ChecklistPayload;
+}
+
 function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: string | null | undefined) {
   const rawSteps = Array.isArray(checklist?.steps) ? checklist.steps : [];
   return rawSteps.map((step, index) => {
@@ -25,13 +32,16 @@ function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: strin
 
 export default async function FinanceGovernanceOnboardingPage() {
   const orgId = await getOrg();
-  const admin = getSupabaseAdmin() as any;
-  const { data } = await admin
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
     .from('org_onboarding_states')
     .select('bootstrap_status, checklist')
     .eq('org_id', orgId)
     .maybeSingle();
-  const steps = mapChecklistToSteps(data?.checklist ?? null, data?.bootstrap_status);
+  if (error) {
+    throw new Error(`Failed to load onboarding state: ${error.message}`);
+  }
+  const steps = mapChecklistToSteps(toChecklistPayload(data?.checklist), data?.bootstrap_status);
 
   return (
     <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
@@ -50,6 +60,9 @@ export default async function FinanceGovernanceOnboardingPage() {
               {index + 1}
             </div>
             <p className="text-base text-slate-100">{step.label}</p>
+            <span className="ml-auto rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-slate-300">
+              {step.status}
+            </span>
           </section>
         ))}
       </div>

--- a/app/finance-governance/app/page.tsx
+++ b/app/finance-governance/app/page.tsx
@@ -3,6 +3,7 @@ import { FinanceGovernanceRepository } from '../../../lib/finance-governance/rep
 import { getOrg } from '../../../lib/server/getOrg';
 
 const repository = new FinanceGovernanceRepository();
+export const dynamic = 'force-dynamic';
 
 export default async function FinanceGovernanceAppHomePage() {
   const orgId = await getOrg();


### PR DESCRIPTION
### Motivation
- Pages in the finance-governance area were switched from hardcoded mocks to real backend/repository calls and need defensive handling for missing or unexpected data shapes. 
- Onboarding used an `as any` Supabase client and lacked error handling, which removes type-safety and can surface runtime errors. 
- Operational pages should serve fresh data for compliance/decisioning flows and surface empty states so the UI is informative when backend returns no rows.

### Description
- Added `export const dynamic = 'force-dynamic'` to workspace, approvals, and case detail pages to ensure fresh server-rendered data. 
- Render an explicit empty-state row in the approvals table when `approvals.length === 0` to avoid an empty table UI. 
- Normalize `detail.timeline` with `Array.isArray(detail.timeline) ? detail.timeline : []` and render a friendly empty-state when no timeline events exist; keys updated to `${item}-${index}` for safety. 
- Replaced `getSupabaseAdmin() as any` with typed client usage, added Supabase query error handling (`const { data, error } = await ...` + throw on `error`), and added a `toChecklistPayload` type guard to safely coerce backend JSON into the expected `ChecklistPayload`. 
- Surface onboarding step status in the UI by rendering a status pill (`{step.status}`) next to each checklist item.

### Testing
- Ran TypeScript checking with `npm run typecheck`, which succeeded after the checklist payload type guard was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ec7256488328a7376e071f26ff60)