### PR TITLE
Add DSG automation flow controller

### DIFF
--- a/app/api/dsg/v1/controller/evaluate/route.ts
+++ b/app/api/dsg/v1/controller/evaluate/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { evaluateAutomationController } from '../../../../../../lib/dsg/controller/automation-controller';
+import type { DsgAutomationControllerRequest } from '../../../../../../lib/dsg/controller/types';
+
+export const dynamic = 'force-dynamic';
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function invalid(message: string) {
+  return NextResponse.json({ ok: false, error: message }, { status: 400 });
+}
+
+function parseBody(body: unknown, nonce: string, idempotencyKey: string): DsgAutomationControllerRequest | null {
+  if (!isObject(body)) return null;
+  if (!isObject(body.actor) || !isObject(body.resource) || !isObject(body.context)) return null;
+
+  const actionId = text(body.actionId);
+  const actionType = text(body.actionType) as DsgAutomationControllerRequest['actionType'];
+
+  if (!actionId || !actionType) return null;
+
+  return {
+    ...(body as Omit<DsgAutomationControllerRequest, 'nonce' | 'idempotencyKey'>),
+    actionId,
+    actionType,
+    nonce,
+    idempotencyKey,
+  };
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const nonce = text(isObject(body) ? body.nonce : null) || text(request.headers.get('x-dsg-nonce'));
+  const idempotencyKey =
+    text(isObject(body) ? body.idempotencyKey : null) || text(request.headers.get('idempotency-key'));
+
+  if (!nonce) return invalid('missing_nonce');
+  if (!idempotencyKey) return invalid('missing_idempotency_key');
+
+  const controllerRequest = parseBody(body, nonce, idempotencyKey);
+  if (!controllerRequest) return invalid('invalid_controller_request');
+
+  const result = evaluateAutomationController(controllerRequest);
+
+  return NextResponse.json(result);
+}

