### PR TITLE
Harden Supabase env setup across Vercel environments and GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     env:
       CI: true
       NEXT_TELEMETRY_DISABLED: 1
+      # Build-safe Supabase public envs for CI (prefer repo variables/secrets, then fallback to deterministic placeholders)
+      NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/OPERATOR_SETUP_CHECKLIST.md
+++ b/docs/OPERATOR_SETUP_CHECKLIST.md
@@ -11,14 +11,25 @@ Run these commands from a machine with network access to Vercel and Supabase.
 
 ## Step 1: Vercel Environment Variables
 
+Set the Supabase public envs in **all three Vercel environments** so every deploy target can build:
+- Production
+- Preview
+- Development
+
+Use either `NEXT_PUBLIC_SUPABASE_ANON_KEY` **or** `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (this codebase supports both).
+
 ```bash
 # Login to Vercel CLI
 npx vercel login
 
 # Add required env vars (values from your Supabase project Settings → API)
-npx vercel env add NEXT_PUBLIC_SUPABASE_URL production
-npx vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY production
-npx vercel env add SUPABASE_SERVICE_ROLE_KEY production
+for ENV in production preview development; do
+  npx vercel env add NEXT_PUBLIC_SUPABASE_URL "$ENV"
+  npx vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY "$ENV"
+  # Optional alternative used by parts of the codebase
+  npx vercel env add NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY "$ENV"
+  npx vercel env add SUPABASE_SERVICE_ROLE_KEY "$ENV"
+done
 
 # Set app URL
 echo "https://tdealer01-crypto-dsg-control-plane.vercel.app" | npx vercel env add APP_URL production
@@ -29,7 +40,21 @@ echo "internal" | npx vercel env add DSG_CORE_MODE production
 
 # Verify all vars are set
 npx vercel env ls production
+npx vercel env ls preview
+npx vercel env ls development
 ```
+
+## Step 1.1: GitHub Actions Secrets/Variables (for CI/Build)
+
+If CI/build runs in GitHub Actions, add the same public Supabase envs in repository **Secrets or Variables**:
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY` (or `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`)
+
+Recommended paths:
+- GitHub repo → **Settings → Secrets and variables → Actions → Variables** (for public, non-sensitive URL)
+- GitHub repo → **Settings → Secrets and variables → Actions → Secrets** (for keys)
+
+This repository’s `CI` workflow is now wired to read those values first and fallback to placeholders only when missing.
 
 ## Step 2: Supabase Migrations
 


### PR DESCRIPTION
### Motivation
- Prevent CI and local build failures caused by missing Supabase public environment variables during Next.js prerender and build. 
- Make deployment instructions explicit so Vercel builds for all targets (Production, Preview, Development) receive the public Supabase envs. 
- Ensure GitHub Actions build environments mirror Vercel by allowing CI to read repository `vars`/`secrets` or fall back to safe placeholders.

### Description
- Injected build-time envs into `.github/workflows/ci.yml` for `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` that prefer GitHub `vars`/`secrets` and fall back to deterministic placeholders. 
- Updated `docs/OPERATOR_SETUP_CHECKLIST.md` to require setting Supabase public envs in Vercel `production`, `preview`, and `development`, and added a `Step 1.1` describing required GitHub Actions Secrets/Variables. 
- Documented that the codebase accepts either `NEXT_PUBLIC_SUPABASE_ANON_KEY` or `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` as the public key used at build time.

### Testing
- Ran `npm run build` with no Supabase envs and observed a prerender/build failure due to missing `NEXT_PUBLIC_SUPABASE_URL` or public key. (failed)
- Ran `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-placeholder npm run build` and confirmed the build completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74a51cb148328b87f17d1ac4cec6d)