### PR TITLE
fix(cron): surface Supabase upsert errors in github-leads response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ out/
 # local env files
 .env
 .env.local
+
+# Claude Code local settings (contains secrets — never commit)
+.claude/settings.local.json
 .env.*.local
 
 # logs

--- a/app/api/cron/github-leads/route.ts
+++ b/app/api/cron/github-leads/route.ts
@@ -68,6 +68,7 @@ export async function GET(request: Request) {
 
   let found = 0;
   let saved = 0;
+  const errors: string[] = [];
 
   for (const fw of FRAMEWORKS) {
     try {
@@ -93,7 +94,7 @@ export async function GET(request: Request) {
           95,
         );
 
-        await (supabase as any).from('leads').upsert(
+        const { error: upsertErr } = await (supabase as any).from('leads').upsert(
           {
             email,
             source: 'github-signal',
@@ -111,7 +112,8 @@ export async function GET(request: Request) {
           },
           { onConflict: 'email,source,github_repo' },
         );
-        saved++;
+        if (!upsertErr) saved++;
+        else errors.push(upsertErr.message);
       }
 
       // Respect GitHub rate limit
@@ -121,5 +123,5 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.json({ ok: true, frameworks_searched: FRAMEWORKS.length, repos_found: found, leads_saved: saved });
+  return NextResponse.json({ ok: true, frameworks_searched: FRAMEWORKS.length, repos_found: found, leads_saved: saved, errors: errors.slice(0, 3) });
 }


### PR DESCRIPTION
Goal:
github-leads cron was reporting `leads_saved: 42` but DB showed 0 rows — Supabase JS client returns `{error}` instead of throwing, so the counter incremented even on failure.

Files changed:
- `app/api/cron/github-leads/route.ts` — check `upsertErr`, only increment `saved` on success, return first 3 errors in response for debugging

Verification:
- [ ] `npx tsc --noEmit` — passed
- [ ] Deploy and re-run `/api/cron/github-leads` — check `errors` field in response to diagnose root cause

Known limits:
- `errors` field is capped at 3 to keep response small

https://claude.ai/code/session_01SNjRRqXGJ3ZqTH2CdvbxJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNjRRqXGJ3ZqTH2CdvbxJ9)_