### PR TITLE
docs(agent): add Claude and tool access contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-command.md
+++ b/.github/ISSUE_TEMPLATE/agent-command.md
@@ -1,0 +1,69 @@
+---
+name: Agent command
+about: Request Claude/Codex/DSG agent work with evidence and safety boundaries
+title: "[agent] "
+labels: ["agent-command", "needs-verification"]
+assignees: []
+---
+
+## Agent trigger
+
+Use one:
+
+```text
+@claude
+@codex
+@agent
+@dsg-agent
+```
+
+## Goal
+
+What should the agent accomplish?
+
+## Scope
+
+Repo/path/files/routes involved:
+
+## Evidence required
+
+What must be inspected before any claim is made?
+
+- [ ] repository files
+- [ ] tests/build/typecheck output
+- [ ] Supabase schema/query/logs
+- [ ] Vercel deployment/build/live endpoint
+- [ ] GitHub PR/commit/workflow metadata
+- [ ] other:
+
+## Verification required
+
+Commands or checks expected:
+
+```bash
+# examples
+npm run typecheck
+npm test
+npm run build
+curl https://example.vercel.app/api/health
+```
+
+## Do not
+
+List forbidden actions for this task:
+
+- Do not commit secrets or tokens.
+- Do not auto-merge.
+- Do not claim production-ready without live evidence.
+
+## Expected output
+
+- [ ] PR with changed files
+- [ ] issue comment only
+- [ ] diagnosis report
+- [ ] migration proposal
+- [ ] deployment/readiness report
+
+## User-visible benefit
+
+What gets easier, safer, or more verifiable for the user?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md — DSG Agent Rules
+
+Read `AGENTS.md` first. This file adds Claude Code specific rules for this repository.
+
+## Truth boundary
+
+Do not claim that a route, deployment, database, migration, job, table, test, integration, or production flow works unless it has been verified from real evidence.
+
+Acceptable evidence includes inspected repository files, command output from a real run, GitHub metadata, Supabase schema/query/log/advisor output, Vercel project/deployment/build-log metadata, or live endpoint response.
+
+If evidence is missing, label the status as `pending`, `blocked`, or `not verified`.
+
+## Tool policy
+
+Allowed:
+
+- inspect files and diffs before editing;
+- create focused branches;
+- make small, reviewable commits;
+- open pull requests with verification evidence;
+- run typecheck, tests, build, smoke checks, and targeted scripts when available;
+- query GitHub, Supabase, and Vercel only through authorized local or connected tools.
+
+Blocked:
+
+- do not commit secrets, tokens, API keys, Supabase service role keys, Vercel tokens, Claude credentials, OpenAI keys, private cookies, or local `.env` values;
+- do not print secret values in logs, PRs, issues, docs, or comments;
+- do not auto-merge production code;
+- do not change production environment variables without explicit approval and visible audit trail;
+- do not claim production-ready, marketplace-ready, or enterprise-ready without live health/readiness evidence.
+
+## Required PR body
+
+Every agent PR must include:
+
+```text
+Goal:
+
+Files changed:
+
+Verification:
+- [ ] command/result
+- [ ] command/result
+
+Known limits:
+
+User-visible benefit:
+
+Next step:
+```
+
+If no command was run, write `Not run` and explain why.
+
+## GitHub command handling
+
+When a GitHub issue or PR comment starts with `@claude`, `@codex`, `@agent`, or `@dsg-agent`, treat it as a proposed task, not as permission to merge.
+
+Before changing code, restate the goal, inspect `AGENTS.md` and relevant files, identify risk, choose the smallest branchable change, and define verification commands.
+
+After changing code, run the narrowest relevant checks, report exact pass/fail results, open or update a PR, and leave production release status as `NO-GO` unless all live gates pass.
+
+## Safe default
+
+If an instruction conflicts with `AGENTS.md`, secrets policy, production safety, or verified evidence, stop and report the conflict instead of guessing.

