### PR TITLE
fix(auth): block backslash open-redirect bypass in getSafeNext and protect operator pages in middleware

### DIFF
--- a/lib/auth/safe-next.ts
+++ b/lib/auth/safe-next.ts
@@ -1,7 +1,12 @@
 const DEFAULT_NEXT_PATH = '/dashboard/executions';
 
 export function getSafeNext(value: string | null | undefined): string {
-  if (!value || !value.startsWith('/') || value.startsWith('//')) {
+  if (
+    !value ||
+    !value.startsWith('/') ||
+    value.startsWith('//') ||
+    value[1] === '\\'
+  ) {
     return DEFAULT_NEXT_PATH;
   }
   return value;

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,11 @@ function isProtectedPath(pathname: string) {
   return (
     pathname === '/dashboard' ||
     pathname.startsWith('/dashboard/') ||
-    pathname === '/app-shell'
+    pathname === '/app-shell' ||
+    pathname === '/approvals' ||
+    pathname.startsWith('/approvals/') ||
+    pathname === '/gateway/monitor' ||
+    pathname.startsWith('/gateway/monitor/')
   );
 }
 


### PR DESCRIPTION
Two security issues fixed:

1. Open redirect bypass in lib/auth/safe-next.ts
   The previous check only blocked values starting with '//' but not '/\'.
   Node's URL constructor resolves new URL('/\\evil.com', base) to
   https://evil.com/ — a full off-domain redirect. An attacker could
   craft ?next=/\evil.com on the login page to silently redirect a
   victim after authentication. Fixed by also rejecting any next value
   whose second character is a backslash (i.e. value[1] === '\\').

2. Unprotected operator pages in middleware.ts
   /approvals and /gateway/monitor were absent from isProtectedPath.
   Both pages run server-side queries against live governance data
   (pending approval queue, gateway monitor events) using the Supabase
   admin client, and neither page performs its own auth check. Any
   unauthenticated visitor could read that data. Fixed by adding both
   paths to isProtectedPath alongside the existing /dashboard and
   /app-shell entries.