### PR TITLE
fix(build): restore TS path alias and correct AppBuilder risk type import

### DIFF
--- a/lib/dsg/app-builder/gate.ts
+++ b/lib/dsg/app-builder/gate.ts
@@ -2,8 +2,8 @@ import type {
   AppBuilderGateIssue,
   AppBuilderGateResult,
   AppBuilderProposedPlan,
-  AppBuilderRiskLevel,
 } from './model';
+import type { AppBuilderRiskLevel } from './status';
 
 const blockedCommands = [
   'rm -rf /',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,13 @@
         "name": "next"
       }
     ],
-    "target": "ES2017"
+    "target": "ES2017",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
### Motivation
- Restore TypeScript alias resolution so imports using `@/*` resolve during Next.js build and API route compilation.
- Fix a type import in the App Builder gate to source `AppBuilderRiskLevel` from the file that actually exports it to eliminate a type-check failure.

### Description
- Add `baseUrl: "."` and `paths` mapping `@/* -> ./*` to `tsconfig.json` to re-enable `@/...` module resolution.
- Change the import in `lib/dsg/app-builder/gate.ts` to `import type { AppBuilderRiskLevel } from './status';` instead of importing it from `./model`.

### Testing
- `npm run build` initially failed with module resolution errors for `@/lib/dsg/app-builder/*` before the `tsconfig.json` fix.
- `npm run build` then failed with a type error for `AppBuilderRiskLevel` before fixing the `gate.ts` import.
- After the changes, `npm run typecheck` succeeds and `npm run build` now completes compilation and type-checking but the build stops at prerender due to missing env vars `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`/`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74301879c83288e28fa6ff0737035)