### PR TITLE
Harden Supabase CI fallback and scope Vercel service-role keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       # Build-safe Supabase public envs for CI (prefer repo variables/secrets, then fallback to deterministic placeholders)
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
-      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || '' }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/OPERATOR_SETUP_CHECKLIST.md
+++ b/docs/OPERATOR_SETUP_CHECKLIST.md
@@ -28,8 +28,14 @@ for ENV in production preview development; do
   npx vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY "$ENV"
   # Optional alternative used by parts of the codebase
   npx vercel env add NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY "$ENV"
-  npx vercel env add SUPABASE_SERVICE_ROLE_KEY "$ENV"
 done
+
+# Server-side service role keys.
+# Do not reuse the production service role key in preview or development.
+# Use separate Supabase projects/keys for non-production environments.
+npx vercel env add SUPABASE_SERVICE_ROLE_KEY production
+npx vercel env add SUPABASE_SERVICE_ROLE_KEY preview
+npx vercel env add SUPABASE_SERVICE_ROLE_KEY development
 
 # Set app URL
 echo "https://tdealer01-crypto-dsg-control-plane.vercel.app" | npx vercel env add APP_URL production


### PR DESCRIPTION
### Motivation
- Prevent build/runtime failures when `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` resolves to an empty string and ensure CI uses a safe fallback chain.
- Reduce risk of leaking powerful server-side secrets by preventing reuse of the production `SUPABASE_SERVICE_ROLE_KEY` in preview/development environments.

### Description
- Change CI env fallback in `.github/workflows/ci.yml` so `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` falls back to `NEXT_PUBLIC_SUPABASE_ANON_KEY` sources and finally a deterministic placeholder instead of `''`.
- Update `docs/OPERATOR_SETUP_CHECKLIST.md` to remove `SUPABASE_SERVICE_ROLE_KEY` from the shared loop and add explicit `npx vercel env add SUPABASE_SERVICE_ROLE_KEY` lines per environment with a clear warning to not reuse production keys.
- Commit changes and open a PR to capture the hardening updates.

### Testing
- Ran `git diff` to verify the staged changes and the diff shows the updated fallback and checklist modifications (success).
- Performed `git commit` to persist the edits locally (success); no CI workflow was executed here so full GitHub Actions verification should be observed in GitHub after the PR is created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f751dffd948328bfd81ac7bec64544)