### PR TITLE
Add aliases for subscription status normalization in dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -105,6 +105,9 @@ function formatSubscriptionStatus(status: string | undefined): string {
     past_due: "Past due",
     unpaid: "Unpaid",
     canceled: "Canceled",
+    cancelled: "Canceled",
+    pastdue: "Past due",
+    in_trial: "Trialing",
     incomplete: "Incomplete",
     incomplete_expired: "Incomplete expired",
   };


### PR DESCRIPTION
### Motivation
- Normalize subscription status labels in the dashboard to handle common variants returned by external systems (e.g. different spellings or underscore forms).

### Description
- Extend `formatSubscriptionStatus` in `app/dashboard/page.tsx` to map `cancelled` → `Canceled`, `pastdue` → `Past due`, and `in_trial` → `Trialing`.

### Testing
- Ran `npm run lint` and the linter reported no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66a9319dc8328a44a1dd6d9c2166d)