### PR TITLE
fix(agents): avoid invalid default policy foreign keys

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -196,10 +196,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: `Maximum ${MAX_AGENTS_PER_ORG} agents per organization` }, { status: 400, headers });
     }
 
-    // policy_id is nullable — resolve if possible, otherwise create agent without one
-    const resolvedPolicyId = requestedPolicyId
-      ? await resolvePolicyId(orgId, requestedPolicyId)
-      : (await resolvePolicyId(orgId, null)) ?? null;
+    const resolvedPolicyId = requestedPolicyId ? await resolvePolicyId(orgId, requestedPolicyId) : null;
 
     if (requestedPolicyId && !resolvedPolicyId) {
       return NextResponse.json({ error: 'policy_id is invalid or not found' }, { status: 400, headers });


### PR DESCRIPTION
## Summary
- Fixes live Agent Management create error after PR #546.
- Stops auto-selecting a default policy when the user leaves Policy ID blank.
- Inserts `policy_id: null` unless the user explicitly provides a valid policy ID.

## Evidence
Supabase postgres logs show `insert or update on table "agents" violates foreign key constraint "agents_policy_id_fkey"`. Live schema allows `agents.policy_id` to be nullable and its FK points to `policies(id)`, while the resolver could return an ID that does not satisfy that FK.

## Test
- Verified live Supabase schema and postgres error logs via Supabase connector.
- Not run locally in this environment.