### PR TITLE
docs: add partner maintainer access boundary

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,55 @@
+# DSG ONE Protected Ownership Boundary
+#
+# Purpose:
+# Allow partner/product work to move fast while protecting DSG core governance,
+# production execution, audit authority, secrets, and deployment-control surfaces.
+
+# Core DSG governance / runtime / proof authority
+/lib/dsg/core/ @tdealer01-crypto
+/lib/dsg/runtime/ @tdealer01-crypto
+/lib/dsg/gates/ @tdealer01-crypto
+/lib/dsg/audit/ @tdealer01-crypto
+/lib/dsg/evidence/ @tdealer01-crypto
+/lib/dsg/executor/ @tdealer01-crypto
+/lib/dsg/policy/ @tdealer01-crypto
+/lib/dsg/crypto/ @tdealer01-crypto
+/lib/dsg/planning/ @tdealer01-crypto
+/lib/dsg/connectors/ @tdealer01-crypto
+
+# High-risk execution APIs
+/app/api/execute/ @tdealer01-crypto
+/app/api/spine/ @tdealer01-crypto
+/app/api/mcp/ @tdealer01-crypto
+/app/api/gateway/tools/ @tdealer01-crypto
+/app/api/executors/ @tdealer01-crypto
+/app/api/model-provider/ @tdealer01-crypto
+/app/api/setup/ @tdealer01-crypto
+
+# Auth / RBAC / billing / internal service
+/lib/auth/ @tdealer01-crypto
+/lib/billing/ @tdealer01-crypto
+/lib/internal/ @tdealer01-crypto
+/app/api/auth/ @tdealer01-crypto
+/app/api/billing/ @tdealer01-crypto
+/app/api/settings/security/ @tdealer01-crypto
+/app/api/settings/access/ @tdealer01-crypto
+
+# Database, migrations, RLS, deployment, CI
+/supabase/migrations/ @tdealer01-crypto
+/.github/workflows/ @tdealer01-crypto
+/vercel.json @tdealer01-crypto
+/next.config.js @tdealer01-crypto
+/middleware.ts @tdealer01-crypto
+
+# Truth, production claims, runbooks
+/README.md @tdealer01-crypto
+/PROJECT_TRUTH.md @tdealer01-crypto
+/docs/REPO_TRUTH.md @tdealer01-crypto
+/docs/RUNBOOK_DEPLOY.md @tdealer01-crypto
+/docs/ops/ @tdealer01-crypto
+/qa-logs/ @tdealer01-crypto
+
+# Partner-facing surfaces
+/app/ @tdealer01-crypto
+/components/ @tdealer01-crypto
+/docs/partner/ @tdealer01-crypto

