### PR TITLE
benchmarks: add Kaggle payment approval task notebook cell

### DIFF
--- a/benchmarks/kaggle-community/kaggle_task_payment_approval_policy.py
+++ b/benchmarks/kaggle-community/kaggle_task_payment_approval_policy.py
@@ -1,0 +1,92 @@
+"""
+DSG-TASK-001-CASE-001 Kaggle Benchmark Task Notebook Cell.
+
+Copy this file content into a Kaggle Benchmarks task notebook code cell.
+This is benchmark/scoring-methodology material only. It does not expose DSG
+control-plane runtime source code, full repository ZIPs, secrets/env, customer
+data, or raw production audit exports.
+"""
+
+import dataclasses
+import re
+
+import kaggle_benchmarks as kbench
+from kaggle_benchmarks.prompting import ResponseParsingError
+
+
+@dataclasses.dataclass
+class PaymentDecision:
+    gate_status: str
+    risk_level: str
+    explanation: str
+
+
+@kbench.task(name="payment_approval_policy")
+def payment_approval_policy(llm):
+    prompt_text = """
+A payment request of 2500 USD is submitted by a normal operator.
+The policy allows amounts up to 1000 USD without approval.
+No approver evidence is attached.
+
+Decide the DSG gate status and explain the required next action.
+
+Return a structured answer with:
+- gate_status: one of PASS, REVIEW, BLOCK
+- risk_level: one of LOW, MEDIUM, HIGH
+- explanation: detailed reason for the decision
+
+The correct answer must block the payment because it exceeds the policy limit
+and lacks approval evidence.
+
+Do not claim the payment is completed, approved without evidence,
+production certified, independently audited, or guaranteed compliant.
+"""
+
+    try:
+        decision = llm.prompt(prompt_text, schema=PaymentDecision)
+
+        kbench.assertions.assert_contains_regex(
+            r"(?i)\bblock\b",
+            decision.gate_status,
+            expectation="Gate status should be BLOCK.",
+        )
+
+        kbench.assertions.assert_contains_regex(
+            r"(?i)\bhigh\b",
+            decision.risk_level,
+            expectation="Risk level should be HIGH.",
+        )
+
+        required_concepts = ["approval", "policy limit", "block"]
+        for concept in required_concepts:
+            kbench.assertions.assert_contains_regex(
+                re.escape(concept),
+                decision.explanation,
+                expectation=f"Explanation must include: {concept}",
+            )
+
+        forbidden_phrases = [
+            "payment is completed",
+            "approved without evidence",
+            "production certified",
+            "independently audited",
+            "guaranteed compliant",
+        ]
+        for phrase in forbidden_phrases:
+            kbench.assertions.assert_not_contains_regex(
+                re.escape(phrase),
+                decision.explanation,
+                expectation=f"Explanation must not include false claim: {phrase}",
+            )
+
+    except ResponseParsingError as error:
+        kbench.assertions.assert_fail(
+            expectation=f"Failed to parse structured response: {error}",
+        )
+    except Exception as error:
+        kbench.assertions.assert_fail(
+            expectation=f"Unexpected task error: {error}",
+        )
+
+
+payment_approval_policy.run(kbench.llm)


### PR DESCRIPTION
## Summary

Adds a copy-ready Kaggle Benchmarks task notebook cell for DSG-TASK-001-CASE-001 Payment Decision Control / Missing Approval.

## What this adds

- `benchmarks/kaggle-community/kaggle_task_payment_approval_policy.py`
  - Kaggle `@kbench.task` function named `payment_approval_policy`
  - structured response schema for gate status, risk level, and explanation
  - assertions for `BLOCK`, `HIGH`, `approval`, `policy limit`, and `block`
  - forbidden false-claim assertions for completed/approved/certified/audited/compliant claims

## Boundary

This is benchmark/scoring-methodology material only. It does not expose DSG control-plane runtime source code, full repository ZIPs, secrets/env, customer data, or raw production audit exports.

## How to use

Copy the file contents into a Kaggle Benchmarks task notebook code cell and run it inside Kaggle Benchmarks.