--- a/docs/TOOL_ACCESS_CONTRACT.md
+++ b/docs/TOOL_ACCESS_CONTRACT.md
@@ -1,0 +1,133 @@
+# Tool Access Contract — DSG Agent Work
+
+This repository can share tool usage rules, command templates, and agent workflow contracts. It must not share real credentials.
+
+## What can be shared through the repository
+
+- Agent operating rules such as `AGENTS.md` and `CLAUDE.md`.
+- GitHub issue templates for agent tasks.
+- Tool capability descriptions.
+- Verification checklists.
+- PR evidence requirements.
+- Safe runbooks for GitHub, Supabase, Vercel, Codex, Claude Code, and other approved development tools.
+
+## What must not be shared through the repository
+
+Never commit or paste:
+
+- Supabase service role keys;
+- Supabase database passwords;
+- Vercel tokens or bypass tokens;
+- Claude, OpenAI, Anthropic, or other model provider API keys;
+- GitHub personal access tokens;
+- cookies, sessions, local storage dumps, or auth state files;
+- `.env`, `.env.local`, `.vercel/.env*`, or any file containing live secrets;
+- screenshots or logs that reveal secret values.
+
+If a secret is accidentally exposed, stop work and rotate the secret before continuing.
+
+## Approved agent command path
+
+Use GitHub issues or PR comments as the command inbox.
+
+Recommended trigger prefixes:
+
+```text
+@claude
+@codex
+@agent
+@dsg-agent
+```
+
+A valid command should include:
+
+```text
+Goal:
+Repo:
+Scope:
+Evidence required:
+Verification required:
+Do not:
+Expected output:
+```
+
+## Required workflow
+
+1. Read repository rules first.
+2. Inspect the real files relevant to the request.
+3. Classify status as `verified`, `pending`, `blocked`, or `failed`.
+4. Make the smallest branchable change.
+5. Run the most relevant checks available.
+6. Open a PR with exact evidence.
+7. Do not auto-merge.
+
+## Tool-specific boundaries
+
+### GitHub
+
+Allowed:
+
+- inspect files, commits, issues, PRs, branches, and workflow metadata;
+- create branches, focused commits, issues, and PRs;
+- add comments with evidence.
+
+Blocked:
+
+- force-push shared branches without explicit instruction;
+- merge without review;
+- create fake evidence or fake test results.
+
+### Supabase
+
+Allowed:
+
+- list project metadata;
+- list tables and migrations;
+- run read-only diagnostic SQL;
+- apply migrations only when explicitly requested and reviewed.
+
+Blocked:
+
+- expose service role keys;
+- run destructive SQL without explicit approval;
+- disable RLS without a written security reason and follow-up remediation.
+
+### Vercel
+
+Allowed:
+
+- inspect projects, deployments, domains, and build logs;
+- fetch protected deployments through authorized Vercel tooling;
+- report deployment state accurately.
+
+Blocked:
+
+- expose Vercel tokens or bypass tokens;
+- claim production is healthy when the latest production deployment is canceled, errored, protected, or not verified;
+- change production environment variables without explicit approval.
+
+### Claude Code / Codex
+
+Allowed:
+
+- use repository rules to perform code review and branch-based fixes;
+- produce PRs with evidence;
+- assist with deterministic verification.
+
+Blocked:
+
+- treat issue comments as permission to merge;
+- skip verification silently;
+- invent unavailable tool access.
+
+## Production readiness rule
+
+The default launch decision is `NO-GO` until live evidence proves otherwise.
+
+Minimum evidence for `GO` must include:
+
+- current production deployment is `READY`;
+- `/api/health` or equivalent returns healthy status;
+- Supabase connectivity is verified;
+- required tests/build/typecheck pass or are explicitly waived with reason;
+- known limitations are documented.


### PR DESCRIPTION
Goal:

Add safe repository-level rules for Claude/Codex/DSG agent work and a GitHub issue template for agent commands.

Files changed:

- `CLAUDE.md`
- `docs/TOOL_ACCESS_CONTRACT.md`
- `.github/ISSUE_TEMPLATE/agent-command.md`

Verification:

- [x] GitHub branch created from latest known `main` commit `dab5510ce3f4aaf371c9318f54f3eb3b2a6a57cd`.
- [x] Files added through GitHub contents API.
- [ ] Runtime build/test not run — documentation/template-only change; no application code modified.

Known limits:

- This does not grant Claude, Codex, Vercel, Supabase, or GitHub tool credentials through the repo.
- This only defines safe rules, command format, and review boundaries.
- Agents still need authorized local/connected tools to act.

User-visible benefit:

Users get a safer GitHub command inbox pattern for requesting agent work without exposing tokens or allowing auto-merge.

Next step:

Review the docs and merge if the policy matches the intended operating model.