### PR TITLE
feat: add DSG Hermes plugin adapters (7 modes)

### DIFF
--- a/app/api/dsg/hermes-plugin/evaluate/route.ts
+++ b/app/api/dsg/hermes-plugin/evaluate/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgPermission } from "@/lib/auth/require-org-permission";
+import {
+  evaluateHermesPluginRequest,
+  type HermesPluginRequest,
+} from "@/lib/dsg/hermes-plugin";
+
+export const dynamic = "force-dynamic";
+
+type DeniedAuth = { ok: false; error: string; status: 401 | 403 };
+
+const ROLE_PERMISSIONS: Record<string, string[]> = {
+  viewer: ["tool:execute_low"],
+  operator: ["tool:execute_low", "tool:execute_medium"],
+  approver: ["tool:execute_low", "tool:execute_medium", "tool:execute_high"],
+  admin: ["tool:execute_low", "tool:execute_medium", "tool:execute_high", "tool:execute_critical"],
+  owner: ["tool:execute_low", "tool:execute_medium", "tool:execute_high", "tool:execute_critical"],
+};
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOrgPermission("org.execute");
+
+  if (auth.ok === false) {
+    const denied = auth as DeniedAuth;
+    return NextResponse.json({ ok: false, error: denied.error }, { status: denied.status });
+  }
+
+  try {
+    const body = (await request.json()) as Partial<HermesPluginRequest>;
+
+    if (!body.mode) {
+      return NextResponse.json(
+        { ok: false, error: "DSG_HERMES_PLUGIN_MODE_REQUIRED" },
+        { status: 400 },
+      );
+    }
+
+    const role = String(auth.role ?? "viewer");
+    const permissions = ROLE_PERMISSIONS[role] ?? ROLE_PERMISSIONS.viewer;
+
+    const evaluation = evaluateHermesPluginRequest({
+      ...body,
+      mode: body.mode,
+      context: {
+        workspaceId: auth.orgId,
+        actorId: auth.userId,
+        role: role as HermesPluginRequest["context"]["role"],
+        permissions,
+        customerName: body.context?.customerName,
+        approvalRequestId: body.context?.approvalRequestId,
+        approvalDecision: body.context?.approvalDecision,
+        approvedBy: body.context?.approvedBy,
+        approvedAt: body.context?.approvedAt,
+        proof: body.context?.proof,
+      },
+    } as HermesPluginRequest);
+
+    return NextResponse.json(
+      {
+        ok: evaluation.canExecute,
+        evaluation,
+        boundary: {
+          statement:
+            "DSG Hermes Plugin evaluates whether Hermes may execute. REVIEW/BLOCK means Hermes must not execute.",
+          certificationClaim: false,
+        },
+      },
+      { status: evaluation.canExecute ? 200 : 409 },
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "DSG_HERMES_PLUGIN_EVALUATION_FAILED",
+        message: "Internal server error",
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/lib/dsg/hermes-plugin.ts
+++ b/lib/dsg/hermes-plugin.ts
@@ -1,0 +1,498 @@
+import { createHash } from "crypto";
+import type {
+  AgentActionEnvelope,
+  AgentActionType,
+  AgentCommandGateResult,
+  AgentCommandGateRequest,
+} from "./agent-command-gate";
+import { evaluateAgentCommandGate } from "./agent-command-gate";
+import type { DataClass, GateDecision, RiskLevel } from "./midmarket-governance-autopilot";
+
+export const HERMES_PLUGIN_VERSION = "dsg-hermes-plugin-v1.0";
+
+export type HermesMode =
+  | "local_operator"
+  | "gated_executor"
+  | "local_proxy"
+  | "github_pr_assistant"
+  | "evidence_generator"
+  | "browser_qa"
+  | "x_search_signal";
+
+export interface HermesPluginContext {
+  workspaceId: string;
+  actorId: string;
+  role: "viewer" | "operator" | "approver" | "admin" | "owner";
+  permissions: string[];
+  customerName?: string;
+  approvalRequestId?: string;
+  approvalDecision?: "approved" | "rejected" | "pending";
+  approvedBy?: string;
+  approvedAt?: string;
+  proof?: {
+    audit?: {
+      preAuditEventId: string;
+      ledgerId: string;
+      chainHeadHash: string;
+    };
+    evidence?: {
+      evidenceManifestId: string;
+      policySnapshotHash: string;
+      runtimeBindingHash?: string;
+    };
+  };
+}
+
+export interface HermesPluginRequest {
+  mode: HermesMode;
+  prompt?: string;
+  commandText?: string;
+  path?: string;
+  url?: string;
+  query?: string;
+  filePaths?: string[];
+  prNumber?: number | string;
+  context: HermesPluginContext;
+}
+
+export interface HermesPreflightBlock {
+  blocked: true;
+  rule: string;
+  reason: string;
+}
+
+export interface HermesPluginEvaluation {
+  pluginVersion: string;
+  mode: HermesMode;
+  canExecute: boolean;
+  decision: GateDecision;
+  status: "HERMES_EXECUTE" | "HERMES_REVIEW_REQUIRED" | "HERMES_BLOCKED";
+  preflightBlock?: HermesPreflightBlock;
+  gateResult?: AgentCommandGateResult;
+  hermesExecutionPrompt?: string;
+  actionEnvelope?: AgentActionEnvelope;
+  reasons: string[];
+  evaluatedAt: string;
+  truthBoundary: string;
+}
+
+interface CommandProfile {
+  actionType: AgentActionType;
+  riskLevel: RiskLevel;
+  targetSystemId: string;
+  operationName: string;
+  dataClasses: DataClass[];
+}
+
+// ─── preflight checks ───────────────────────────────────────────────────────
+
+const SENSITIVE_FILE_PATTERNS: RegExp[] = [
+  /\.env(\.|$)/i,
+  /\bsecrets?\b/i,
+  /\btokens?\b/i,
+  /private[_-]?key/i,
+  /\.pem$/i,
+  /credentials?/i,
+  /\.ssh\//i,
+  /\bid_rsa\b/,
+];
+
+const DANGEROUS_DEPLOY_PATTERNS: RegExp[] = [
+  /--prod\b/,
+  /deploy:prod\b/,
+  /--production\b/,
+  /:production\b/,
+];
+
+const PUBLIC_PROXY_PATTERNS: RegExp[] = [
+  /0\.0\.0\.0/,
+  /--public\b/,
+  /\bngrok\b/i,
+  /--host\s+0\.0\.0\.0/,
+];
+
+const AUTO_MERGE_PATTERNS: RegExp[] = [
+  /auto[\s_-]?merge/i,
+  /\bautomerge\b/i,
+  /merge\s+without\s+review/i,
+];
+
+const X_TRUTH_CLAIM_PATTERNS: RegExp[] = [
+  /x\s+confirms?\b/i,
+  /verified\s+by\s+x\b/i,
+  /trending\s+proves?\b/i,
+  /\btrue\s+fact\s+from\s+x\b/i,
+];
+
+function checkSensitiveFileAccess(req: HermesPluginRequest): HermesPreflightBlock | null {
+  const text = [req.commandText, req.prompt, ...(req.filePaths ?? [])].filter(Boolean).join(" ");
+  const matched = SENSITIVE_FILE_PATTERNS.find((p) => p.test(text));
+  if (!matched) return null;
+  return {
+    blocked: true,
+    rule: "NO_SECRET_FILE_ACCESS",
+    reason:
+      "Hermes may not read, write, or export files matching sensitive patterns (.env, token, secret, private key, credentials, .pem, .ssh). If access is required, use the DSG evidence gate with an approved proof chain.",
+  };
+}
+
+function checkDangerousDeploy(req: HermesPluginRequest): HermesPreflightBlock | null {
+  const text = [req.commandText, req.prompt].filter(Boolean).join(" ");
+  const matched = DANGEROUS_DEPLOY_PATTERNS.find((p) => p.test(text));
+  if (!matched) return null;
+  return {
+    blocked: true,
+    rule: "NO_PRODUCTION_DEPLOY_WITHOUT_APPROVAL",
+    reason:
+      "Production deploy commands (--prod, deploy:prod, --production) require an approved approval proof (approvalDecision=approved) and full audit/evidence binding before DSG will issue an action envelope.",
+  };
+}
+
+function checkPublicProxy(req: HermesPluginRequest): HermesPreflightBlock | null {
+  const text = [req.commandText, req.prompt, req.url].filter(Boolean).join(" ");
+  const matched = PUBLIC_PROXY_PATTERNS.find((p) => p.test(text));
+  if (!matched) return null;
+  return {
+    blocked: true,
+    rule: "NO_PUBLIC_PROXY",
+    reason:
+      "Hermes proxy must not bind to 0.0.0.0 or expose via a public tunnel (ngrok, --public). Use localhost-only binding for safe local operation.",
+  };
+}
+
+function checkAutoMerge(req: HermesPluginRequest): HermesPreflightBlock | null {
+  const text = [req.commandText, req.prompt].filter(Boolean).join(" ");
+  const matched = AUTO_MERGE_PATTERNS.find((p) => p.test(text));
+  if (!matched) return null;
+  return {
+    blocked: true,
+    rule: "NO_AUTO_MERGE",
+    reason:
+      "PR auto-merge is blocked. All pull requests require human review before merge. Hermes may prepare and push the PR but must not trigger the merge action.",
+  };
+}
+
+function checkXSearchTruthClaim(req: HermesPluginRequest): HermesPreflightBlock | null {
+  const text = [req.query, req.prompt].filter(Boolean).join(" ");
+  const matched = X_TRUTH_CLAIM_PATTERNS.find((p) => p.test(text));
+  if (!matched) return null;
+  return {
+    blocked: true,
+    rule: "NO_X_SEARCH_UNREVIEWED_TRUTH_CLAIM",
+    reason:
+      "X/Twitter search results must not be treated as verified truth without human review. Rephrase to treat results as signals that require review before acting.",
+  };
+}
+
+function runPreflightChecks(req: HermesPluginRequest): HermesPreflightBlock | null {
+  switch (req.mode) {
+    case "local_operator":
+      return checkSensitiveFileAccess(req) ?? checkDangerousDeploy(req);
+    case "gated_executor":
+      return checkSensitiveFileAccess(req) ?? checkDangerousDeploy(req);
+    case "local_proxy":
+      return checkPublicProxy(req) ?? checkSensitiveFileAccess(req);
+    case "github_pr_assistant":
+      return checkAutoMerge(req);
+    case "evidence_generator":
+      return null;
+    case "browser_qa":
+      return null;
+    case "x_search_signal":
+      return checkXSearchTruthClaim(req);
+  }
+}
+
+// ─── command profile per mode ────────────────────────────────────────────────
+
+function buildCommandProfile(req: HermesPluginRequest): CommandProfile {
+  switch (req.mode) {
+    case "local_operator": {
+      const cmd = (req.commandText ?? "").trim();
+      const isReadOnly = /^(cat|ls|find|grep|echo|pwd|which|head|tail|wc|diff|stat|file)\b/.test(cmd);
+      return {
+        actionType: isReadOnly ? "read" : "write",
+        riskLevel: isReadOnly ? "low" : "medium",
+        targetSystemId: "local-shell",
+        operationName: cmd.split(/\s+/)[0] || "shell-command",
+        dataClasses: ["internal"],
+      };
+    }
+    case "gated_executor": {
+      const cmd = (req.commandText ?? req.prompt ?? "").trim();
+      return {
+        actionType: "write",
+        riskLevel: "medium",
+        targetSystemId: "gated-target",
+        operationName: cmd.split(/\s+/)[0] || "execute",
+        dataClasses: ["internal"],
+      };
+    }
+    case "local_proxy": {
+      return {
+        actionType: "write",
+        riskLevel: "medium",
+        targetSystemId: "local-network",
+        operationName: "proxy-server-start",
+        dataClasses: ["internal"],
+      };
+    }
+    case "github_pr_assistant": {
+      const prId = req.prNumber ? String(req.prNumber) : "new";
+      return {
+        actionType: "write",
+        riskLevel: "medium",
+        targetSystemId: "github",
+        operationName: `pr-${prId}-assist`,
+        dataClasses: ["internal"],
+      };
+    }
+    case "evidence_generator": {
+      return {
+        actionType: "write",
+        riskLevel: "low",
+        targetSystemId: "dsg-evidence-store",
+        operationName: "evidence-generate",
+        dataClasses: ["internal"],
+      };
+    }
+    case "browser_qa": {
+      const target = (req.path ?? req.url ?? "page").replace(/^\//, "");
+      return {
+        actionType: "observe",
+        riskLevel: "low",
+        targetSystemId: "browser",
+        operationName: `qa-${target.split("?")[0].slice(0, 40)}`,
+        dataClasses: ["public"],
+      };
+    }
+    case "x_search_signal": {
+      return {
+        actionType: "observe",
+        riskLevel: "low",
+        targetSystemId: "x-twitter-api",
+        operationName: "x-search-signal",
+        dataClasses: ["public"],
+      };
+    }
+  }
+}
+
+// ─── gate request builder ────────────────────────────────────────────────────
+
+function buildGateRequest(req: HermesPluginRequest, now: Date): AgentCommandGateRequest {
+  const commandId = sha256({
+    mode: req.mode,
+    commandText: req.commandText,
+    prompt: req.prompt,
+    path: req.path,
+    bucket: Math.floor(now.getTime() / 5000),
+  }).slice(0, 32);
+
+  const sessionId = sha256({
+    actorId: req.context.actorId,
+    workspaceId: req.context.workspaceId,
+    window: Math.floor(now.getTime() / 300_000),
+  }).slice(0, 32);
+
+  const profile = buildCommandProfile(req);
+  const isMutation = ["write", "delete", "payment", "deploy", "admin"].includes(profile.actionType);
+
+  return {
+    workspaceId: req.context.workspaceId,
+    customerName: req.context.customerName,
+    runtime: {
+      agentId: `hermes-${req.context.actorId}`,
+      agentName: `Hermes/${req.mode}`,
+      agentType: "ai-agent",
+      sessionId,
+      agentWillExecuteAction: true,
+      requiresResultCallback: true,
+      resultCallbackUrl: "/api/dsg/agent-command-gate/result",
+    },
+    command: {
+      commandId,
+      actionType: profile.actionType,
+      targetSystemId: profile.targetSystemId,
+      operationName: profile.operationName,
+      riskLevel: profile.riskLevel,
+      dataClasses: profile.dataClasses,
+      path: req.path,
+      idempotencyKey: isMutation ? sha256({ commandId, mode: req.mode }).slice(0, 24) : undefined,
+      rollbackPlanId: isMutation ? `rollback-${commandId.slice(0, 16)}` : undefined,
+    },
+    rbac: {
+      actorId: req.context.actorId,
+      role: req.context.role,
+      permissions: req.context.permissions,
+      approvalRequestId: req.context.approvalRequestId,
+      approvalDecision: req.context.approvalDecision,
+      approvedBy: req.context.approvedBy,
+      approvedAt: req.context.approvedAt,
+    },
+    audit: {
+      preAuditEventId: req.context.proof?.audit?.preAuditEventId ?? "",
+      ledgerId: req.context.proof?.audit?.ledgerId ?? "",
+      chainHeadHash: req.context.proof?.audit?.chainHeadHash ?? "",
+    },
+    evidence: {
+      evidenceManifestId: req.context.proof?.evidence?.evidenceManifestId ?? "",
+      policySnapshotHash: req.context.proof?.evidence?.policySnapshotHash ?? "",
+      runtimeBindingHash: req.context.proof?.evidence?.runtimeBindingHash,
+    },
+  };
+}
+
+// ─── execution prompt builder ────────────────────────────────────────────────
+
+function buildHermesExecutionPrompt(
+  req: HermesPluginRequest,
+  gateResult: AgentCommandGateResult,
+): string {
+  const env = gateResult.actionEnvelope!;
+  const callback = env.mustReturnResultTo;
+
+  switch (req.mode) {
+    case "local_operator":
+      return [
+        `DSG PASS — Hermes may execute the following shell command on the local machine.`,
+        `Command: ${req.commandText}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `After execution, post the observed result to: ${callback}`,
+      ].join("\n");
+
+    case "gated_executor":
+      return [
+        `DSG PASS — Hermes may execute the gated command.`,
+        `Command: ${req.commandText ?? req.prompt}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `After execution, post the observed result to: ${callback}`,
+      ].join("\n");
+
+    case "local_proxy":
+      return [
+        `DSG PASS — Hermes may start a local proxy server on localhost only.`,
+        `Command: ${req.commandText}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `CRITICAL: Proxy MUST bind to 127.0.0.1/localhost only. Do NOT bind to 0.0.0.0.`,
+        `After starting, post the result (port, pid, status) to: ${callback}`,
+      ].join("\n");
+
+    case "github_pr_assistant":
+      return [
+        `DSG PASS — Hermes may assist with GitHub PR ${req.prNumber ?? "(new)"}.`,
+        `Prompt: ${req.prompt}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `CRITICAL: Hermes may NOT trigger auto-merge. Human review is required before merge.`,
+        `After completing PR actions, post the result (PR URL, changed files, status) to: ${callback}`,
+      ].join("\n");
+
+    case "evidence_generator":
+      return [
+        `DSG PASS — Hermes may generate evidence artifacts.`,
+        `Prompt: ${req.prompt}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `After generating, post the evidence item IDs and manifest hash to: ${callback}`,
+      ].join("\n");
+
+    case "browser_qa":
+      return [
+        `DSG PASS — Hermes may open the browser and perform QA.`,
+        `Target: ${req.path ?? req.url}`,
+        `Prompt: ${req.prompt}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `After QA, post the observed result (console errors, broken routes, CTA status) to: ${callback}`,
+      ].join("\n");
+
+    case "x_search_signal":
+      return [
+        `DSG PASS — Hermes may query X/Twitter for signals.`,
+        `Query: ${req.query ?? req.prompt}`,
+        `Envelope ID: ${env.envelopeId}`,
+        `Expires at: ${env.expiresAt}`,
+        `IMPORTANT: X search results are SIGNALS ONLY. They must be reviewed before being treated as verified truth.`,
+        `After searching, post the observed signal data (not conclusions) to: ${callback}`,
+      ].join("\n");
+  }
+}
+
+// ─── main export ─────────────────────────────────────────────────────────────
+
+export function evaluateHermesPluginRequest(
+  req: HermesPluginRequest,
+  now: Date = new Date(),
+): HermesPluginEvaluation {
+  const evaluatedAt = now.toISOString();
+
+  const preflightBlock = runPreflightChecks(req);
+  if (preflightBlock) {
+    return {
+      pluginVersion: HERMES_PLUGIN_VERSION,
+      mode: req.mode,
+      canExecute: false,
+      decision: "BLOCK",
+      status: "HERMES_BLOCKED",
+      preflightBlock,
+      reasons: ["preflight_block", `preflight:${preflightBlock.rule}`],
+      evaluatedAt,
+      truthBoundary:
+        "DSG Hermes Plugin blocked this request before gate evaluation. Hermes must not execute.",
+    };
+  }
+
+  const gateRequest = buildGateRequest(req, now);
+  const gateResult = evaluateAgentCommandGate(gateRequest, now);
+
+  const canExecute = gateResult.canAgentExecute;
+  const decision = gateResult.decision;
+  const status: HermesPluginEvaluation["status"] = canExecute
+    ? "HERMES_EXECUTE"
+    : decision === "REVIEW"
+      ? "HERMES_REVIEW_REQUIRED"
+      : "HERMES_BLOCKED";
+
+  return {
+    pluginVersion: HERMES_PLUGIN_VERSION,
+    mode: req.mode,
+    canExecute,
+    decision,
+    status,
+    gateResult,
+    hermesExecutionPrompt: canExecute ? buildHermesExecutionPrompt(req, gateResult) : undefined,
+    actionEnvelope: gateResult.actionEnvelope,
+    reasons: gateResult.reasons,
+    evaluatedAt,
+    truthBoundary: canExecute
+      ? "DSG Hermes Plugin has approved this Hermes action. Hermes may execute, then must post the observed result back to DSG for audit and evidence recording."
+      : "DSG Hermes Plugin has not approved this Hermes action. REVIEW or BLOCK means Hermes must not execute.",
+  };
+}
+
+// ─── internal utilities ───────────────────────────────────────────────────────
+
+function sha256(value: unknown): string {
+  return createHash("sha256").update(stableJson(value)).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortStable(value));
+}
+
+function sortStable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortStable);
+  if (value !== null && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortStable((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}

--- a/tests/dsg/hermes-plugin.test.ts
+++ b/tests/dsg/hermes-plugin.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import { evaluateHermesPluginRequest, type HermesPluginRequest } from "../../lib/dsg/hermes-plugin";
+
+const REAL_PROOF = {
+  audit: {
+    preAuditEventId: "audit_evt_real_001",
+    ledgerId: "ledger_real_001",
+    chainHeadHash: "real_chain_head_hash",
+  },
+  evidence: {
+    evidenceManifestId: "evidence_manifest_real_001",
+    policySnapshotHash: "real_policy_snapshot_hash",
+  },
+};
+
+const BASE_CONTEXT = {
+  workspaceId: "ws_test_001",
+  actorId: "user_test_001",
+  role: "operator" as const,
+  permissions: ["tool:execute_low", "tool:execute_medium"],
+};
+
+// ─── browser_qa ─────────────────────────────────────────────────────────────
+
+describe("browser_qa", () => {
+  it("PASS when audit/evidence proof is present", () => {
+    const req: HermesPluginRequest = {
+      mode: "browser_qa",
+      prompt: "Open /proofgate and check broken route, console error, CTA visibility",
+      commandText: "browser qa /proofgate",
+      path: "/proofgate",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("PASS");
+    expect(r.canExecute).toBe(true);
+    expect(r.status).toBe("HERMES_EXECUTE");
+    expect(r.hermesExecutionPrompt).toContain("DSG PASS");
+    expect(r.actionEnvelope?.envelopeId).toBeTruthy();
+    console.log("\n--- browser_qa PASS ---");
+    console.log("decision:", r.decision);
+    console.log("envelopeId:", r.actionEnvelope?.envelopeId);
+    console.log("expiresAt:", r.actionEnvelope?.expiresAt);
+    console.log("prompt:\n", r.hermesExecutionPrompt);
+  });
+
+  it("BLOCK when audit/evidence proof is missing", () => {
+    const req: HermesPluginRequest = {
+      mode: "browser_qa",
+      prompt: "Check /proofgate",
+      path: "/proofgate",
+      context: { ...BASE_CONTEXT },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("BLOCK");
+    expect(r.canExecute).toBe(false);
+    console.log("\n--- browser_qa BLOCK (no proof) ---");
+    console.log("reasons:", r.reasons);
+  });
+});
+
+// ─── local_operator ──────────────────────────────────────────────────────────
+
+describe("local_operator", () => {
+  it("PASS for read command with proof", () => {
+    const req: HermesPluginRequest = {
+      mode: "local_operator",
+      commandText: "ls -la /tmp",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("PASS");
+    expect(r.gateResult?.invariantChecks.find((c) => c.name === "audit_hook_bound")?.status).toBe("PASS");
+    console.log("\n--- local_operator ls PASS ---");
+    console.log("decision:", r.decision, "| actionType:", r.gateResult?.actionEnvelope?.allowedAction);
+  });
+
+  it("PREFLIGHT BLOCK when touching .env file", () => {
+    const req: HermesPluginRequest = {
+      mode: "local_operator",
+      commandText: "cat .env.production",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("BLOCK");
+    expect(r.preflightBlock?.rule).toBe("NO_SECRET_FILE_ACCESS");
+    console.log("\n--- local_operator .env PREFLIGHT BLOCK ---");
+    console.log("rule:", r.preflightBlock?.rule);
+    console.log("reason:", r.preflightBlock?.reason);
+  });
+
+  it("PREFLIGHT BLOCK when deploy --prod", () => {
+    const req: HermesPluginRequest = {
+      mode: "local_operator",
+      commandText: "vercel deploy --prod",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.preflightBlock?.rule).toBe("NO_PRODUCTION_DEPLOY_WITHOUT_APPROVAL");
+    console.log("\n--- local_operator deploy --prod PREFLIGHT BLOCK ---");
+    console.log("rule:", r.preflightBlock?.rule);
+  });
+});
+
+// ─── local_proxy ─────────────────────────────────────────────────────────────
+
+describe("local_proxy", () => {
+  it("PREFLIGHT BLOCK on ngrok", () => {
+    const req: HermesPluginRequest = {
+      mode: "local_proxy",
+      commandText: "ngrok http 3000",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.preflightBlock?.rule).toBe("NO_PUBLIC_PROXY");
+    console.log("\n--- local_proxy ngrok PREFLIGHT BLOCK ---");
+    console.log("rule:", r.preflightBlock?.rule);
+  });
+
+  it("PREFLIGHT BLOCK on 0.0.0.0", () => {
+    const req: HermesPluginRequest = {
+      mode: "local_proxy",
+      commandText: "node proxy.js --host 0.0.0.0",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.preflightBlock?.rule).toBe("NO_PUBLIC_PROXY");
+    console.log("\n--- local_proxy 0.0.0.0 PREFLIGHT BLOCK ---");
+  });
+});
+
+// ─── github_pr_assistant ─────────────────────────────────────────────────────
+
+describe("github_pr_assistant", () => {
+  it("PREFLIGHT BLOCK on auto-merge", () => {
+    const req: HermesPluginRequest = {
+      mode: "github_pr_assistant",
+      prompt: "auto-merge PR #42 after CI passes",
+      prNumber: 42,
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.preflightBlock?.rule).toBe("NO_AUTO_MERGE");
+    console.log("\n--- github_pr_assistant auto-merge PREFLIGHT BLOCK ---");
+    console.log("rule:", r.preflightBlock?.rule);
+  });
+
+  it("PASS for normal PR assist with proof", () => {
+    const req: HermesPluginRequest = {
+      mode: "github_pr_assistant",
+      prompt: "Review PR #42 and add a summary comment",
+      prNumber: 42,
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("PASS");
+    console.log("\n--- github_pr_assistant PASS ---");
+    console.log("decision:", r.decision, "| op:", r.gateResult?.actionEnvelope?.operationName);
+  });
+});
+
+// ─── x_search_signal ─────────────────────────────────────────────────────────
+
+describe("x_search_signal", () => {
+  it("PREFLIGHT BLOCK when X confirms used as truth", () => {
+    const req: HermesPluginRequest = {
+      mode: "x_search_signal",
+      query: "x confirms DSG is trending",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.preflightBlock?.rule).toBe("NO_X_SEARCH_UNREVIEWED_TRUTH_CLAIM");
+    console.log("\n--- x_search_signal truth claim PREFLIGHT BLOCK ---");
+    console.log("rule:", r.preflightBlock?.rule);
+  });
+
+  it("PASS for normal signal search with proof", () => {
+    const req: HermesPluginRequest = {
+      mode: "x_search_signal",
+      query: "#ProofGate DSG launch signal",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("PASS");
+    expect(r.hermesExecutionPrompt).toContain("SIGNALS ONLY");
+    console.log("\n--- x_search_signal PASS ---");
+    console.log("decision:", r.decision);
+    console.log("prompt snippet:", r.hermesExecutionPrompt?.split("\n").slice(0, 3).join(" | "));
+  });
+});
+
+// ─── evidence_generator ──────────────────────────────────────────────────────
+
+describe("evidence_generator", () => {
+  it("PASS with proof", () => {
+    const req: HermesPluginRequest = {
+      mode: "evidence_generator",
+      prompt: "Generate deployment evidence for release v1.2.0",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("PASS");
+    console.log("\n--- evidence_generator PASS ---");
+    console.log("decision:", r.decision, "| target:", r.gateResult?.actionEnvelope?.targetSystemId);
+  });
+});
+
+// ─── gated_executor ──────────────────────────────────────────────────────────
+
+describe("gated_executor", () => {
+  it("BLOCK without proof (gate rejects)", () => {
+    const req: HermesPluginRequest = {
+      mode: "gated_executor",
+      commandText: "npm run build",
+      context: { ...BASE_CONTEXT },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.canExecute).toBe(false);
+    console.log("\n--- gated_executor BLOCK (no proof) ---");
+    console.log("reasons:", r.reasons.slice(0, 3));
+  });
+
+  it("PASS with proof", () => {
+    const req: HermesPluginRequest = {
+      mode: "gated_executor",
+      commandText: "npm run build",
+      context: { ...BASE_CONTEXT, proof: REAL_PROOF },
+    };
+    const r = evaluateHermesPluginRequest(req);
+    expect(r.decision).toBe("PASS");
+    console.log("\n--- gated_executor PASS ---");
+    console.log("envelopeId:", r.actionEnvelope?.envelopeId);
+  });
+});


### PR DESCRIPTION
## Goal

Add `lib/dsg/hermes-plugin.ts` — a DSG-gated execution adapter for Hermes with 7 modes — and `app/api/dsg/hermes-plugin/evaluate/route.ts` as the HTTP entry point.

Every mode routes through the existing `evaluateAgentCommandGate`, so the existing audit/evidence binding requirement is fully enforced. Preflight blocks are added on top for high-risk patterns that the gate alone doesn't cover.

## Files changed

- `lib/dsg/hermes-plugin.ts` — plugin core, 7 modes, preflight checks, gate integration
- `app/api/dsg/hermes-plugin/evaluate/route.ts` — `POST /api/dsg/hermes-plugin/evaluate`
- `tests/dsg/hermes-plugin.test.ts` — 14 test cases across all modes

## Modes

| Mode | ActionType | RiskLevel |
|------|-----------|----------|
| `local_operator` | `read` / `write` (auto-detected) | `low` / `medium` |
| `gated_executor` | `write` | `medium` |
| `local_proxy` | `write` | `medium` |
| `github_pr_assistant` | `write` | `medium` |
| `evidence_generator` | `write` | `low` |
| `browser_qa` | `observe` | `low` |
| `x_search_signal` | `observe` | `low` |

## Preflight blocks (before gate)

| Rule | Triggers on |
|------|------------|
| `NO_SECRET_FILE_ACCESS` | `.env`, `secret`, `token`, `private key`, `.pem`, credentials |
| `NO_PRODUCTION_DEPLOY_WITHOUT_APPROVAL` | `--prod`, `deploy:prod`, `--production` |
| `NO_PUBLIC_PROXY` | `0.0.0.0`, `ngrok`, `--public` |
| `NO_AUTO_MERGE` | `auto-merge`, `automerge`, `merge without review` |
| `NO_X_SEARCH_UNREVIEWED_TRUTH_CLAIM` | `x confirms`, `verified by x`, `trending proves` |

## Verification

```
✓ tests/dsg/hermes-plugin.test.ts  14/14 passed
✓ All existing DSG tests unaffected (agent-command-gate, midmarket-governance-autopilot, dsg-core, etc.)
✗ 2 pre-existing failures unrelated to this PR (mcp-call, access-entry-pages)
```

## Known limits

- `gated_executor` defaults to `write/medium` — caller cannot yet override actionType/riskLevel per-command
- No DB persistence of hermes plugin evaluations (gate decisions are evaluated in-memory only)
- `x_search_signal` truth-claim preflight covers obvious patterns only; nuanced cases still pass

## User-visible benefit

Hermes can request DSG approval before executing any of the 7 action types. REVIEW/BLOCK stops execution before it happens. PASS returns a signed `actionEnvelope` with a callback obligation to `/api/dsg/agent-command-gate/result`.

## Next step

- Wire Hermes agent to call `POST /api/dsg/hermes-plugin/evaluate` before each tool execution
- Persist plugin evaluations to the audit ledger via `agent-command-gate-repository`

---
_Generated by [Claude Code](https://claude.ai/code/session_016GckM8FSsq2oTRAu3HtN8p)_