### PR TITLE
feat: browser_qa no-audit pass + hermesProof in agent-chat + result callback

### DIFF
--- a/app/api/agent-chat/route.ts
+++ b/app/api/agent-chat/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: Request) {
     origin: new URL(request.url).origin,
     authHeader: request.headers.get('authorization') || '',
     cookieHeader: request.headers.get('cookie') || '',
+    hermesProof: body?.hermesProof ?? undefined,
   };
 
   const sessionKey = `${access.orgId}:${sessionId}`;

--- a/lib/agent/executor.ts
+++ b/lib/agent/executor.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { resolveGate } from '../gate';
 import { evaluateHermesPluginRequest, type HermesMode } from '../dsg/hermes-plugin';
 import type { AgentContext } from './context';
@@ -22,6 +23,43 @@ function roleToPermissions(role: AgentContext['role']): string[] {
 }
 
 type HermesPluginContext = Parameters<typeof evaluateHermesPluginRequest>[0]['context'];
+
+function postHermesResult(
+  context: AgentContext,
+  envelope: NonNullable<ReturnType<typeof evaluateHermesPluginRequest>['actionEnvelope']>,
+  result: unknown,
+  startedAt: string,
+): void {
+  const completedAt = new Date().toISOString();
+  const observedResultHash = createHash('sha256')
+    .update(JSON.stringify(result ?? null))
+    .digest('hex');
+  const body = {
+    workspaceId: envelope.workspaceId,
+    agentId: envelope.agentId,
+    sessionId: envelope.sessionId,
+    commandId: envelope.commandId,
+    envelopeId: envelope.envelopeId,
+    decisionHash: envelope.decisionHash,
+    status: 'SUCCESS',
+    startedAt,
+    completedAt,
+    observedResultHash,
+    evidenceItemIds: [`observe:${envelope.envelopeId}`],
+  };
+  fetch(`${context.origin}${envelope.mustReturnResultTo}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: context.authHeader,
+      cookie: context.cookieHeader,
+    },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  }).catch(() => {
+    // fire-and-forget — result callback failure does not block the caller
+  });
+}
 
 export async function executeToolSafely(
   tool: AgentTool,
@@ -97,5 +135,12 @@ export async function executeToolSafely(
     return { stabilized: true, reason: gateResult.reason, requiresApproval: true };
   }
 
-  return tool.execute(params, context);
+  const startedAt = new Date().toISOString();
+  const result = await tool.execute(params, context);
+
+  if (hermesResult.actionEnvelope) {
+    postHermesResult(context, hermesResult.actionEnvelope, result, startedAt);
+  }
+
+  return result;
 }

--- a/lib/agent/executor.ts
+++ b/lib/agent/executor.ts
@@ -57,6 +57,7 @@ export async function executeToolSafely(
     prompt: `Execute tool: ${tool.name}`,
     path: typeof params.url === 'string' ? params.url : undefined,
     url: typeof params.url === 'string' ? params.url : undefined,
+    payload: params,
     context: {
       workspaceId: context.orgId,
       actorId: agentId,

--- a/lib/dsg/hermes-plugin.ts
+++ b/lib/dsg/hermes-plugin.ts
@@ -52,6 +52,7 @@ export interface HermesPluginRequest {
   query?: string;
   filePaths?: string[];
   prNumber?: number | string;
+  payload?: Record<string, unknown>;
   context: HermesPluginContext;
 }
 
@@ -281,11 +282,14 @@ function buildCommandProfile(req: HermesPluginRequest): CommandProfile {
 // ─── gate request builder ────────────────────────────────────────────────────
 
 function buildGateRequest(req: HermesPluginRequest, now: Date): AgentCommandGateRequest {
+  const payloadHash = req.payload ? sha256(req.payload) : undefined;
+
   const commandId = sha256({
     mode: req.mode,
     commandText: req.commandText,
     prompt: req.prompt,
     path: req.path,
+    payloadHash,
     bucket: Math.floor(now.getTime() / 5000),
   }).slice(0, 32);
 
@@ -318,6 +322,7 @@ function buildGateRequest(req: HermesPluginRequest, now: Date): AgentCommandGate
       riskLevel: profile.riskLevel,
       dataClasses: profile.dataClasses,
       path: req.path,
+      payloadHash,
       idempotencyKey: isMutation ? sha256({ commandId, mode: req.mode }).slice(0, 24) : undefined,
       rollbackPlanId: isMutation ? `rollback-${commandId.slice(0, 16)}` : undefined,
     },

--- a/lib/dsg/hermes-plugin.ts
+++ b/lib/dsg/hermes-plugin.ts
@@ -451,6 +451,28 @@ export function evaluateHermesPluginRequest(
     };
   }
 
+  // observe-only modes (browser_qa, x_search_signal) pass without full audit binding
+  const profile = buildCommandProfile(req);
+  if (profile.actionType === "observe" && !req.context.proof) {
+    const prompt = [
+      `DSG PASS (observe, no-audit) — Hermes may ${req.mode === "browser_qa" ? "open browser and QA" : "search"}.`,
+      req.path ?? req.url ?? req.query ?? req.prompt ?? "",
+      "No mutation will occur. No result callback required.",
+    ].filter(Boolean).join("\n");
+    return {
+      pluginVersion: HERMES_PLUGIN_VERSION,
+      mode: req.mode,
+      canExecute: true,
+      decision: "PASS",
+      status: "HERMES_EXECUTE",
+      hermesExecutionPrompt: prompt,
+      reasons: ["observe_no_audit_pass"],
+      evaluatedAt,
+      truthBoundary:
+        "DSG Hermes Plugin approved this observe-only action without audit binding. No mutations. No result callback required.",
+    };
+  }
+
   const gateRequest = buildGateRequest(req, now);
   const gateResult = evaluateAgentCommandGate(gateRequest, now);
 

--- a/tests/dsg/hermes-plugin.test.ts
+++ b/tests/dsg/hermes-plugin.test.ts
@@ -44,7 +44,7 @@ describe("browser_qa", () => {
     console.log("prompt:\n", r.hermesExecutionPrompt);
   });
 
-  it("BLOCK when audit/evidence proof is missing", () => {
+  it("PASS without proof (observe-no-audit fast path)", () => {
     const req: HermesPluginRequest = {
       mode: "browser_qa",
       prompt: "Check /proofgate",
@@ -52,10 +52,13 @@ describe("browser_qa", () => {
       context: { ...BASE_CONTEXT },
     };
     const r = evaluateHermesPluginRequest(req);
-    expect(r.decision).toBe("BLOCK");
-    expect(r.canExecute).toBe(false);
-    console.log("\n--- browser_qa BLOCK (no proof) ---");
+    expect(r.decision).toBe("PASS");
+    expect(r.canExecute).toBe(true);
+    expect(r.reasons).toContain("observe_no_audit_pass");
+    expect(r.actionEnvelope).toBeUndefined();
+    console.log("\n--- browser_qa PASS (no proof, observe fast path) ---");
     console.log("reasons:", r.reasons);
+    console.log("prompt:", r.hermesExecutionPrompt);
   });
 });
 

--- a/tests/unit/agent/executor-hermes.test.ts
+++ b/tests/unit/agent/executor-hermes.test.ts
@@ -120,15 +120,17 @@ describe("browser_navigate maps to browser_qa mode", () => {
     console.log("\n--- browser_navigate PASS (browser_qa mode) ---");
   });
 
-  it("BLOCK without proof", async () => {
+  it("PASS without proof (observe-no-audit fast path)", async () => {
     const ctx = { ...BASE_CONTEXT, role: "org_admin" as const };
     const result = await executeToolSafely(
       BROWSER_TOOL,
       { agent_id: "ag_001", url: "/proofgate" },
       ctx,
     ) as Record<string, unknown>;
-    expect(result.blocked).toBe(true);
-    expect(result.hermesDecision).toBe("BLOCK");
+    // observe mode passes without proof — no mutation risk
+    expect(result.blocked).toBeUndefined();
+    expect(result.navigated).toBe(true);
+    console.log("\n--- browser_navigate PASS (no proof, observe fast path) ---");
   });
 });
 


### PR DESCRIPTION
## Goal

Complete the Hermes end-to-end flow so `browser_qa` works without requiring audit proof, callers can supply `hermesProof` via agent-chat request body, and executed tool results are reported back to DSG automatically.

## Files changed

- `lib/dsg/hermes-plugin.ts` — observe-no-audit fast path for browser_qa / x_search_signal
- `app/api/agent-chat/route.ts` — parse `hermesProof` from body → AgentContext
- `lib/agent/executor.ts` — fire-and-forget result POST after tool.execute()
- `tests/dsg/hermes-plugin.test.ts` — update browser_qa test (PASS without proof)
- `tests/unit/agent/executor-hermes.test.ts` — update browser_navigate test (PASS without proof)

## Full flow now working

```
User: "ตรวจ /proofgate มี broken route มั้ย"
         ↓
agent-chat → planner → browser_navigate tool
         ↓
executeToolSafely()
  → Hermes gate: browser_qa, no proof → observe fast path → PASS (no audit needed)
  → resolveGate() → PASS
  → browser_navigate.execute() → { navigated: true, ... }
  → postHermesResult() → fire-and-forget POST /api/dsg/agent-command-gate/result
         ↓
SSE: { type: "step_result", result: { navigated: true, ... } }
```

## Calling with proof (write tools)

```json
POST /api/agent-chat
{
  "message": "create agent MyBot",
  "hermesProof": {
    "audit": { "preAuditEventId": "...", "ledgerId": "...", "chainHeadHash": "..." },
    "evidence": { "evidenceManifestId": "...", "policySnapshotHash": "..." }
  }
}
```

## Verification

```
✓ tests/dsg/hermes-plugin.test.ts         16/16 passed
✓ tests/unit/agent/executor-hermes.test.ts  7/7  passed
```

## Known limits

- `evidenceItemIds` in result callback uses `["observe:{envelopeId}"]` placeholder — real evidence IDs require evidence store integration
- `hermesProof` is trusted as-is from the caller body; production should validate proof freshness server-side

## Next step

Auto-generate proof binding from Supabase ledger before write tool calls (Option A).

---
_Generated by [Claude Code](https://claude.ai/code/session_016GckM8FSsq2oTRAu3HtN8p)_