### PR TITLE
feat(automation): implement DSG ONE Auto Mode control UI on /automation

### DIFF
--- a/app/automation/page.tsx
+++ b/app/automation/page.tsx
@@ -1,126 +1,209 @@
+'use client';
+
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import { ActionPathGraph } from '../../components/ActionPathGraph';
+import { ConstraintChecklist } from '../../components/ConstraintChecklist';
+import { EvidenceDrawer } from '../../components/EvidenceDrawer';
+import { GateResultCard } from '../../components/GateResultCard';
+import type { GateStatus } from '../../components/StatusBadge';
 
-const flow = [
-  {
-    step: 'Agent action',
-    body: 'An agent, workflow, finance approval, questionnaire, connector call, policy change, or deployment action submits an explicit action request.',
-  },
-  {
-    step: 'Policy',
-    body: 'DSG classifies action type, actor, resource, data classification, connector risk, and required approval before the action can proceed.',
-  },
-  {
-    step: 'Evidence',
-    body: 'Evidence must be verified or repository-stated. Demo-only, unsupported, or blocked evidence cannot become a passing consumer-facing decision.',
-  },
-  {
-    step: 'Approval',
-    body: 'High-risk, secret, top-secret, deployment, and policy-change actions require human approval context before execution can be allowed.',
-  },
-  {
-    step: 'Proof',
-    body: 'The automation controller calls the existing deterministic gate scaffold and returns proofHash, inputHash, constraintSetHash, policyVersion, and structured constraint results.',
-  },
-  {
-    step: 'Audit',
-    body: 'The response includes an audit preview derived from the gate result. This is not a WORM storage or cryptographic-signature completion claim.',
-  },
-  {
-    step: 'Execute / block',
-    body: 'Only PASS is executable. REVIEW and BLOCK stop execution and return remediation reasons for the operator.',
-  },
-];
+type DomainOption = 'agent_action' | 'workflow_automation' | 'finance_approval' | 'deployment_action' | 'connector_call';
+type RiskOption = 'low' | 'medium' | 'high' | 'critical';
+type ModeOption = 'monitor' | 'gateway' | 'dry_run';
 
