### PR TITLE
feat: auto-setup on first login + expert chatbot on /try + ledger migration

### DIFF
--- a/app/api/try/chat/route.ts
+++ b/app/api/try/chat/route.ts
@@ -1,0 +1,238 @@
+import { NextResponse } from 'next/server';
+import { logServerError, serverErrorResponse } from '../../../../lib/security/error-response';
+import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60 * 1000;
+const MAX_MESSAGES = 12;
+const MAX_MESSAGE_LENGTH = 2000;
+const DEFAULT_OPENAI_MODEL = 'gpt-4.1-mini';
+const DEFAULT_OPENROUTER_MODEL = 'openai/gpt-4.1-mini';
+
+const SYSTEM_PROMPT = `You are DSG Expert Assistant — a specialist in DSG (Deterministic Safety Gate) for AI Agent governance.
+
+PRODUCT KNOWLEDGE:
+- DSG Gate sits between an AI agent and its targets (APIs, databases, files). Every action the agent attempts passes through DSG first.
+- The Gate metaphor: like an immigration checkpoint — agents must declare their intended actions upfront, receive a timestamp stamp, then only perform what they declared. If they try something undeclared or exceed time limits, DSG blocks them automatically.
+- Decisions: ALLOW (action passes), BLOCK (action rejected), REVIEW (needs human approval), AUDIT (logged only, not blocked).
+- Every decision has: hash, timestamp (ms), reason, and prev_hash linking to prior entry — forming a cryptographic chain.
+- Any modification to historical records breaks the chain — tamper-evident by design.
+- Invariant system (MAKK-8): 8 deterministic invariants that every agent action must satisfy. Not probability-based — a violation either happens or it doesn't.
+- Modes: audit_only (log all), gate (log + block violations), full (log + block + chain verification per request).
+
+SETUP PROCESS:
+1. Sign up at /signup (30 seconds, no credit card)
+2. Verify email → receive API key immediately
+3. In your agent code: POST to /api/gate/inspect with { action, session_id } to check permission
+4. Agent declares its intentions at session start via POST /api/gate/declare with { actions[], ttl_minutes }
+5. DSG stamps each allowed action, logs everything, blocks anything undeclared or over TTL
+
+API INTEGRATION EXAMPLE:
+POST https://your-dsg-instance.com/api/try/gate
+{ "session_id": "sess_abc", "declared_actions": ["read_file", "send_email"], "ttl_minutes": 30 }
+→ Returns: { "ok": true, "declaration_stamp": "DSG-A3F8E2C1", "expires_at": "..." }
+
+Then for each action:
+POST /api/try/gate
+{ "session_id": "sess_abc", "action": "read_file path=/reports/q1.pdf" }
+→ Returns: { "decision": "ALLOW", "stamp": "DSG-B7D4F1A9" } or { "decision": "BLOCK", "reason": "..." }
+
+PRICING (after 15-day free trial):
+- Pro: $99/month — unlimited gate evaluations, 90-day audit trail, 3 API keys, email support
+- Business: $299/month — team management, webhooks, PDF export, priority support
+- Enterprise: $999/month — custom policy engine, 99.9% SLA, dedicated onboarding
+
+TRIAL DETAILS:
+- 15 days, full features, no credit card
+- Production API key from day 1 (not a sandbox)
+- Audit trail is real — not simulated
+- Direct founder support during trial
+
+COMMON QUESTIONS:
+- "How do I connect my agent?" → Add 2 API calls to your agent: declare at session start, inspect before each action
+- "What happens when gate blocks?" → Returns { decision: "BLOCK", reason: "..." }, your agent receives the rejection and should handle it gracefully
+- "Is the audit trail tamper-proof?" → Yes — SHA256 hash chain, any modification breaks the chain, retroactively detectable
+- "Can I use it with LangChain/AutoGen/CrewAI?" → Yes — wrap each tool call with the gate inspect call
+- "What is MAKK-8?" → 8 deterministic invariants (rightView, rightResolve, rightSpeech, rightConduct, rightLivelihood, rightEffort, rightMindfulness, rightSamadhi) — ensures agent actions are coherent, bounded, and reversible
+- "ต่อยังไง?" → เพิ่ม 2 บรรทัดในโค้ด agent: declare ตอนเริ่ม session, inspect ก่อนทุก action
+- "ฟรีทดลองได้นานแค่ไหน?" → 15 วัน เต็มรูปแบบ ไม่ต้องใส่บัตรเครดิต
+- "บล็อกยังไง?" → DSG เช็คทุก action ก่อนผ่าน ถ้าไม่ได้แจ้งไว้ล่วงหน้า หรือเกินเวลา TTL — บล็อกทันที
+
+TONE: Expert, concise, helpful. Answer in the language the user writes in (Thai or English). Be specific — give code examples when asked. Never claim false capabilities.`;
+
+type ChatMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+type Provider = 'openai' | 'openrouter';
+
+type OpenAIResponse = {
+  output_text?: string;
+  output?: Array<{ content?: Array<{ text?: string }> }>;
+  error?: { message?: string };
+};
+
+type OpenRouterResponse = {
+  choices?: Array<{ message?: { content?: string | null } }>;
+  error?: { message?: string };
+};
+
+type ChatResult = {
+  ok: boolean;
+  answer: string;
+  model: string | null;
+  provider: Provider | 'fallback';
+};
+
+function normalizeMessages(body: unknown): ChatMessage[] {
+  const candidate = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+
+  if (Array.isArray(candidate.messages)) {
+    return (candidate.messages as unknown[])
+      .filter((m): m is ChatMessage => {
+        if (!m || typeof m !== 'object') return false;
+        const item = m as Partial<ChatMessage>;
+        return (item.role === 'user' || item.role === 'assistant') && typeof item.content === 'string';
+      })
+      .slice(-MAX_MESSAGES)
+      .map((m) => ({ role: m.role, content: m.content.slice(0, MAX_MESSAGE_LENGTH) }));
+  }
+
+  const message = typeof candidate.message === 'string' ? candidate.message.trim() : '';
+  return message ? [{ role: 'user', content: message.slice(0, MAX_MESSAGE_LENGTH) }] : [];
+}
+
+function isSecretLike(v: string | undefined) {
+  return Boolean(v && (v.startsWith('sk-') || v.startsWith('sk_') || v.startsWith('sk-or-')));
+}
+
+function safeModel(v: string | undefined, fallback: string) {
+  return !v || isSecretLike(v) ? fallback : v;
+}
+
+function extractOpenAIText(payload: OpenAIResponse): string {
+  if (typeof payload.output_text === 'string' && payload.output_text.trim()) return payload.output_text.trim();
+  return (
+    payload.output
+      ?.flatMap((i) => i.content ?? [])
+      .map((c) => c.text ?? '')
+      .join('\n')
+      .trim() || ''
+  );
+}
+
+function fallbackAnswer(message: string): string {
+  const lower = message.toLowerCase();
+  if (/ต่อ|connect|integrate|ใช้ยังไง|how to use/.test(lower)) {
+    return 'เพิ่ม 2 บรรทัดในโค้ด agent ของคุณ: (1) POST /api/try/gate ด้วย declared_actions ตอนเริ่ม session (2) POST /api/try/gate ด้วย action ก่อนทุกครั้งที่จะทำ — DSG จะ stamp ถ้า ALLOW หรือ return reason ถ้า BLOCK';
+  }
+  if (/ราคา|price|pricing|แพ็ก/.test(lower)) {
+    return 'ทดลองฟรี 15 วัน (ไม่ต้องใส่บัตร) → Pro $99/เดือน → Business $299/เดือน → Enterprise $999/เดือน ดูรายละเอียดที่ /pricing';
+  }
+  if (/block|บล็อก/.test(lower)) {
+    return 'DSG บล็อก action ที่: (1) ไม่ได้แจ้งไว้ใน declared_actions (2) เกินเวลา TTL ที่กำหนด (3) มี pattern ที่เป็นอันตราย เช่น "delete all", "drop table", "bypass policy" — return { decision: "BLOCK", reason: "..." }';
+  }
+  if (/สมัคร|signup|start|เริ่ม/.test(lower)) {
+    return 'สมัครได้ที่ /signup ใช้เวลา 30 วินาที ไม่ต้องใส่บัตรเครดิต ได้ API key ทันทีหลัง verify email';
+  }
+  return 'ถามเรื่อง DSG Gate, วิธีต่อ agent, audit trail, หรือ pricing ได้เลยครับ — พร้อมตอบทั้งไทยและอังกฤษ';
+}
+
+async function callOpenAI(messages: ChatMessage[]): Promise<ChatResult> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return { ok: false, answer: fallbackAnswer(messages.at(-1)?.content ?? ''), model: null, provider: 'fallback' };
+
+  const model = safeModel(process.env.OPENAI_MODEL, DEFAULT_OPENAI_MODEL);
+  const conv = messages.map((m) => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${m.content}`).join('\n\n');
+
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model, instructions: SYSTEM_PROMPT, input: conv, max_output_tokens: 800 }),
+  });
+
+  const payload = (await res.json().catch(() => ({}))) as OpenAIResponse;
+  if (!res.ok) return { ok: false, answer: fallbackAnswer(messages.at(-1)?.content ?? ''), model, provider: 'openai' };
+
+  const text = extractOpenAIText(payload);
+  return { ok: true, answer: text || fallbackAnswer(messages.at(-1)?.content ?? ''), model, provider: 'openai' };
+}
+
+async function callOpenRouter(messages: ChatMessage[]): Promise<ChatResult> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) return { ok: false, answer: fallbackAnswer(messages.at(-1)?.content ?? ''), model: null, provider: 'fallback' };
+
+  const model = safeModel(process.env.OPENROUTER_MODEL, DEFAULT_OPENROUTER_MODEL);
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+      'HTTP-Referer': process.env.NEXT_PUBLIC_SITE_URL ?? 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+      'X-Title': 'DSG Trial Expert Assistant',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
+      max_tokens: 800,
+      temperature: 0.15,
+    }),
+  });
+
+  const payload = (await res.json().catch(() => ({}))) as OpenRouterResponse;
+  if (!res.ok) return { ok: false, answer: fallbackAnswer(messages.at(-1)?.content ?? ''), model, provider: 'openrouter' };
+
+  const text = payload.choices?.[0]?.message?.content?.trim() ?? '';
+  return { ok: true, answer: text || fallbackAnswer(messages.at(-1)?.content ?? ''), model, provider: 'openrouter' };
+}
+
+async function callModel(messages: ChatMessage[]): Promise<ChatResult> {
+  const requested = (process.env.PUBLIC_CHAT_PROVIDER ?? process.env.AI_PROVIDER ?? '').toLowerCase();
+  if (requested === 'openrouter') return callOpenRouter(messages);
+  if (requested === 'openai') return callOpenAI(messages);
+  if (process.env.OPENAI_API_KEY) return callOpenAI(messages);
+  if (process.env.OPENROUTER_API_KEY) return callOpenRouter(messages);
+  return { ok: false, answer: fallbackAnswer(messages.at(-1)?.content ?? ''), model: null, provider: 'fallback' };
+}
+
+const TRY_SUGGESTIONS = [
+  'วิธีต่อ agent กับ DSG',
+  'What happens when gate blocks?',
+  'อธิบาย audit trail',
+  'ราคาหลังทดลองฟรี',
+  'DSG กับ LangChain ใช้ยังไง',
+];
+
+export async function POST(request: Request) {
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, 'try-chat'),
+    limit: RATE_LIMIT,
+    windowMs: RATE_WINDOW_MS,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, RATE_LIMIT);
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429, headers });
+  }
+
+  const body = await request.json().catch(() => null);
+  const messages = normalizeMessages(body);
+
+  if (!messages.length || messages.at(-1)?.role !== 'user') {
+    return NextResponse.json({ error: 'message required' }, { status: 400, headers });
+  }
+
+  try {
+    const result = await callModel(messages);
+    return NextResponse.json(
+      { ok: result.ok, reply: result.answer, provider: result.provider, suggestions: TRY_SUGGESTIONS },
+      { status: 200, headers },
+    );
+  } catch (error) {
+    logServerError(error, 'try-chat');
+    return serverErrorResponse({ headers });
+  }
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '../../lib/supabase/server';
 import Link from 'next/link';
 import AgentChatWidget from '../../components/AgentChatWidget';
+import AutoSetupTrigger from '../../components/AutoSetupTrigger';
 import DashboardNav from '../../components/DashboardNav';
 
 export const dynamic = 'force-dynamic';
@@ -31,6 +32,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
           </div>
         </div>
       </div>
+      <AutoSetupTrigger />
       {children}
       <AgentChatWidget />
     </div>

--- a/app/try/page.tsx
+++ b/app/try/page.tsx
@@ -1,0 +1,287 @@
+import Link from 'next/link';
+import TryChatWidget from '../../components/TryChatWidget';
+
+const TRIAL_FEATURES = [
+  {
+    icon: '🛂',
+    title: 'AI Agent Gate',
+    desc: 'ประกาศสิทธิ์ล่วงหน้า — DSG ตรวจทุก action ก่อนผ่าน ประทับตราเวลาและบันทึก',
+  },
+  {
+    icon: '📋',
+    title: 'Audit Trail จริง',
+    desc: 'ทุก decision มี hash, timestamp, และ reason — export PDF ให้ audit ได้ทันที',
+  },
+  {
+    icon: '🔑',
+    title: 'API Key พร้อมใช้',
+    desc: 'รับ API key ทันทีหลัง signup — ต่อกับ agent ได้ใน 5 นาที',
+  },
+  {
+    icon: '👥',
+    title: 'Team Management',
+    desc: 'เพิ่มทีม กำหนด role OWNER / ADMIN / OPERATOR / VIEWER ควบคุมว่าใครทำอะไรได้',
+  },
+  {
+    icon: '🔔',
+    title: 'Webhook & Notifications',
+    desc: 'ส่ง event ไปยัง Slack, PagerDuty, หรือ endpoint ของคุณเมื่อ gate block หรืออนุมัติ',
+  },
+  {
+    icon: '📊',
+    title: 'Finance Governance',
+    desc: 'Approval workflow, case tracking, และ PDF audit report สำหรับ AI agent ด้านการเงิน',
+  },
+];
+
+const WHAT_YOU_GET = [
+  '✓ ใช้ได้เต็มรูปแบบ 15 วัน — ไม่มีฟีเจอร์ที่ถูก lock',
+  '✓ ไม่ต้องใส่ข้อมูลบัตรเครดิต',
+  '✓ API key สำหรับ production ทันที',
+  '✓ Audit trail จริง — ไม่ใช่ sandbox',
+  '✓ Setup เสร็จใน 5 นาที',
+  '✓ Support ตรงจาก founder ตลอด 15 วัน',
+];
+
+const STEPS = [
+  { num: '1', title: 'สร้างบัญชี', desc: 'กรอก email + workspace name — ใช้เวลา 30 วินาที' },
+  { num: '2', title: 'รับ API Key', desc: 'ได้ key ทันทีหลัง verify email — พร้อมใช้กับ agent' },
+  { num: '3', title: 'ประกาศ Policy', desc: 'บอก DSG ว่า agent ของคุณทำอะไรได้บ้าง' },
+  { num: '4', title: 'เห็น Audit Trail', desc: 'ทุก action มี stamp, reason, และ proof — real-time' },
+];
+
+const PLANS_AFTER_TRIAL = [
+  {
+    name: 'Pro',
+    price: '$99',
+    per: '/เดือน',
+    highlight: false,
+    features: ['Gate evaluation ไม่จำกัด', 'Audit trail 90 วัน', 'API key 3 ชุด', 'Email support'],
+  },
+  {
+    name: 'Business',
+    price: '$299',
+    per: '/เดือน',
+    highlight: true,
+    features: ['ทุกอย่างใน Pro', 'Team management', 'Webhook & Notifications', 'PDF export', 'Priority support'],
+  },
+  {
+    name: 'Enterprise',
+    price: '$999',
+    per: '/เดือน',
+    highlight: false,
+    features: ['ทุกอย่างใน Business', 'Custom policy engine', 'SLA 99.9%', 'Dedicated onboarding', 'Custom audit report'],
+  },
+];
+
+export default function TryPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+
+      {/* Nav */}
+      <nav className="border-b border-white/5 bg-slate-900/60 px-6 py-4 sticky top-0 z-10 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between">
+          <Link href="/" className="text-lg font-black text-white">DSG</Link>
+          <div className="flex items-center gap-4">
+            <Link href="/pricing" className="text-sm text-slate-400 hover:text-white transition-colors hidden sm:block">Pricing</Link>
+            <Link href="/auth/login" className="text-sm text-slate-400 hover:text-white transition-colors">เข้าสู่ระบบ</Link>
+          </div>
+        </div>
+      </nav>
+
+      {/* Hero */}
+      <section className="px-4 pt-20 pb-16 text-center">
+        <div className="mx-auto max-w-3xl">
+          <span className="inline-block rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1 text-xs font-bold text-emerald-300 uppercase tracking-widest mb-6">
+            ทดลองฟรี 15 วัน · ไม่ต้องใส่บัตรเครดิต
+          </span>
+          <h1 className="text-5xl font-black tracking-tight leading-tight md:text-6xl">
+            ควบคุม AI Agent<br />
+            <span className="text-emerald-400">ก่อนมันทำให้คุณเดือดร้อน</span>
+          </h1>
+          <p className="mt-6 text-lg text-slate-400 leading-8 max-w-2xl mx-auto">
+            DSG นั่งระหว่าง AI agent กับระบบของคุณ — ตรวจทุก action ประทับตราเวลา บันทึก audit trail
+            และบล็อกสิ่งที่ไม่ได้รับอนุญาต ก่อนที่จะสายเกินไป
+          </p>
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Link
+              href="/signup"
+              className="rounded-2xl bg-emerald-500 px-10 py-4 text-base font-black text-slate-950 hover:bg-emerald-400 transition-all hover:scale-105 shadow-lg shadow-emerald-500/25"
+            >
+              เริ่มทดลองฟรี 15 วัน →
+            </Link>
+            <Link
+              href="/demo"
+              className="rounded-2xl border border-white/15 px-8 py-4 text-base font-bold text-slate-300 hover:text-white hover:border-white/30 transition-colors"
+            >
+              ดู demo ก่อน
+            </Link>
+          </div>
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-5 text-xs text-slate-500">
+            {WHAT_YOU_GET.slice(0, 3).map(w => <span key={w}>{w}</span>)}
+          </div>
+        </div>
+      </section>
+
+      {/* What you get */}
+      <section className="px-4 pb-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="rounded-3xl border border-white/10 bg-slate-900 p-8 md:p-12">
+            <div className="grid gap-10 lg:grid-cols-2 items-center">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-widest text-emerald-400 mb-3">สิ่งที่ได้รับทันที</p>
+                <h2 className="text-3xl font-black text-white mb-6">ใช้งานเต็มรูปแบบ<br />ตั้งแต่วันแรก</h2>
+                <ul className="space-y-3">
+                  {WHAT_YOU_GET.map(item => (
+                    <li key={item} className="flex items-center gap-3 text-sm text-slate-300">
+                      <span className="text-emerald-400">{item.slice(0, 1)}</span>
+                      <span>{item.slice(2)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Simulated audit log */}
+              <div className="rounded-2xl border border-slate-800 bg-slate-950 p-5 font-mono text-xs space-y-3">
+                <div className="flex items-center gap-2 mb-4">
+                  <div className="h-2.5 w-2.5 rounded-full bg-emerald-500 animate-pulse" />
+                  <span className="text-emerald-400 font-bold">DSG Gate — Live Audit Trail</span>
+                </div>
+                {[
+                  { time: '09:14:22', action: 'read invoice #INV-4821', decision: 'ALLOW', stamp: 'DSG-A3F8E2C1' },
+                  { time: '09:14:35', action: 'send payment notification', decision: 'ALLOW', stamp: 'DSG-B7D4F1A9' },
+                  { time: '09:14:51', action: 'delete all records', decision: 'BLOCK', stamp: null },
+                  { time: '09:15:03', action: 'approve invoice $850', decision: 'ALLOW', stamp: 'DSG-C2E9D5B3' },
+                  { time: '09:15:22', action: 'transfer $50,000 external', decision: 'BLOCK', stamp: null },
+                ].map((log, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <span className="text-slate-600 shrink-0">{log.time}</span>
+                    <span className={`shrink-0 font-bold ${log.decision === 'ALLOW' ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {log.decision === 'ALLOW' ? '[ALLOW]' : '[BLOCK]'}
+                    </span>
+                    <span className="text-slate-400 truncate">{log.action}</span>
+                    {log.stamp && <span className="shrink-0 text-slate-600">{log.stamp}</span>}
+                  </div>
+                ))}
+                <div className="border-t border-white/5 pt-3 text-slate-600">
+                  decisions: 5 · allowed: 3 · blocked: 2 · pdf ready ↓
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="px-4 pb-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="text-center mb-10">
+            <p className="text-xs font-bold uppercase tracking-widest text-slate-500 mb-3">ฟีเจอร์ที่ได้รับในช่วงทดลอง</p>
+            <h2 className="text-3xl font-black text-white">ครบทุกอย่างที่ production ต้องการ</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {TRIAL_FEATURES.map(f => (
+              <div key={f.title} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 hover:border-emerald-500/30 hover:bg-emerald-500/5 transition-all">
+                <div className="text-2xl mb-3">{f.icon}</div>
+                <h3 className="font-black text-white mb-2">{f.title}</h3>
+                <p className="text-sm text-slate-400 leading-6">{f.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Setup steps */}
+      <section className="px-4 pb-20">
+        <div className="mx-auto max-w-4xl">
+          <div className="text-center mb-10">
+            <h2 className="text-3xl font-black text-white">Setup ใน 4 ขั้นตอน</h2>
+            <p className="mt-3 text-slate-400">จาก signup ถึง production-ready ใน 5 นาที</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-4">
+            {STEPS.map((s, i) => (
+              <div key={s.num} className="relative">
+                {i < STEPS.length - 1 && (
+                  <div className="hidden md:block absolute top-6 left-full w-full h-px bg-white/10 z-0" />
+                )}
+                <div className="relative z-10 rounded-2xl border border-white/10 bg-slate-900 p-5 text-center">
+                  <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/20 text-lg font-black text-emerald-400">
+                    {s.num}
+                  </div>
+                  <h3 className="font-black text-white text-sm mb-1">{s.title}</h3>
+                  <p className="text-xs text-slate-400 leading-5">{s.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing after trial */}
+      <section className="px-4 pb-20">
+        <div className="mx-auto max-w-5xl">
+          <div className="text-center mb-10">
+            <p className="text-xs font-bold uppercase tracking-widest text-slate-500 mb-3">หลังครบ 15 วัน</p>
+            <h2 className="text-3xl font-black text-white">เลือก plan ที่เหมาะกับทีม</h2>
+            <p className="mt-3 text-slate-400">ยกเลิกได้ทุกเมื่อ ไม่มีค่าใช้จ่ายแอบแฝง</p>
+          </div>
+          <div className="grid gap-5 md:grid-cols-3">
+            {PLANS_AFTER_TRIAL.map(plan => (
+              <div
+                key={plan.name}
+                className={`rounded-3xl border p-7 ${
+                  plan.highlight
+                    ? 'border-emerald-500/50 bg-emerald-500/10 ring-1 ring-emerald-500/20'
+                    : 'border-white/10 bg-white/[0.03]'
+                }`}
+              >
+                {plan.highlight && (
+                  <div className="mb-3 inline-block rounded-full bg-emerald-500/20 px-3 py-0.5 text-xs font-bold text-emerald-300">
+                    แนะนำ
+                  </div>
+                )}
+                <h3 className="text-xl font-black text-white">{plan.name}</h3>
+                <div className="mt-2 mb-5">
+                  <span className="text-3xl font-black text-white">{plan.price}</span>
+                  <span className="text-slate-400 text-sm">{plan.per}</span>
+                </div>
+                <ul className="space-y-2">
+                  {plan.features.map(f => (
+                    <li key={f} className="flex items-center gap-2 text-sm text-slate-300">
+                      <span className="text-emerald-400">✓</span>
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="px-4 pb-24">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="rounded-3xl border border-emerald-500/20 bg-[linear-gradient(135deg,rgba(16,185,129,0.14),rgba(15,23,42,0.95)_50%)] p-12">
+            <h2 className="text-4xl font-black text-white">เริ่มได้เลยวันนี้</h2>
+            <p className="mt-4 text-slate-400 leading-7">
+              ไม่ต้องใส่บัตรเครดิต ไม่มีสัญญาผูกมัด<br />
+              ถ้าหลัง 15 วันแล้วไม่ถูกใจ — ยกเลิกและลบ account ได้ทันที
+            </p>
+            <Link
+              href="/signup"
+              className="mt-8 inline-block rounded-2xl bg-emerald-500 px-12 py-4 text-lg font-black text-slate-950 hover:bg-emerald-400 transition-all hover:scale-105 shadow-lg shadow-emerald-500/20"
+            >
+              เริ่มทดลองฟรี 15 วัน →
+            </Link>
+            <p className="mt-4 text-xs text-slate-500">
+              มีคำถาม? ติดต่อ founder โดยตรง — ตอบภายใน 4 ชั่วโมง
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <TryChatWidget />
+    </main>
+  );
+}

--- a/components/AutoSetupTrigger.tsx
+++ b/components/AutoSetupTrigger.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const STORAGE_KEY = 'dsg_auto_setup_triggered_v1';
+
+export default function AutoSetupTrigger() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    localStorage.setItem(STORAGE_KEY, '1');
+
+    fetch('/api/setup/auto', { method: 'POST' })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.api_key) {
+          // Store one-time API key for the skills page to display
+          sessionStorage.setItem('dsg_new_api_key', data.api_key);
+          sessionStorage.setItem('dsg_new_agent_id', data.agent_id ?? '');
+        }
+      })
+      .catch(() => {
+        // Reset so it retries on next load
+        localStorage.removeItem(STORAGE_KEY);
+      });
+  }, []);
+
+  return null;
+}

--- a/components/TryChatWidget.tsx
+++ b/components/TryChatWidget.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type ChatLine = {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+const ENDPOINT = '/api/try/chat';
+const STORAGE_KEY = 'dsg_try_chat_v1';
+const MAX_HISTORY = 40;
+
+const SUGGESTIONS = [
+  'วิธีต่อ agent กับ DSG',
+  'What is the DSG Gate?',
+  'ราคาหลังทดลองฟรี',
+  'How does audit trail work?',
+  'DSG กับ LangChain ใช้ยังไง',
+];
+
+function makeLine(role: ChatLine['role'], content: string): ChatLine {
+  return { id: `${role}-${Date.now()}-${Math.random().toString(16).slice(2)}`, role, content };
+}
+
+export default function TryChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [lines, setLines] = useState<ChatLine[]>([
+    makeLine('system', 'DSG Expert พร้อมตอบ — ถามเรื่อง gate, audit trail, การต่อ agent, หรือ pricing ได้เลย 🛂'),
+  ]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as ChatLine[];
+      if (Array.isArray(parsed) && parsed.length > 0) setLines(parsed.slice(-MAX_HISTORY));
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(lines.slice(-MAX_HISTORY))); } catch { /* ignore */ }
+  }, [lines]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [lines, open]);
+
+  async function submit(message: string) {
+    if (!message.trim() || busy) return;
+    setBusy(true);
+
+    const history = lines
+      .filter((l) => l.role !== 'system')
+      .slice(-10)
+      .map((l) => ({ role: l.role as 'user' | 'assistant', content: l.content }));
+
+    setLines((prev) => [...prev, makeLine('user', message)]);
+    setDraft('');
+
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ messages: [...history, { role: 'user', content: message }] }),
+      });
+      const data = await res.json().catch(() => ({})) as { reply?: string; error?: string };
+      setLines((prev) => [...prev, makeLine('assistant', data.reply ?? data.error ?? 'ขอโทษครับ ลองใหม่อีกครั้ง')]);
+    } catch {
+      setLines((prev) => [...prev, makeLine('assistant', 'เชื่อมต่อไม่ได้ ลองใหม่อีกครั้งครับ')]);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full border border-emerald-500/40 bg-slate-900 px-4 py-3 text-sm font-bold text-emerald-300 shadow-lg shadow-emerald-500/10 transition hover:scale-105 hover:border-emerald-400 hover:bg-slate-800"
+        aria-label="Ask DSG Expert"
+      >
+        <span className="text-lg">🛂</span>
+        <span>ถาม DSG Expert</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex h-[540px] w-[390px] flex-col rounded-2xl border border-slate-700 bg-slate-950 shadow-2xl shadow-black/60">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-3">
+        <div>
+          <p className="text-sm font-black text-slate-100">🛂 DSG Expert</p>
+          <p className="text-[10px] text-slate-400">ถาม-ตอบ ทั้งไทยและอังกฤษ · ทดลองฟรี 15 วัน</p>
+        </div>
+        <button
+          onClick={() => setOpen(false)}
+          className="text-slate-400 hover:text-white"
+          aria-label="Close"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-3">
+        {lines.map((line) => (
+          <div
+            key={line.id}
+            className={
+              line.role === 'user'
+                ? 'ml-auto max-w-[88%] rounded-xl border border-emerald-500/30 bg-emerald-500/15 px-3 py-2 text-xs text-emerald-100'
+                : line.role === 'system'
+                  ? 'max-w-[92%] rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-400 italic'
+                  : 'max-w-[92%] rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-100'
+            }
+          >
+            <pre className="whitespace-pre-wrap break-words font-sans">{line.content}</pre>
+          </div>
+        ))}
+        {busy && (
+          <div className="max-w-[92%] rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-400">
+            กำลังคิด...
+          </div>
+        )}
+      </div>
+
+      {/* Quick suggestions */}
+      <div className="flex gap-1.5 overflow-x-auto border-t border-slate-800 px-3 py-2">
+        {SUGGESTIONS.map((s) => (
+          <button
+            key={s}
+            onClick={() => submit(s)}
+            disabled={busy}
+            className="whitespace-nowrap rounded-lg border border-slate-700 bg-slate-900 px-2.5 py-1 text-[10px] font-medium text-slate-300 transition hover:border-emerald-400 hover:text-emerald-300 disabled:opacity-50"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-slate-800 p-3">
+        <div className="flex gap-2">
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                void submit(draft);
+              }
+            }}
+            placeholder="ถามเรื่อง DSG..."
+            className="flex-1 rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none focus:border-emerald-400"
+          />
+          <button
+            onClick={() => submit(draft)}
+            disabled={busy || !draft.trim()}
+            className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-bold text-black disabled:bg-slate-700 disabled:text-slate-400"
+          >
+            {busy ? '...' : 'ส่ง'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260516500000_create_dsg_agent_ledger.sql
+++ b/supabase/migrations/20260516500000_create_dsg_agent_ledger.sql
@@ -1,0 +1,122 @@
+-- DSG Agent Ledger — universal, append-only, hash-chained
+-- Captures every action every agent takes across all domains.
+-- Each entry cryptographically links to the previous via prev_hash,
+-- so any deletion, insertion, or reordering breaks the chain.
+
+-- Per-org configuration: choose audit-only, gate+audit, or full chain
+create table if not exists public.dsg_ledger_config (
+  org_id       text primary key,
+  mode         text not null default 'gate' check (mode in ('audit_only', 'gate', 'full')),
+  gate_enabled boolean not null default true,
+  audit_enabled boolean not null default true,
+  chain_enabled boolean not null default true,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+comment on table public.dsg_ledger_config is
+  'Per-org DSG mode: audit_only = log only, gate = log+block, full = log+block+chain verification';
+
+alter table public.dsg_ledger_config enable row level security;
+-- No direct client access — mutated via service-role API routes only
+
+-- Universal agent action ledger with hash chain
+create table if not exists public.dsg_agent_ledger (
+  id           bigserial primary key,
+
+  -- Monotonic sequence per org — gap = evidence of deletion
+  org_id       text not null,
+  seq          bigint not null,
+
+  -- What the agent tried to do
+  action       text not null,
+  agent_id     text,
+  session_id   text,
+  context      jsonb not null default '{}'::jsonb,
+
+  -- Gate decision
+  decision     text not null check (decision in ('ALLOW', 'BLOCK', 'REVIEW', 'AUDIT')),
+  reason       text,
+  mode         text not null check (mode in ('audit_only', 'gate', 'full')),
+
+  -- Invariant checks (MAKK-8 snapshot)
+  invariant_snapshot jsonb,
+
+  -- Cryptographic chain
+  -- entry_hash = SHA256(org_id || seq || action || decision || timestamp_ms || prev_hash)
+  entry_hash   text not null,
+  prev_hash    text,               -- NULL only for seq=0 (genesis)
+
+  -- Timestamps
+  timestamp_ms bigint not null,    -- unix ms, deterministic, no timezone drift
+  created_at   timestamptz not null default now(),
+
+  constraint dsg_agent_ledger_org_seq unique (org_id, seq)
+);
+
+comment on column public.dsg_agent_ledger.seq is
+  'Monotonic per org. Any gap proves deletion. Any reorder breaks the hash chain.';
+
+comment on column public.dsg_agent_ledger.entry_hash is
+  'SHA256 of all fields including prev_hash. Tamper with any field → hash mismatch.';
+
+comment on column public.dsg_agent_ledger.prev_hash is
+  'Hash of entry at (seq-1). NULL for genesis. Chain broken if this does not match stored entry_hash of previous row.';
+
+create index if not exists dsg_agent_ledger_org_seq_idx
+  on public.dsg_agent_ledger (org_id, seq);
+
+create index if not exists dsg_agent_ledger_org_time_idx
+  on public.dsg_agent_ledger (org_id, timestamp_ms desc);
+
+create index if not exists dsg_agent_ledger_decision_idx
+  on public.dsg_agent_ledger (org_id, decision, timestamp_ms desc);
+
+-- WORM: no updates, no deletes — modification detected via hash chain
+create or replace function public.raise_ledger_immutable()
+returns trigger language plpgsql as $$
+begin
+  raise exception 'dsg_agent_ledger is append-only. Modifications detected via hash chain.';
+end;
+$$;
+
+create trigger dsg_agent_ledger_no_update
+  before update on public.dsg_agent_ledger
+  for each row execute function public.raise_ledger_immutable();
+
+create trigger dsg_agent_ledger_no_delete
+  before delete on public.dsg_agent_ledger
+  for each row execute function public.raise_ledger_immutable();
+
+alter table public.dsg_agent_ledger enable row level security;
+
+-- Authenticated users may read their own org's ledger (select only — no insert/update/delete)
+create policy dsg_agent_ledger_org_select
+  on public.dsg_agent_ledger
+  for select
+  to authenticated
+  using (org_id = (auth.jwt() ->> 'org_id'));
+
+-- Next-sequence RPC for atomic, race-free seq generation
+create or replace function public.dsg_ledger_next_seq(p_org_id text)
+returns bigint language sql security definer as $$
+  select coalesce(max(seq), -1) + 1
+  from public.dsg_agent_ledger
+  where org_id = p_org_id;
+$$;
+
+revoke execute on function public.dsg_ledger_next_seq(text) from public;
+grant execute on function public.dsg_ledger_next_seq(text) to service_role;
+
+-- Latest entry hash for chain continuation
+create or replace function public.dsg_ledger_latest_hash(p_org_id text)
+returns text language sql security definer as $$
+  select entry_hash
+  from public.dsg_agent_ledger
+  where org_id = p_org_id
+  order by seq desc
+  limit 1;
+$$;
+
+revoke execute on function public.dsg_ledger_latest_hash(text) from public;
+grant execute on function public.dsg_ledger_latest_hash(text) to service_role;


### PR DESCRIPTION
Goal:
Ship three production features cleanly on top of current main (post-PR #525 squash merge). Branch has exactly 2 commits, no conflict.

Files changed:
- `components/AutoSetupTrigger.tsx` — silent client component, fires `POST /api/setup/auto` once on first dashboard visit (localStorage-gated). Stores one-time API key in sessionStorage for Skills page to surface.
- `app/dashboard/layout.tsx` — mounts AutoSetupTrigger so every new authenticated user gets org auto-configured on arrival
- `components/TryChatWidget.tsx` — floating expert chat widget on `/try`, bilingual Thai/English, quick-suggestion chips, localStorage history, calls `/api/try/chat`
- `app/api/try/chat/route.ts` — public expert chat API (rate-limited 30/min), deep DSG system prompt: gate metaphor, API integration examples, MAKK-8, ALLOW/BLOCK/REVIEW decisions, pricing — falls back gracefully without AI key
- `app/try/page.tsx` — production-ready 15-day free trial landing page with TryChatWidget wired in
- `supabase/migrations/20260516500000_create_dsg_agent_ledger.sql` — WORM hash-chained ledger tables + RPCs (migration already applied to production DB ✅)

Verification:
- [x] `npx tsc --noEmit` — zero errors
- [x] `git log origin/main..HEAD` — exactly 2 commits, no conflict
- [x] Supabase migration applied to production ✅ (`dsg_agent_ledger`, `dsg_ledger_config` tables exist, RPCs verified)
- [x] `/api/try/chat` falls back to rule-based answers without AI key — no hard runtime dependency
- [x] `AutoSetupTrigger` idempotent — localStorage flag prevents duplicate calls; `/api/setup/auto` handles EXISTS cases
- [ ] Set `OPENAI_API_KEY` or `OPENROUTER_API_KEY` on Vercel for live AI responses in TryChatWidget

Known limits:
- AutoSetupTrigger uses a single localStorage key (not scoped per org-id). Acceptable for current single-org-per-user trial model.
- TryChatWidget uses simple JSON (not streaming). Streaming can be added later if latency is an issue.

User-visible benefit:
- Visitors to `/try` get a floating expert chatbot that answers integration questions in Thai/English before signing up
- After email confirmation, dashboard silently auto-configures the org (policy + agent + billing + roles) — no manual steps
- Every agent action can be recorded in a tamper-evident hash chain; retroactive proof of non-tampering is cryptographically verifiable

Next step:
1. Set `OPENAI_API_KEY` or `OPENROUTER_API_KEY` on Vercel
2. Monitor first-login auto-setup via `[auto-setup]` prefix in Vercel function logs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNjRRqXGJ3ZqTH2CdvbxJ9)_