### PR TITLE
Fix workflow copy and UDG oscillation threshold

### DIFF
--- a/lib/runtime/udg-gate.ts
+++ b/lib/runtime/udg-gate.ts
@@ -149,7 +149,7 @@ export function evaluateCospinUDGGate(
   }
 
   const oscillation = oscillationScore(current, envelope.nextState);
-  if (oscillation > policy.maxOscillation) {
+  if (oscillation >= policy.maxOscillation) {
     return { decision: 'STABILIZE', reason: 'OSCILLATION_FREQUENCY_EXCEEDED', metrics: { velocity, drift, oscillation } };
   }
 

--- a/tests/integration/ui/finance-governance-live-workflow.test.ts
+++ b/tests/integration/ui/finance-governance-live-workflow.test.ts
@@ -9,7 +9,7 @@ describe('finance governance live workflow dashboard surface', () => {
   it('shows submit/approve/reject/escalate actions connected to API endpoints', () => {
     const source = read('app/finance-governance/live/workflow/page.tsx');
 
-    expect(source).toContain('Submit sample workflow item');
+    expect(source).toContain('Submit selected workflow item');
     expect(source).toContain("void runApprovalAction(item.id, 'approve')");
     expect(source).toContain("void runApprovalAction(item.id, 'reject')");
     expect(source).toContain("void runApprovalAction(item.id, 'escalate')");


### PR DESCRIPTION
### Motivation

- Keep the integration assertion in `tests/integration/ui/finance-governance-live-workflow.test.ts` consistent with the actual UI button text in `app/finance-governance/live/workflow/page.tsx` so the integration check reflects reality.
- Ensure the UDG gate stabilizes when the oscillation score reaches the configured ceiling so that a score equal to `policy.maxOscillation` is treated as a stabilization case (matches recent unit test scenario).

### Description

- Updated the integration test expectation in `tests/integration/ui/finance-governance-live-workflow.test.ts` (changed the submit button copy check from `"Submit sample workflow item"` to `"Submit selected workflow item"`).
- Changed the oscillation threshold comparison in `lib/runtime/udg-gate.ts` from `oscillation > policy.maxOscillation` to `oscillation >= policy.maxOscillation` so equal scores trigger `STABILIZE`.
- Changes are limited to the two files above and are implemented as a focused, minimal fix.

### Testing

- Ran `npm test -- tests/unit/runtime/udg-gate.test.ts tests/integration/ui/finance-governance-live-workflow.test.ts` and both targeted test files passed (all tests green).
- Ran `git diff --check` as a lightweight verification and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05db464990832884de0bf4e29a2b48)