-const safeClaims = [
-  'Vanta-inspired workflow structure, not copied Vanta text.',
-  'No customer logos, fake testimonials, acceptance-rate claims, or certification claims.',
-  'No mock proof or random decision path in the controller.',
-  'Uses the repository deterministic TypeScript static_check gate scaffold boundary.',
-  'Production-readiness is not claimed from this page or route alone.',
-];
+const domainLabels: Record<DomainOption, string> = {
+  agent_action: 'AI agent',
+  workflow_automation: 'workflow automation',
+  finance_approval: 'finance action',
+  deployment_action: 'deployment action',
+  connector_call: 'connector/API call',
+};
+
+const modeLabels: Record<ModeOption, string> = {
+  monitor: 'Monitor Mode',
+  gateway: 'Gateway Mode',
+  dry_run: 'Dry Run',
+};
+
+function deriveGateStatus(risk: RiskOption, mode: ModeOption): GateStatus {
+  if (mode === 'gateway' && risk === 'critical') return 'UNSUPPORTED';
+  return 'REVIEW';
+}
 
 export default function AutomationPage() {
+  const [goal, setGoal] = useState('Deploy AI agent to production with customer-data access');
+  const [domain, setDomain] = useState<DomainOption>('deployment_action');
+  const [risk, setRisk] = useState<RiskOption>('high');
+  const [mode, setMode] = useState<ModeOption>('dry_run');
+
+  const gateStatus = useMemo(() => deriveGateStatus(risk, mode), [risk, mode]);
+  const requiredApproval = risk === 'high' || risk === 'critical' || domain === 'deployment_action';
+
+  const requestPreview = useMemo(() => {
+    const nonce = 'draft-nonce-auto-mode';
+    const idempotencyKey = 'draft-idempotency-auto-mode';
+    return {
+      actionId: 'act-auto-mode-draft-001',
+      actionType: domain,
+      actor: { userId: 'user-1', role: 'operator', workspaceId: 'org-1' },
+      resource: {
+        type: domain === 'deployment_action' ? 'deployment_pipeline' : 'workflow',
+        id: 'resource-1',
+        classification: risk === 'critical' ? 'top_secret' : risk === 'high' ? 'secret' : risk === 'medium' ? 'internal' : 'public',
+      },
+      connector: { id: 'connector-1', name: 'deployment pipeline', riskLevel: risk },
+      evidence: [{ id: 'ev-1', title: 'Repo evidence', state: 'REPO_STATED' }],
+      context: {
+        requirement_clear: goal.trim().length > 10,
+        tool_available: true,
+        permission_granted: true,
+        secret_bound: false,
+        dependency_resolved: true,
+        testable: true,
+        audit_hook_available: true,
+        approval_available: !requiredApproval,
+      },
+      nonce,
+      idempotencyKey,
+    };
+  }, [domain, goal, requiredApproval, risk]);
+
   return (
     <main className="min-h-screen bg-[#07080a] text-white">
       <section className="border-b border-white/10 bg-[radial-gradient(circle_at_18%_12%,rgba(245,197,92,0.16),transparent_28%),linear-gradient(180deg,#090a0d_0%,#07080a_100%)]">
         <div className="mx-auto max-w-7xl px-6 py-16">
-          <p className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
-            DSG Automation Flow
-          </p>
-          <h1 className="mt-7 max-w-5xl text-5xl font-bold leading-tight md:text-7xl">
-            Govern agent actions before they execute.
-          </h1>
-          <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
-            DSG maps automation requests through policy, evidence, approval, deterministic proof, audit preview, and execute/block control. This page describes the DSG-native flow without copying third-party marketing claims or presenting unverified claims as facts.
-          </p>
+          <p className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">DSG ONE Auto Mode</p>
+          <h1 className="mt-7 max-w-5xl text-5xl font-bold leading-tight md:text-7xl">Auto Mode for governed AI actions</h1>
+          <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">Describe the action you want. DSG ONE turns it into a governed plan, maps policy/evidence/approval, and evaluates the deterministic gate scaffold before execution.</p>
+          <p className="mt-4 max-w-4xl rounded-2xl border border-amber-300/25 bg-amber-300/10 p-4 text-sm text-amber-100">Hard boundary: this page is draft UI for planning/evaluation and does not execute real actions or prove production-readiness by itself.</p>
           <div className="mt-8 flex flex-wrap gap-4">
-            <Link href="/enterprise-proof/demo" className="rounded-2xl bg-amber-300 px-6 py-4 font-semibold text-slate-950 hover:bg-amber-200">
-              View gate evidence
-            </Link>
-            <Link href="/docs" className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 hover:border-amber-300/30">
-              Review truth boundary
-            </Link>
+            <button className="rounded-2xl bg-amber-300 px-6 py-4 font-semibold text-slate-950 hover:bg-amber-200">Generate governed plan</button>
+            <button className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 hover:border-amber-300/30">View gate evidence</button>
           </div>
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 py-16">
-        <div className="grid gap-4 lg:grid-cols-7">
-          {flow.map((item, index) => (
-            <article key={item.step} className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-300/25 bg-amber-300/10 text-sm font-bold text-amber-100">
-                {index + 1}
-              </div>
-              <h2 className="mt-5 text-xl font-semibold text-white">{item.step}</h2>
-              <p className="mt-3 text-sm leading-7 text-slate-300">{item.body}</p>
-            </article>
-          ))}
+      <section className="mx-auto grid max-w-7xl gap-6 px-6 py-12 lg:grid-cols-2">
+        <article className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+          <h2 className="text-2xl font-semibold">Goal input</h2>
+          <p className="mt-2 text-sm text-slate-300">Sample/draft input state for Auto Mode generation.</p>
+          <label className="mt-6 block text-sm font-medium">Goal</label>
+          <textarea value={goal} onChange={(event) => setGoal(event.target.value)} className="mt-2 h-28 w-full rounded-xl border border-white/15 bg-black/30 p-3 text-sm" />
+
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <label className="text-sm">Action domain
+              <select value={domain} onChange={(event) => setDomain(event.target.value as DomainOption)} className="mt-2 w-full rounded-xl border border-white/15 bg-black/30 p-2">
+                {Object.entries(domainLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+            <label className="text-sm">Risk level
+              <select value={risk} onChange={(event) => setRisk(event.target.value as RiskOption)} className="mt-2 w-full rounded-xl border border-white/15 bg-black/30 p-2">
+                {(['low', 'medium', 'high', 'critical'] as RiskOption[]).map((item) => <option key={item} value={item}>{item}</option>)}
+              </select>
+            </label>
+            <label className="text-sm">Mode
+              <select value={mode} onChange={(event) => setMode(event.target.value as ModeOption)} className="mt-2 w-full rounded-xl border border-white/15 bg-black/30 p-2">
+                {Object.entries(modeLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+          </div>
+        </article>
+
+        <article className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+          <div className="flex items-start justify-between gap-4">
+            <h2 className="text-2xl font-semibold">Generated plan</h2>
+            <span className="rounded-full border border-amber-200/30 bg-amber-200/10 px-3 py-1 text-xs text-amber-100">Generated draft — not executed</span>
+          </div>
+          <ul className="mt-4 space-y-2 text-sm text-slate-200">
+            <li><strong>requested action:</strong> {domain}</li>
+            <li><strong>actor:</strong> operator / workspace org-1</li>
+            <li><strong>resource:</strong> {requestPreview.resource.type} ({requestPreview.resource.classification})</li>
+            <li><strong>policyVersion:</strong> 1.0 (draft mapping)</li>
+            <li><strong>required approval:</strong> {requiredApproval ? 'required' : 'not required'}</li>
+            <li><strong>required evidence:</strong> policyVersion, inputHash, replayProtection</li>
+            <li><strong>connector dependency:</strong> deployment pipeline</li>
+            <li><strong>risk reason:</strong> {risk} risk selected for {domainLabels[domain]}</li>
+            <li><strong>mode:</strong> {modeLabels[mode]}</li>
+          </ul>
+        </article>
+      </section>
+
+      <section className="mx-auto grid max-w-7xl gap-6 px-6 pb-8">
+        <ActionPathGraph
+          actor={{ id: 'actor-1', title: 'operator:user-1', subtitle: 'workspace org-1' }}
+          action={{ id: 'action-1', title: domain, subtitle: goal }}
+          policies={[{ id: 'p1', title: 'policy version', subtitle: '1.0' }, { id: 'p2', title: 'approval gate', subtitle: requiredApproval ? 'required' : 'optional' }]}
+          gateResult={gateStatus}
+          finalDecision={gateStatus === 'UNSUPPORTED' ? 'UNSUPPORTED — connector/policy path incomplete' : 'REVIEW — approval required before execution'}
+          demoLabel="sample/draft"
+        />
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <GateResultCard
+              status={gateStatus}
+              summary={gateStatus === 'UNSUPPORTED' ? 'UNSUPPORTED — backend wiring or connector capability is incomplete for this path.' : 'REVIEW — approval required before execution.'}
+              reason={gateStatus === 'UNSUPPORTED' ? 'connector_or_policy_capability_unavailable' : 'required_approval_not_available'}
+              nextReviewerOrAction="Security/ops approver"
+              ruleRefs={['dsg.automation.controller', 'static_check gate scaffold']}
+              demoLabel="sample/draft"
+            />
+          </div>
+          <EvidenceDrawer
+            title="Evidence drawer"
+            demoLabel="sample/draft"
+            fields={[
+              { key: 'policyVersion', label: 'policyVersion', availability: 'present', detail: 'Mapped from deterministic policy scaffold.' },
+              { key: 'inputHash', label: 'inputHash', availability: 'planned', detail: 'Present only after evaluation response.' },
+              { key: 'constraintSetHash', label: 'constraintSetHash', availability: 'planned', detail: 'Present only after evaluation response.' },
+              { key: 'proofHash', label: 'proofHash', availability: 'missing', detail: 'Missing until /evaluate is called.' },
+              { key: 'nonce', label: 'replayProtection.nonce', availability: 'present', detail: requestPreview.nonce },
+              { key: 'idempotencyKey', label: 'idempotencyKey', availability: 'present', detail: requestPreview.idempotencyKey },
+              { key: 'requestHash', label: 'requestHash', availability: 'planned', detail: 'Derived after request evaluation.' },
+              { key: 'export', label: 'evidence export', availability: 'unsupported', detail: 'Export pack button is UI-only in this draft page.' },
+            ]}
+          />
         </div>
+
+        <ConstraintChecklist
+          demoLabel="sample/draft"
+          items={[
+            { id: 'requirement', label: 'requirement clear', detail: 'Goal text is explicit and testable.', state: goal.trim().length > 10 ? 'pass' : 'review' },
+            { id: 'tool', label: 'tool available', detail: 'Controller endpoint exists for evaluation.', state: 'pass' },
+            { id: 'permission', label: 'permission granted', detail: 'Draft actor permission context supplied.', state: 'pass' },
+            { id: 'secret', label: 'secret bound', detail: 'Secret binding still required for this sample.', state: 'fail' },
+            { id: 'dependency', label: 'dependency resolved', detail: 'Connector dependency mapped to deployment pipeline.', state: 'pass' },
+            { id: 'testable', label: 'testable', detail: 'Draft request preview can be submitted to evaluate endpoint.', state: 'pass' },
+            { id: 'audit', label: 'audit hook available', detail: 'Audit hook field included in request context.', state: 'pass' },
+            { id: 'replay', label: 'replay protection present', detail: 'Nonce + idempotency key included.', state: 'pass' },
+          ]}
+        />
       </section>
 
       <section className="border-y border-white/10 bg-[#0b0d10]">
-        <div className="mx-auto grid max-w-7xl gap-8 px-6 py-16 lg:grid-cols-[0.9fr_1.1fr]">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.3em] text-slate-500">Controller endpoint</p>
-            <h2 className="mt-4 text-4xl font-semibold text-white">One control point for AI automation.</h2>
-            <p className="mt-4 text-sm leading-7 text-slate-300">
-              The controller route is designed as the runtime entry for governed automation decisions. It accepts explicit action context and reuses the existing deterministic gate scaffold instead of fabricating proof or randomizing outcomes.
-            </p>
-          </div>
-          <pre className="overflow-x-auto rounded-3xl border border-white/10 bg-black/40 p-5 text-xs leading-6 text-slate-200"><code>{`POST /api/dsg/v1/controller/evaluate
-x-dsg-nonce: <required>
-idempotency-key: <required>
-
-{
-  "actionId": "act-001",
-  "actionType": "agent_action",
-  "actor": { "userId": "user-1", "role": "operator", "workspaceId": "org-1" },
-  "resource": { "type": "workflow", "id": "wf-1", "classification": "internal" },
-  "evidence": [{ "id": "ev-1", "title": "Repo evidence", "state": "REPO_STATED" }],
-  "context": {
-    "requirement_clear": true,
-    "tool_available": true,
-    "permission_granted": true,
-    "secret_bound": true,
-    "dependency_resolved": true,
-    "testable": true,
-    "audit_hook_available": true
-  }
-}`}</code></pre>
-        </div>
-      </section>
-
-      <section className="mx-auto max-w-7xl px-6 py-16">
-        <div className="rounded-[2rem] border border-emerald-300/20 bg-emerald-300/10 p-7">
-          <p className="text-[11px] uppercase tracking-[0.3em] text-emerald-200">Consumer-safe boundary</p>
-          <h2 className="mt-4 text-3xl font-semibold text-white">What this automation flow does and does not claim.</h2>
-          <div className="mt-6 grid gap-3 md:grid-cols-2">
-            {safeClaims.map((claim) => (
-              <div key={claim} className="rounded-2xl border border-emerald-200/20 bg-black/20 p-4 text-sm leading-7 text-emerald-50">
-                {claim}
-              </div>
-            ))}
-          </div>
+        <div className="mx-auto grid max-w-7xl gap-6 px-6 py-12 lg:grid-cols-2">
+          <article>
+            <p className="text-[11px] uppercase tracking-[0.3em] text-slate-500">Controller request preview</p>
+            <h3 className="mt-4 text-3xl font-semibold">POST /api/dsg/v1/controller/evaluate</h3>
+            <p className="mt-4 text-sm text-slate-300">JSON preview generated from current user selections. This is sample/draft state unless explicitly evaluated.</p>
+            <pre className="mt-4 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-4 text-xs leading-6 text-slate-200"><code>{JSON.stringify(requestPreview, null, 2)}</code></pre>
+          </article>
+          <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+            <h3 className="text-2xl font-semibold">Decision boundary</h3>
+            <ul className="mt-4 space-y-3 text-sm text-slate-300">
+              <li><strong>Dry Run:</strong> no execution, evaluation-only behavior.</li>
+              <li><strong>Monitor Mode:</strong> customer runtime executes; DSG records decision/evidence.</li>
+              <li><strong>Gateway Mode:</strong> DSG-controlled executor required before execution.</li>
+              <li>This page does not prove production readiness by itself.</li>
+            </ul>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link href="/" className="rounded-xl border border-white/15 px-4 py-2 text-sm">Open Dashboard</Link>
+              <Link href="/enterprise-proof/demo" className="rounded-xl border border-white/15 px-4 py-2 text-sm">Open Evidence Pack</Link>
+              <Link href="/docs" className="rounded-xl border border-white/15 px-4 py-2 text-sm">Read Docs</Link>
+              <Link href="/policies" className="rounded-xl border border-white/15 px-4 py-2 text-sm">Review Policies</Link>
+            </div>
+          </article>
         </div>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Replace the existing static automation flow explainer with an interactive Auto Mode control UI so users can draft governed plans, inspect gate outcomes, and preview controller requests in a clearly marked draft state.
- Provide a client-only safety-first UI that maps goal → generated plan → constraints/evidence → gate preview without executing actions or claiming production readiness.

### Description
- Replaced the `/automation` page content with a client-side Auto Mode UI implemented in `app/automation/page.tsx`, adding a hero, goal input panel, domain/risk/mode selectors, and CTAs. 
- Integrated existing components `ActionPathGraph`, `GateResultCard`, `ConstraintChecklist`, and `EvidenceDrawer` to render the action path, gate outcome, constraints checklist, and evidence panel respectively, and labeled these areas `sample/draft` where appropriate. 
- Added a generated-plan panel and a JSON `requestPreview` that reflects current user selections and is shown as the `POST /api/dsg/v1/controller/evaluate` request preview, with all draft evidence fields marked `present/planned/missing/unsupported`. 
- Preserved backend contract and routes (no API behavior changes to `app/api/dsg/v1/controller/evaluate/route.ts`) and ensured all truth-boundary rules are followed (no execution, no production/proof claims, PASS not shown without real evaluation). 

### Testing
- Ran `npm run ux:routes` and verification completed successfully with `ok: true` and no route failures. 
- Ran `npm run build`; compilation progressed but the build failed at prerender due to missing environment variables required by an unrelated page (`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`/`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`), so the project build did not complete end-to-end. 
- No API or unit test changes were made and no API behavior was modified during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66cd634f4832892c889fc4c0df727)