### PR TITLE
Update test baseline, migration list, and go-live evidence for 2026-05-15

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -92,3 +92,31 @@ Go-live remains blocked until RUNBOOK evidence is closed for:
 
 Documentation rule:
 - keep test-baseline truth and production-readiness truth as separate sections so test success is not misread as full cutover completion.
+
+### Decision 008
+Status: accepted
+Type: test-baseline update (May 15, 2026)
+
+The May 15, 2026 Vitest run supersedes the April 17, 2026 baseline.
+
+Current baseline:
+- `77 test files passed, 2 skipped, 0 failed`
+- `252 tests passed, 4 skipped, 0 failed`
+- TypeScript typecheck: zero errors
+
+Authoritative evidence:
+- `qa-logs/npm-test-2026-05-15.log`
+- `qa-logs/test-summary.md`
+
+Also confirmed in this session:
+- No legacy `/api/finance-governance/server-store/` callers exist in app/lib/components/scripts
+- All 34 Supabase migrations are present in `supabase/migrations/` and now listed in `RUNBOOK_DEPLOY.md`
+- Remaining go-live blockers are environment-dependent (Vercel access, production Supabase, direct outbound network) — not code defects
+
+### Decision 009
+Status: accepted
+Type: go-live blocker classification
+
+The 2026-05-03 go-live evidence failures (`CONNECT tunnel failed, response 403`) are confirmed as outbound proxy restrictions of the sandbox execution environment, not application-layer or code defects. They must be re-run from GitHub Actions or a direct-network shell with valid Vercel deployment credentials to produce closeable evidence.
+
+This classification prevents future sessions from treating these network-constrained failures as code bugs to patch.

--- a/PROJECT_TRUTH.md
+++ b/PROJECT_TRUTH.md
@@ -1,6 +1,6 @@
 # PROJECT_TRUTH
 
-Last reviewed: 2026-05-02
+Last reviewed: 2026-05-15
 Mode: active
 Status: merged into main; derived from real repository files only
 
@@ -56,31 +56,42 @@ Minimum deployment truth includes:
 - authenticated operator checks must include runtime/control-plane surfaces
 - live E2E against Supabase/staging is part of the intended validation path
 
-## Test baseline resolution (April 17, 2026)
+## Test baseline resolution (May 15, 2026)
 
-The earlier 85-vs-185 mismatch is now resolved in favor of the latest committed evidence set.
+Three historical baselines exist; use the newest committed run as current truth:
 
-- Historical snapshot (valid for April 11, 2026): `85 tests`, `41 test files`, `0 failures`
-- Current authoritative baseline (committed April 17, 2026): `185 tests passed, 3 skipped, 0 failed` and `62 test files passed, 1 skipped, 0 failed`
+| Date | Files | Tests | Status |
+|---|---|---|---|
+| 2026-04-11 | 41 passed | 85 passed | superseded |
+| 2026-04-17 | 62 passed, 1 skipped | 185 passed, 3 skipped | superseded |
+| 2026-05-15 | 77 passed, 2 skipped | 252 passed, 4 skipped | **current** |
 
 Authoritative evidence files:
 
-- `qa-logs/npm-test-2026-04-17.log`
+- `qa-logs/npm-test-2026-05-15.log`
 - `qa-logs/npm-test.log`
 - `qa-logs/test-summary.md`
-- `docs/STATUS_SNAPSHOT_2026-04-17.md`
 
-Working rule: preserve older snapshots as historical context, but treat the April 17, 2026 artifact set as the current repo baseline until superseded by a newer committed run.
+Working rule: preserve older snapshots as historical context, but treat the May 15, 2026 artifact set as the current repo baseline until superseded by a newer committed run.
 
+TypeScript typecheck: **passes with zero errors** (verified May 15, 2026).
 
 ## Production-readiness status boundary
 
 Repository test truth and production go-live truth are intentionally separate:
 
-- Test truth (current): April 17, 2026 committed Vitest baseline = `185 passed, 3 skipped, 0 failed`.
+- Test truth (current): May 15, 2026 committed Vitest baseline = `252 passed, 4 skipped, 0 failed`.
 - Go-live truth (current): **not yet complete** until runbook evidence is closed for deployment readiness, env validation, migration apply state, deployed smoke checks, authenticated operator checks, and live staging/E2E validation.
 
