### PR TITLE
Redo PR #480: improve subscription status label formatting

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -96,8 +96,22 @@ type DeterminismResult = {
 
 
 function formatSubscriptionStatus(status: string | undefined): string {
-  if (!status) return "-";
-  return status
+  if (!status) return "Not set";
+
+  const normalized = status.trim().toLowerCase();
+  const knownStatuses: Record<string, string> = {
+    active: "Active",
+    trialing: "Trialing",
+    past_due: "Past due",
+    unpaid: "Unpaid",
+    canceled: "Canceled",
+    incomplete: "Incomplete",
+    incomplete_expired: "Incomplete expired",
+  };
+
+  if (knownStatuses[normalized]) return knownStatuses[normalized];
+
+  return normalized
     .split(/[\s_-]+/)
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
@@ -486,7 +500,7 @@ export default function DashboardPage() {
             </div>
             <div className="border border-white/10 bg-white/[0.03] p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Subscription</p>
-              <p className="mt-3 text-sm text-slate-200">{formatSubscriptionStatus(summary?.subscription_status)}</p>
+              <p className="mt-3 text-sm font-medium text-slate-200">{formatSubscriptionStatus(summary?.subscription_status)}</p>
             </div>
             <div className="border border-white/10 bg-white/[0.03] p-4">
               <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Period end</p>


### PR DESCRIPTION
### Motivation
- Make the dashboard subscription status clearer by mapping common billing states to friendly labels, showing an explicit placeholder when missing, and improving visual emphasis for readability.

### Description
- Update `formatSubscriptionStatus` in `app/dashboard/page.tsx` to return `"Not set"` when `status` is falsy and to map known statuses (`active`, `trialing`, `past_due`, `unpaid`, `canceled`, `incomplete`, `incomplete_expired`) to human-friendly labels.
- Preserve the existing fallback by normalizing and title-casing unknown status strings using the existing split/transform logic.
- Increase visual emphasis of the subscription value in the billing card by adding `font-medium` to the value element.

### Testing
- Ran `npm run lint -- --file app/dashboard/page.tsx` and the linter completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65af2dbf8832898084687f4c1ec33)