--- a/app/automation/page.tsx
+++ b/app/automation/page.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link';
+
+const flow = [
+  {
+    step: 'Agent action',
+    body: 'An agent, workflow, finance approval, questionnaire, connector call, policy change, or deployment action submits an explicit action request.',
+  },
+  {
+    step: 'Policy',
+    body: 'DSG classifies action type, actor, resource, data classification, connector risk, and required approval before the action can proceed.',
+  },
+  {
+    step: 'Evidence',
+    body: 'Evidence must be verified or repository-stated. Demo-only, unsupported, or blocked evidence cannot become a passing consumer-facing decision.',
+  },
+  {
+    step: 'Approval',
+    body: 'High-risk, secret, top-secret, deployment, and policy-change actions require human approval context before execution can be allowed.',
+  },
+  {
+    step: 'Proof',
+    body: 'The automation controller calls the existing deterministic gate scaffold and returns proofHash, inputHash, constraintSetHash, policyVersion, and structured constraint results.',
+  },
+  {
+    step: 'Audit',
+    body: 'The response includes an audit preview derived from the gate result. This is not a WORM storage or cryptographic-signature completion claim.',
+  },
+  {
+    step: 'Execute / block',
+    body: 'Only PASS is executable. REVIEW and BLOCK stop execution and return remediation reasons for the operator.',
+  },
+];
+
+const safeClaims = [
+  'Vanta-inspired workflow structure, not copied Vanta text.',
+  'No customer logos, fake testimonials, acceptance-rate claims, or certification claims.',
+  'No mock proof or random decision path in the controller.',
+  'Uses the repository deterministic TypeScript static_check gate scaffold boundary.',
+  'Production-readiness is not claimed from this page or route alone.',
+];
+
+export default function AutomationPage() {
+  return (
+    <main className="min-h-screen bg-[#07080a] text-white">
+      <section className="border-b border-white/10 bg-[radial-gradient(circle_at_18%_12%,rgba(245,197,92,0.16),transparent_28%),linear-gradient(180deg,#090a0d_0%,#07080a_100%)]">
+        <div className="mx-auto max-w-7xl px-6 py-16">
+          <p className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
+            DSG Automation Flow
+          </p>
+          <h1 className="mt-7 max-w-5xl text-5xl font-bold leading-tight md:text-7xl">
+            Govern agent actions before they execute.
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+            DSG maps automation requests through policy, evidence, approval, deterministic proof, audit preview, and execute/block control. This page describes the DSG-native flow without copying third-party marketing claims or presenting unverified claims as facts.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Link href="/enterprise-proof/demo" className="rounded-2xl bg-amber-300 px-6 py-4 font-semibold text-slate-950 hover:bg-amber-200">
+              View gate evidence
+            </Link>
+            <Link href="/docs" className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 hover:border-amber-300/30">
+              Review truth boundary
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-16">
+        <div className="grid gap-4 lg:grid-cols-7">
+          {flow.map((item, index) => (
+            <article key={item.step} className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-300/25 bg-amber-300/10 text-sm font-bold text-amber-100">
+                {index + 1}
+              </div>
+              <h2 className="mt-5 text-xl font-semibold text-white">{item.step}</h2>
+              <p className="mt-3 text-sm leading-7 text-slate-300">{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-[#0b0d10]">
+        <div className="mx-auto grid max-w-7xl gap-8 px-6 py-16 lg:grid-cols-[0.9fr_1.1fr]">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.3em] text-slate-500">Controller endpoint</p>
+            <h2 className="mt-4 text-4xl font-semibold text-white">One control point for AI automation.</h2>
+            <p className="mt-4 text-sm leading-7 text-slate-300">
+              The controller route is designed as the runtime entry for governed automation decisions. It accepts explicit action context and reuses the existing deterministic gate scaffold instead of fabricating proof or randomizing outcomes.
+            </p>
+          </div>
+          <pre className="overflow-x-auto rounded-3xl border border-white/10 bg-black/40 p-5 text-xs leading-6 text-slate-200"><code>{`POST /api/dsg/v1/controller/evaluate
+x-dsg-nonce: <required>
+idempotency-key: <required>
+
+{
+  "actionId": "act-001",
+  "actionType": "agent_action",
+  "actor": { "userId": "user-1", "role": "operator", "workspaceId": "org-1" },
+  "resource": { "type": "workflow", "id": "wf-1", "classification": "internal" },
+  "evidence": [{ "id": "ev-1", "title": "Repo evidence", "state": "REPO_STATED" }],
+  "context": {
+    "requirement_clear": true,
+    "tool_available": true,
+    "permission_granted": true,
+    "secret_bound": true,
+    "dependency_resolved": true,
+    "testable": true,
+    "audit_hook_available": true
+  }
+}`}</code></pre>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-16">
+        <div className="rounded-[2rem] border border-emerald-300/20 bg-emerald-300/10 p-7">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-emerald-200">Consumer-safe boundary</p>
+          <h2 className="mt-4 text-3xl font-semibold text-white">What this automation flow does and does not claim.</h2>
+          <div className="mt-6 grid gap-3 md:grid-cols-2">
+            {safeClaims.map((claim) => (
+              <div key={claim} className="rounded-2xl border border-emerald-200/20 bg-black/20 p-4 text-sm leading-7 text-emerald-50">
+                {claim}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/lib/dsg/controller/automation-controller.ts
+++ b/lib/dsg/controller/automation-controller.ts
@@ -1,0 +1,191 @@
+import { evaluateDeterministicGate } from '../deterministic/gate-engine';
+import type { DeterministicRiskLevel } from '../deterministic/types';
+import type {
+  DsgAutomationControllerRequest,
+  DsgAutomationControllerResult,
+  DsgAutomationPolicyResult,
+  DsgEvidenceState,
+} from './types';
+
+const POLICY_VERSION = '1.0';
+
+function asBoolean(context: Record<string, unknown>, key: string) {
+  return context[key] === true;
+}
+
+function highestRisk(a: DeterministicRiskLevel, b: DeterministicRiskLevel): DeterministicRiskLevel {
+  const order: Record<DeterministicRiskLevel, number> = {
+    low: 1,
+    medium: 2,
+    high: 3,
+    critical: 4,
+  };
+  return order[b] > order[a] ? b : a;
+}
+
+function riskFromClassification(classification: DsgAutomationControllerRequest['resource']['classification']): DeterministicRiskLevel {
+  if (classification === 'top_secret') return 'critical';
+  if (classification === 'secret') return 'high';
+  if (classification === 'internal') return 'medium';
+  return 'low';
+}
+
+function riskFromAction(actionType: DsgAutomationControllerRequest['actionType']): DeterministicRiskLevel {
+  if (actionType === 'deployment_action') return 'high';
+  if (actionType === 'policy_change') return 'high';
+  if (actionType === 'finance_approval') return 'medium';
+  if (actionType === 'connector_call') return 'medium';
+  return 'low';
+}
+
+function evidenceStates(request: DsgAutomationControllerRequest): DsgEvidenceState[] {
+  return Array.isArray(request.evidence) ? request.evidence.map((item) => item.state) : [];
+}
+
+function hasBlockingEvidence(request: DsgAutomationControllerRequest) {
+  return evidenceStates(request).some((state) => state === 'BLOCKED' || state === 'UNSUPPORTED');
+}
+
+function hasOnlySafeEvidenceStates(request: DsgAutomationControllerRequest) {
+  const states = evidenceStates(request);
+  if (states.length === 0) return false;
+  return states.every((state) => state === 'VERIFIED' || state === 'REPO_STATED');
+}
+
+function approvalRequired(request: DsgAutomationControllerRequest, riskLevel: DeterministicRiskLevel) {
+  if (riskLevel === 'critical' || riskLevel === 'high') return true;
+  if (request.actionType === 'deployment_action') return true;
+  if (request.actionType === 'policy_change') return true;
+  if (request.resource.classification === 'secret' || request.resource.classification === 'top_secret') return true;
+  return false;
+}
+
+function evaluatePolicy(request: DsgAutomationControllerRequest): DsgAutomationPolicyResult {
+  let riskLevel = riskFromAction(request.actionType);
+  riskLevel = highestRisk(riskLevel, riskFromClassification(request.resource.classification));
+  if (request.connector?.riskLevel) {
+    riskLevel = highestRisk(riskLevel, request.connector.riskLevel);
+  }
+
+  const requiredApproval = approvalRequired(request, riskLevel);
+  const failureReasons: string[] = [];
+
+  if (!request.actor.userId || !request.actor.role || !request.actor.workspaceId) {
+    failureReasons.push('missing_actor_identity');
+  }
+
+  if (!request.resource.id || !request.resource.type) {
+    failureReasons.push('missing_resource_identity');
+  }
+
+  if (hasBlockingEvidence(request)) {
+    failureReasons.push('blocked_or_unsupported_evidence_present');
+  }
+
+  if (requiredApproval && !asBoolean(request.context, 'approval_available')) {
+    failureReasons.push('required_approval_not_available');
+  }
+
+  return {
+    policyRef: `dsg.automation.${request.actionType}`,
+    policyVersion: POLICY_VERSION,
+    riskLevel,
+    requiredApproval,
+    failureReasons,
+  };
+}
+
+function buildGateContext(request: DsgAutomationControllerRequest, policy: DsgAutomationPolicyResult) {
+  const evidenceIsUsable = hasOnlySafeEvidenceStates(request) && !hasBlockingEvidence(request);
+  const permissionGranted = asBoolean(request.context, 'permission_granted') && policy.failureReasons.length === 0;
+
+  return {
+    requirement_clear: asBoolean(request.context, 'requirement_clear'),
+    tool_available: asBoolean(request.context, 'tool_available'),
+    permission_granted: permissionGranted,
+    secret_bound:
+      request.resource.classification === 'public'
+        ? true
+        : asBoolean(request.context, 'secret_bound'),
+    dependency_resolved: asBoolean(request.context, 'dependency_resolved'),
+    testable: asBoolean(request.context, 'testable'),
+    deploy_target_ready:
+      request.actionType === 'deployment_action'
+        ? asBoolean(request.context, 'deploy_target_ready')
+        : true,
+    audit_hook_available: asBoolean(request.context, 'audit_hook_available'),
+    evidence_available: evidenceIsUsable,
+    approval_available: policy.requiredApproval
+      ? asBoolean(request.context, 'approval_available')
+      : true,
+  };
+}
+
+function remediationFor(result: Pick<DsgAutomationControllerResult, 'decision' | 'policy'>) {
+  if (result.decision === 'PASS') return [];
+
+  const remediation = new Set<string>();
+  result.policy.failureReasons.forEach((reason) => remediation.add(reason));
+  remediation.add('verify_action_requirement_context');
+  remediation.add('attach_verified_or_repo_stated_evidence');
+  remediation.add('confirm_actor_permission_and_org_scope');
+  remediation.add('confirm_audit_hook_before_execution');
+
+  if (result.policy.requiredApproval) {
+    remediation.add('attach_human_approval_before_execution');
+  }
+
+  return Array.from(remediation);
+}
+
+export function evaluateAutomationController(
+  request: DsgAutomationControllerRequest
+): DsgAutomationControllerResult {
+  const policy = evaluatePolicy(request);
+  const gate = evaluateDeterministicGate({
+    planId: request.actionId,
+    policyRef: policy.policyRef,
+    policyVersion: policy.policyVersion,
+    riskLevel: policy.riskLevel,
+    previousProofHash: request.previousProofHash,
+    nonce: request.nonce,
+    idempotencyKey: request.idempotencyKey,
+    context: buildGateContext(request, policy),
+  });
+
+  const partial = {
+    decision: gate.gateStatus,
+    policy,
+  };
+
+  const remediation = remediationFor(partial);
+
+  return {
+    ok: gate.gateStatus === 'PASS',
+    type: 'dsg-automation-controller-decision',
+    decision: gate.gateStatus,
+    actionType: request.actionType,
+    riskLevel: policy.riskLevel,
+    requiredApproval: policy.requiredApproval,
+    policy,
+    gate,
+    audit: {
+      auditRequired: true,
+      policyRef: policy.policyRef,
+      policyVersion: policy.policyVersion,
+      proofHash: gate.proof.proofHash,
+      inputHash: gate.proof.inputHash,
+      decision: gate.gateStatus,
+      note: 'Audit preview is derived from the deterministic gate scaffold response. It is not a WORM storage or cryptographic-signature completion claim.',
+    },
+    remediation,
+    evidenceBoundary: {
+      statement:
+        'DSG Automation Controller maps agent/workflow actions through policy, evidence, approval, deterministic proof/gate, and audit preview before execute/block. It reuses the repository deterministic gate scaffold and does not create mock proof, random decision, fake testimonial, or certification claim.',
+      source: 'repo_gate_scaffold',
+      externalSolverInvoked: false,
+      productionReadyClaim: false,
+      consumerClaimSafe: true,
+    },
+  };
+}

--- a/lib/dsg/controller/types.ts
+++ b/lib/dsg/controller/types.ts
@@ -1,0 +1,97 @@
+import type {
+  DeterministicGateDecision,
+  DeterministicGateStatus,
+  DeterministicRiskLevel,
+  ResourceClassification,
+} from '../deterministic/types';
+
+export type DsgAutomationActionType =
+  | 'agent_action'
+  | 'connector_call'
+  | 'finance_approval'
+  | 'deployment_action'
+  | 'evidence_export'
+  | 'questionnaire_response'
+  | 'policy_change';
+
+export type DsgAutomationDecision = DeterministicGateStatus;
+
+export type DsgAutomationProvider = 'webhook' | 'rest' | 'zapier' | 'make' | 'n8n' | 'internal';
+
+export type DsgEvidenceState = 'VERIFIED' | 'REPO_STATED' | 'DEMO_ONLY' | 'UNSUPPORTED' | 'BLOCKED';
+
+export type DsgAutomationActor = {
+  userId: string;
+  role: string;
+  workspaceId: string;
+};
+
+export type DsgAutomationResource = {
+  type: string;
+  id: string;
+  classification: ResourceClassification;
+};
+
+export type DsgAutomationConnector = {
+  id: string;
+  provider: DsgAutomationProvider;
+  riskLevel?: DeterministicRiskLevel;
+};
+
+export type DsgAutomationEvidence = {
+  id: string;
+  title: string;
+  state: DsgEvidenceState;
+  source?: string;
+};
+
+export type DsgAutomationControllerRequest = {
+  actionId: string;
+  actionType: DsgAutomationActionType;
+  actor: DsgAutomationActor;
+  resource: DsgAutomationResource;
+  connector?: DsgAutomationConnector;
+  evidence?: DsgAutomationEvidence[];
+  context: Record<string, unknown>;
+  previousProofHash?: string;
+  nonce: string;
+  idempotencyKey: string;
+};
+
+export type DsgAutomationPolicyResult = {
+  policyRef: string;
+  policyVersion: string;
+  riskLevel: DeterministicRiskLevel;
+  requiredApproval: boolean;
+  failureReasons: string[];
+};
+
+export type DsgAutomationAuditPreview = {
+  auditRequired: true;
+  policyRef: string;
+  policyVersion: string;
+  proofHash?: string;
+  inputHash?: string;
+  decision: DsgAutomationDecision;
+  note: string;
+};
+
+export type DsgAutomationControllerResult = {
+  ok: boolean;
+  type: 'dsg-automation-controller-decision';
+  decision: DsgAutomationDecision;
+  actionType: DsgAutomationActionType;
+  riskLevel: DeterministicRiskLevel;
+  requiredApproval: boolean;
+  policy: DsgAutomationPolicyResult;
+  gate: DeterministicGateDecision;
+  audit: DsgAutomationAuditPreview;
+  remediation: string[];
+  evidenceBoundary: {
+    statement: string;
+    source: 'repo_gate_scaffold';
+    externalSolverInvoked: false;
+    productionReadyClaim: false;
+    consumerClaimSafe: true;
+  };
+};

--- a/tests/unit/dsg/automation-controller.test.ts
+++ b/tests/unit/dsg/automation-controller.test.ts
@@ -1,0 +1,110 @@
+import { evaluateAutomationController } from '../../../lib/dsg/controller/automation-controller';
+import type { DsgAutomationControllerRequest } from '../../../lib/dsg/controller/types';
+
+function baseRequest(overrides: Partial<DsgAutomationControllerRequest> = {}): DsgAutomationControllerRequest {
+  return {
+    actionId: 'act-test-001',
+    actionType: 'agent_action',
+    actor: {
+      userId: 'user-test-001',
+      role: 'operator',
+      workspaceId: 'org-test-001',
+    },
+    resource: {
+      type: 'workflow',
+      id: 'wf-test-001',
+      classification: 'internal',
+    },
+    evidence: [
+      {
+        id: 'ev-test-001',
+        title: 'Repository-stated control evidence',
+        state: 'REPO_STATED',
+        source: 'repo',
+      },
+    ],
+    context: {
+      requirement_clear: true,
+      tool_available: true,
+      permission_granted: true,
+      secret_bound: true,
+      dependency_resolved: true,
+      testable: true,
+      audit_hook_available: true,
+    },
+    nonce: 'nonce-test-001',
+    idempotencyKey: 'idem-test-001',
+    ...overrides,
+  };
+}
+
+describe('DSG automation controller', () => {
+  it('passes a fully evidenced low-risk agent action through the real deterministic gate scaffold', () => {
+    const result = evaluateAutomationController(
+      baseRequest({
+        resource: {
+          type: 'workflow',
+          id: 'wf-public-001',
+          classification: 'public',
+        },
+      })
+    );
+
+    expect(result.type).toBe('dsg-automation-controller-decision');
+    expect(result.ok).toBe(true);
+    expect(result.decision).toBe('PASS');
+    expect(result.gate.proof.proofHash).toBeTruthy();
+    expect(result.evidenceBoundary.externalSolverInvoked).toBe(false);
+    expect(result.evidenceBoundary.productionReadyClaim).toBe(false);
+  });
+
+  it('does not pass high-risk action when required approval is missing', () => {
+    const result = evaluateAutomationController(
+      baseRequest({
+        actionType: 'deployment_action',
+        resource: {
+          type: 'deployment',
+          id: 'deploy-test-001',
+          classification: 'secret',
+        },
+        context: {
+          requirement_clear: true,
+          tool_available: true,
+          permission_granted: true,
+          secret_bound: true,
+          dependency_resolved: true,
+          testable: true,
+          deploy_target_ready: true,
+          audit_hook_available: true,
+          approval_available: false,
+        },
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.requiredApproval).toBe(true);
+    expect(result.decision).not.toBe('PASS');
+    expect(result.policy.failureReasons).toContain('required_approval_not_available');
+    expect(result.remediation).toContain('attach_human_approval_before_execution');
+  });
+
+  it('blocks unsupported evidence from becoming a passing consumer-facing decision', () => {
+    const result = evaluateAutomationController(
+      baseRequest({
+        evidence: [
+          {
+            id: 'ev-unsupported-001',
+            title: 'Unsupported customer claim',
+            state: 'UNSUPPORTED',
+            source: 'unverified-copy',
+          },
+        ],
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.decision).not.toBe('PASS');
+    expect(result.policy.failureReasons).toContain('blocked_or_unsupported_evidence_present');
+    expect(result.remediation).toContain('attach_verified_or_repo_stated_evidence');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a DSG-native automation flow based on the requested Vanta-inspired structure without copying Vanta text, testimonials, logos, metrics, or unsupported claims.

Core flow implemented:

```text
Agent action → policy → evidence → approval → proof → audit → execute/block
```

## What changed

- Added `POST /api/dsg/v1/controller/evaluate`
- Added `lib/dsg/controller/*` automation controller types and evaluator
- Added `/automation` consumer-safe product page
- Added unit tests for controller pass/block boundaries

## Safety / truth boundaries

- No mock proof path added
- No random decision path added
- Controller calls the existing `evaluateDeterministicGate()` scaffold
- No Vanta copy, testimonials, customer claims, acceptance-rate claims, or certification claims added
- Keeps repo truth boundary: deterministic TypeScript `static_check` scaffold, no external Z3 production invocation claim, no production-ready claim

## Validation

- Diff checked against `main`: branch is 5 commits ahead, 0 behind
- Added unit tests in `tests/unit/dsg/automation-controller.test.ts`
- I could not run CI locally from this GitHub connector session; CI should run on the PR

## Files

- `app/api/dsg/v1/controller/evaluate/route.ts`
- `app/automation/page.tsx`
- `lib/dsg/controller/automation-controller.ts`
- `lib/dsg/controller/types.ts`
- `tests/unit/dsg/automation-controller.test.ts`