### PR TITLE
Fix PR #486 pre-merge checks and refresh lockfile

### DIFF
--- a/artifacts/deterministic-module/verification-result.json
+++ b/artifacts/deterministic-module/verification-result.json
@@ -1,7 +1,7 @@
 {
   "ok": true,
   "type": "dsg-deterministic-module-verification",
-  "checkedAt": "2026-05-03T00:54:19.836Z",
+  "checkedAt": "2026-05-03T11:28:03.832Z",
   "requiredFiles": 9,
   "requiredTextChecks": 13,
   "failures": [],

--- a/artifacts/ux-route-map/ux-route-map-result.json
+++ b/artifacts/ux-route-map/ux-route-map-result.json
@@ -1,7 +1,7 @@
 {
   "ok": true,
   "type": "dsg-ux-route-map-verification",
-  "checkedAt": "2026-05-03T00:52:19.102Z",
+  "checkedAt": "2026-05-03T11:28:00.548Z",
   "routeChecks": 12,
   "flowOutcomeChecks": 3,
   "failures": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "postcss": "^8.4.38",
         "supabase": "^2.89.0",
         "tailwindcss": "^3.4.3",
-        "typescript": "^5.6.3",
         "vitest": "^2.1.9"
       }
     },
@@ -8600,6 +8599,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10548,6 +10548,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
### Motivation
- Ensure PR #486 passes repository hygiene checks by resolving lockfile drift, verifying UX/deterministic artifacts, and removing temporary probe files if present. 
- Preserve Step 15 architecture and runtime behavior while performing only non-invasive validation and artifact updates. 

### Description
- Ran `npm install --package-lock-only --ignore-scripts` and committed the refreshed `package-lock.json`. 
- Re-ran verification commands `npm run ux:routes` and `npm run verify:deterministic` and committed the updated generated artifacts under `artifacts/`. 
- Confirmed the three probe/temporary files (`docs/STEP_15_REV_A_PROBE.md`, `lib/dsg/app-builder/minimal.ts`, `app/api/dsg/app-builder/jobs/[jobId]/approval/README.md`) are not present on the branch, so no deletions were needed. 
- Did not add fake environment values, did not weaken tests, and did not bypass CI or runtime validation; no runtime or architectural changes were made to Step 15. 

### Testing
- Ran `npm install --package-lock-only --ignore-scripts` which completed successfully and produced a changed `package-lock.json` that was committed. 
- Ran `npm run ux:routes` which completed with `ok: true` and no failures. 
- Ran `npm run verify:deterministic` which completed with `ok: true` and no failures. 
- Ran `npm run build` which failed during prerender with missing Supabase public environment variables and was not bypassed, specifically: `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` (or `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`). 
- CI was not re-triggered from this environment; local validation shows the only remaining blocker is the absent Supabase public env vars required for `next build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f731202f248328b07d66673d92ca86)