### PR TITLE
chore: trigger Vercel redeploy for PR #483

### DIFF
--- a/redeploy-trigger.txt
+++ b/redeploy-trigger.txt
@@ -1,3 +1,3 @@
-Redeploy trigger after empty commit dbf80da7b4775fb08c0900cd098e3c6854497c04
-Timestamp (UTC): 2026-04-30T19:17:57Z
-Reason: create a real file change so Vercel/Git detects a new deployable diff.
+Redeploy trigger for PR #483
+Timestamp (UTC): 2026-05-02T22:24:37Z
+Reason: force a new Vercel deployment from Git by committing a real diff.


### PR DESCRIPTION
### Motivation
- Force Vercel to create a fresh deployment by producing a real repository diff for PR `#483` using an explicit redeploy trigger file.

### Description
- Replace `redeploy-trigger.txt` contents to include `Redeploy trigger for PR #483`, a fresh UTC timestamp `2026-05-02T22:24:37Z`, and the reason `force a new Vercel deployment from Git by committing a real diff`.

### Testing
- Verified updated file contents and a clean working tree using `nl -ba redeploy-trigger.txt` and `git status --short`, which showed no outstanding changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67980c4c08328b7383320642bb26c)