### PR TITLE
Add governed DSG planner generate endpoint with OpenRouter free fallback

### DIFF
--- a/app/api/dsg/v1/planner/generate/route.ts
+++ b/app/api/dsg/v1/planner/generate/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { generateDraftPlan, validatePlannerInput } from '../../../../../../lib/dsg/planner/generate';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const input = validatePlannerInput(body);
+  if (!input) {
+    return NextResponse.json({ ok: false, error: 'invalid_planner_request' }, { status: 400 });
+  }
+
+  const result = await generateDraftPlan(input);
+  return NextResponse.json(result);
+}

--- a/app/automation/page.tsx
+++ b/app/automation/page.tsx
@@ -8,16 +8,16 @@ import { EvidenceDrawer } from '../../components/EvidenceDrawer';
 import { GateResultCard } from '../../components/GateResultCard';
 import type { GateStatus } from '../../components/StatusBadge';
 
-type DomainOption = 'agent_action' | 'workflow_automation' | 'finance_approval' | 'deployment_action' | 'connector_call';
+type DomainOption = 'ai_agent' | 'workflow_automation' | 'finance_action' | 'deployment_action' | 'connector_api_call';
 type RiskOption = 'low' | 'medium' | 'high' | 'critical';
 type ModeOption = 'monitor' | 'gateway' | 'dry_run';
 
 const domainLabels: Record<DomainOption, string> = {
-  agent_action: 'AI agent',
+  ai_agent: 'AI agent',
   workflow_automation: 'workflow automation',
-  finance_approval: 'finance action',
+  finance_action: 'finance action',
   deployment_action: 'deployment action',
-  connector_call: 'connector/API call',
+  connector_api_call: 'connector/API call',
 };
 
 const modeLabels: Record<ModeOption, string> = {
@@ -34,8 +34,26 @@ function deriveGateStatus(risk: RiskOption, mode: ModeOption): GateStatus {
 export default function AutomationPage() {
   const [goal, setGoal] = useState('Deploy AI agent to production with customer-data access');
   const [domain, setDomain] = useState<DomainOption>('deployment_action');
+  const [plannerResult, setPlannerResult] = useState<any>(null);
+  const [plannerLoading, setPlannerLoading] = useState(false);
   const [risk, setRisk] = useState<RiskOption>('high');
   const [mode, setMode] = useState<ModeOption>('dry_run');
+
+
+  async function generatePlan() {
+    setPlannerLoading(true);
+    try {
+      const response = await fetch('/api/dsg/v1/planner/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goal, domain, riskLevel: risk, mode }),
+      });
+      const json = await response.json();
+      setPlannerResult(json);
+    } finally {
+      setPlannerLoading(false);
+    }
+  }
 
   const gateStatus = useMemo(() => deriveGateStatus(risk, mode), [risk, mode]);
   const requiredApproval = risk === 'high' || risk === 'critical' || domain === 'deployment_action';
@@ -78,7 +96,7 @@ export default function AutomationPage() {
           <p className="mt-6 max-w-4xl text-lg leading-8 text-slate-300">Describe the action you want. DSG ONE turns it into a governed plan, maps policy/evidence/approval, and evaluates the deterministic gate scaffold before execution.</p>
           <p className="mt-4 max-w-4xl rounded-2xl border border-amber-300/25 bg-amber-300/10 p-4 text-sm text-amber-100">Hard boundary: this page is draft UI for planning/evaluation and does not execute real actions or prove production-readiness by itself.</p>
           <div className="mt-8 flex flex-wrap gap-4">
-            <button className="rounded-2xl bg-amber-300 px-6 py-4 font-semibold text-slate-950 hover:bg-amber-200">Generate governed plan</button>
+            <button onClick={generatePlan} className="rounded-2xl bg-amber-300 px-6 py-4 font-semibold text-slate-950 hover:bg-amber-200">{plannerLoading ? 'Generating...' : 'Generate governed plan'}</button>
             <button className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 hover:border-amber-300/30">View gate evidence</button>
           </div>
         </div>
@@ -116,14 +134,15 @@ export default function AutomationPage() {
             <span className="rounded-full border border-amber-200/30 bg-amber-200/10 px-3 py-1 text-xs text-amber-100">Generated draft — not executed</span>
           </div>
           <ul className="mt-4 space-y-2 text-sm text-slate-200">
-            <li><strong>requested action:</strong> {domain}</li>
+            <li><strong>requested action:</strong> {plannerResult?.plan?.requestedAction || domain}</li>
             <li><strong>actor:</strong> operator / workspace org-1</li>
             <li><strong>resource:</strong> {requestPreview.resource.type} ({requestPreview.resource.classification})</li>
-            <li><strong>policyVersion:</strong> 1.0 (draft mapping)</li>
-            <li><strong>required approval:</strong> {requiredApproval ? 'required' : 'not required'}</li>
+            <li><strong>policyVersion:</strong> {plannerResult?.plan?.policyVersion || '1.0'} (draft mapping)</li>
+            <li><strong>required approval:</strong> {plannerResult?.plan?.requiredApproval || (requiredApproval ? 'required' : 'not required')}</li>
             <li><strong>required evidence:</strong> policyVersion, inputHash, replayProtection</li>
-            <li><strong>connector dependency:</strong> deployment pipeline</li>
-            <li><strong>risk reason:</strong> {risk} risk selected for {domainLabels[domain]}</li>
+            <li><strong>connector dependency:</strong> {plannerResult?.plan?.connectorDependency || 'deployment pipeline'}</li>
+            <li><strong>risk reason:</strong> {plannerResult?.plan?.riskReason || `${risk} risk selected for ${domainLabels[domain]}`}</li>
+            <li><strong>planner source:</strong> {plannerResult?.source || 'not_generated'}</li>
             <li><strong>mode:</strong> {modeLabels[mode]}</li>
           </ul>
         </article>

--- a/artifacts/deterministic-module/verification-result.json
+++ b/artifacts/deterministic-module/verification-result.json
@@ -1,7 +1,7 @@
 {
   "ok": true,
   "type": "dsg-deterministic-module-verification",
-  "checkedAt": "2026-05-02T10:24:26.481Z",
+  "checkedAt": "2026-05-03T00:54:19.836Z",
   "requiredFiles": 9,
   "requiredTextChecks": 13,
   "failures": [],

--- a/artifacts/ux-route-map/ux-route-map-result.json
+++ b/artifacts/ux-route-map/ux-route-map-result.json
@@ -1,7 +1,7 @@
 {
   "ok": true,
   "type": "dsg-ux-route-map-verification",
-  "checkedAt": "2026-05-02T10:31:26.426Z",
+  "checkedAt": "2026-05-03T00:52:19.102Z",
   "routeChecks": 12,
   "flowOutcomeChecks": 3,
   "failures": [],

--- a/lib/dsg/planner/generate.ts
+++ b/lib/dsg/planner/generate.ts
@@ -1,0 +1,169 @@
+export type PlannerDomain = 'ai_agent' | 'workflow_automation' | 'finance_action' | 'deployment_action' | 'connector_api_call';
+export type PlannerRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+export type PlannerMode = 'monitor' | 'gateway' | 'dry_run';
+
+export type PlannerGenerateInput = {
+  goal: string;
+  domain: PlannerDomain;
+  riskLevel: PlannerRiskLevel;
+  mode: PlannerMode;
+};
+
+type PlannerStep = {
+  id: string;
+  title: string;
+  purpose: string;
+  evidenceRequired: string[];
+  risk: string;
+};
+
+export type DraftPlan = {
+  requestedAction: string;
+  actor: string;
+  resource: string;
+  riskLevel: string;
+  policyVersion: '1.0';
+  requiredApproval: string;
+  requiredEvidence: string[];
+  connectorDependency: string;
+  riskReason: string;
+  steps: PlannerStep[];
+};
+
+export type PlannerGenerateResponse = {
+  ok: boolean;
+  type: 'dsg-generated-draft-plan';
+  source: 'llm_draft' | 'fallback_local_draft';
+  provider: 'openrouter';
+  model: 'openrouter/free';
+  execution: 'not_executed';
+  plan: DraftPlan;
+  claimBoundary: {
+    draftOnly: true;
+    notExecuted: true;
+    notGateDecision: true;
+  };
+  review?: { reason: 'invalid_plan_schema' | 'provider_unavailable'; status: 'REVIEW' };
+};
+
+const OPENROUTER_TIMEOUT_MS = 12_000;
+const OPENROUTER_MAX_TOKENS = 700;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function validatePlannerInput(body: unknown): PlannerGenerateInput | null {
+  if (!isObject(body)) return null;
+  const goal = text(body.goal);
+  const domain = text(body.domain) as PlannerDomain;
+  const riskLevel = text(body.riskLevel) as PlannerRiskLevel;
+  const mode = text(body.mode) as PlannerMode;
+  if (!goal) return null;
+  if (!['ai_agent', 'workflow_automation', 'finance_action', 'deployment_action', 'connector_api_call'].includes(domain)) return null;
+  if (!['low', 'medium', 'high', 'critical'].includes(riskLevel)) return null;
+  if (!['monitor', 'gateway', 'dry_run'].includes(mode)) return null;
+  return { goal, domain, riskLevel, mode };
+}
+
+function fallbackDraft(input: PlannerGenerateInput): DraftPlan {
+  return {
+    requestedAction: input.goal,
+    actor: 'operator',
+    resource: input.domain,
+    riskLevel: input.riskLevel,
+    policyVersion: '1.0',
+    requiredApproval: input.riskLevel === 'high' || input.riskLevel === 'critical' ? 'security_approver' : 'operator',
+    requiredEvidence: ['policyVersion', 'inputHash', 'nonce', 'idempotencyKey'],
+    connectorDependency: input.domain === 'connector_api_call' ? 'connector_registry' : 'none',
+    riskReason: `${input.riskLevel} risk in ${input.mode} mode for ${input.domain}`,
+    steps: [
+      { id: 's1', title: 'Classify request intent', purpose: 'Map requested action to deterministic control taxonomy.', evidenceRequired: ['goal_text'], risk: input.riskLevel },
+      { id: 's2', title: 'Prepare controller input', purpose: 'Build draft payload for deterministic evaluate route.', evidenceRequired: ['policyVersion', 'nonce'], risk: input.riskLevel },
+    ],
+  };
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string' && item.trim().length > 0);
+}
+
+export function validateDraftPlan(value: unknown): DraftPlan | null {
+  if (!isObject(value)) return null;
+  const steps = value.steps;
+  if (!Array.isArray(steps) || !steps.length) return null;
+  const normalizedSteps: PlannerStep[] = [];
+  for (const step of steps) {
+    if (!isObject(step)) return null;
+    const id = text(step.id);
+    const title = text(step.title);
+    const purpose = text(step.purpose);
+    const risk = text(step.risk);
+    if (!id || !title || !purpose || !risk || !isStringArray(step.evidenceRequired)) return null;
+    normalizedSteps.push({ id, title, purpose, risk, evidenceRequired: step.evidenceRequired.map((item) => item.trim()) });
+  }
+
+  const plan: DraftPlan = {
+    requestedAction: text(value.requestedAction),
+    actor: text(value.actor),
+    resource: text(value.resource),
+    riskLevel: text(value.riskLevel),
+    policyVersion: '1.0',
+    requiredApproval: text(value.requiredApproval),
+    requiredEvidence: isStringArray(value.requiredEvidence) ? value.requiredEvidence.map((item) => item.trim()) : [],
+    connectorDependency: text(value.connectorDependency),
+    riskReason: text(value.riskReason),
+    steps: normalizedSteps,
+  };
+
+  if (!plan.requestedAction || !plan.actor || !plan.resource || !plan.riskLevel || !plan.requiredApproval || !plan.requiredEvidence.length || !plan.connectorDependency || !plan.riskReason) return null;
+  return plan;
+}
+
+export async function generateDraftPlan(input: PlannerGenerateInput): Promise<PlannerGenerateResponse> {
+  const apiKey = process.env.OPENROUTER_API_KEY?.trim();
+  if (!apiKey) {
+    return { ok: true, type: 'dsg-generated-draft-plan', source: 'fallback_local_draft', provider: 'openrouter', model: 'openrouter/free', execution: 'not_executed', plan: fallbackDraft(input), claimBoundary: { draftOnly: true, notExecuted: true, notGateDecision: true }, review: { reason: 'provider_unavailable', status: 'REVIEW' } };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPENROUTER_TIMEOUT_MS);
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': process.env.OPENROUTER_SITE_URL || 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+        'X-Title': process.env.OPENROUTER_APP_NAME || 'DSG ONE',
+      },
+      body: JSON.stringify({
+        model: 'openrouter/free',
+        max_tokens: OPENROUTER_MAX_TOKENS,
+        temperature: 0.1,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: 'Return strict JSON draft plan only. Never claim execution or gate decision.' },
+          { role: 'user', content: `Generate draft plan JSON for goal="${input.goal}", domain="${input.domain}", riskLevel="${input.riskLevel}", mode="${input.mode}".` },
+        ],
+      }),
+    });
+    if (!response.ok) throw new Error(`openrouter_${response.status}`);
+    const json = (await response.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    const content = text(json.choices?.[0]?.message?.content);
+    const parsed = content ? JSON.parse(content) : null;
+    const plan = validateDraftPlan(parsed);
+    if (!plan) {
+      return { ok: true, type: 'dsg-generated-draft-plan', source: 'fallback_local_draft', provider: 'openrouter', model: 'openrouter/free', execution: 'not_executed', plan: fallbackDraft(input), claimBoundary: { draftOnly: true, notExecuted: true, notGateDecision: true }, review: { reason: 'invalid_plan_schema', status: 'REVIEW' } };
+    }
+    return { ok: true, type: 'dsg-generated-draft-plan', source: 'llm_draft', provider: 'openrouter', model: 'openrouter/free', execution: 'not_executed', plan, claimBoundary: { draftOnly: true, notExecuted: true, notGateDecision: true } };
+  } catch {
+    return { ok: true, type: 'dsg-generated-draft-plan', source: 'fallback_local_draft', provider: 'openrouter', model: 'openrouter/free', execution: 'not_executed', plan: fallbackDraft(input), claimBoundary: { draftOnly: true, notExecuted: true, notGateDecision: true }, review: { reason: 'provider_unavailable', status: 'REVIEW' } };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/unit/dsg/planner-generate.test.ts
+++ b/tests/unit/dsg/planner-generate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { validateDraftPlan, validatePlannerInput } from '../../../lib/dsg/planner/generate';
+
+describe('dsg planner generate', () => {
+  it('validates planner input', () => {
+    expect(validatePlannerInput({ goal: 'test', domain: 'ai_agent', riskLevel: 'low', mode: 'monitor' })).toBeTruthy();
+    expect(validatePlannerInput({ goal: '', domain: 'ai_agent', riskLevel: 'low', mode: 'monitor' })).toBeNull();
+  });
+
+  it('validates draft plan schema', () => {
+    const plan = validateDraftPlan({
+      requestedAction: 'x', actor: 'operator', resource: 'ai_agent', riskLevel: 'low', policyVersion: '1.0',
+      requiredApproval: 'operator', requiredEvidence: ['policyVersion'], connectorDependency: 'none', riskReason: 'test',
+      steps: [{ id: 's1', title: 't', purpose: 'p', evidenceRequired: ['goal_text'], risk: 'low' }],
+    });
+    expect(plan).toBeTruthy();
+    expect(validateDraftPlan({ steps: [] })).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a backend planner for DSG ONE Auto Mode that converts a user `goal` into a governed draft action plan while keeping the deterministic gate as the final authority.  
- Prefer free provider routing (`openrouter/free`) for low-cost dev usage while enforcing strict safety boundaries and a deterministic fallback when provider or schema validation fails.  

### Description
- Add `POST /api/dsg/v1/planner/generate` route (`app/api/dsg/v1/planner/generate/route.ts`) that validates incoming input and returns a draft planner response.  
- Implement planner logic in `lib/dsg/planner/generate.ts` with strict input validation (`validatePlannerInput`), strict draft schema validation (`validateDraftPlan`), OpenRouter `openrouter/free` call with timeout and max token cap, and a deterministic `fallback_local_draft` when the provider is unavailable or the LLM output fails schema checks; all responses include an explicit `claimBoundary` indicating draft-only/non-executed.  
- Update the automation UI (`app/automation/page.tsx`) so the "Generate governed plan" button calls the new planner endpoint, shows a loading state, and surfaces `plannerResult`/`planner source` in the Generated plan panel.  
- Add unit tests (`tests/unit/dsg/planner-generate.test.ts`) that cover planner input validation and draft plan schema validation.  

### Testing
- Ran `npm run ux:routes` and the UX route verification completed successfully.  
- Ran unit tests with `npm run test -- tests/unit/dsg/planner-generate.test.ts` and both tests passed.  
- Ran `npm run build` which failed during prerender because required public Supabase env vars are not set: missing `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` (or `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`).  
- Ran `npm run verify:deterministic` and deterministic-module verification passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69baf29688328a8d4d15728ad4c53)