### PR TITLE
Format subscription status display in dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -94,6 +94,16 @@ type DeterminismResult = {
   error: string | null;
 };
 
+
+function formatSubscriptionStatus(status: string | undefined): string {
+  if (!status) return "-";
+  return status
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
 function normalizeAgent(input: unknown): Agent | null {
   if (!input || typeof input !== "object") return null;
   const row = input as Record<string, unknown>;
@@ -476,7 +486,7 @@ export default function DashboardPage() {
             </div>
             <div className="border border-white/10 bg-white/[0.03] p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Subscription</p>
-              <p className="mt-3 text-sm text-slate-200">{summary?.subscription_status || "-"}</p>
+              <p className="mt-3 text-sm text-slate-200">{formatSubscriptionStatus(summary?.subscription_status)}</p>
             </div>
             <div className="border border-white/10 bg-white/[0.03] p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Period end</p>


### PR DESCRIPTION
### Motivation
- Make the subscription status shown on the dashboard more user-friendly by normalizing casing and separators instead of rendering raw status strings.

### Description
- Add `formatSubscriptionStatus` in `app/dashboard/page.tsx` to split status values on spaces/underscores/dashes, capitalize each word, join them with spaces, return `"-"` for empty values, and replace the raw `summary?.subscription_status` usage with `formatSubscriptionStatus(summary?.subscription_status)` in the UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60640cbd08328999515b6771f617b)