### PR TITLE
fix(agents): satisfy typed insert with UUID agent ids

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -212,6 +212,7 @@ export async function POST(request: Request) {
     const { data: inserted, error } = await supabase
       .from('agents')
       .insert({
+        id: randomUUID(),
         org_id: orgId,
         name,
         policy_id: resolvedPolicyId,


### PR DESCRIPTION
## Summary
- Fixes build failure after PR #545.
- Keeps `agents.id` as UUID by sending `randomUUID()` instead of omitting the required typed field.
- Avoids the old invalid `agt_...` string ID format.

## Evidence
Vercel/Next build failed because `Database.public.Tables.agents.Insert.id` is typed as required. Runtime schema expects UUID, so this hotfix provides a valid UUID value.

## Test
- Not run locally in this environment.