--- a/docs/partner/PARTNER_ACCESS_POLICY.md
+++ b/docs/partner/PARTNER_ACCESS_POLICY.md
@@ -1,0 +1,187 @@
+# DSG ONE Partner Access Policy
+
+## Purpose
+
+This policy defines what a DSG ONE implementation/commercial partner may access before and after legal agreement.
+
+The goal is to let the partner build, fix, operate, and sell the storefront, Bubble operator layer, and partner-facing product surface without exposing DSG core governance authority, production secrets, customer data, or production execution bypasses.
+
+## Operating Model
+
+```text
+Open contribution
+Controlled production
+Partner API boundary
+Owner-held DSG core authority
+Automated checkpoint gates
+```
+
+## Phase 0 — Before NDA / Before Legal Agreement
+
+Allowed:
+- Public documentation
+- Public product pages
+- Public health/readiness endpoints
+- API contract preview
+- OpenAPI examples
+- Bubble integration discussion
+- Demo screenshots / demo workspace
+- GitHub read access or fork/PR access if approved
+- Staging/partner-preview API token if scoped and revocable
+
+Not allowed:
+- Production secrets
+- Supabase service role key
+- Direct production database access
+- Vercel production environment edit
+- GitHub admin
+- GitHub Actions secrets
+- Internal service token
+- Stripe secret key
+- Provider API keys
+- Production execution authority
+- Policy-write authority
+- Cross-customer data access
+- Destructive migrations
+
+## Phase 1 — After NDA
+
+Allowed:
+- Full architecture review
+- Repository access
+- Branch / PR contribution
+- API contract and route map
+- Non-secret migration files
+- Partner integration guide
+- Staging URL
+- Staging partner API token
+- Demo workspace
+- Redacted logs
+- Preview deployments
+- Bubble operator build access
+
+Still protected:
+- Production secrets
+- Supabase service role
+- Direct production DB admin
+- Vercel production env values
+- GitHub repo admin
+- Internal service token
+- Core execution bypass
+- Customer raw data
+- Cross-workspace data
+
+## Phase 2 — After Pilot / Maintainer Agreement
+
+Allowed:
+- Partner Maintainer role
+- GitHub write access
+- Staging deploy and test
+- Preview deployment review
+- Partner API facade improvements
+- Storefront and Bubble UI management
+- Customer onboarding surface
+- Checkout/commercialization shell
+- Non-core backend fixes
+- Production deployment only when gates pass and protected paths are not touched
+
+Checkpoint required:
+- DSG core governance changes
+- Policy / gate / execution logic
+- Audit ledger / evidence / replay proof authority
+- Auth / RBAC
+- Billing secret logic
+- Production environment
+- Destructive migrations
+- Deployment-control changes
+- Cross-workspace access
+- Any high/critical-risk action
+
+## Partner Maintainer Allowed Work
+
+Partner may maintain and improve:
+- Bubble storefront
+- Bubble operator UI
+- Landing pages
+- Pricing pages
+- Request-access flow
+- Checkout UI
+- Onboarding flow
+- Partner dashboard
+- Customer demo workspace
+- API response mapping
+- Partner API facade
+- Documentation
+- Integration guide
+- Customer-facing product copy
+- Staging validation
+- Preview deployment testing
+
+## Protected Core Boundary
+
+Partner must not bypass owner checkpoint for:
+- lib/dsg/core/**
+- lib/dsg/runtime/**
+- lib/dsg/gates/**
+- lib/dsg/audit/**
+- lib/dsg/evidence/**
+- lib/dsg/executor/**
+- lib/dsg/policy/**
+- lib/dsg/crypto/**
+- app/api/execute/**
+- app/api/spine/**
+- app/api/mcp/**
+- app/api/gateway/tools/**
+- app/api/executors/**
+- supabase/migrations/**
+- production env/secrets
+- production DB authority
+- deployment authority
+- billing secrets
+
+## Legal Boundary
+
+NDA protects confidential information.
+Access control protects the production system.
+Both are required.
+
+Before broad backend/operations access, the following agreements should be in place:
+- NDA
+- Master Service Agreement
+- Data Processing Agreement if any personal data is processed
+- IP ownership / assignment
+- Security addendum
+- Incident response clause
+- Access revocation clause
+- No unauthorized production claims clause
+- No cross-customer data access clause
+- No secret copying clause
+- No production deployment bypass clause
+
+## Claim Boundary
+
+Allowed customer-facing claim:
+DSG ONE provides a governed runtime control layer for AI, workflow, finance, and deployment actions with policy gates, readiness checks, audit evidence, and operator monitoring.
+
+Forbidden unless separately verified:
+- Production-certified
+- Bank-certified
+- ISO certified
+- Guaranteed compliance
+- Fully autonomous payment approval
+- All customer systems protected
+- External Z3 production solver complete
+- WORM evidence storage complete
+- Third-party audited
+
+## Access Revocation
+
+All partner access must be revocable.
+
+Access must be revoked immediately if:
+- agreement terminates
+- key/token is suspected leaked
+- unauthorized data export occurs
+- production boundary is bypassed
+- false customer-facing claims are published
+- protected core is modified without checkpoint

--- a/docs/partner/PARTNER_API_SCOPES.md
+++ b/docs/partner/PARTNER_API_SCOPES.md
@@ -1,0 +1,90 @@
+# DSG ONE Partner API Scopes
+
+## Goal
+
+Expose enough API access for storefront, Bubble operator UI, onboarding, sales, demo, and partner-managed product operations without exposing production secrets, raw customer data, or core execution authority.
+
+## Pre-sign Scopes
+
+- partner.status.read
+- partner.catalog.read
+- partner.docs.read
+- partner.demo.read
+- partner.readiness.read
+- partner.evidence.summary.read
+- partner.audit.summary.read
+- partner.leads.write
+- partner.checkout.write
+
+## Post-NDA Scopes
+
+- partner.workspace.read
+- partner.runtime.summary.read
+- partner.approvals.read
+- partner.cases.read
+- partner.usage.read
+- partner.capacity.read
+- partner.onboarding.write
+- partner.integration.read
+- partner.facade.read
+
+## Partner Maintainer Scopes
+
+- partner.facade.write
+- partner.storefront.write
+- partner.onboarding.write
+- partner.checkout.write
+- partner.demo.manage
+- partner.workspace.preview
+- partner.logs.redacted.read
+- partner.preview.deploy
+
+## Not Allowed Without Owner Checkpoint
+
+- partner.execute.write
+- partner.policy.write
+- partner.secret.read
+- partner.secret.write
+- partner.deploy.production
+- partner.database.admin
+- partner.cross_workspace.read
+- partner.audit.raw_export
+- partner.evidence.raw_export
+- partner.billing.admin
+- partner.auth.admin
+- partner.rbac.write
+
+## Partner API Facade Endpoints
+
+- GET /api/partner/v1/status
+- GET /api/partner/v1/catalog
+- GET /api/partner/v1/docs
+- GET /api/partner/v1/demo
+- GET /api/partner/v1/readiness
+- GET /api/partner/v1/workspace-summary
+- GET /api/partner/v1/runtime-summary
+- GET /api/partner/v1/evidence-summary
+- GET /api/partner/v1/audit-summary
+- GET /api/partner/v1/finance-governance
+- GET /api/partner/v1/usage
+- GET /api/partner/v1/capacity
+- POST /api/partner/v1/leads
+- POST /api/partner/v1/onboarding
+- POST /api/partner/v1/checkout
+
+## Internal APIs Not For Direct Partner Use
+
+- POST /api/execute
+- POST /api/spine/execute
+- POST /api/mcp/call
+- POST /api/gateway/tools/execute
+- POST /api/executors/dispatch
+- POST /api/model-provider/openrouter
+- POST /api/setup/auto
+- POST /api/agents/*/rotate-key
+
+## Data Boundary
+
+Partner-visible data should be workspace scoped, partner-org scoped, redacted, paginated, rate limited, audited, and metadata-first.
+
+Partner-visible data should not include raw customer payload, secrets, full production DB rows, cross-customer data, unredacted audit ledger, bank details, card data, full invoice documents, or production env values.