-Do not claim full production readiness from Vitest evidence alone. Latest runbook evidence: `qa-logs/go-live-evidence-2026-05-03.md` (NO-GO / not closed).
+Do not claim full production readiness from Vitest evidence alone. Latest runbook evidence: `qa-logs/go-live-evidence-2026-05-15.md` (NOT CLOSED — external deployment checks pending).
+
+Remaining go-live blockers (require external environment — Vercel access, production Supabase credentials, direct outbound network):
+- Vercel production deployment status = `Ready`
+- Production environment variables complete and validated
+- Supabase migrations applied in-order (all 34 migrations through `20260512090000_create_agent_gate_settings.sql`)
+- `/api/health` and `/api/readiness` smoke checks pass on deployed target
+- Authenticated operator checks pass
+- Live staging/E2E validation recorded
 
 Do not upgrade beyond scaffold truth without new evidence:
 

--- a/docs/RUNBOOK_DEPLOY.md
+++ b/docs/RUNBOOK_DEPLOY.md
@@ -214,6 +214,43 @@ Run migrations for the target environment before traffic cutover.
 
 - Validate schema changes via application smoke checks.
 
+**Complete migration order (all 34 files as of 2026-05-15):**
+
+1. `20260323053000_product_loop_scaffold.sql`
+2. `20260323054500_product_loop_rls.sql`
+3. `20260323110000_billing_checkout_flow.sql`
+4. `20260323140000_schema_constraints_hardening.sql`
+5. `20260323141000_rls_policy_hardening.sql`
+6. `20260329120000_trial_signup_flow.sql`
+7. `20260330_monitor_stats.sql`
+8. `20260331_runtime_spine.sql`
+9. `20260331_runtime_spine_rpc.sql`
+10. `20260401093000_batch3_enterprise_identity_rollout.sql`
+11. `20260401120000_enterprise_access_batch2.sql`
+12. `20260401123000_access_requests_org_scope.sql`
+13. `20260401_runtime_rbac.sql`
+14. `20260401_schema_policies_table.sql`
+15. `20260402100000_usage_counters_unique.sql`
+16. `20260402_billing_quota_in_rpc.sql`
+17. `20260404_runtime_spine_rpc_hardening.sql`
+18. `202604110015_create_dsg_app_builder_jobs.sql`
+19. `20260411101500_finance_governance_workflow.sql`
+20. `20260413090000_integration_profiles.sql`
+21. `20260417000000_full_schema_sync.sql`
+22. `20260424010000_finance_governance_control_layer.sql`
+23. `20260426090000_finance_workflow_action_audit_evidence.sql`
+24. `202604261825_agent_model_provider_keys.sql`
+25. `20260426193300_release_gate_entitlements.sql`
+26. `20260429060000_finance_governance_audit_ledger.sql`
+27. `20260430_gateway_managed_connectors.sql`
+28. `20260430_gateway_monitor_events.sql`
+29. `202605040016_create_dsg_governed_memory_layer.sql`
+30. `202605060001_create_dsg_midmarket_governance_autopilot.sql`
+31. `202605060002_create_dsg_agent_command_gate.sql`
+32. `20260507_prepare_governance_event_trigger.sql`
+33. `20260508_governance_decision_events.sql`
+34. `20260512090000_create_agent_gate_settings.sql`
+
 ### One-command runtime RPC + PostgREST cache recovery
 When `rpc_commit` fails because PostgREST cannot find `public.runtime_commit_execution(...)` in schema cache:
 

