### PR TITLE
fix: bind Hermes gate to concrete tool params (Codex P1)

### DIFF
--- a/lib/agent/executor.ts
+++ b/lib/agent/executor.ts
@@ -57,6 +57,7 @@ export async function executeToolSafely(
     prompt: `Execute tool: ${tool.name}`,
     path: typeof params.url === 'string' ? params.url : undefined,
     url: typeof params.url === 'string' ? params.url : undefined,
+    payload: params,
     context: {
       workspaceId: context.orgId,
       actorId: agentId,

--- a/lib/dsg/hermes-plugin.ts
+++ b/lib/dsg/hermes-plugin.ts
@@ -52,6 +52,7 @@ export interface HermesPluginRequest {
   query?: string;
   filePaths?: string[];
   prNumber?: number | string;
+  payload?: Record<string, unknown>;
   context: HermesPluginContext;
 }
 
@@ -281,11 +282,14 @@ function buildCommandProfile(req: HermesPluginRequest): CommandProfile {
 // ─── gate request builder ────────────────────────────────────────────────────
 
 function buildGateRequest(req: HermesPluginRequest, now: Date): AgentCommandGateRequest {
+  const payloadHash = req.payload ? sha256(req.payload) : undefined;
+
   const commandId = sha256({
     mode: req.mode,
     commandText: req.commandText,
     prompt: req.prompt,
     path: req.path,
+    payloadHash,
     bucket: Math.floor(now.getTime() / 5000),
   }).slice(0, 32);
 
@@ -318,6 +322,7 @@ function buildGateRequest(req: HermesPluginRequest, now: Date): AgentCommandGate
       riskLevel: profile.riskLevel,
       dataClasses: profile.dataClasses,
       path: req.path,
+      payloadHash,
       idempotencyKey: isMutation ? sha256({ commandId, mode: req.mode }).slice(0, 24) : undefined,
       rollbackPlanId: isMutation ? `rollback-${commandId.slice(0, 16)}` : undefined,
     },


### PR DESCRIPTION
## Goal

Fix Codex P1 on PR #551: Hermes command identity was not bound to the actual tool params, allowing two different mutations with the same tool ID in the same 5-second window to share the same audit envelope.

## Root cause

`buildGateRequest()` derived `commandId` only from `{ mode, commandText, prompt, path, bucket }`. Two calls to `update_agent` with different patches, or `telegram_send` to different recipients, in the same 5-second bucket got identical `commandId` and `payloadHash=undefined`.

## Fix

- Added `payload?: Record<string, unknown>` field to `HermesPluginRequest`
- `buildGateRequest()` computes `payloadHash = sha256(req.payload)` and includes it in both the `commandId` derivation and `AgentCommandProposal.payloadHash`
- `executeToolSafely()` now passes `payload: params` into the Hermes request

Every distinct `params` object now produces a unique command identity and a payload-bound audit envelope.

## Files changed

- `lib/dsg/hermes-plugin.ts` — add `payload` field, wire payloadHash into commandId + proposal
- `lib/agent/executor.ts` — pass `payload: params` in Hermes request

## Verification

```
✓ tests/dsg/hermes-plugin.test.ts       16/16 passed
✓ tests/unit/agent/executor-hermes.test.ts  7/7 passed
```

## Known limits

None introduced by this fix.

## User-visible benefit

Each distinct tool invocation (different params) is now cryptographically distinct in the DSG audit ledger — the evidence envelope cannot be reused across different mutations.

## Next step

Wire `hermesProof` from agent-chat request body into `AgentContext`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GckM8FSsq2oTRAu3HtN8p)_