### PR TITLE
fix(agents): create agents with live UUID schema

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -203,13 +203,11 @@ export async function POST(request: Request) {
 
     const apiKey = buildApiKey();
     const apiKeyHash = createHash('sha256').update(apiKey).digest('hex');
-    const agentId = `agt_${randomUUID().replace(/-/g, '')}`;
     const now = new Date().toISOString();
 
     const { data: inserted, error } = await supabase
       .from('agents')
       .insert({
-        id: agentId,
         org_id: orgId,
         name,
         policy_id: resolvedPolicyId,


### PR DESCRIPTION
## Summary
- Fixes Agent Management create flow against the live Supabase schema.
- Lets Postgres generate `agents.id` as UUID instead of sending `agt_...` string IDs.
- Keeps generated DSG API keys and hashed storage unchanged.

## Evidence
Live Supabase `public.agents.id` is UUID with `gen_random_uuid()` default, while the previous route sent a string `agt_...`, causing create-agent inserts to fail with Internal server error.

## Test
- Not run locally in this environment.