--- a/docs/partner/PARTNER_MAINTAINER_RUNBOOK.md
+++ b/docs/partner/PARTNER_MAINTAINER_RUNBOOK.md
@@ -1,0 +1,43 @@
+# DSG ONE Partner Maintainer Runbook
+
+## Role
+
+Partner Maintainer may operate storefront, Bubble UI, partner integration, staging review, and non-core product fixes.
+
+Partner Maintainer is not production owner and cannot bypass protected checkpoints.
+
+## Fast Path — No Owner Block Needed
+
+Partner can move fast on frontend UI, storefront copy, pricing layout, request-access flow, Bubble operator UI, partner API mapping, docs, integration examples, demo assets, non-sensitive bugfixes, staging tests, and preview checks.
+
+## Checkpoint Path — Owner Review Required
+
+Owner checkpoint is required for core governance engine, policy/gate/execution logic, audit/evidence/replay logic, auth/RBAC, billing secrets, production env, service role, destructive database migration, production deploy authority, GitHub/Vercel/Supabase admin changes, and cross-customer data access.
+
+## Incident Severity
+
+SEV-0: production down, data exposure, payment issue, secret leak, policy bypass.
+
+SEV-1: API unavailable, onboarding broken, checkout broken, readiness failing.
+
+SEV-2: UI bug, mapping bug, copy issue, dashboard layout issue.
+
+SEV-3: feature request or product improvement.
+
+## Production Claim Rule
+
+No partner may publish customer-facing production claims unless backed by current evidence.
+
+Required evidence:
+- deployment Ready state
+- env validation
+- Supabase applied-state proof
+- /api/health smoke
+- /api/readiness smoke
+- finance readiness smoke
+- authenticated operator checks
+- live staging/E2E validation
+
+If evidence is missing, use staging-review, scaffold, demo, preview, or not production-ready.
+
+Do not claim production-certified, bank-certified, guaranteed compliance, fully autonomous approval, or third-party audited.

