### PR TITLE
fix(eu-ai-act): full English landing page

### DIFF
--- a/app/eu-ai-act/page.tsx
+++ b/app/eu-ai-act/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'EU AI Act Compliance for AI Agents — DSG ONE',
   description:
-    'EU AI Act บังคับใช้แล้ว AI agent ต้องมี audit trail, human oversight และ real-time intervention. DSG ONE ต่อ 1 บรรทัด ผ่าน compliance ได้เลย ไม่รื้อระบบเดิม',
+    'EU AI Act is now in force. AI agents need audit trails, human oversight, and real-time intervention. Connect DSG ONE in one line — compliant without rebuilding your stack.',
 };
 
 const COMPARISON = [
@@ -18,20 +18,20 @@ const ARTICLES = [
   {
     id: 'Art. 9',
     title: 'Risk Management',
-    requirement: 'ต้องมีระบบป้องกันความเสี่ยงก่อนเกิดเหตุ ไม่ใช่แค่ log หลังเกิด',
-    dsg: 'Gate ทุก action ก่อน execute — บล็อกทันทีถ้า risk สูง',
+    requirement: 'Must prevent risks before they occur — logging after the fact is not sufficient.',
+    dsg: 'Gates every action before execution — blocks immediately when risk threshold is exceeded.',
   },
   {
     id: 'Art. 12',
     title: 'Record Keeping',
-    requirement: 'บันทึกทุก action ของ AI พร้อม timestamp และ context',
-    dsg: 'Cryptographic audit trail — ทุก action มี hash พิสูจน์ได้ว่าไม่ถูกแก้ไข',
+    requirement: 'Log every AI action with timestamp, context, and decision rationale.',
+    dsg: 'Cryptographic audit trail — every action is hashed, tamper-proof, and verifiable.',
   },
   {
     id: 'Art. 14',
     title: 'Human Oversight',
-    requirement: 'มนุษย์ต้องสามารถ intervene และหยุด AI ได้ทันที',
-    dsg: 'BLOCK response + approval workflow — หยุด agent ได้ก่อนเกิดความเสียหาย',
+    requirement: 'Humans must be able to intervene and stop the AI system at any time.',
+    dsg: 'BLOCK response + approval workflow — stops the agent before damage occurs.',
   },
 ];
 
@@ -49,29 +49,29 @@ export default function EUAIActPage() {
       <section className="border-b border-red-500/20 bg-gradient-to-b from-red-950/40 to-slate-950 px-6 py-20">
         <div className="mx-auto max-w-5xl text-center">
           <div className="mb-4 inline-block rounded-full border border-red-500/40 bg-red-500/10 px-4 py-1.5 text-sm font-semibold text-red-300">
-            EU AI Act บังคับใช้แล้ว — องค์กรของคุณพร้อมหรือยัง?
+            EU AI Act is now in force — is your organization ready?
           </div>
           <h1 className="mt-6 text-4xl font-black leading-tight md:text-6xl">
-            AI agent ของคุณ<br />
-            <span className="text-red-400">ทำอะไรอยู่ — คุณรู้มั้ย?</span>
+            Do you know what your<br />
+            <span className="text-red-400">AI agent is doing right now?</span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-300">
-            เครื่องมืออื่นบอกหลังเกิดเหตุ<br />
-            <strong className="text-white">DSG ONE บล็อกก่อนเกิดความเสียหาย</strong> พร้อม audit trail ที่พิสูจน์ได้ทางคณิตศาสตร์
+            Other tools tell you what happened <em>after</em> the damage is done.<br />
+            <strong className="text-white">DSG ONE blocks before the action executes</strong> — with a cryptographic audit trail that is mathematically provable.
           </p>
-          <p className="mt-3 text-slate-400">ต่อ 1 บรรทัด ผ่าน EU AI Act Articles 9, 12, 14 ได้เลย — ไม่รื้อระบบเดิม</p>
+          <p className="mt-3 text-slate-400">One-line setup. Passes EU AI Act Articles 9, 12 &amp; 14. No changes to your existing stack.</p>
           <div className="mt-10 flex flex-wrap justify-center gap-4">
             <Link
               href="/request-access"
               className="rounded-xl bg-emerald-400 px-8 py-3.5 font-bold text-black hover:bg-emerald-300"
             >
-              ขอ Free Access →
+              Get Free Access →
             </Link>
             <Link
               href="/ai-compliance"
               className="rounded-xl border border-slate-600 px-8 py-3.5 font-bold text-slate-200 hover:border-slate-400"
             >
-              ดู Compliance Evidence
+              View Compliance Evidence
             </Link>
           </div>
         </div>
@@ -80,19 +80,19 @@ export default function EUAIActPage() {
       {/* Comparison Table */}
       <section className="px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="mb-3 text-center text-3xl font-black">เปรียบเทียบกับเครื่องมืออื่น</h2>
+          <h2 className="mb-3 text-center text-3xl font-black">How DSG ONE compares</h2>
           <p className="mb-10 text-center text-slate-400">
-            กล้องวงจรปิด = รู้ว่าโจรเข้ามาแล้ว &nbsp;|&nbsp; DSG ONE = ยาม + กล้อง — หยุดก่อนเข้า พร้อมหลักฐาน
+            A CCTV camera tells you a thief broke in &nbsp;|&nbsp; DSG ONE is the security guard — stops them at the door, with evidence
           </p>
           <div className="overflow-x-auto rounded-2xl border border-slate-700">
             <table className="w-full text-sm">
               <thead className="border-b border-slate-700 bg-slate-800 text-left text-xs uppercase tracking-wider text-slate-400">
                 <tr>
-                  <th className="px-5 py-4">เครื่องมือ</th>
+                  <th className="px-5 py-4">Tool</th>
                   <th className="px-5 py-4 text-center">Audit Trail</th>
-                  <th className="px-5 py-4 text-center">บล็อกก่อนทำ</th>
-                  <th className="px-5 py-4 text-center">ผ่าน Art.14</th>
-                  <th className="px-5 py-4 text-center">พิสูจน์ทางคณิตฯ</th>
+                  <th className="px-5 py-4 text-center">Blocks Before Acting</th>
+                  <th className="px-5 py-4 text-center">Passes Art. 14</th>
+                  <th className="px-5 py-4 text-center">Mathematically Provable</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-800">
@@ -125,8 +125,8 @@ export default function EUAIActPage() {
       {/* EU AI Act Articles */}
       <section className="bg-slate-900/50 px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="mb-3 text-center text-3xl font-black">DSG ONE ครอบคลุมทุก Article</h2>
-          <p className="mb-12 text-center text-slate-400">ต่อ DSG ONE 1 บรรทัด — ผ่านข้อกำหนดหลักทั้ง 3 ของ EU AI Act</p>
+          <h2 className="mb-3 text-center text-3xl font-black">Covers all three critical Articles</h2>
+          <p className="mb-12 text-center text-slate-400">One DSG ONE connection — satisfies the core EU AI Act requirements for high-risk AI systems</p>
           <div className="grid gap-6 md:grid-cols-3">
             {ARTICLES.map((a) => (
               <div key={a.id} className="rounded-2xl border border-slate-700 bg-slate-800/50 p-6">
@@ -152,12 +152,12 @@ export default function EUAIActPage() {
               <h2 className="mb-6 text-3xl font-black">Prevention ≠ Detection</h2>
               <div className="space-y-4">
                 <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4">
-                  <div className="mb-1 text-sm font-bold text-red-400">เครื่องมืออื่น — Detection</div>
-                  <p className="text-sm text-slate-300">รู้ว่า agent ลบ production database ไปแล้ว<br />แต่ข้อมูลหายไปแล้ว ไม่สามารถย้อนกลับได้</p>
+                  <div className="mb-1 text-sm font-bold text-red-400">Other tools — Detection</div>
+                  <p className="text-sm text-slate-300">You find out your agent deleted the production database.<br />The data is gone. You cannot undo it.</p>
                 </div>
                 <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
                   <div className="mb-1 text-sm font-bold text-emerald-400">DSG ONE — Prevention</div>
-                  <p className="text-sm text-slate-300">บล็อก action ก่อนที่ agent จะลบ<br />แจ้งเตือน + บันทึกหลักฐาน ในเวลาเดียวกัน</p>
+                  <p className="text-sm text-slate-300">The action is blocked before the agent executes it.<br />Alert sent. Evidence recorded. Zero damage.</p>
                 </div>
               </div>
             </div>
@@ -169,8 +169,8 @@ export default function EUAIActPage() {
                 <div>timestamp: 2026-05-18T04:32:00Z</div>
                 <div>requestHash: <span className="text-slate-400">sha256:8f3a2b...</span></div>
                 <div>recordHash: <span className="text-slate-400">sha256:1c9d4e...</span></div>
-                <div className="pt-2 text-slate-400"># ไม่มีใครแก้ย้อนหลังได้</div>
-                <div className="text-slate-400"># พิสูจน์ได้ทางคณิตศาสตร์</div>
+                <div className="pt-2 text-slate-400"># tamper-proof — immutable record</div>
+                <div className="text-slate-400"># mathematically verifiable</div>
               </div>
             </div>
           </div>
@@ -180,8 +180,8 @@ export default function EUAIActPage() {
       {/* Code — 1 line setup */}
       <section className="bg-slate-900/50 px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="mb-3 text-center text-3xl font-black">ต่อ 1 บรรทัด ไม่รื้อระบบเดิม</h2>
-          <p className="mb-10 text-center text-slate-400">ระบบ AI agent ที่มีอยู่ยังทำงานเหมือนเดิม — DSG ONE เพิ่มชั้นป้องกันเข้าไปเท่านั้น</p>
+          <h2 className="mb-3 text-center text-3xl font-black">One line. No changes to your existing stack.</h2>
+          <p className="mb-10 text-center text-slate-400">Your existing agent keeps running exactly as before — DSG ONE adds a governance layer in front of it.</p>
           <div className="grid gap-6 md:grid-cols-3">
             {FRAMEWORKS.map((fw) => (
               <div key={fw.name} className="rounded-2xl border border-slate-700 bg-slate-800/60 p-5">
@@ -196,12 +196,24 @@ export default function EUAIActPage() {
       {/* ICP */}
       <section className="px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="mb-10 text-center text-3xl font-black">ใครต้องใช้ DSG ONE บ้าง</h2>
+          <h2 className="mb-10 text-center text-3xl font-black">Who needs DSG ONE</h2>
           <div className="grid gap-4 md:grid-cols-3">
             {[
-              { icon: '🏦', title: 'Fintech / ธนาคาร', desc: 'AI agent จัดการธุรกรรม — ต้องมี audit trail + block unauthorized actions ตาม BOT / SEC' },
-              { icon: '📋', title: 'กำลัง Audit SOC 2 / ISO 42001', desc: 'Auditor ต้องการหลักฐานว่า AI ทำอะไรและถูกควบคุมอย่างไร — DSG ONE ให้ evidence package ได้เลย' },
-              { icon: '🇹🇭', title: 'บริษัทไทยกับ PDPA', desc: 'AI agent ที่จัดการข้อมูลส่วนตัว — ต้องบันทึกว่าใครเข้าถึงอะไร เมื่อไหร่ ทำไม' },
+              {
+                icon: '🏦',
+                title: 'Fintech & Banks',
+                desc: 'AI agents handling transactions must have audit trails and block unauthorized actions per financial regulators.',
+              },
+              {
+                icon: '📋',
+                title: 'SOC 2 / ISO 42001 Audits',
+                desc: 'Auditors require evidence that your AI is controlled and monitored. DSG ONE generates the evidence package automatically.',
+              },
+              {
+                icon: '🌐',
+                title: 'Any Company with GDPR / PDPA',
+                desc: 'AI agents that touch personal data must log who accessed what, when, and why — and be able to prove it.',
+              },
             ].map((icp) => (
               <div key={icp.title} className="rounded-2xl border border-slate-700 bg-slate-800/50 p-6">
                 <div className="mb-3 text-3xl">{icp.icon}</div>
@@ -216,27 +228,27 @@ export default function EUAIActPage() {
       {/* CTA */}
       <section className="border-t border-emerald-500/20 bg-emerald-950/20 px-6 py-20">
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="mb-4 text-3xl font-black">พร้อม compliance ใน 5 นาที</h2>
+          <h2 className="mb-4 text-3xl font-black">Compliant in 5 minutes</h2>
           <p className="mb-8 text-slate-300">
-            ทีมเราจะช่วย setup และ verify ว่าระบบของคุณผ่าน EU AI Act Article 9, 12, 14<br />
-            ฟรี ไม่มีค่าใช้จ่าย ทดลองใช้ได้เลย
+            Our team will help you set up and verify that your system passes<br />
+            EU AI Act Articles 9, 12, and 14. Free. No credit card required.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/request-access"
               className="rounded-xl bg-emerald-400 px-8 py-4 text-lg font-bold text-black hover:bg-emerald-300"
             >
-              ขอ Free Access →
+              Get Free Access →
             </Link>
             <Link
               href="/ai-compliance"
               className="rounded-xl border border-slate-600 px-8 py-4 text-lg font-bold text-slate-200 hover:border-slate-400"
             >
-              ดู Compliance Evidence
+              View Compliance Evidence
             </Link>
           </div>
           <p className="mt-6 text-sm text-slate-500">
-            ไม่ต้องใส่บัตรเครดิต · Setup ใน 5 นาที · ไม่รื้อระบบเดิม
+            No credit card · 5-minute setup · No changes to your existing stack
           </p>
         </div>
       </section>


### PR DESCRIPTION
Goal: Full English only on /eu-ai-act landing page — remove all Thai text.

Files changed:
- `app/eu-ai-act/page.tsx` — 100% English: hero, comparison table headers, article cards, prevention/detection, ICP section, CTA

Verification:
- [x] No Thai characters anywhere in the page
- [x] metadata description in English
- [x] typecheck clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNjRRqXGJ3ZqTH2CdvbxJ9)_