### PR TITLE
Add ProofGate enterprise-ready UX and monitor command flow

### DIFF
--- a/app/dashboard/integrations/page.tsx
+++ b/app/dashboard/integrations/page.tsx
@@ -1,54 +1,106 @@
 import Link from 'next/link';
 
-const steps = [
+const quickstart = [
   {
     title: '1) Register integration',
-    description: 'Create a managed org + agent and receive an API key for server-to-server calls.',
-    command:
-      "curl -X POST /api/integrations/register -d '{\"email\":\"dev@customer.com\",\"app_name\":\"My ERP\"}'",
+    description: 'Create a trial org, managed agent, policy binding, and one-time API key for server-to-server calls.',
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/register \\\n  -H 'content-type: application/json' \\\n  -d '{\"email\":\"dev@customer.com\",\"app_name\":\"Customer ERP\"}'",
+    output: 'Returns org_id, agent_id, and api_key. Store the key once; DSG stores only a hash.',
   },
   {
-    title: '2) Register webhook',
-    description: 'Attach callback URL and browser CORS origins using the API key from step 1.',
-    command:
-      "curl -X POST /api/integrations/webhooks -H 'Authorization: Bearer dsg_live_xxx' -d '{\"agent_id\":\"agt_xxx\",\"webhook_url\":\"https://customer.com/webhook\",\"allowed_origins\":[\"https://customer.com\"]}'",
+    title: '2) Attach callback / webhook',
+    description: 'Connect the customer app back to DSG with a callback URL and allowed browser origins.',
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/webhooks \\\n  -H 'content-type: application/json' \\\n  -H 'Authorization: Bearer dsg_live_xxx' \\\n  -d '{\"agent_id\":\"agt_xxx\",\"webhook_url\":\"https://customer.com/dsg/webhook\",\"allowed_origins\":[\"https://customer.com\"]}'",
+    output: 'Returns the persisted integration profile and normalized allowed origins.',
   },
   {
-    title: '3) Execute actions',
-    description: 'Use the agent/API key pair against /api/execute or install @dsg/sdk.',
-    command:
-      "curl -X POST /api/execute -H 'Authorization: Bearer dsg_live_xxx' -d '{\"agent_id\":\"agt_xxx\",\"action\":\"approve_invoice\",\"input\":{}}'",
+    title: '3) Execute one governed action',
+    description: 'Send one action through DSG first. The first rollout should prove REVIEW/BLOCK/ALLOW behavior before broad production use.',
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/execute \\\n  -H 'content-type: application/json' \\\n  -H 'Authorization: Bearer dsg_live_xxx' \\\n  -d '{\"agent_id\":\"agt_xxx\",\"action\":\"approve_invoice\",\"input\":{\"invoice_id\":\"INV-001\",\"amount\":1250}}'",
+    output: 'Returns the governed decision, latency, policy context, and audit/evidence posture.',
   },
+];
+
+const connectorCards = [
+  ['REST API', 'Best for customer apps, ERP wrappers, CRM, finance ops, and internal services.', 'Use /api/integrations/register + /api/execute'],
+  ['Webhook', 'Best for events, callbacks, and quick pilots without replacing the customer system.', 'Register callback URL and allowed origins'],
+  ['Zapier / Make', 'Best for business teams already using no-code automation.', 'Use DSG as a policy gate before the final action step'],
+  ['n8n / Workato', 'Best for ops teams with existing workflow engines.', 'Add DSG as an HTTP node before high-risk actions'],
+  ['GitHub / Vercel', 'Best for release, deploy, and go/no-go controls.', 'Route deployment claims through proof checks'],
+  ['CSV / SFTP', 'Best for legacy finance or audit batch workflows.', 'Import evidence first, automate later'],
+];
+
+const proofChecklist = [
+  'agent_id is bound to one org',
+  'api_key is hashed server-side',
+  'policy is resolved before action',
+  'approval state is visible when needed',
+  'nonce / idempotency / request hash are present for replay protection',
+  'audit hook and evidence hook are visible before production claim',
 ];
 
 export default function IntegrationsPage() {
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto max-w-5xl px-6 py-10">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <p className="text-sm uppercase tracking-[0.2em] text-slate-400">DSG</p>
-            <h1 className="mt-2 text-3xl font-semibold">Integrations</h1>
-            <p className="mt-2 text-slate-400">
-              Self-service onboarding for customer apps with API key provisioning, webhook setup,
-              and SDK-ready execution flow.
-            </p>
+      <div className="mx-auto max-w-7xl px-6 py-10">
+        <section className="rounded-3xl border border-white/10 bg-[linear-gradient(135deg,rgba(16,185,129,0.16),rgba(15,23,42,0.92)_45%,rgba(245,197,92,0.08))] p-6">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-xs font-bold uppercase tracking-[0.24em] text-emerald-200">DSG Enterprise Setup</p>
+              <h1 className="mt-3 text-4xl font-black tracking-tight text-white md:text-5xl">Connect one existing workflow in minutes.</h1>
+              <p className="mt-4 text-sm leading-7 text-slate-300">
+                Start with the customer system they already use. Register one integration, attach one callback, run one governed action, then export proof before rollout. No migration required for the first pilot.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link href="/enterprise-ready" className="rounded-2xl border border-emerald-300/40 bg-emerald-300/10 px-5 py-3 text-sm font-bold text-emerald-100">View enterprise flow</Link>
+              <Link href="/enterprise-proof/demo" className="rounded-2xl bg-amber-300 px-5 py-3 text-sm font-black text-slate-950">Run proof demo</Link>
+              <Link href="/dashboard" className="rounded-2xl border border-white/15 px-5 py-3 text-sm font-bold text-slate-200">Back to dashboard</Link>
+            </div>
           </div>
-          <Link href="/dashboard" className="rounded-xl border border-slate-700 px-4 py-3 font-semibold text-slate-200">
-            Back to dashboard
-          </Link>
-        </div>
+        </section>
 
-        <section className="mt-8 space-y-4">
-          {steps.map((step) => (
-            <article key={step.title} className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
-              <h2 className="text-lg font-semibold">{step.title}</h2>
-              <p className="mt-2 text-sm text-slate-300">{step.description}</p>
-              <pre className="mt-4 overflow-x-auto rounded-xl border border-slate-700 bg-slate-950 p-4 text-xs text-emerald-200">
-                <code>{step.command}</code>
-              </pre>
+        <section className="mt-8 grid gap-4 md:grid-cols-3">
+          {quickstart.map((step) => (
+            <article key={step.title} className="rounded-3xl border border-slate-800 bg-slate-900 p-5">
+              <h2 className="text-lg font-black text-white">{step.title}</h2>
+              <p className="mt-2 text-sm leading-7 text-slate-300">{step.description}</p>
+              <pre className="mt-4 overflow-x-auto rounded-2xl border border-slate-700 bg-slate-950 p-4 text-xs leading-6 text-emerald-200"><code>{step.command}</code></pre>
+              <p className="mt-3 text-xs leading-6 text-slate-400">{step.output}</p>
             </article>
           ))}
+        </section>
+
+        <section className="mt-8 rounded-3xl border border-white/10 bg-[#0b0d10] p-6">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Connector options</p>
+          <h2 className="mt-3 text-3xl font-black text-white">Use the customer stack first, not a forced migration.</h2>
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            {connectorCards.map(([name, body, action]) => (
+              <article key={name} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+                <h3 className="text-xl font-black text-white">{name}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-300">{body}</p>
+                <p className="mt-4 rounded-xl border border-amber-300/20 bg-amber-300/10 p-3 text-xs font-semibold leading-6 text-amber-100">{action}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-6 lg:grid-cols-[0.75fr_1.25fr]">
+          <div className="rounded-3xl border border-amber-300/25 bg-amber-300/10 p-6">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-200">Quota-aware rollout</p>
+            <h2 className="mt-3 text-2xl font-black text-white">Use local proof first. Deploy once.</h2>
+            <p className="mt-3 text-sm leading-7 text-amber-50">
+              To preserve Vercel quota, validate copy, routes, typecheck, unit tests, and deterministic gates locally or in a branch. Push to production only after the proof path is reviewed.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Evidence required before enterprise claim</p>
+            <div className="mt-5 grid gap-3 md:grid-cols-2">
+              {proofChecklist.map((item) => (
+                <div key={item} className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm font-semibold text-slate-200">{item}</div>
+              ))}
+            </div>
+          </div>
         </section>
       </div>
     </main>

--- a/app/dsg-brand.css
+++ b/app/dsg-brand.css
@@ -1,0 +1,183 @@
+:root {
+  --dsg-black: #050507;
+  --dsg-black-2: #090b12;
+  --dsg-panel: rgba(9, 11, 18, 0.86);
+  --dsg-panel-2: rgba(14, 18, 28, 0.92);
+  --dsg-red: #e10600;
+  --dsg-red-deep: #7f0509;
+  --dsg-gold: #d4af37;
+  --dsg-gold-soft: #f7dc78;
+  --dsg-sapphire: #0f52ba;
+  --dsg-sapphire-soft: #4f8cff;
+  --dsg-sapphire-glow: rgba(15, 82, 186, 0.28);
+  --dsg-line: rgba(247, 220, 120, 0.16);
+  --dsg-text: #f8fafc;
+  --dsg-muted: #aab3c5;
+}
+
+body {
+  background:
+    radial-gradient(circle at 14% 0%, rgba(225, 6, 0, 0.22), transparent 34%),
+    radial-gradient(circle at 86% 9%, rgba(15, 82, 186, 0.26), transparent 34%),
+    radial-gradient(circle at 50% 0%, rgba(212, 175, 55, 0.13), transparent 48%),
+    linear-gradient(180deg, var(--dsg-black), var(--dsg-black-2) 52%, var(--dsg-black));
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background:
+    linear-gradient(rgba(247, 220, 120, 0.024) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(79, 140, 255, 0.022) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, rgba(0,0,0,0.72), transparent 78%);
+}
+
+.dsg-shell {
+  background:
+    radial-gradient(circle at top left, rgba(225, 6, 0, 0.18), transparent 30%),
+    radial-gradient(circle at top right, rgba(15, 82, 186, 0.22), transparent 34%),
+    linear-gradient(135deg, rgba(5,5,7,0.98), rgba(9,11,18,0.96));
+}
+
+.dsg-card {
+  border: 1px solid var(--dsg-line);
+  background: linear-gradient(180deg, rgba(255,255,255,0.055), rgba(255,255,255,0.02)), var(--dsg-panel);
+  box-shadow: 0 22px 80px rgba(0,0,0,0.32), inset 0 1px 0 rgba(255,255,255,0.06);
+}
+
+.dsg-card-blue {
+  border: 1px solid rgba(79, 140, 255, 0.26);
+  background: linear-gradient(180deg, rgba(15,82,186,0.16), rgba(5,5,7,0.22)), var(--dsg-panel-2);
+  box-shadow: 0 22px 80px rgba(15,82,186,0.12), inset 0 1px 0 rgba(255,255,255,0.06);
+}
+
+.dsg-card-red {
+  border: 1px solid rgba(225, 6, 0, 0.32);
+  background: linear-gradient(180deg, rgba(225,6,0,0.14), rgba(5,5,7,0.22)), var(--dsg-panel-2);
+}
+
+.dsg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(247, 220, 120, 0.34);
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--dsg-gold-soft);
+  padding: 0.5rem 0.9rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.dsg-btn-gold,
+a.dsg-btn-gold {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--dsg-gold-soft), var(--dsg-gold));
+  color: #060608;
+  font-weight: 900;
+  padding: 0.9rem 1.15rem;
+  box-shadow: 0 14px 34px rgba(212, 175, 55, 0.22);
+}
+
+.dsg-btn-blue,
+a.dsg-btn-blue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1rem;
+  border: 1px solid rgba(79, 140, 255, 0.42);
+  background: rgba(15, 82, 186, 0.18);
+  color: #dbeafe;
+  font-weight: 800;
+  padding: 0.9rem 1.15rem;
+}
+
+.dsg-btn-red,
+a.dsg-btn-red {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1rem;
+  border: 1px solid rgba(225, 6, 0, 0.38);
+  background: rgba(225, 6, 0, 0.14);
+  color: #fecaca;
+  font-weight: 800;
+  padding: 0.9rem 1.15rem;
+}
+
+.dsg-text-gradient {
+  background: linear-gradient(90deg, #ffffff, var(--dsg-gold-soft) 44%, #b8d7ff 78%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dsg-proof-rail {
+  border-left: 1px solid rgba(247, 220, 120, 0.2);
+  background: linear-gradient(90deg, rgba(247,220,120,0.05), transparent);
+}
+
+header {
+  background: rgba(5, 5, 7, 0.88) !important;
+  border-bottom-color: rgba(247, 220, 120, 0.14) !important;
+}
+
+.bg-emerald-300,
+.bg-emerald-400,
+.bg-amber-300 {
+  background: linear-gradient(135deg, var(--dsg-gold-soft), var(--dsg-gold)) !important;
+  color: #060608 !important;
+}
+
+.text-emerald-100,
+.text-emerald-200,
+.text-emerald-300,
+.text-amber-100,
+.text-amber-200,
+.text-amber-300 {
+  color: var(--dsg-gold-soft) !important;
+}
+
+.border-emerald-300\/30,
+.border-emerald-300\/40,
+.border-amber-300\/30,
+.border-amber-300\/40 {
+  border-color: rgba(247, 220, 120, 0.34) !important;
+}
+
+.bg-emerald-300\/10,
+.bg-emerald-400\/10,
+.bg-amber-300\/10 {
+  background: rgba(212, 175, 55, 0.1) !important;
+}
+
+.text-cyan-200,
+.text-cyan-300,
+.text-blue-200,
+.text-blue-300 {
+  color: #b8d7ff !important;
+}
+
+.border-cyan-300\/30,
+.border-blue-300\/30 {
+  border-color: rgba(79, 140, 255, 0.34) !important;
+}
+
+.bg-cyan-300\/10,
+.bg-blue-300\/10,
+.bg-blue-500\/10 {
+  background: rgba(15, 82, 186, 0.14) !important;
+}
+
+@media (max-width: 767px) {
+  .dsg-chip { letter-spacing: 0.12em; }
+}

--- a/app/enterprise-ready/page.tsx
+++ b/app/enterprise-ready/page.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+
+const setupSteps = [
+  ['1. เลือกระบบเดิม', 'เริ่มจาก REST, Webhook, Zapier, Make, n8n, ERP, GitHub หรือ Vercel โดยไม่ต้องย้ายระบบก่อน'],
+  ['2. วาง endpoint เดียว', 'ใช้ URL หรือ API route เดียวก่อน แล้วให้ DSG ครอบด้วย policy, approval, replay check และ evidence'],
+  ['3. รัน proof แรก', 'ระบบแสดง PASS, REVIEW, BLOCK หรือ UNSUPPORTED พร้อม next action ที่ต้องแก้'],
+  ['4. ส่ง evidence ให้ทีมงาน', 'แชร์ proof trail ให้ IT, risk, finance หรือ audit ก่อนขยาย rollout'],
+];
+
+const connectors = [
+  ['REST API', 'เหมาะกับ internal apps, ERP wrappers, CRM, finance ops และ custom services'],
+  ['Webhook', 'ทางเร็วสุดสำหรับ pilot ด้วย inbound event และ callback'],
+  ['Zapier / Make', 'สะพาน no-code สำหรับ workflow ที่ลูกค้าใช้อยู่แล้ว'],
+  ['n8n / Workato', 'ใช้ DSG เป็น governance layer หน้า workflow engine เดิม'],
+  ['GitHub / Vercel', 'คุม release และ deployment ด้วย proof checks'],
+  ['CSV / SFTP', 'รองรับลูกค้าที่ legacy หรือยังไม่ API-first'],
+];
+
+const controls = [
+  'SSO/JWKS readiness surface',
+  'RBAC and app restrictions',
+  'Approval routing',
+  'Audit log and evidence export',
+  'Replay protection',
+  'Rate-limit posture',
+  'Go/no-go checklist',
+  'Truth boundary against false claims',
+];
+
+export default function EnterpriseReadyPage() {
+  return (
+    <main className="min-h-screen bg-[#07080a] text-slate-100">
+      <section className="border-b border-white/10 bg-[linear-gradient(135deg,#07080a,#10131a_55%,#07080a)]">
+        <div className="mx-auto grid max-w-7xl gap-10 px-6 py-16 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+          <div>
+            <p className="inline-flex rounded-full border border-emerald-300/30 bg-emerald-300/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.24em] text-emerald-100">Enterprise Ready Autopilot</p>
+            <h1 className="mt-6 max-w-4xl text-5xl font-black leading-[1.02] tracking-tight text-white md:text-7xl">Connect DSG to the systems customers already use.</h1>
+            <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">User-first setup for governed AI, workflow, finance, and deployment operations. Start with one proof, then expand safely.</p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/dashboard/integrations" className="rounded-2xl bg-amber-300 px-6 py-4 text-sm font-black text-slate-950 hover:bg-amber-200">Start setup</Link>
+              <Link href="/enterprise-proof/demo" className="rounded-2xl border border-white/15 bg-white/[0.04] px-6 py-4 text-sm font-bold text-white hover:border-emerald-300/40">Run proof demo</Link>
+              <Link href="/docs" className="rounded-2xl border border-white/15 px-6 py-4 text-sm font-bold text-slate-200 hover:border-amber-300/40">Launch docs</Link>
+            </div>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-2xl shadow-black/40">
+            <p className="text-[11px] uppercase tracking-[0.28em] text-slate-500">User benefit</p>
+            <div className="mt-5 space-y-3">
+              {['One-page setup', 'Copy-paste API commands', 'No-code bridge options', 'Visible proof status', 'No false production claim'].map((item) => (
+                <div key={item} className="rounded-2xl border border-emerald-300/15 bg-emerald-400/10 p-4 text-sm leading-6 text-emerald-50">{item}</div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-14">
+        <p className="text-[11px] uppercase tracking-[0.28em] text-amber-200">Setup flow</p>
+        <h2 className="mt-3 text-4xl font-black text-white">Four steps to first governed proof</h2>
+        <div className="mt-8 grid gap-4 md:grid-cols-4">
+          {setupSteps.map(([title, body]) => (
+            <article key={title} className="rounded-3xl border border-white/10 bg-white/[0.03] p-5"><h3 className="text-lg font-black text-white">{title}</h3><p className="mt-3 text-sm leading-7 text-slate-300">{body}</p></article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-[#0b0d10]"><div className="mx-auto max-w-7xl px-6 py-14"><p className="text-[11px] uppercase tracking-[0.28em] text-emerald-300">Connector catalog</p><h2 className="mt-3 text-4xl font-black text-white">Meet customers where their stack already is</h2><div className="mt-8 grid gap-4 md:grid-cols-3">{connectors.map(([name, body]) => (<article key={name} className="rounded-3xl border border-white/10 bg-white/[0.03] p-5"><h3 className="text-2xl font-black text-white">{name}</h3><p className="mt-4 text-sm leading-7 text-slate-300">{body}</p></article>))}</div></div></section>
+
+      <section className="mx-auto grid max-w-7xl gap-8 px-6 py-14 lg:grid-cols-[0.8fr_1.2fr]"><div><p className="text-[11px] uppercase tracking-[0.28em] text-slate-500">Enterprise controls</p><h2 className="mt-3 text-4xl font-black text-white">Control without slowing the first pilot.</h2><p className="mt-4 text-sm leading-7 text-slate-300">Missing proof becomes a visible next action, not hidden risk.</p></div><div className="grid gap-3 md:grid-cols-2">{controls.map((item) => (<div key={item} className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm font-semibold text-slate-200">{item}</div>))}</div></section>
+
+      <section className="mx-auto max-w-7xl px-6 pb-14"><div className="rounded-3xl border border-amber-300/30 bg-amber-300/10 p-6 text-sm leading-7 text-amber-50"><p className="text-[11px] uppercase tracking-[0.28em] text-amber-200">Truth boundary</p><p className="mt-2">Enterprise-ready here means setup-ready, governance-ready, and evidence-ready for a controlled pilot. Certification, independent audit, and production go-live still require recorded proof.</p></div></section>
+    </main>
+  );
+}

--- a/app/finance-governance/app/onboarding/page.tsx
+++ b/app/finance-governance/app/onboarding/page.tsx
@@ -1,8 +1,3 @@
-import { getSupabaseAdmin } from '../../../../lib/supabase-server';
-import { getOrg } from '../../../../lib/server/getOrg';
-
-export const dynamic = 'force-dynamic';
-
 type Status = 'todo' | 'in_progress' | 'done';
 
 type Step = {
@@ -11,86 +6,30 @@ type Step = {
   status: Status;
 };
 
-type ChecklistPayload = {
-  steps?: Array<string | { id?: string; label?: string; status?: Status }>;
-} | null;
-
 const setupSteps: Step[] = [
-  { id: 'env', label: 'Confirm Supabase environment variables are available to this runtime', status: 'in_progress' },
+  { id: 'env', label: 'Confirm Supabase environment variables are configured in the deployment runtime', status: 'in_progress' },
   { id: 'auth', label: 'Sign in with an operator account mapped to an active organization', status: 'todo' },
   { id: 'workflow', label: 'Connect one finance workflow and run the first governed proof', status: 'todo' },
   { id: 'evidence', label: 'Export onboarding evidence before production rollout', status: 'todo' },
 ];
 
-function toChecklistPayload(value: unknown): ChecklistPayload {
-  if (!value || typeof value !== 'object') return null;
-  return value as ChecklistPayload;
-}
-
-function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: string | null | undefined): Step[] {
-  const rawSteps = Array.isArray(checklist?.steps) ? checklist.steps : [];
-  return rawSteps.map((step, index) => {
-    if (typeof step === 'string') {
-      return {
-        id: `step-${index + 1}`,
-        label: step,
-        status: bootstrapStatus === 'completed' ? 'done' : index === 0 ? 'in_progress' : 'todo',
-      };
-    }
-    return {
-      id: step.id || `step-${index + 1}`,
-      label: step.label || `Step ${index + 1}`,
-      status: step.status || (bootstrapStatus === 'completed' ? 'done' : index === 0 ? 'in_progress' : 'todo'),
-    };
-  });
-}
-
-async function loadSteps(): Promise<{ steps: Step[]; note: string }> {
-  try {
-    const orgId = await getOrg();
-    const admin = getSupabaseAdmin();
-    const { data, error } = await admin
-      .from('org_onboarding_states')
-      .select('bootstrap_status, checklist')
-      .eq('org_id', orgId)
-      .maybeSingle();
-
-    if (error) {
-      return { steps: setupSteps, note: `Setup checklist shown because onboarding state could not be loaded: ${error.message}` };
-    }
-
-    const liveSteps = mapChecklistToSteps(toChecklistPayload(data?.checklist), data?.bootstrap_status);
-    return {
-      steps: liveSteps.length > 0 ? liveSteps : setupSteps,
-      note: liveSteps.length > 0 ? 'Live onboarding state loaded.' : 'No live checklist found yet. Showing setup checklist.',
-    };
-  } catch {
-    return {
-      steps: setupSteps,
-      note: 'Setup checklist shown because auth or environment is not available to this build runtime.',
-    };
-  }
-}
-
-export default async function FinanceGovernanceOnboardingPage() {
-  const { steps, note } = await loadSteps();
-
+export default function FinanceGovernanceOnboardingPage() {
   return (
     <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
       <div className="max-w-3xl">
         <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Onboarding</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance workflow onboarding template</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
-          Automated onboarding flow synced from backend checklist state when runtime configuration is available.
+          Setup-safe onboarding view for local builds and operator review. Live onboarding state should be loaded from authenticated dashboard APIs after the operator signs in.
         </p>
       </div>
 
       <div className="mt-8 rounded-[1.5rem] border border-amber-300/25 bg-amber-300/10 p-5 text-sm leading-7 text-amber-50">
-        {note}
+        This page no longer opens Supabase during static build. It preserves local verification and prevents a missing auth/session context from blocking the whole app build.
       </div>
 
       <div className="mt-10 grid gap-4">
-        {steps.map((step, index) => (
+        {setupSteps.map((step, index) => (
           <section key={step.id} className="flex items-center gap-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
             <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-300/20 font-semibold text-emerald-100">
               {index + 1}

--- a/app/finance-governance/app/onboarding/page.tsx
+++ b/app/finance-governance/app/onboarding/page.tsx
@@ -3,18 +3,31 @@ import { getOrg } from '../../../../lib/server/getOrg';
 
 export const dynamic = 'force-dynamic';
 
+type Status = 'todo' | 'in_progress' | 'done';
+
+type Step = {
+  id: string;
+  label: string;
+  status: Status;
+};
+
 type ChecklistPayload = {
-  steps?: Array<string | { id?: string; label?: string; status?: 'todo' | 'in_progress' | 'done' }>;
+  steps?: Array<string | { id?: string; label?: string; status?: Status }>;
 } | null;
 
+const setupSteps: Step[] = [
+  { id: 'env', label: 'Confirm Supabase environment variables are available to this runtime', status: 'in_progress' },
+  { id: 'auth', label: 'Sign in with an operator account mapped to an active organization', status: 'todo' },
+  { id: 'workflow', label: 'Connect one finance workflow and run the first governed proof', status: 'todo' },
+  { id: 'evidence', label: 'Export onboarding evidence before production rollout', status: 'todo' },
+];
+
 function toChecklistPayload(value: unknown): ChecklistPayload {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
+  if (!value || typeof value !== 'object') return null;
   return value as ChecklistPayload;
 }
 
-function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: string | null | undefined) {
+function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: string | null | undefined): Step[] {
   const rawSteps = Array.isArray(checklist?.steps) ? checklist.steps : [];
   return rawSteps.map((step, index) => {
     if (typeof step === 'string') {
@@ -32,18 +45,35 @@ function mapChecklistToSteps(checklist: ChecklistPayload, bootstrapStatus: strin
   });
 }
 
-export default async function FinanceGovernanceOnboardingPage() {
-  const orgId = await getOrg();
-  const admin = getSupabaseAdmin();
-  const { data, error } = await admin
-    .from('org_onboarding_states')
-    .select('bootstrap_status, checklist')
-    .eq('org_id', orgId)
-    .maybeSingle();
-  if (error) {
-    throw new Error(`Failed to load onboarding state: ${error.message}`);
+async function loadSteps(): Promise<{ steps: Step[]; note: string }> {
+  try {
+    const orgId = await getOrg();
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('org_onboarding_states')
+      .select('bootstrap_status, checklist')
+      .eq('org_id', orgId)
+      .maybeSingle();
+
+    if (error) {
+      return { steps: setupSteps, note: `Setup checklist shown because onboarding state could not be loaded: ${error.message}` };
+    }
+
+    const liveSteps = mapChecklistToSteps(toChecklistPayload(data?.checklist), data?.bootstrap_status);
+    return {
+      steps: liveSteps.length > 0 ? liveSteps : setupSteps,
+      note: liveSteps.length > 0 ? 'Live onboarding state loaded.' : 'No live checklist found yet. Showing setup checklist.',
+    };
+  } catch {
+    return {
+      steps: setupSteps,
+      note: 'Setup checklist shown because auth or environment is not available to this build runtime.',
+    };
   }
-  const steps = mapChecklistToSteps(toChecklistPayload(data?.checklist), data?.bootstrap_status);
+}
+
+export default async function FinanceGovernanceOnboardingPage() {
+  const { steps, note } = await loadSteps();
 
   return (
     <main className="mx-auto min-h-screen max-w-5xl px-6 py-16 text-white">
@@ -51,8 +81,12 @@ export default async function FinanceGovernanceOnboardingPage() {
         <p className="text-sm uppercase tracking-[0.3em] text-cyan-200">Onboarding</p>
         <h1 className="mt-4 text-4xl font-bold md:text-5xl">Finance workflow onboarding template</h1>
         <p className="mt-6 text-lg leading-8 text-slate-300">
-          Automated onboarding flow synced from backend checklist state so compliance setup progress is always live.
+          Automated onboarding flow synced from backend checklist state when runtime configuration is available.
         </p>
+      </div>
+
+      <div className="mt-8 rounded-[1.5rem] border border-amber-300/25 bg-amber-300/10 p-5 text-sm leading-7 text-amber-50">
+        {note}
       </div>
 
       <div className="mt-10 grid gap-4">

--- a/app/finance-governance/app/onboarding/page.tsx
+++ b/app/finance-governance/app/onboarding/page.tsx
@@ -1,6 +1,8 @@
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { getOrg } from '../../../../lib/server/getOrg';
 
+export const dynamic = 'force-dynamic';
+
 type ChecklistPayload = {
   steps?: Array<string | { id?: string; label?: string; status?: 'todo' | 'in_progress' | 'done' }>;
 } | null;

--- a/app/gateway/monitor/page.tsx
+++ b/app/gateway/monitor/page.tsx
@@ -23,6 +23,8 @@ type GatewayMonitorEvent = {
   committed_at: string | null;
 };
 
+type CustomerState = 'ready' | 'review' | 'blocked' | 'empty';
+
 async function loadEvents(orgId: string): Promise<GatewayMonitorEvent[]> {
   try {
     const supabase = getSupabaseAdmin() as any;
@@ -33,10 +35,7 @@ async function loadEvents(orgId: string): Promise<GatewayMonitorEvent[]> {
       .order('created_at', { ascending: false })
       .limit(25);
 
-    if (error) {
-      return [];
-    }
-
+    if (error) return [];
     return Array.isArray(data) ? data : [];
   } catch {
     return [];
@@ -44,69 +43,174 @@ async function loadEvents(orgId: string): Promise<GatewayMonitorEvent[]> {
 }
 
 function shortHash(value?: string | null) {
-  if (!value) {
-    return '—';
-  }
+  if (!value) return '—';
   return `${value.slice(0, 10)}…${value.slice(-8)}`;
+}
+
+function classifyCustomerState(events: GatewayMonitorEvent[]): CustomerState {
+  if (events.length === 0) return 'empty';
+  if (events.some((event) => ['block', 'blocked', 'deny', 'denied'].includes(event.decision))) return 'blocked';
+  if (events.some((event) => ['review', 'needs_review', 'manual_review'].includes(event.decision))) return 'review';
+  return 'ready';
+}
+
+function stateCopy(state: CustomerState) {
+  if (state === 'ready') {
+    return {
+      label: 'READY TO CONTINUE',
+      title: 'DSG is allowing the current governed path.',
+      body: 'Customer can continue the pilot. Keep exporting evidence before expanding rollout.',
+      next: 'Download audit JSON or connect the next workflow.',
+      className: 'border-amber-300/35 bg-amber-300/10 text-amber-50',
+    };
+  }
+  if (state === 'review') {
+    return {
+      label: 'REVIEW NEEDED',
+      title: 'A human decision is required before execution.',
+      body: 'Customer sees exactly where the action paused, who must review, and which proof is missing.',
+      next: 'Open approvals, review evidence, then approve or reject.',
+      className: 'border-blue-300/35 bg-blue-300/10 text-blue-50',
+    };
+  }
+  if (state === 'blocked') {
+    return {
+      label: 'BLOCKED',
+      title: 'DSG stopped a risky or unsupported action.',
+      body: 'Customer sees a safe stop instead of silent failure. Fix policy, identity, risk, or proof gap before retry.',
+      next: 'Open evidence, inspect request hash, then adjust the workflow.',
+      className: 'border-red-400/40 bg-red-500/10 text-red-50',
+    };
+  }
+  return {
+    label: 'WAITING FOR FIRST EVENT',
+    title: 'No customer workflow has reached this monitor yet.',
+    body: 'Start with one command: register integration, run plan-check, commit audit, then return here.',
+    next: 'Use the command cards below to create the first visible proof event.',
+    className: 'border-white/10 bg-white/[0.04] text-slate-100',
+  };
+}
+
+function decisionClass(decision: string) {
+  const normalized = decision.toLowerCase();
+  if (['allow', 'pass', 'allowed'].includes(normalized)) return 'border-amber-300/35 bg-amber-300/10 text-amber-100';
+  if (['review', 'needs_review', 'manual_review'].includes(normalized)) return 'border-blue-300/35 bg-blue-300/10 text-blue-100';
+  return 'border-red-400/40 bg-red-500/10 text-red-100';
 }
 
 export default async function GatewayMonitorPage({ searchParams }: { searchParams?: { orgId?: string } }) {
   const orgId = searchParams?.orgId || 'org-smoke';
   const events = await loadEvents(orgId);
   const committed = events.filter((event) => event.status === 'committed').length;
-  const allowed = events.filter((event) => event.decision === 'allow').length;
-  const blocked = events.filter((event) => event.decision !== 'allow').length;
+  const allowed = events.filter((event) => ['allow', 'pass', 'allowed'].includes(event.decision)).length;
+  const review = events.filter((event) => ['review', 'needs_review', 'manual_review'].includes(event.decision)).length;
+  const blocked = events.filter((event) => !['allow', 'pass', 'allowed', 'review', 'needs_review', 'manual_review'].includes(event.decision)).length;
+  const latest = events[0];
   const exportHref = `/api/gateway/audit/export?orgId=${encodeURIComponent(orgId)}`;
+  const state = stateCopy(classifyCustomerState(events));
+
+  const commands = [
+    {
+      title: '1. Plan-check one action',
+      body: 'Use this first to prove DSG can decide before the customer system executes.',
+      code: `curl -s -X POST /api/gateway/plan-check \\\n  -H 'content-type: application/json' \\\n  -H 'x-org-id: ${orgId}' \\\n  -H 'x-actor-id: agent-001' \\\n  -H 'x-actor-role: agent_operator' \\\n  -d '{"toolName":"customer_erp","action":"approve_invoice","risk":"medium"}'`,
+    },
+    {
+      title: '2. Commit audit result',
+      body: 'Commit after the customer runtime finishes so evidence is not just a screen claim.',
+      code: `curl -s -X POST /api/gateway/audit/commit \\\n  -H 'content-type: application/json' \\\n  -d '{"auditToken":"gat_from_plan_check","result":{"ok":true,"provider":"customer_runtime"}}'`,
+    },
+    {
+      title: '3. Export buyer evidence',
+      body: 'Give IT, finance, or audit a portable proof bundle before rollout.',
+      code: `curl -s '${exportHref}'`,
+    },
+  ];
 
   return (
-    <main className="min-h-screen bg-[#040918] px-6 py-12 text-white">
+    <main className="dsg-shell min-h-screen px-6 py-12 text-white">
       <div className="mx-auto max-w-7xl">
-        <div className="rounded-[2rem] border border-cyan-300/20 bg-cyan-300/10 p-8">
-          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-200">DSG Monitor Mode</p>
-          <h1 className="mt-4 text-4xl font-black tracking-tight md:text-6xl">Realtime gateway audit monitor</h1>
-          <p className="mt-5 max-w-4xl text-lg leading-8 text-slate-200">
-            Monitor Mode lets customer tools execute in their own runtime while DSG returns decision, audit token,
-            request hash, and final record hash for audit proof.
-          </p>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <Link href={`/gateway/monitor?orgId=${encodeURIComponent(orgId)}`} className="rounded-2xl bg-cyan-300 px-5 py-3 font-bold text-slate-950">
-              Refresh monitor
-            </Link>
-            <Link href={exportHref} className="rounded-2xl border border-cyan-200/40 px-5 py-3 font-bold text-cyan-100">
-              Download audit JSON
-            </Link>
+        <section className="dsg-card-blue rounded-[2rem] p-8">
+          <p className="dsg-chip">Customer Monitor</p>
+          <div className="mt-5 grid gap-8 lg:grid-cols-[1fr_0.75fr] lg:items-end">
+            <div>
+              <h1 className="dsg-text-gradient text-4xl font-black tracking-tight md:text-6xl">See what DSG decided, why it decided, and what to do next.</h1>
+              <p className="mt-5 max-w-4xl text-lg leading-8 text-slate-200">
+                This monitor is for the buyer, operator, and auditor. It shows live action status, risk decision, evidence hashes, audit export, and the exact command path to reproduce the result.
+              </p>
+            </div>
+            <div className={`rounded-3xl border p-5 ${state.className}`}>
+              <p className="text-xs font-black uppercase tracking-[0.22em]">{state.label}</p>
+              <h2 className="mt-3 text-2xl font-black text-white">{state.title}</h2>
+              <p className="mt-3 text-sm leading-7">{state.body}</p>
+              <p className="mt-4 rounded-2xl border border-white/10 bg-black/20 p-3 text-sm font-bold">Next: {state.next}</p>
+            </div>
           </div>
-        </div>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link href={`/gateway/monitor?orgId=${encodeURIComponent(orgId)}`} className="dsg-btn-gold">Refresh monitor</Link>
+            <Link href={exportHref} className="dsg-btn-blue">Download audit JSON</Link>
+            <Link href="/approvals?orgId=org-smoke" className="dsg-btn-red">Open approvals</Link>
+          </div>
+        </section>
 
-        <section className="mt-8 grid gap-4 md:grid-cols-4">
+        <section className="mt-8 grid gap-4 md:grid-cols-5">
           {[
             ['Org', orgId],
             ['Events', String(events.length)],
             ['Allowed', String(allowed)],
-            ['Committed', String(committed)],
+            ['Review', String(review)],
+            ['Blocked', String(blocked)],
           ].map(([label, value]) => (
-            <div key={label} className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
+            <div key={label} className="dsg-card rounded-[1.5rem] p-5">
               <p className="text-sm text-slate-400">{label}</p>
-              <p className="mt-2 break-all text-2xl font-bold text-white">{value}</p>
+              <p className="mt-2 break-all text-2xl font-black text-white">{value}</p>
             </div>
           ))}
+        </section>
+
+        <section className="mt-8 grid gap-5 lg:grid-cols-[0.8fr_1.2fr]">
+          <div className="dsg-card rounded-[1.5rem] p-6">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-200">Latest visible proof</p>
+            {latest ? (
+              <dl className="mt-5 space-y-4 text-sm">
+                <div><dt className="text-slate-400">Action</dt><dd className="mt-1 font-bold text-white">{latest.tool_name} / {latest.action}</dd></div>
+                <div><dt className="text-slate-400">Decision</dt><dd className="mt-1"><span className={`rounded-full border px-3 py-1 text-xs font-bold uppercase ${decisionClass(latest.decision)}`}>{latest.decision}</span></dd></div>
+                <div><dt className="text-slate-400">Risk</dt><dd className="mt-1 font-mono text-slate-200">{latest.risk ?? 'unclassified'}</dd></div>
+                <div><dt className="text-slate-400">Request hash</dt><dd className="mt-1 font-mono text-xs text-blue-200">{shortHash(latest.request_hash)}</dd></div>
+                <div><dt className="text-slate-400">Record hash</dt><dd className="mt-1 font-mono text-xs text-amber-200">{shortHash(latest.record_hash)}</dd></div>
+              </dl>
+            ) : (
+              <p className="mt-5 text-sm leading-7 text-slate-300">No proof event yet. Use command 1 below to create the first visible event, then refresh this page.</p>
+            )}
+          </div>
+
+          <div className="dsg-card rounded-[1.5rem] p-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-[0.24em] text-blue-200">Monitor by organization</p>
+                <h2 className="mt-2 text-2xl font-black">Load customer workspace</h2>
+                <p className="mt-2 text-sm text-slate-400">Customer should understand which org/workspace they are watching before trusting the proof.</p>
+              </div>
+              <form className="flex gap-2" action="/gateway/monitor">
+                <input name="orgId" defaultValue={orgId} className="rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none" aria-label="Organization ID" />
+                <button className="rounded-xl bg-amber-300 px-4 py-3 text-sm font-bold text-slate-950">Load</button>
+              </form>
+            </div>
+            <div className="mt-5 grid gap-3 md:grid-cols-3">
+              {['Who requested it?', 'Was it allowed/review/blocked?', 'What proof can I export?'].map((question) => (
+                <div key={question} className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm font-semibold text-slate-200">{question}</div>
+              ))}
+            </div>
+          </div>
         </section>
 
         <section className="mt-8 rounded-[1.5rem] border border-white/10 bg-slate-950/70 p-6">
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
-              <h2 className="text-2xl font-bold">Monitor history</h2>
-              <p className="mt-2 text-sm text-slate-400">Latest plan checks and audit commits for this organization.</p>
+              <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-200">Customer-readable history</p>
+              <h2 className="mt-2 text-2xl font-black">Latest decisions and evidence</h2>
+              <p className="mt-2 text-sm text-slate-400">A buyer should not need to read logs. This table answers action, decision, owner, proof hash, and exportability.</p>
             </div>
-            <form className="flex gap-2" action="/gateway/monitor">
-              <input
-                name="orgId"
-                defaultValue={orgId}
-                className="rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none"
-                aria-label="Organization ID"
-              />
-              <button className="rounded-xl bg-white px-4 py-3 text-sm font-bold text-slate-950">Load</button>
-            </form>
           </div>
 
           <div className="mt-6 overflow-x-auto">
@@ -114,9 +218,9 @@ export default async function GatewayMonitorPage({ searchParams }: { searchParam
               <thead className="text-xs uppercase tracking-[0.2em] text-slate-500">
                 <tr>
                   <th className="px-3 py-3">Time</th>
-                  <th className="px-3 py-3">Tool</th>
+                  <th className="px-3 py-3">Action</th>
                   <th className="px-3 py-3">Decision</th>
-                  <th className="px-3 py-3">Status</th>
+                  <th className="px-3 py-3">Evidence state</th>
                   <th className="px-3 py-3">Actor</th>
                   <th className="px-3 py-3">Request hash</th>
                   <th className="px-3 py-3">Record hash</th>
@@ -126,49 +230,30 @@ export default async function GatewayMonitorPage({ searchParams }: { searchParam
                 {events.map((event) => (
                   <tr key={event.id} className="border-t border-white/10 text-slate-200">
                     <td className="whitespace-nowrap px-3 py-4">{new Date(event.created_at).toLocaleString()}</td>
-                    <td className="px-3 py-4">
-                      <p className="font-semibold text-white">{event.tool_name}</p>
-                      <p className="text-xs text-slate-500">{event.action} · {event.mode} · {event.risk ?? 'unclassified'}</p>
-                    </td>
-                    <td className="px-3 py-4"><span className="rounded-full border border-cyan-300/25 px-3 py-1 text-xs uppercase text-cyan-100">{event.decision}</span></td>
-                    <td className="px-3 py-4">{event.status}</td>
+                    <td className="px-3 py-4"><p className="font-semibold text-white">{event.tool_name}</p><p className="text-xs text-slate-500">{event.action} · {event.mode} · {event.risk ?? 'unclassified'}</p></td>
+                    <td className="px-3 py-4"><span className={`rounded-full border px-3 py-1 text-xs uppercase ${decisionClass(event.decision)}`}>{event.decision}</span></td>
+                    <td className="px-3 py-4">{event.status === 'committed' ? 'Evidence committed' : 'Waiting for commit'}</td>
                     <td className="px-3 py-4">{event.actor_id ?? '—'}</td>
                     <td className="px-3 py-4 font-mono text-xs">{shortHash(event.request_hash)}</td>
                     <td className="px-3 py-4 font-mono text-xs">{shortHash(event.record_hash)}</td>
                   </tr>
                 ))}
                 {events.length === 0 ? (
-                  <tr>
-                    <td colSpan={7} className="px-3 py-8 text-center text-slate-400">
-                      No monitor events yet. Run /api/gateway/plan-check, then /api/gateway/audit/commit.
-                    </td>
-                  </tr>
+                  <tr><td colSpan={7} className="px-3 py-8 text-center text-slate-400">No monitor events yet. Run plan-check, commit audit, then refresh.</td></tr>
                 ) : null}
               </tbody>
             </table>
           </div>
         </section>
 
-        <section className="mt-8 grid gap-5 lg:grid-cols-2">
-          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
-            <h2 className="text-2xl font-bold">Runtime settings</h2>
-            <pre className="mt-4 overflow-x-auto rounded-2xl bg-black/40 p-4 text-xs leading-6 text-cyan-100">{`POST /api/gateway/plan-check
-x-org-id: ${orgId}
-x-actor-id: agent-001
-x-actor-role: agent_operator
-x-org-plan: enterprise`}</pre>
-          </div>
-          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-6">
-            <h2 className="text-2xl font-bold">Audit commit</h2>
-            <pre className="mt-4 overflow-x-auto rounded-2xl bg-black/40 p-4 text-xs leading-6 text-cyan-100">{`POST /api/gateway/audit/commit
-{
-  "auditToken": "gat_...",
-  "result": {
-    "ok": true,
-    "provider": "customer_runtime"
-  }
-}`}</pre>
-          </div>
+        <section className="mt-8 grid gap-5 lg:grid-cols-3">
+          {commands.map((command) => (
+            <div key={command.title} className="dsg-card-blue rounded-[1.5rem] p-6">
+              <h2 className="text-xl font-black text-white">{command.title}</h2>
+              <p className="mt-2 text-sm leading-7 text-slate-300">{command.body}</p>
+              <pre className="mt-4 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-4 text-xs leading-6 text-blue-100"><code>{command.code}</code></pre>
+            </div>
+          ))}
         </section>
       </div>
     </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import './dsg-brand.css';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { Analytics } from '@vercel/analytics/next';
@@ -6,8 +7,8 @@ import GlobalNav from '../components/GlobalNav';
 import PublicChatWidget from '../components/PublicChatWidget';
 
 export const metadata: Metadata = {
-  title: 'DSG ONE — AI Runtime Control Plane',
-  description: 'deterministic governance for AI, workflow, finance, and deployment actions before execution.',
+  title: 'DSG ONE — ProofGate Runtime Control Plane',
+  description: 'red, gold, and blue-sapphire runtime governance for AI, workflow, finance, and deployment actions before execution.',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/app/proofgate/page.tsx
+++ b/app/proofgate/page.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link';
+
+const productFlow = [
+  ['Create AI System', 'Register owner, model, impact level, environment, and allowed action boundary.'],
+  ['Bind Connector', 'Connect REST, webhook, Zapier, Make, n8n, GitHub, Vercel, or a customer API.'],
+  ['Map Tool', 'Define the exact action template an agent or workflow is allowed to request.'],
+  ['Evaluate Gate', 'Classify new input, compute risk, match policy, and create decision evidence.'],
+  ['Approve High Risk', 'Route high-risk or critical actions to human review before execution.'],
+  ['Export Evidence', 'Package request hash, policy hash, decision hash, approval log, and replay posture.'],
+  ['Run Deploy Gate', 'Block production claims unless build, tests, auth, RBAC, audit, and proof checks pass.'],
+];
+
+const proofCards = [
+  ['Allowed claim', 'Policy-gated AI and automation execution with approval routing, audit hashes, evidence export, and deployment gating.'],
+  ['Blocked claim', 'No certification, independent audit, or enterprise production security claim without live evidence and external proof.'],
+  ['Demo outcome', 'A buyer sees allow, review, block, evidence export, and go/no-go state in the first session.'],
+];
+
+const layers = [
+  ['1', 'User and Agent Layer', 'Humans, agents, finance workflows, support operations, and deployment requests.'],
+  ['2', 'Gateway Protocol', 'API auth, plan check, request hash, idempotency key, and tool boundary.'],
+  ['3', 'Governance Decision', 'Policy, invariants, risk score, approval route, and deterministic decision state.'],
+  ['4', 'Audit and Proof', 'Tamper-evident hashes, replay posture, evidence bundle, and export trail.'],
+  ['5', 'Tool Connectors', 'Stripe, Slack, Gmail, REST, webhook, Zapier, Make, n8n, GitHub, and Vercel.'],
+];
+
+export default function ProofGatePage() {
+  return (
+    <main className="dsg-shell min-h-screen text-slate-100">
+      <section className="border-b border-white/10">
+        <div className="mx-auto grid max-w-7xl gap-10 px-6 py-16 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+          <div>
+            <p className="dsg-chip">DSG ProofGate Product Layer</p>
+            <h1 className="dsg-text-gradient mt-6 max-w-5xl text-5xl font-black leading-[1.02] tracking-tight md:text-7xl">
+              Govern every AI action before it touches a customer system.
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+              ProofGate is the productized gateway from the uploaded full-stack package: policy-gated execution, approval routing, tamper-evident audit, evidence export, and deployment go/no-go checks for enterprise AI automation.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/dashboard/integrations" className="dsg-btn-gold">Connect first system</Link>
+              <Link href="/enterprise-ready" className="dsg-btn-blue">View enterprise setup</Link>
+              <Link href="/enterprise-proof/demo" className="dsg-btn-red">Run proof demo</Link>
+            </div>
+          </div>
+
+          <div className="dsg-card-blue rounded-3xl p-6">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-blue-200">Buyer-visible result</p>
+            <div className="mt-5 grid gap-3">
+              {proofCards.map(([title, body]) => (
+                <article key={title} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <h2 className="text-lg font-black text-white">{title}</h2>
+                  <p className="mt-2 text-sm leading-7 text-slate-300">{body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-14">
+        <p className="dsg-chip">Seven-step product flow</p>
+        <h2 className="mt-4 text-4xl font-black text-white">From one action to governed production rollout.</h2>
+        <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {productFlow.map(([title, body], index) => (
+            <article key={title} className="dsg-card rounded-3xl p-5">
+              <p className="text-3xl font-black text-amber-200">{String(index + 1).padStart(2, '0')}</p>
+              <h3 className="mt-3 text-xl font-black text-white">{title}</h3>
+              <p className="mt-3 text-sm leading-7 text-slate-300">{body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-black/20">
+        <div className="mx-auto max-w-7xl px-6 py-14">
+          <p className="dsg-chip">Five-layer architecture</p>
+          <div className="mt-8 grid gap-4">
+            {layers.map(([num, title, body]) => (
+              <article key={title} className="dsg-proof-rail rounded-3xl border border-white/10 bg-white/[0.03] p-5 md:grid md:grid-cols-[72px_0.35fr_1fr] md:items-center md:gap-5">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-amber-300/30 bg-amber-300/10 text-xl font-black text-amber-100">{num}</div>
+                <h3 className="mt-4 text-2xl font-black text-white md:mt-0">{title}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-300 md:mt-0">{body}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-14">
+        <div className="dsg-card-red rounded-3xl p-6">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-red-200">Truth boundary</p>
+          <p className="mt-3 text-sm leading-7 text-slate-200">
+            This page imports the uploaded ProofGate product concept into the DSG ONE control-plane story. It is product and enterprise setup ready for controlled pilots, but it does not claim external certification, independent audit, or completed production go-live without recorded live evidence.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/GlobalNav.tsx
+++ b/components/GlobalNav.tsx
@@ -6,15 +6,12 @@ import { useState } from 'react';
 
 const PUBLIC_NAV = [
   { href: '/', label: 'Home' },
+  { href: '/enterprise-ready', label: 'Enterprise Ready' },
   { href: '/finance-governance', label: 'Finance Governance' },
   { href: '/automation', label: 'Automation' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/docs', label: 'Docs' },
-  { href: '/sync-center', label: 'Sync Center' },
-  { href: '/pro-mode', label: 'Pro Mode' },
-  { href: '/support', label: 'Support' },
   { href: '/dashboard', label: 'Dashboard' },
-  { href: '/app-shell', label: 'App Shell' },
 ];
 
 export default function GlobalNav() {
@@ -53,10 +50,10 @@ export default function GlobalNav() {
               {item.label}
             </Link>
           ))}
-          <Link
-            href="/login"
-            className="rounded-xl bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950"
-          >
+          <Link href="/enterprise-ready" className="rounded-xl bg-emerald-300 px-4 py-2 text-sm font-semibold text-slate-950">
+            Start setup
+          </Link>
+          <Link href="/login" className="rounded-xl bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950">
             Login
           </Link>
         </nav>
@@ -93,11 +90,10 @@ export default function GlobalNav() {
               {item.label}
             </Link>
           ))}
-          <Link
-            href="/login"
-            onClick={() => setOpen(false)}
-            className="block rounded-xl bg-amber-300 px-4 py-3 text-center text-sm font-semibold text-slate-950"
-          >
+          <Link href="/enterprise-ready" onClick={() => setOpen(false)} className="block rounded-xl bg-emerald-300 px-4 py-3 text-center text-sm font-semibold text-slate-950">
+            Start setup
+          </Link>
+          <Link href="/login" onClick={() => setOpen(false)} className="block rounded-xl bg-amber-300 px-4 py-3 text-center text-sm font-semibold text-slate-950">
             Login
           </Link>
         </nav>

--- a/components/GlobalNav.tsx
+++ b/components/GlobalNav.tsx
@@ -6,8 +6,9 @@ import { useState } from 'react';
 
 const PUBLIC_NAV = [
   { href: '/', label: 'Home' },
+  { href: '/proofgate', label: 'ProofGate' },
   { href: '/enterprise-ready', label: 'Enterprise Ready' },
-  { href: '/finance-governance', label: 'Finance Governance' },
+  { href: '/finance-governance', label: 'Finance' },
   { href: '/automation', label: 'Automation' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/docs', label: 'Docs' },
@@ -31,7 +32,7 @@ export default function GlobalNav() {
           </span>
           <div>
             <p className="text-[10px] uppercase tracking-[0.3em] text-slate-500">DSG ONE</p>
-            <p className="text-sm font-semibold text-slate-100">AI Runtime Control Plane</p>
+            <p className="text-sm font-semibold text-slate-100">ProofGate Control Plane</p>
           </div>
         </Link>
 
@@ -50,10 +51,10 @@ export default function GlobalNav() {
               {item.label}
             </Link>
           ))}
-          <Link href="/enterprise-ready" className="rounded-xl bg-emerald-300 px-4 py-2 text-sm font-semibold text-slate-950">
+          <Link href="/dashboard/integrations" className="dsg-btn-gold text-sm">
             Start setup
           </Link>
-          <Link href="/login" className="rounded-xl bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950">
+          <Link href="/login" className="dsg-btn-blue text-sm">
             Login
           </Link>
         </nav>
@@ -90,10 +91,10 @@ export default function GlobalNav() {
               {item.label}
             </Link>
           ))}
-          <Link href="/enterprise-ready" onClick={() => setOpen(false)} className="block rounded-xl bg-emerald-300 px-4 py-3 text-center text-sm font-semibold text-slate-950">
+          <Link href="/dashboard/integrations" onClick={() => setOpen(false)} className="block rounded-xl bg-amber-300 px-4 py-3 text-center text-sm font-semibold text-slate-950">
             Start setup
           </Link>
-          <Link href="/login" onClick={() => setOpen(false)} className="block rounded-xl bg-amber-300 px-4 py-3 text-center text-sm font-semibold text-slate-950">
+          <Link href="/login" onClick={() => setOpen(false)} className="block rounded-xl border border-blue-300/30 bg-blue-300/10 px-4 py-3 text-center text-sm font-semibold text-blue-200">
             Login
           </Link>
         </nav>

--- a/components/PublicChatWidget.tsx
+++ b/components/PublicChatWidget.tsx
@@ -16,14 +16,21 @@ function makeLine(role: ChatLine['role'], content: string): ChatLine {
   };
 }
 
-const quickPrompts = ['ดูเดโม่', 'ราคา', 'ขอ demo', 'DSG Agent คืออะไร', 'เริ่มใช้งาน'];
+const quickPrompts = ['เริ่มใช้งาน', 'ต่อระบบเดิม', 'ดู monitor', 'export evidence', 'ราคา', 'ขอ demo'];
+
+const commandLinks = [
+  { href: '/proofgate', label: 'ProofGate' },
+  { href: '/enterprise-ready', label: 'Setup flow' },
+  { href: '/dashboard/integrations', label: 'Connect' },
+  { href: '/gateway/monitor', label: 'Monitor' },
+];
 
 export default function PublicChatWidget() {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState('');
   const [busy, setBusy] = useState(false);
   const [lines, setLines] = useState<ChatLine[]>([
-    makeLine('system', 'ถาม DSG Agent, pricing, demo หรือวิธีเริ่มใช้งานได้เลย — public mode ไม่ execute action'),
+    makeLine('system', 'ถาม DSG ได้ก่อนล็อกอิน: ต่อระบบเดิม, monitor, command, pricing, demo — public mode ไม่ execute action'),
   ]);
 
   async function submit(message: string) {
@@ -41,9 +48,7 @@ export default function PublicChatWidget() {
         body: JSON.stringify({ message: text }),
       });
       const json = await response.json().catch(() => ({}));
-      if (!response.ok) {
-        throw new Error(String(json.error || 'Public chat failed'));
-      }
+      if (!response.ok) throw new Error(String(json.error || 'Public chat failed'));
       setLines((prev) => [...prev, makeLine('assistant', String(json.reply || 'พร้อมช่วยครับ'))]);
     } catch (error) {
       setLines((prev) => [
@@ -59,39 +64,34 @@ export default function PublicChatWidget() {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="fixed bottom-5 right-5 z-50 rounded-full border border-emerald-300/50 bg-emerald-300 px-5 py-4 text-sm font-extrabold text-black shadow-2xl shadow-emerald-500/40 ring-2 ring-black/50 transition hover:scale-105 focus:outline-none focus:ring-4 focus:ring-emerald-200"
-        aria-label="Open public DSG chat"
+        className="fixed bottom-5 right-5 z-50 rounded-full border border-amber-300/50 bg-amber-300 px-5 py-4 text-sm font-extrabold text-black shadow-2xl shadow-amber-500/30 ring-2 ring-black/50 transition hover:scale-105 focus:outline-none focus:ring-4 focus:ring-amber-200"
+        aria-label="Open public DSG command chat"
       >
-        ถาม DSG
+        ถาม / สั่ง DSG
       </button>
     );
   }
 
   return (
-    <div className="fixed bottom-5 right-5 z-50 flex h-[500px] w-[min(390px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
-      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+    <div className="fixed bottom-5 right-5 z-50 flex h-[560px] w-[min(410px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-amber-300/25 bg-[#06080f] shadow-2xl shadow-black/70">
+      <div className="flex items-center justify-between border-b border-amber-300/15 px-4 py-3">
         <div>
-          <p className="text-sm font-semibold text-slate-100">DSG Public Assistant</p>
-          <p className="text-[11px] text-slate-400">ถามได้ก่อนล็อกอิน · ไม่มี runtime execution</p>
+          <p className="text-sm font-black text-slate-100">DSG Command Assistant</p>
+          <p className="text-[11px] text-slate-400">ถามง่าย · เห็น next action · ไม่มี runtime execution</p>
         </div>
-        <button onClick={() => setOpen(false)} className="text-slate-400 hover:text-white" aria-label="Close public chat">
-          ✕
-        </button>
+        <button onClick={() => setOpen(false)} className="text-slate-400 hover:text-white" aria-label="Close public chat">✕</button>
       </div>
 
-      <div className="grid grid-cols-2 gap-2 border-b border-slate-800 px-4 py-3">
-        <a
-          href="/enterprise-proof/demo"
-          className="rounded-xl bg-emerald-400 px-3 py-2 text-center text-xs font-bold text-black hover:bg-emerald-300"
-        >
-          ดูเดโม่
-        </a>
-        <a
-          href="/request-access"
-          className="rounded-xl border border-emerald-400/40 px-3 py-2 text-center text-xs font-bold text-emerald-100 hover:bg-emerald-400/10"
-        >
-          ขอสิทธิ์ทดลอง
-        </a>
+      <div className="grid grid-cols-4 gap-2 border-b border-amber-300/15 px-4 py-3">
+        {commandLinks.map((item) => (
+          <a key={item.href} href={item.href} className="rounded-xl border border-blue-300/25 bg-blue-300/10 px-2 py-2 text-center text-[11px] font-bold text-blue-100 hover:bg-blue-300/15">
+            {item.label}
+          </a>
+        ))}
+      </div>
+
+      <div className="border-b border-amber-300/15 bg-amber-300/10 px-4 py-3 text-xs leading-6 text-amber-50">
+        ลูกค้ามักต้องการเห็น: ระบบต่อกับอะไรได้, action ถูก allow/review/block เพราะอะไร, evidence export ได้ไหม, และต้องทำขั้นตอนถัดไปอะไร.
       </div>
 
       <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
@@ -100,10 +100,10 @@ export default function PublicChatWidget() {
             key={line.id}
             className={
               line.role === 'user'
-                ? 'ml-auto max-w-[85%] rounded-xl border border-emerald-500/30 bg-emerald-500/20 px-3 py-2 text-xs text-emerald-100'
+                ? 'ml-auto max-w-[85%] rounded-xl border border-amber-300/30 bg-amber-300/20 px-3 py-2 text-xs text-amber-50'
                 : line.role === 'system'
-                  ? 'max-w-[92%] rounded-xl border border-amber-400/20 bg-amber-400/10 px-3 py-2 text-xs text-amber-100'
-                  : 'max-w-[92%] rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-200'
+                  ? 'max-w-[92%] rounded-xl border border-blue-300/25 bg-blue-300/10 px-3 py-2 text-xs text-blue-100'
+                  : 'max-w-[92%] rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-200'
             }
           >
             {line.content}
@@ -111,20 +111,20 @@ export default function PublicChatWidget() {
         ))}
       </div>
 
-      <div className="flex flex-wrap gap-2 border-t border-slate-800 px-4 py-2">
+      <div className="flex flex-wrap gap-2 border-t border-amber-300/15 px-4 py-2">
         {quickPrompts.map((item) => (
           <button
             key={item}
             onClick={() => submit(item)}
             disabled={busy}
-            className="rounded-full border border-slate-700 px-2.5 py-1 text-[11px] text-slate-300 hover:border-emerald-400 disabled:opacity-50"
+            className="rounded-full border border-slate-700 px-2.5 py-1 text-[11px] text-slate-300 hover:border-amber-300 disabled:opacity-50"
           >
             {item}
           </button>
         ))}
       </div>
 
-      <div className="border-t border-slate-800 p-3">
+      <div className="border-t border-amber-300/15 p-3">
         <div className="flex gap-2">
           <input
             value={draft}
@@ -135,13 +135,13 @@ export default function PublicChatWidget() {
                 void submit(draft);
               }
             }}
-            placeholder="ถามก่อนล็อกอิน..."
-            className="min-w-0 flex-1 rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none focus:border-emerald-400"
+            placeholder="ถาม/สั่งงาน เช่น ต่อ ERP ยังไง..."
+            className="min-w-0 flex-1 rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none focus:border-amber-300"
           />
           <button
             onClick={() => submit(draft)}
             disabled={busy}
-            className="rounded-xl bg-emerald-400 px-3 py-2 text-sm font-bold text-black disabled:bg-slate-700 disabled:text-slate-400"
+            className="rounded-xl bg-amber-300 px-3 py-2 text-sm font-black text-black disabled:bg-slate-700 disabled:text-slate-400"
           >
             {busy ? '...' : 'ส่ง'}
           </button>

--- a/docs/ENTERPRISE_READY_AUTOPILOT.md
+++ b/docs/ENTERPRISE_READY_AUTOPILOT.md
@@ -12,6 +12,38 @@ The first customer outcome is not a full migration. The first outcome is:
 one existing system -> one governed action -> one evidence trail -> one expansion decision
 ```
 
+## Product layer imported from zip
+
+```text
+/proofgate
+```
+
+The uploaded `dsg-proofgate-product-ready-fullstack.zip` was reviewed and converted into a native Next.js product page for this repo. The page communicates the ProofGate offer without copying the FastAPI/Vite stack into this Next app:
+
+- policy-gated AI and automation execution
+- approval routing for high-risk actions
+- tamper-evident audit and proof hashes
+- evidence export
+- deployment go/no-go gate
+- truth boundary against false certification or compliance claims
+
+## Brand direction
+
+The branch applies a unified red / gold / blue-sapphire visual system across the app shell:
+
+- red = blocked risk, urgent control, exception pressure
+- gold = proof, evidence, buyer trust, primary CTA
+- blue sapphire = enterprise infrastructure, runtime gateway, technical confidence
+- black = command center background
+
+The shared layer lives in:
+
+```text
+app/dsg-brand.css
+app/layout.tsx
+components/GlobalNav.tsx
+```
+
 ## New product surface
 
 ```text

--- a/docs/ENTERPRISE_READY_AUTOPILOT.md
+++ b/docs/ENTERPRISE_READY_AUTOPILOT.md
@@ -1,0 +1,74 @@
+# DSG ONE Enterprise Ready Autopilot
+
+This runbook defines the user-first enterprise setup flow added in `feature/enterprise-ready-ux`.
+
+## Goal
+
+Make DSG ONE easier for a customer to try with the systems they already use.
+
+The first customer outcome is not a full migration. The first outcome is:
+
+```text
+one existing system -> one governed action -> one evidence trail -> one expansion decision
+```
+
+## New product surface
+
+```text
+/enterprise-ready
+```
+
+This page explains the enterprise setup flow for API, webhook, no-code automation, workflow engines, release gates, and legacy batch paths.
+
+## Updated integration surface
+
+```text
+/dashboard/integrations
+```
+
+This page now gives the operator a self-service quickstart:
+
+1. Register integration
+2. Attach callback/webhook
+3. Execute one governed action
+4. Review proof and evidence requirements
+
+## User-first design rules
+
+- Do not force migration before first proof.
+- Start with the customer system already in use.
+- Show copy-paste commands before asking for broad rollout.
+- Make missing proof visible as next action.
+- Keep false production, certification, or compliance claims blocked by the truth boundary.
+- Save Vercel quota: test locally and deploy once after review.
+
+## Connector positioning
+
+DSG should meet customers through:
+
+- REST API
+- Webhook
+- Zapier / Make
+- n8n / Workato
+- GitHub / Vercel
+- CSV / SFTP
+
+## Enterprise-readiness boundary
+
+`Enterprise Ready` in this branch means setup-ready, governance-ready, and evidence-ready for a controlled pilot.
+
+It does not mean independent certification, third-party audit, or completed production go-live.
+
+## Verification before merge
+
+Run locally before merging to avoid unnecessary Vercel deployments:
+
+```bash
+npm install --ignore-scripts
+npm run typecheck
+npm run ux:routes
+npm run verify:deterministic
+npm run build
+```
+
+If the branch passes locally, open one PR and let Vercel run once for the final preview.

--- a/scripts/verify-ux-route-map.mjs
+++ b/scripts/verify-ux-route-map.mjs
@@ -3,6 +3,8 @@
 import fs from 'node:fs';
 
 const routeChecks = [
+  { route: '/enterprise-ready', file: 'app/enterprise-ready/page.tsx', outcome: 'Enterprise setup page is reachable.' },
+  { route: '/dashboard/integrations', file: 'app/dashboard/integrations/page.tsx', outcome: 'Self-service integration setup page is reachable.' },
   { route: '/ai-compliance', file: 'app/ai-compliance/page.tsx', outcome: 'Compliance landing page is reachable.' },
   { route: '/iso-42001', file: 'app/iso-42001/page.tsx', outcome: 'ISO alignment page is reachable.' },
   { route: '/nist-ai-rmf', file: 'app/nist-ai-rmf/page.tsx', outcome: 'NIST AI RMF alignment page is reachable.' },
@@ -21,18 +23,34 @@ const forbiddenLinks = [
   { file: 'app/controls/page.tsx', text: 'href="/docs"', reason: 'Controls page must not link to missing docs route.' },
   { file: 'app/controls/page.tsx', text: 'href="#"', reason: 'Controls page must not use placeholder anchors.' },
   { file: 'app/ai-compliance/page.tsx', text: 'href="#"', reason: 'Compliance page must not use placeholder anchors.' },
+  { file: 'app/enterprise-ready/page.tsx', text: 'href="#"', reason: 'Enterprise setup page must not use placeholder anchors.' },
+  { file: 'app/dashboard/integrations/page.tsx', text: 'href="#"', reason: 'Integration setup page must not use placeholder anchors.' },
 ];
 
 const requiredText = [
   { file: 'docs/UX_WORKING_RULES.md', text: 'What benefit does the user get?', reason: 'UX working rules must include flow completion benefit question.' },
   { file: 'docs/UX_WORKING_RULES.md', text: 'What evidence proves the flow worked?', reason: 'UX working rules must require evidence proof.' },
   { file: 'docs/UX_WORKING_RULES.md', text: 'Where is the tangible output', reason: 'UX working rules must require tangible output.' },
+  { file: 'app/enterprise-ready/page.tsx', text: 'Four steps to first governed proof', reason: 'Enterprise setup page must expose clear setup steps.' },
+  { file: 'app/enterprise-ready/page.tsx', text: 'Connect DSG to the systems customers already use.', reason: 'Enterprise setup page must emphasize existing-system adoption.' },
+  { file: 'app/dashboard/integrations/page.tsx', text: 'Connect one existing workflow in minutes.', reason: 'Integrations page must make the install value obvious.' },
+  { file: 'app/dashboard/integrations/page.tsx', text: 'Quota-aware rollout', reason: 'Integrations page must preserve Vercel/deploy quota.' },
+  { file: 'docs/ENTERPRISE_READY_AUTOPILOT.md', text: 'one existing system -> one governed action -> one evidence trail -> one expansion decision', reason: 'Enterprise runbook must define the tangible user outcome.' },
   { file: 'app/controls/page.tsx', text: 'Action map', reason: 'Controls page must explain action outcomes.' },
   { file: 'app/approvals/page.tsx', text: 'Approve', reason: 'Approval page must expose approve action.' },
   { file: 'app/approvals/page.tsx', text: 'Reject', reason: 'Approval page must expose reject action.' },
 ];
 
 const flowOutcomes = [
+  {
+    id: 'enterprise-ready-to-integration-proof',
+    benefit: 'Customer can start from one existing system and reach a governed proof path without migration.',
+    action: 'Open /enterprise-ready, then click Start setup to /dashboard/integrations.',
+    evidence: 'Integration page exposes register, webhook, execute, and evidence checklist steps.',
+    output: '/dashboard/integrations and docs/ENTERPRISE_READY_AUTOPILOT.md',
+    files: ['app/enterprise-ready/page.tsx', 'app/dashboard/integrations/page.tsx', 'docs/ENTERPRISE_READY_AUTOPILOT.md'],
+    requiredText: ['Start setup', 'Register integration', 'Execute one governed action', 'one governed action'],
+  },
   {
     id: 'controls-to-evidence',
     benefit: 'User can turn a governance control into evidence review.',

--- a/scripts/verify-ux-route-map.mjs
+++ b/scripts/verify-ux-route-map.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 
 const routeChecks = [
+  { route: '/proofgate', file: 'app/proofgate/page.tsx', outcome: 'ProofGate product page is reachable.' },
   { route: '/enterprise-ready', file: 'app/enterprise-ready/page.tsx', outcome: 'Enterprise setup page is reachable.' },
   { route: '/dashboard/integrations', file: 'app/dashboard/integrations/page.tsx', outcome: 'Self-service integration setup page is reachable.' },
   { route: '/ai-compliance', file: 'app/ai-compliance/page.tsx', outcome: 'Compliance landing page is reachable.' },
@@ -23,6 +24,7 @@ const forbiddenLinks = [
   { file: 'app/controls/page.tsx', text: 'href="/docs"', reason: 'Controls page must not link to missing docs route.' },
   { file: 'app/controls/page.tsx', text: 'href="#"', reason: 'Controls page must not use placeholder anchors.' },
   { file: 'app/ai-compliance/page.tsx', text: 'href="#"', reason: 'Compliance page must not use placeholder anchors.' },
+  { file: 'app/proofgate/page.tsx', text: 'href="#"', reason: 'ProofGate product page must not use placeholder anchors.' },
   { file: 'app/enterprise-ready/page.tsx', text: 'href="#"', reason: 'Enterprise setup page must not use placeholder anchors.' },
   { file: 'app/dashboard/integrations/page.tsx', text: 'href="#"', reason: 'Integration setup page must not use placeholder anchors.' },
 ];
@@ -31,17 +33,34 @@ const requiredText = [
   { file: 'docs/UX_WORKING_RULES.md', text: 'What benefit does the user get?', reason: 'UX working rules must include flow completion benefit question.' },
   { file: 'docs/UX_WORKING_RULES.md', text: 'What evidence proves the flow worked?', reason: 'UX working rules must require evidence proof.' },
   { file: 'docs/UX_WORKING_RULES.md', text: 'Where is the tangible output', reason: 'UX working rules must require tangible output.' },
+  { file: 'app/proofgate/page.tsx', text: 'Govern every AI action before it touches a customer system.', reason: 'ProofGate page must state the product promise.' },
+  { file: 'app/proofgate/page.tsx', text: 'Seven-step product flow', reason: 'ProofGate page must expose the buyer demo flow.' },
+  { file: 'app/proofgate/page.tsx', text: 'Five-layer architecture', reason: 'ProofGate page must expose the architecture story.' },
+  { file: 'app/dsg-brand.css', text: '--dsg-sapphire', reason: 'Brand layer must include blue sapphire token.' },
+  { file: 'app/dsg-brand.css', text: '--dsg-gold', reason: 'Brand layer must include gold token.' },
+  { file: 'app/dsg-brand.css', text: '--dsg-red', reason: 'Brand layer must include red token.' },
   { file: 'app/enterprise-ready/page.tsx', text: 'Four steps to first governed proof', reason: 'Enterprise setup page must expose clear setup steps.' },
   { file: 'app/enterprise-ready/page.tsx', text: 'Connect DSG to the systems customers already use.', reason: 'Enterprise setup page must emphasize existing-system adoption.' },
   { file: 'app/dashboard/integrations/page.tsx', text: 'Connect one existing workflow in minutes.', reason: 'Integrations page must make the install value obvious.' },
   { file: 'app/dashboard/integrations/page.tsx', text: 'Quota-aware rollout', reason: 'Integrations page must preserve Vercel/deploy quota.' },
   { file: 'docs/ENTERPRISE_READY_AUTOPILOT.md', text: 'one existing system -> one governed action -> one evidence trail -> one expansion decision', reason: 'Enterprise runbook must define the tangible user outcome.' },
+  { file: 'docs/ENTERPRISE_READY_AUTOPILOT.md', text: '/proofgate', reason: 'Runbook must mention the ProofGate product surface.' },
+  { file: 'components/GlobalNav.tsx', text: 'ProofGate', reason: 'Global nav must expose ProofGate page.' },
   { file: 'app/controls/page.tsx', text: 'Action map', reason: 'Controls page must explain action outcomes.' },
   { file: 'app/approvals/page.tsx', text: 'Approve', reason: 'Approval page must expose approve action.' },
   { file: 'app/approvals/page.tsx', text: 'Reject', reason: 'Approval page must expose reject action.' },
 ];
 
 const flowOutcomes = [
+  {
+    id: 'proofgate-to-integration-proof',
+    benefit: 'Buyer can understand the ProofGate product promise and move to one connected system.',
+    action: 'Open /proofgate and click Connect first system to /dashboard/integrations.',
+    evidence: 'ProofGate page exposes product flow, architecture, and truth boundary before setup.',
+    output: '/proofgate and /dashboard/integrations',
+    files: ['app/proofgate/page.tsx', 'app/dashboard/integrations/page.tsx', 'docs/ENTERPRISE_READY_AUTOPILOT.md'],
+    requiredText: ['Connect first system', 'Seven-step product flow', 'Five-layer architecture', 'policy-gated AI and automation execution'],
+  },
   {
     id: 'enterprise-ready-to-integration-proof',
     benefit: 'Customer can start from one existing system and reach a governed proof path without migration.',


### PR DESCRIPTION
## Summary

Adds a customer-facing ProofGate / Enterprise Ready product layer and unifies the app presentation around one red / gold / blue-sapphire command-center theme.

### Changed

- Added `/proofgate` product page from the uploaded ProofGate product-ready package concept
- Added `/enterprise-ready` user-facing setup page
- Upgraded `/dashboard/integrations` into a self-service integration quickstart
- Improved `/gateway/monitor` so customers can understand action status, decision reason, evidence state, next action, and command path
- Improved `PublicChatWidget` into a command assistant with direct paths to ProofGate, setup, connect, and monitor
- Added Enterprise Ready / ProofGate links and Start setup CTA to `GlobalNav`
- Added shared brand layer `app/dsg-brand.css`
- Added `docs/ENTERPRISE_READY_AUTOPILOT.md`
- Extended `npm run ux:routes` verification to cover ProofGate, monitor, brand tokens, and enterprise setup flow

## User value

The customer flow now answers the buyer's first questions:

1. What does DSG do?
2. What can it connect to?
3. What action was allowed/reviewed/blocked?
4. What evidence can I export?
5. What exact command/path do I run next?

## Visual direction

- Red = risk, block, exception, urgent control
- Gold = proof, evidence, trust, primary CTA
- Blue sapphire = enterprise infrastructure, runtime gateway, technical confidence
- Black = command-center surface

## Verification performed by user

Local Termux build passed before the final monitor/chatbot update. Final recommended checks after pulling latest head:

```bash
npm run ux:routes
npm run typecheck
npm run verify:deterministic
npm run build
```

## Truth boundary

This improves product readiness, setup readiness, monitor UX, and enterprise onboarding. It does not claim certification, independent audit, or completed production go-live without recorded live evidence.