--- a/docs/partner/PARTNER_MESSAGE_TO_ANKIT.md
+++ b/docs/partner/PARTNER_MESSAGE_TO_ANKIT.md
@@ -1,0 +1,37 @@
+# Message to Ankit — Partner Maintainer Access Model
+
+Hi Ankit,
+
+I want Wartin Labs to be able to move quickly on the storefront, Bubble operator layer, partner-facing product surface, onboarding, checkout, and customer demo workflow.
+
+My preferred model is broad Partner Maintainer access with protected DSG core checkpoints.
+
+You would be able to manage and improve:
+- Bubble storefront and operator UI
+- customer-facing pages
+- onboarding and request-access flows
+- checkout/commercialization shell
+- partner dashboard
+- API mapping and integration work
+- partner API facade improvements
+- frontend/backend non-core fixes
+- staging and preview testing
+- customer demo workflow
+- production deployment when automated gates pass and protected core paths are not changed
+
+The protected boundaries would remain:
+- DSG core governance engine
+- policy/gate/execution logic
+- audit ledger and replay proof authority
+- production secrets
+- Supabase service role
+- Vercel production environment variables
+- GitHub Actions secrets
+- production database direct access
+- destructive migrations
+- cross-customer data access
+
+The goal is not to slow your team down. The goal is to give Wartin Labs broad operational autonomy while keeping only the high-risk control points behind automated checkpoints and owner review.
+
+Best,
+Thanawat

--- a/docs/partner/PARTNER_ONBOARDING_CHECKLIST.md
+++ b/docs/partner/PARTNER_ONBOARDING_CHECKLIST.md
@@ -1,0 +1,68 @@
+# DSG ONE Partner Onboarding Checklist
+
+## Before Access
+
+- [ ] Partner identity verified
+- [ ] Company verified
+- [ ] Contact email verified
+- [ ] Access purpose written
+- [ ] Environment selected: staging / partner-preview
+- [ ] No production secrets shared
+- [ ] No Supabase service role shared
+- [ ] No Vercel production env edit access
+- [ ] No GitHub admin access
+- [ ] Access revocation owner assigned
+
+## Before NDA
+
+Allowed:
+- [ ] Public docs
+- [ ] API overview
+- [ ] Staging/demo URL
+- [ ] Demo workspace
+- [ ] Scoped partner token if needed
+- [ ] GitHub read/fork access if approved
+
+Blocked:
+- [ ] Production secrets
+- [ ] Service role
+- [ ] Production DB
+- [ ] Internal service token
+- [ ] Execution API authority
+- [ ] Policy write
+- [ ] Deployment authority
+
+## After NDA
+
+Allowed:
+- [ ] Repository access
+- [ ] Architecture docs
+- [ ] API contracts
+- [ ] Staging token
+- [ ] Preview deployment logs
+- [ ] Redacted logs
+- [ ] Partner API facade work
+- [ ] Bubble integration work
+
+Still protected:
+- [ ] Production env values
+- [ ] Service role
+- [ ] GitHub admin
+- [ ] Vercel owner/admin
+- [ ] Direct production DB
+- [ ] Core governance bypass
+
+## Required Gates Before Production Claim
+
+- [ ] Typecheck PASS
+- [ ] Tests PASS
+- [ ] E2E live PASS, not skipped
+- [ ] Vercel Ready verified
+- [ ] Env validation PASS
+- [ ] Supabase applied-state proof PASS
+- [ ] /api/health PASS
+- [ ] /api/readiness PASS
+- [ ] /api/finance-governance/readiness PASS
+- [ ] Authenticated operator checks PASS
+- [ ] GO/NO-GO PASS
+- [ ] Evidence committed to qa-logs/


### PR DESCRIPTION
## Summary

Adds Partner Maintainer access boundary documentation for DSG ONE.

This PR creates:

- `.github/CODEOWNERS`
- `docs/partner/PARTNER_ACCESS_POLICY.md`
- `docs/partner/PARTNER_API_SCOPES.md`
- `docs/partner/PARTNER_MAINTAINER_RUNBOOK.md`
- `docs/partner/PARTNER_ONBOARDING_CHECKLIST.md`
- `docs/partner/PARTNER_MESSAGE_TO_ANKIT.md`

## Purpose

Allow partner/product work to move quickly while protecting DSG core governance, production execution, audit authority, secrets, and deployment-control surfaces.

## Boundary

Partner can help with:

- storefront
- Bubble operator UI
- partner API facade
- onboarding
- checkout
- docs
- non-core product fixes
- staging/preview validation

Protected checkpoint remains required for:

- DSG core governance
- policy/gate/execution logic
- audit/evidence/replay
- auth/RBAC
- billing secrets
- production env
- Supabase service role
- production DB authority
- destructive migrations
- cross-customer data access

## Claim

This is documentation and access-boundary policy only.  
No production readiness claim is changed by this PR.