--- a/qa-logs/go-live-evidence-2026-05-15.md
+++ b/qa-logs/go-live-evidence-2026-05-15.md
@@ -1,0 +1,43 @@
+# DSG ONE Go-Live Evidence — 2026-05-15
+
+## Target
+- URL: https://tdealer01-crypto-dsg-control-plane.vercel.app
+- Branch: claude/analyze-files-tbmNa
+- Environment: production / staging-review
+
+## Repository-level checks (runnable without external credentials)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Vitest baseline (252 tests) | ✅ PASS | qa-logs/npm-test-2026-05-15.log |
+| TypeScript typecheck | ✅ PASS | zero errors, verified 2026-05-15 |
+| No legacy server-store callers | ✅ PASS | rg found zero callers in app/lib/components/scripts |
+| Migration inventory complete | ✅ PASS | 34 migrations in supabase/migrations/, all listed in RUNBOOK_DEPLOY.md |
+| RUNBOOK_DEPLOY.md migration list | ✅ UPDATED | includes all 34 migrations through 20260512090000_create_agent_gate_settings.sql |
+
+## External environment checks (require Vercel access + direct outbound network)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Vercel deployment Ready | NOT VERIFIED | requires GitHub Actions with VERCEL_TOKEN / VERCEL_ORG_ID / VERCEL_PROJECT_ID |
+| Env validation | NOT VERIFIED | run `vercel env ls production` from authenticated shell |
+| Supabase applied-state proof | NOT VERIFIED | run `supabase db push --linked` with production credentials |
+| /api/health smoke | NOT VERIFIED | sandbox proxy blocks outbound (CONNECT 403) — re-run from GitHub Actions |
+| /api/readiness smoke | NOT VERIFIED | same proxy restriction |
+| Finance readiness smoke | NOT VERIFIED | same proxy restriction |
+| Authenticated operator checks | NOT VERIFIED | requires live deployment + org credentials |
+| Live staging/E2E validation | SKIPPED | requires NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in shell |
+
+## Root cause of NOT VERIFIED items
+
+All external checks fail with `curl: (56) CONNECT tunnel failed, response 403` — this is an outbound proxy restriction of the sandbox execution environment. The application code has no defects causing these failures.
+
+**Resolution path:** Run the Vercel Production CLI Bypass GitHub Actions workflow (`vercel-prod-cli-bypass.yml`) from a direct-network shell with the required secrets set. That workflow:
+1. Deploys via `vercel deploy --prebuilt --prod`
+2. Runs `/api/health` check automatically
+3. Publishes deployment URL and health result in workflow summary
+
+## Final Decision
+
+Production-readiness gate: **NOT CLOSED** — external deployment evidence not yet captured.
+Repository code state: **CLEAN** — tests pass, typecheck clean, no legacy callers, migration list complete.

--- a/qa-logs/npm-test-2026-05-15.log
+++ b/qa-logs/npm-test-2026-05-15.log
@@ -1,0 +1,10 @@
+
+> test
+> vitest run
+
+ RUN  v2.1.9 /workspace/tdealer01-crypto-dsg-control-plane
+
+ Test Files  77 passed | 2 skipped (79)
+      Tests  252 passed | 4 skipped (256)
+   Start at  16:38:06
+   Duration  10.38s (transform 1.80s, setup 0ms, collect 2.18s, tests 6.95s, environment 15ms, prepare 5.29s)

--- a/qa-logs/test-summary.md
+++ b/qa-logs/test-summary.md
@@ -1,13 +1,21 @@
-# Test Execution Summary (2026-04-17 UTC)
+# Test Execution Summary (2026-05-15 UTC)
 
 ## Aggregated Vitest run (`npm test`)
-- Test files: **62 passed, 1 skipped, 0 failed**
-- Tests: **185 passed, 3 skipped, 0 failed**
+- Test files: **77 passed, 2 skipped, 0 failed**
+- Tests: **252 passed, 4 skipped, 0 failed**
 - Raw logs:
-  - `qa-logs/npm-test-2026-04-17.log`
+  - `qa-logs/npm-test-2026-05-15.log`
   - `qa-logs/npm-test.log` (rolling latest)
 
+## Historical baselines
+| Date | Files | Tests |
+|---|---|---|
+| 2026-04-11 | 41 passed, 0 failed | 85 passed |
+| 2026-04-17 | 62 passed, 1 skipped | 185 passed, 3 skipped |
+| 2026-05-15 | 77 passed, 2 skipped | 252 passed, 4 skipped |
+
 ## Notes
-- This run supersedes the older 85-test baseline documented on April 11, 2026.
-- Skipped tests are expected in the current local environment and are not failures.
-- E2E Playwright coverage still depends on browser binary availability in the execution environment.
+- The May 15, 2026 run is the current authoritative baseline.
+- Skipped tests are expected in the local environment (live-db tests require production Supabase credentials).
+- E2E Playwright coverage still depends on browser binary availability and live environment variables.
+- TypeScript typecheck passes with zero errors.


### PR DESCRIPTION
- Vitest baseline: 252 passed / 4 skipped / 0 failed (77 files) — up from 185/62
- TypeScript typecheck: zero errors
- RUNBOOK_DEPLOY.md: added all 34 migrations (previously listed only 14)
- PROJECT_TRUTH.md: updated last-reviewed date, new test baseline table, updated go-live evidence pointer
- DECISION_LOG.md: added decisions 008 and 009 (test-baseline update, blocker classification)
- qa-logs/go-live-evidence-2026-05-15.md: repository checks PASS; external deployment checks NOT CLOSED (proxy-blocked sandbox, require GitHub Actions)
- qa-logs/npm-test-2026-05-15.log: committed current test run output

https://claude.ai/code/session_01SNjRRqXGJ3ZqTH2CdvbxJ9