### PR TITLE
fix: harden ProofGate production security boundaries

### DIFF
--- a/app/api/cron/content-gen/route.ts
+++ b/app/api/cron/content-gen/route.ts
@@ -4,6 +4,7 @@
 import { NextResponse } from 'next/server';
 import { executeTool } from '../../../../lib/marketing/mcp-tools';
 import { getResend } from '../../../../lib/resend';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -38,18 +39,16 @@ function getWeekNumber(): number {
 }
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'content-gen');
+  if (!auth.ok) return auth.response;
 
   if (!process.env.ANTHROPIC_API_KEY) {
-    return NextResponse.json({ ok: false, error: 'ANTHROPIC_API_KEY not configured' }, { status: 200 });
+    return NextResponse.json({ ok: false, error: 'ANTHROPIC_API_KEY not configured' }, { status: 200, headers: auth.headers });
   }
 
   const founderEmail = process.env.FOUNDER_EMAIL;
   if (!founderEmail) {
-    return NextResponse.json({ ok: false, error: 'FOUNDER_EMAIL not set' }, { status: 200 });
+    return NextResponse.json({ ok: false, error: 'FOUNDER_EMAIL not set' }, { status: 200, headers: auth.headers });
   }
 
   const week = getWeekNumber();
@@ -62,32 +61,29 @@ export async function GET(request: Request) {
 
   const errors: string[] = [];
 
-  // Generate SEO article
   let article: Record<string, unknown> = {};
   try {
     article = await executeTool('generate_seo_article', { keyword });
-  } catch (err) {
-    errors.push(`article: ${err instanceof Error ? err.message : 'failed'}`);
+  } catch {
+    errors.push('article: failed');
   }
 
-  // Generate 3 LinkedIn posts
   const linkedinPosts: Array<{ angle: string; post: string }> = [];
   for (const angle of angles) {
     try {
       const result = await executeTool('generate_linkedin_post', { angle });
       linkedinPosts.push({ angle, post: String((result as Record<string, unknown>).post ?? '') });
-    } catch (err) {
-      errors.push(`linkedin(${angle}): ${err instanceof Error ? err.message : 'failed'}`);
+    } catch {
+      errors.push(`linkedin(${angle}): failed`);
     }
   }
 
-  // Email everything to founder
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
   const resend = getResend();
 
   if (resend.configured) {
     const articleSection = article.title
-      ? `<h2>📝 SEO Article — Week ${week}</h2>
+      ? `<h2>SEO Article — Week ${week}</h2>
          <p><strong>Keyword:</strong> ${keyword}</p>
          <p><strong>Title:</strong> ${article.title}</p>
          <p><strong>Meta:</strong> ${article.meta_description}</p>
@@ -99,7 +95,7 @@ export async function GET(request: Request) {
       .map(
         (p, i) =>
           `<h3>LinkedIn Post ${i + 1} — ${p.angle}</h3>
-           <div style="background:#f0f9ff;padding:16px;border-radius:8px;white-space:pre-wrap;font-size:14px">${p.post}</div>`
+           <div style="background:#f0f9ff;padding:16px;border-radius:8px;white-space:pre-wrap;font-size:14px">${p.post.slice(0, 3000)}</div>`
       )
       .join('<br/>');
 
@@ -110,9 +106,9 @@ export async function GET(request: Request) {
         <h1 style="color:#1e293b">DSG ONE — Weekly Content Package</h1>
         <p style="color:#64748b">Generated ${new Date().toISOString().split('T')[0]} · Week ${week} · <a href="${appUrl}/quickstart">Quickstart</a></p>
         ${articleSection}
-        <h2>📣 LinkedIn Posts (copy-paste ready)</h2>
+        <h2>LinkedIn Posts (copy-paste ready)</h2>
         ${postsSection}
-        ${errors.length ? `<p style="color:#ef4444">⚠️ Errors: ${errors.join(', ')}</p>` : ''}
+        ${errors.length ? `<p style="color:#ef4444">Errors: ${errors.join(', ')}</p>` : ''}
       </div>`,
     });
   }
@@ -125,5 +121,5 @@ export async function GET(request: Request) {
     linkedin_posts_generated: linkedinPosts.length,
     emailed_to: founderEmail,
     errors: errors.slice(0, 5),
-  });
+  }, { headers: auth.headers });
 }

--- a/app/api/cron/drip-emails/route.ts
+++ b/app/api/cron/drip-emails/route.ts
@@ -1,8 +1,9 @@
 // Daily cron: send trial drip emails at D7 (mid-point) and D13 (expiry warning)
-// Vercel cron calls this with Authorization: Bearer CRON_SECRET
+// Vercel cron calls this with Authorization: Bearer CRON_DRIP_EMAILS_SECRET or CRON_SECRET.
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { sendTrialMidpoint, sendTrialExpiry } from '../../../../lib/email/sales';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,13 +12,8 @@ function daysBetween(a: Date, b: Date) {
 }
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const auth = request.headers.get('authorization');
-    if (auth !== `Bearer ${secret}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-  }
+  const auth = requireCronAuth(request, 'drip-emails');
+  if (!auth.ok) return auth.response;
 
   const supabase = getSupabaseAdmin();
   const now = new Date();
@@ -31,7 +27,7 @@ export async function GET(request: Request) {
     .not('customer_email', 'is', null);
 
   if (error || !trials) {
-    return NextResponse.json({ error: error?.message || 'query failed' }, { status: 500 });
+    return NextResponse.json({ error: 'query failed' }, { status: 500, headers: auth.headers });
   }
 
   let sent = 0;
@@ -95,5 +91,5 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.json({ ok: true, processed: trials.length, sent });
+  return NextResponse.json({ ok: true, processed: trials.length, sent }, { headers: auth.headers });
 }

--- a/app/api/cron/github-leads/route.ts
+++ b/app/api/cron/github-leads/route.ts
@@ -4,6 +4,7 @@
 
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,7 +16,7 @@ const FRAMEWORKS = [
   { name: 'openai-agents', query: 'openai-agents filename:requirements.txt', lang: 'python' },
   { name: 'openai-agents-js', query: '"@openai/agents" filename:package.json', lang: 'javascript' },
   { name: 'pydantic-ai', query: 'pydantic-ai filename:requirements.txt', lang: 'python' },
-];
+] as const;
 
 type GHRepo = {
   full_name: string;
@@ -32,6 +33,64 @@ type GHUser = {
   name?: string | null;
   company?: string | null;
 };
+
+type LeadInsert = {
+  email: string;
+  source: 'github-signal';
+  intent: 'high';
+  intent_score: number;
+  framework: string;
+  github_repo: string;
+  github_stars: number;
+  company: string | null;
+  messages: Array<{ role: 'system'; content: string }>;
+  last_seen_at: string;
+};
+
+function truncate(value: string | null | undefined, max: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, max);
+}
+
+function isValidEmail(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= 255 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function isValidRepoName(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= 255 && /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value);
+}
+
+function validateLead(input: {
+  email: unknown;
+  framework: string;
+  repo: GHRepo;
+  user: GHUser;
+  intentScore: number;
+}): LeadInsert | null {
+  if (!isValidEmail(input.email)) return null;
+  if (!isValidRepoName(input.repo.full_name)) return null;
+
+  const stars = Number(input.repo.stargazers_count);
+  if (!Number.isInteger(stars) || stars < 0) return null;
+
+  return {
+    email: input.email,
+    source: 'github-signal',
+    intent: 'high',
+    intent_score: Math.max(0, Math.min(100, Math.trunc(input.intentScore))),
+    framework: input.framework.slice(0, 50),
+    github_repo: input.repo.full_name,
+    github_stars: stars,
+    company: truncate(input.user.company, 255),
+    messages: [{
+      role: 'system',
+      content: `Found via GitHub: ${input.repo.html_url} (${stars}★) — uses ${input.framework}`.slice(0, 1000),
+    }],
+    last_seen_at: new Date().toISOString(),
+  };
+}
 
 async function searchGitHub(query: string, token?: string): Promise<GHRepo[]> {
   const headers: Record<string, string> = {
@@ -51,16 +110,14 @@ async function searchGitHub(query: string, token?: string): Promise<GHRepo[]> {
 async function getGitHubUser(login: string, token?: string): Promise<GHUser | null> {
   const headers: Record<string, string> = { accept: 'application/vnd.github+json' };
   if (token) headers.authorization = `Bearer ${token}`;
-  const res = await fetch(`https://api.github.com/users/${login}`, { headers });
+  const res = await fetch(`https://api.github.com/users/${encodeURIComponent(login)}`, { headers });
   if (!res.ok) return null;
   return res.json() as Promise<GHUser>;
 }
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'github-leads');
+  if (!auth.ok) return auth.response;
 
   const token = process.env.GITHUB_TOKEN;
   const supabase = getSupabaseAdmin();
@@ -76,49 +133,38 @@ export async function GET(request: Request) {
 
       for (const repo of repos) {
         found++;
-        // Only recently active repos
         if (repo.updated_at < cutoffDate) continue;
-        // Skip low-signal repos — enterprise leads only
         if (repo.stargazers_count < 20) continue;
 
         const ownerLogin = repo.owner?.login;
         if (!ownerLogin) continue;
 
-        // Fetch public user profile for email
         const user = await getGitHubUser(ownerLogin, token);
-        const email = user?.email;
-        if (!email || !email.includes('@')) continue;
+        if (!user) continue;
 
-        const intentScore = Math.min(
-          40 + Math.floor(repo.stargazers_count / 10),
-          95,
-        );
-
-        const { error: insertErr } = await (supabase as any).from('leads').insert({
-          email,
-          source: 'github-signal',
-          intent: 'high',
-          intent_score: intentScore,
+        const intentScore = Math.min(40 + Math.floor(repo.stargazers_count / 10), 95);
+        const validated = validateLead({
+          email: user.email,
           framework: fw.name,
-          github_repo: repo.full_name,
-          github_stars: repo.stargazers_count,
-          company: user?.company ?? null,
-          messages: [{
-            role: 'system',
-            content: `Found via GitHub: ${repo.html_url} (${repo.stargazers_count}★) — uses ${fw.name}`,
-          }],
-          last_seen_at: new Date().toISOString(),
+          repo,
+          user,
+          intentScore,
         });
+        if (!validated) continue;
+
+        const { error: insertErr } = await supabase.from('leads').insert(validated as never);
         if (!insertErr) saved++;
-        else if ((insertErr as any).code !== '23505') errors.push(insertErr.message);
+        else if (insertErr.code !== '23505') errors.push(insertErr.message);
       }
 
-      // Respect GitHub rate limit
       await new Promise(r => setTimeout(r, 1200));
     } catch {
-      // continue to next framework
+      // Continue to next framework without leaking provider details.
     }
   }
 
-  return NextResponse.json({ ok: true, frameworks_searched: FRAMEWORKS.length, repos_found: found, leads_saved: saved, errors: errors.slice(0, 3) });
+  return NextResponse.json(
+    { ok: true, frameworks_searched: FRAMEWORKS.length, repos_found: found, leads_saved: saved, errors: errors.slice(0, 3) },
+    { headers: auth.headers },
+  );
 }

--- a/app/api/cron/github-leads/route.ts
+++ b/app/api/cron/github-leads/route.ts
@@ -120,7 +120,7 @@ export async function GET(request: Request) {
   if (!auth.ok) return auth.response;
 
   const token = process.env.GITHUB_TOKEN;
-  const supabase = getSupabaseAdmin();
+  const supabase = getSupabaseAdmin() as any;
   const cutoffDate = new Date(Date.now() - 30 * 86_400_000).toISOString();
 
   let found = 0;
@@ -152,9 +152,9 @@ export async function GET(request: Request) {
         });
         if (!validated) continue;
 
-        const { error: insertErr } = await supabase.from('leads').insert(validated as never);
+        const { error: insertErr } = await supabase.from('leads').insert(validated);
         if (!insertErr) saved++;
-        else if (insertErr.code !== '23505') errors.push(insertErr.message);
+        else if (insertErr.code !== '23505') errors.push(String(insertErr.message ?? 'insert failed'));
       }
 
       await new Promise(r => setTimeout(r, 1200));

--- a/app/api/cron/lead-followup/route.ts
+++ b/app/api/cron/lead-followup/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { sendGitHubLeadFollowup } from '../../../../lib/email/sales';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,17 +14,14 @@ const FOLLOWUP_AFTER_DAYS = 3;
 const FOLLOWUP_WINDOW_DAYS = 10;
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'lead-followup');
+  if (!auth.ok) return auth.response;
 
   const supabase = getSupabaseAdmin();
   const now = new Date();
   const windowStart = new Date(now.getTime() - FOLLOWUP_WINDOW_DAYS * 86_400_000).toISOString();
   const windowEnd = new Date(now.getTime() - FOLLOWUP_AFTER_DAYS * 86_400_000).toISOString();
 
-  // Leads that were outreached 3-10 days ago, not unsubscribed, real emails only
   const { data: leads, error } = await (supabase as any)
     .from('leads')
     .select('id, email, framework, github_repo, messages')
@@ -37,7 +35,7 @@ export async function GET(request: Request) {
     .limit(BATCH_SIZE);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'query failed' }, { status: 500, headers: auth.headers });
   }
 
   let sent = 0;
@@ -45,9 +43,8 @@ export async function GET(request: Request) {
   const errors: string[] = [];
 
   for (const lead of leads ?? []) {
-    const messages: Array<{ role: string }> = lead.messages ?? [];
+    const messages: Array<{ role: string }> = Array.isArray(lead.messages) ? lead.messages : [];
 
-    // Skip if follow-up already sent
     if (messages.some((m) => m.role === 'followup')) {
       skipped++;
       continue;
@@ -71,9 +68,9 @@ export async function GET(request: Request) {
         .eq('id', lead.id);
 
       if (!updateErr) sent++;
-      else errors.push(updateErr.message);
-    } catch (e) {
-      errors.push(e instanceof Error ? e.message : String(e));
+      else errors.push('update failed');
+    } catch {
+      errors.push('send failed');
     }
   }
 
@@ -83,5 +80,5 @@ export async function GET(request: Request) {
     followups_sent: sent,
     skipped,
     errors: errors.slice(0, 3),
-  });
+  }, { headers: auth.headers });
 }

--- a/app/api/cron/lead-outreach/route.ts
+++ b/app/api/cron/lead-outreach/route.ts
@@ -5,16 +5,15 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { sendGitHubLeadOutreach } from '../../../../lib/email/sales';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
 const BATCH_SIZE = 20;
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'lead-outreach');
+  if (!auth.ok) return auth.response;
 
   const supabase = getSupabaseAdmin();
 
@@ -28,7 +27,7 @@ export async function GET(request: Request) {
     .limit(BATCH_SIZE);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'query failed' }, { status: 500, headers: auth.headers });
   }
 
   let sent = 0;
@@ -49,9 +48,9 @@ export async function GET(request: Request) {
         .eq('id', lead.id);
 
       if (!updateErr) sent++;
-      else errors.push(updateErr.message);
-    } catch (e) {
-      errors.push(e instanceof Error ? e.message : String(e));
+      else errors.push('update failed');
+    } catch {
+      errors.push('send failed');
     }
   }
 
@@ -60,5 +59,5 @@ export async function GET(request: Request) {
     leads_found: (leads ?? []).length,
     emails_sent: sent,
     errors: errors.slice(0, 3),
-  });
+  }, { headers: auth.headers });
 }

--- a/app/api/cron/marketing-agent/route.ts
+++ b/app/api/cron/marketing-agent/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import { MARKETING_TOOL_DEFINITIONS, executeTool } from '../../../../lib/marketing/mcp-tools';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -62,8 +63,7 @@ Never call more than one tool in a single step.`,
   });
 
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Anthropic API ${res.status}: ${body.slice(0, 200)}`);
+    throw new Error(`Anthropic API ${res.status}`);
   }
   return res.json() as Promise<ClaudeResponse>;
 }
@@ -84,19 +84,16 @@ async function logAgentRun(
       error: error ?? null,
     });
   } catch {
-    // Table may not exist yet — log to console only
     console.log('[marketing-agent] run logged to console (table not found)', { summary, actions, status });
   }
 }
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'marketing-agent');
+  if (!auth.ok) return auth.response;
 
   if (!process.env.ANTHROPIC_API_KEY) {
-    return NextResponse.json({ ok: false, error: 'ANTHROPIC_API_KEY not configured' }, { status: 200 });
+    return NextResponse.json({ ok: false, error: 'ANTHROPIC_API_KEY not configured' }, { status: 200, headers: auth.headers });
   }
 
   const messages: ClaudeMessage[] = [
@@ -156,10 +153,9 @@ export async function GET(request: Request) {
       actions: actionsLog,
       summary: finalSummary,
       run_at: new Date().toISOString(),
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Unknown error';
-    await logAgentRun('Agent run failed', actionsLog, 'error', msg);
-    return NextResponse.json({ ok: false, error: msg, actions: actionsLog }, { status: 200 });
+    }, { headers: auth.headers });
+  } catch {
+    await logAgentRun('Agent run failed', actionsLog, 'error', 'marketing_agent_failed');
+    return NextResponse.json({ ok: false, error: 'marketing_agent_failed', actions: actionsLog }, { status: 200, headers: auth.headers });
   }
 }

--- a/app/api/cron/smart-drip/route.ts
+++ b/app/api/cron/smart-drip/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { getMilestones, hasSent, recordSend } from '../../../../lib/marketing/milestones';
 import { personalizeEmail } from '../../../../lib/marketing/ai-email';
 import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 import {
   sendBehavioralNoAgent,
   sendBehavioralEnableBlock,
@@ -17,10 +18,8 @@ function daysBetween(a: Date, b: Date) {
 }
 
 export async function GET(request: Request) {
-  const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret && request.headers.get('authorization') !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'smart-drip');
+  if (!auth.ok) return auth.response;
 
   const admin = getSupabaseAdmin();
   const now = new Date();
@@ -34,7 +33,7 @@ export async function GET(request: Request) {
 
   if (error) {
     logApiError('api/cron/smart-drip', error, { stage: 'load-trials' });
-    return NextResponse.json({ error: internalErrorMessage() }, { status: 500 });
+    return NextResponse.json({ error: internalErrorMessage() }, { status: 500, headers: auth.headers });
   }
 
   const results: string[] = [];
@@ -111,5 +110,5 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.json({ ok: true, processed: trials?.length ?? 0, sent: results });
+  return NextResponse.json({ ok: true, processed: trials?.length ?? 0, sent: results }, { headers: auth.headers });
 }

--- a/app/api/cron/social-listen/route.ts
+++ b/app/api/cron/social-listen/route.ts
@@ -6,6 +6,7 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { sendFounderAlertFirstBlock } from '../../../../lib/email/sales';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,7 +60,7 @@ function scorePost(title: string, body: string): { score: number; matched: strin
 }
 
 async function fetchReddit(subreddit: string): Promise<RedditPost[]> {
-  const url = `https://www.reddit.com/r/${subreddit}/new.json?limit=25&t=day`;
+  const url = `https://www.reddit.com/r/${encodeURIComponent(subreddit)}/new.json?limit=25&t=day`;
   const res = await fetch(url, {
     headers: { 'User-Agent': 'DSGGrowthBot/1.0' },
   });
@@ -84,10 +85,8 @@ async function fetchHN(): Promise<HNItem[]> {
 }
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'social-listen');
+  if (!auth.ok) return auth.response;
 
   const supabase = getSupabaseAdmin();
   const alerts: string[] = [];
@@ -101,7 +100,8 @@ export async function GET(request: Request) {
         const { score, matched } = scorePost(post.title, post.selftext);
         if (score < 30) continue;
 
-        const fakeEmail = `reddit_${post.author}@social-lead.dsg.internal`;
+        const safeAuthor = String(post.author || 'unknown').replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 80);
+        const fakeEmail = `reddit_${safeAuthor}@social-lead.dsg.internal`;
 
         const { error: redditErr } = await (supabase as any).from('leads').insert({
           email: fakeEmail,
@@ -109,17 +109,17 @@ export async function GET(request: Request) {
           intent: score >= 60 ? 'high' : 'browse',
           intent_score: score,
           framework: 'reddit',
-          company: `r/${sub}`,
+          company: `r/${sub}`.slice(0, 255),
           messages: [{
             role: 'system',
-            content: `Reddit r/${sub}: "${post.title}" — score ${score} — matched: ${matched.join(', ')} — ${post.url}`,
+            content: `Reddit r/${sub}: "${post.title}" — score ${score} — matched: ${matched.join(', ')} — ${post.url}`.slice(0, 1000),
           }],
           last_seen_at: new Date().toISOString(),
         });
         if (!redditErr || (redditErr as any).code === '23505') saved++;
 
         if (score >= 60) {
-          alerts.push(`[Reddit r/${sub}] "${post.title}" score=${score}`);
+          alerts.push(`[Reddit r/${sub}] "${post.title}" score=${score}`.slice(0, 300));
         }
       }
       await new Promise(r => setTimeout(r, 500));
@@ -133,7 +133,8 @@ export async function GET(request: Request) {
       const { score, matched } = scorePost(item.title, item.story_text ?? '');
       if (score < 30) continue;
 
-      const fakeEmail = `hn_${item.author}@social-lead.dsg.internal`;
+      const safeAuthor = String(item.author || 'unknown').replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 80);
+      const fakeEmail = `hn_${safeAuthor}@social-lead.dsg.internal`;
       const { error: hnErr } = await (supabase as any).from('leads').insert({
         email: fakeEmail,
         source: 'hn-signal',
@@ -142,14 +143,14 @@ export async function GET(request: Request) {
         framework: 'hackernews',
         messages: [{
           role: 'system',
-          content: `HN: "${item.title}" — score ${score} — matched: ${matched.join(', ')} — https://news.ycombinator.com/item?id=${item.objectID}`,
+          content: `HN: "${item.title}" — score ${score} — matched: ${matched.join(', ')} — https://news.ycombinator.com/item?id=${item.objectID}`.slice(0, 1000),
         }],
         last_seen_at: new Date().toISOString(),
       });
       if (!hnErr || (hnErr as any).code === '23505') saved++;
 
       if (score >= 60) {
-        alerts.push(`[HN] "${item.title}" score=${score}`);
+        alerts.push(`[HN] "${item.title}" score=${score}`.slice(0, 300));
       }
     }
   } catch { /* skip HN failure */ }
@@ -165,5 +166,5 @@ export async function GET(request: Request) {
     });
   }
 
-  return NextResponse.json({ ok: true, leads_saved: saved, hot_alerts: alerts.length, alerts });
+  return NextResponse.json({ ok: true, leads_saved: saved, hot_alerts: alerts.length, alerts }, { headers: auth.headers });
 }

--- a/app/api/cron/trial-invite/route.ts
+++ b/app/api/cron/trial-invite/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { sendLeadTrialInvite } from '../../../../lib/email/sales';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,15 +13,12 @@ const BATCH_SIZE = 20;
 const INVITE_AFTER_FOLLOWUP_DAYS = 7;
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'trial-invite');
+  if (!auth.ok) return auth.response;
 
   const supabase = getSupabaseAdmin();
   const cutoff = new Date(Date.now() - INVITE_AFTER_FOLLOWUP_DAYS * 86_400_000).toISOString();
 
-  // Leads that: received outreach, not unsubscribed, real emails, outreached 7+ days ago
   const { data: leads, error } = await (supabase as any)
     .from('leads')
     .select('id, email, framework, github_repo, messages')
@@ -33,7 +31,7 @@ export async function GET(request: Request) {
     .limit(BATCH_SIZE);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: 'query failed' }, { status: 500, headers: auth.headers });
   }
 
   let sent = 0;
@@ -41,9 +39,8 @@ export async function GET(request: Request) {
   const errors: string[] = [];
 
   for (const lead of leads ?? []) {
-    const messages: Array<{ role: string }> = lead.messages ?? [];
+    const messages: Array<{ role: string }> = Array.isArray(lead.messages) ? lead.messages : [];
 
-    // Skip if trial invite already sent
     if (messages.some((m) => m.role === 'trial_invite')) {
       skipped++;
       continue;
@@ -67,9 +64,9 @@ export async function GET(request: Request) {
         .eq('id', lead.id);
 
       if (!updateErr) sent++;
-      else errors.push(updateErr.message);
-    } catch (e) {
-      errors.push(e instanceof Error ? e.message : String(e));
+      else errors.push('update failed');
+    } catch {
+      errors.push('send failed');
     }
   }
 
@@ -79,5 +76,5 @@ export async function GET(request: Request) {
     invites_sent: sent,
     skipped,
     errors: errors.slice(0, 3),
-  });
+  }, { headers: auth.headers });
 }

--- a/app/api/cron/weekly-report/route.ts
+++ b/app/api/cron/weekly-report/route.ts
@@ -4,25 +4,23 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { getResend } from '../../../../lib/resend';
+import { requireCronAuth } from '../../../../lib/security/cron-auth';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const auth = requireCronAuth(request, 'weekly-report');
+  if (!auth.ok) return auth.response;
 
   const founderEmail = process.env.FOUNDER_EMAIL;
   if (!founderEmail) {
-    return NextResponse.json({ ok: false, error: 'FOUNDER_EMAIL not set' }, { status: 200 });
+    return NextResponse.json({ ok: false, error: 'FOUNDER_EMAIL not set' }, { status: 200, headers: auth.headers });
   }
 
   const admin = getSupabaseAdmin();
   const weekAgo = new Date(Date.now() - 7 * 86_400_000).toISOString();
   const now = new Date().toISOString();
 
-  // ── Lead pipeline metrics ────────────────────────────────────────────────
   const { data: allLeads } = await (admin as any).from('leads').select('source, intent, outreach_sent, outreach_sent_at, intent_score, created_at, messages');
   const leads = (allLeads ?? []) as Array<{
     source: string; intent: string; outreach_sent: boolean; outreach_sent_at: string | null;
@@ -41,7 +39,6 @@ export async function GET(request: Request) {
     ? Math.round(leads.map(l => l.intent_score || 0).reduce((a, b) => a + b, 0) / leads.length)
     : 0;
 
-  // ── Trial signups ────────────────────────────────────────────────────────
   const { data: signups } = await (admin as any)
     .from('trial_signups')
     .select('status, created_at')
@@ -50,7 +47,6 @@ export async function GET(request: Request) {
   const newSignups = signupRows.length;
   const completedSignups = signupRows.filter(s => s.status === 'completed').length;
 
-  // ── Organizations ────────────────────────────────────────────────────────
   const { count: totalOrgs } = await (admin as any)
     .from('organizations')
     .select('id', { count: 'exact', head: true });
@@ -59,7 +55,6 @@ export async function GET(request: Request) {
     .select('id', { count: 'exact', head: true })
     .gte('created_at', weekAgo);
 
-  // ── Marketing agent runs ─────────────────────────────────────────────────
   let agentRuns: Array<{ run_at: string; summary: string; actions_taken: string[]; status: string }> = [];
   try {
     const { data } = await (admin as any)
@@ -73,7 +68,6 @@ export async function GET(request: Request) {
     // table may not exist yet
   }
 
-  // ── Build email HTML ─────────────────────────────────────────────────────
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
   const dateRange = `${new Date(weekAgo).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} – ${new Date(now).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
 
@@ -88,7 +82,7 @@ export async function GET(request: Request) {
     ? agentRuns.map(r =>
         `<tr>
           <td style="padding:8px;font-size:12px;color:#64748b">${new Date(r.run_at).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}</td>
-          <td style="padding:8px;font-size:12px">${r.summary?.slice(0, 120) ?? '—'}</td>
+          <td style="padding:8px;font-size:12px">${String(r.summary ?? '—').slice(0, 120)}</td>
           <td style="padding:8px;text-align:center"><span style="color:${r.status === 'ok' ? '#10b981' : '#ef4444'}">${r.status === 'ok' ? '✓' : '✗'}</span></td>
         </tr>`
       ).join('')
@@ -162,7 +156,6 @@ export async function GET(request: Request) {
   </div>
 </div>`;
 
-  // ── Send email ───────────────────────────────────────────────────────────
   const resend = getResend();
   let emailed = false;
   if (resend.configured) {
@@ -188,5 +181,5 @@ export async function GET(request: Request) {
       agent_runs_this_week: agentRuns.length,
     },
     emailed_to: emailed ? founderEmail : null,
-  });
+  }, { headers: auth.headers });
 }

--- a/app/api/dsg/v1/gates/evaluate/route.ts
+++ b/app/api/dsg/v1/gates/evaluate/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from 'next/server';
 import { evaluateDeterministicGate } from '../../../../../../lib/dsg/deterministic/gate-engine';
-import type { DeterministicProofRequest } from '../../../../../../lib/dsg/deterministic/types';
+import { validateDeterministicProofRequest } from '../../../../../../lib/dsg/deterministic/request-validation';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../../../lib/security/rate-limit';
+import { readJsonBody } from '../../../../../../lib/security/request-json';
 
 export const dynamic = 'force-dynamic';
-
-function text(value: unknown) {
-  return typeof value === 'string' ? value.trim() : '';
-}
 
 export async function POST(request: Request) {
   const rateLimitResult = await applyRateLimit({
@@ -23,33 +20,23 @@ export async function POST(request: Request) {
     );
   }
 
-  const body = await request.json().catch(() => null) as Partial<DeterministicProofRequest> | null;
-
-  if (!body || !body.context || typeof body.context !== 'object') {
-    return NextResponse.json({ ok: false, error: 'missing_context' }, { status: 400 });
+  const body = await readJsonBody(request, { maxBytes: 16_000 });
+  if (!body.ok) {
+    return NextResponse.json(
+      { ok: false, error: body.error },
+      { status: body.status, headers: rateLimitHeaders },
+    );
   }
 
-  const nonce = text(body.nonce) || text(request.headers.get('x-dsg-nonce'));
-  const idempotencyKey = text(body.idempotencyKey) || text(request.headers.get('idempotency-key'));
-
-  if (!nonce) {
-    return NextResponse.json({ ok: false, error: 'missing_nonce' }, { status: 400 });
+  const validated = validateDeterministicProofRequest(body.value);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { ok: false, error: validated.error, details: validated.details ?? [] },
+      { status: 400, headers: rateLimitHeaders },
+    );
   }
 
-  if (!idempotencyKey) {
-    return NextResponse.json({ ok: false, error: 'missing_idempotency_key' }, { status: 400 });
-  }
-
-  const result = evaluateDeterministicGate({
-    planId: body.planId,
-    policyRef: body.policyRef,
-    policyVersion: body.policyVersion,
-    riskLevel: body.riskLevel,
-    previousProofHash: body.previousProofHash,
-    nonce,
-    idempotencyKey,
-    context: body.context,
-  });
+  const result = evaluateDeterministicGate(validated.value);
 
   return NextResponse.json(
     {

--- a/app/api/try/gate/route.ts
+++ b/app/api/try/gate/route.ts
@@ -1,16 +1,21 @@
-// DSG Gate — public trial gate with full agent feedback on BLOCK
-// Immigration checkpoint: declare → stamp → inspect → rethink if blocked
-//
-// BLOCK response includes session state + guidance so the agent LLM can
-// decide next step without human intervention.
+// DSG Gate — trial gate with agent feedback on BLOCK.
+// Production hardening: Redis-backed sessions, signed stamps, bounded JSON,
+// optional public-trial mode, and explicit production secrets.
 
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { Redis } from '@upstash/redis';
 import { NextResponse } from 'next/server';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
+import { readJsonBody } from '../../../../lib/security/request-json';
+import { verifyBearerSecret } from '../../../../lib/security/secure-token';
 
 export const dynamic = 'force-dynamic';
 
 const RATE_LIMIT = 60;
 const RATE_WINDOW_MS = 60_000;
+const MAX_BODY_BYTES = 16_000;
+const SESSION_KEY_PREFIX = 'try-gate:session:';
+const AUDIT_KEY_PREFIX = 'try-gate:audit:';
 
 type Session = {
   session_id: string;
@@ -21,15 +26,17 @@ type Session = {
   created_at: number;
 };
 
-const sessions = new Map<string, Session>();
+type AuditEntry = {
+  timestamp_ms: number;
+  session_id: string;
+  decision: 'ALLOW' | 'BLOCK';
+  action?: string;
+  reason?: string;
+  stamp: string | null;
+};
 
-// Clean expired sessions every 5 minutes
-setInterval(() => {
-  const now = Date.now();
-  for (const [id, s] of sessions) {
-    if (s.expires_at < now) sessions.delete(id);
-  }
-}, 5 * 60_000);
+const devSessions = new Map<string, Session>();
+let redis: Redis | null = null;
 
 const BLOCKED_PATTERNS = [
   /delete\s+all/i, /drop\s+table/i, /truncate/i,
@@ -39,8 +46,140 @@ const BLOCKED_PATTERNS = [
   /exfiltrate/i, /steal/i,
 ];
 
-function makeStamp(): string {
-  return `DSG-${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
+function isProduction() {
+  return process.env.NODE_ENV === 'production';
+}
+
+function json(error: string, status: number, headers?: HeadersInit) {
+  return NextResponse.json({ error }, { status, headers });
+}
+
+function getRedis(): Redis | null {
+  if (redis) return redis;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  redis = new Redis({ url, token });
+  return redis;
+}
+
+function sessionKey(sessionId: string) {
+  return `${SESSION_KEY_PREFIX}${sessionId}`;
+}
+
+function auditKey(sessionId: string) {
+  return `${AUDIT_KEY_PREFIX}${sessionId}`;
+}
+
+function getStampSecret(): string | null {
+  const secret = process.env.DSG_STAMP_SECRET?.trim();
+  if (secret && secret.length >= 32) return secret;
+  if (!isProduction()) return 'dev-only-dsg-stamp-secret-minimum-32-bytes';
+  return null;
+}
+
+function makeStamp(input: { sessionId: string; action: string; timestamp: number }): string | null {
+  const secret = getStampSecret();
+  if (!secret) return null;
+  const nonce = randomBytes(8).toString('hex');
+  const payload = `${input.sessionId}:${input.action}:${input.timestamp}:${nonce}`;
+  const signature = createHmac('sha256', secret).update(payload).digest('hex').slice(0, 32).toUpperCase();
+  return `DSG-${input.timestamp}-${nonce.toUpperCase()}-${signature}`;
+}
+
+function verifyStamp(stamp: string, input: { sessionId: string; action: string }): boolean {
+  const secret = getStampSecret();
+  if (!secret) return false;
+  const parts = stamp.split('-');
+  if (parts.length !== 4 || parts[0] !== 'DSG') return false;
+  const [, timestamp, nonce, signature] = parts;
+  if (!/^\d+$/.test(timestamp) || !/^[A-F0-9]{16}$/i.test(nonce) || !/^[A-F0-9]{32}$/i.test(signature)) return false;
+  const payload = `${input.sessionId}:${input.action}:${timestamp}:${nonce.toLowerCase()}`;
+  const expected = createHmac('sha256', secret).update(payload).digest('hex').slice(0, 32).toUpperCase();
+  return timingSafeEqual(Buffer.from(signature.toUpperCase()), Buffer.from(expected));
+}
+
+async function getSession(sessionId: string): Promise<Session | null> {
+  const r = getRedis();
+  if (!r) {
+    if (isProduction()) throw new Error('redis_session_store_required');
+    return devSessions.get(sessionId) ?? null;
+  }
+  return await r.get<Session>(sessionKey(sessionId));
+}
+
+async function setSession(sessionId: string, session: Session, ttlSeconds: number) {
+  const r = getRedis();
+  if (!r) {
+    if (isProduction()) throw new Error('redis_session_store_required');
+    devSessions.set(sessionId, session);
+    return;
+  }
+  await r.set(sessionKey(sessionId), session, { ex: ttlSeconds });
+}
+
+async function deleteSession(sessionId: string) {
+  const r = getRedis();
+  if (!r) {
+    if (!isProduction()) devSessions.delete(sessionId);
+    return;
+  }
+  await r.del(sessionKey(sessionId));
+}
+
+async function appendAudit(entry: AuditEntry, ttlSeconds: number) {
+  const r = getRedis();
+  if (!r) return;
+  const key = auditKey(entry.session_id);
+  await r.rpush(key, JSON.stringify(entry));
+  await r.expire(key, ttlSeconds);
+}
+
+function isValidSessionId(value: unknown): value is string {
+  return typeof value === 'string' && value.length >= 3 && value.length <= 128 && /^[A-Za-z0-9_.:-]+$/.test(value);
+}
+
+function parseDeclaredActions(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 50) return null;
+  const actions = value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => item.slice(0, 200));
+  if (actions.length === 0) return null;
+  return Array.from(new Set(actions));
+}
+
+function parseTtlMinutes(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 30;
+  return Math.max(1, Math.min(Math.trunc(value), 120));
+}
+
+function parseAction(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const action = value.trim().slice(0, 500);
+  return action ? action : null;
+}
+
+function authorizeTryGate(request: Request): NextResponse | null {
+  if (process.env.DSG_TRY_GATE_PUBLIC_TRIAL === 'true') return null;
+
+  const configured = Boolean(process.env.DSG_TRY_GATE_API_KEY || process.env.DSG_TRY_GATE_API_KEY_SHA256);
+  if (!configured) {
+    if (isProduction()) {
+      return json('try_gate_auth_required', 503, { 'Cache-Control': 'no-store' });
+    }
+    return null;
+  }
+
+  if (!verifyBearerSecret(request, {
+    expected: process.env.DSG_TRY_GATE_API_KEY,
+    expectedSha256: process.env.DSG_TRY_GATE_API_KEY_SHA256,
+  })) {
+    return json('Unauthorized', 401, { 'Cache-Control': 'no-store' });
+  }
+
+  return null;
 }
 
 function matchesDeclared(action: string, declared: string[]): boolean {
@@ -58,7 +197,6 @@ function hasBlockedPattern(action: string): string | null {
   return null;
 }
 
-// Build rich guidance for the agent LLM to rethink after BLOCK
 function buildBlockGuidance(reason: string, session: Session, action: string): object {
   const ttlRemainingMs = Math.max(0, session.expires_at - Date.now());
   const ttlRemainingMin = Math.round(ttlRemainingMs / 60_000);
@@ -104,6 +242,9 @@ function buildBlockGuidance(reason: string, session: Session, action: string): o
 }
 
 export async function POST(request: Request) {
+  const authResponse = authorizeTryGate(request);
+  if (authResponse) return authResponse;
+
   const rateLimit = await applyRateLimit({
     key: getRateLimitKey(request, 'try-gate'),
     limit: RATE_LIMIT,
@@ -114,39 +255,40 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'rate_limit_exceeded', decision: 'BLOCK' }, { status: 429, headers });
   }
 
-  const body = await request.json().catch(() => null) as Record<string, unknown> | null;
-  if (!body) return NextResponse.json({ error: 'invalid_body' }, { status: 400, headers });
+  const parsed = await readJsonBody<Record<string, unknown>>(request, { maxBytes: MAX_BODY_BYTES });
+  if (!parsed.ok) return json(parsed.error, parsed.status, headers);
+  const body = parsed.value;
 
-  const sessionId = typeof body.session_id === 'string' ? body.session_id : null;
+  const sessionId = body.session_id;
+  if (!isValidSessionId(sessionId)) return json('session_id invalid or required', 400, headers);
 
-  // ── DECLARE: register session with declared actions ──────────────────────────
   if (Array.isArray(body.declared_actions)) {
-    if (!sessionId) return NextResponse.json({ error: 'session_id required' }, { status: 400, headers });
+    const declaredActions = parseDeclaredActions(body.declared_actions);
+    if (!declaredActions) return json('declared_actions must be a non-empty string array with max 50 items', 400, headers);
 
-    const ttlMin = typeof body.ttl_minutes === 'number' ? Math.min(body.ttl_minutes, 120) : 30;
-    const declaredActions = (body.declared_actions as unknown[])
-      .filter((a): a is string => typeof a === 'string')
-      .map(a => a.slice(0, 200));
+    const ttlMin = parseTtlMinutes(body.ttl_minutes);
+    const ttlSeconds = ttlMin * 60;
+    const timestamp = Date.now();
+    const stamp = makeStamp({ sessionId, action: 'declare', timestamp });
+    if (!stamp) return json('stamp_secret_required', 503, headers);
 
-    if (declaredActions.length === 0) {
-      return NextResponse.json({ error: 'declared_actions must be a non-empty string array' }, { status: 400, headers });
-    }
-
-    const stamp = makeStamp();
-    const expiresAt = Date.now() + ttlMin * 60_000;
-    sessions.set(sessionId, {
+    const expiresAt = Date.now() + ttlSeconds * 1000;
+    const session: Session = {
       session_id: sessionId,
       declared_actions: declaredActions,
       expires_at: expiresAt,
       stamps: [stamp],
       blocked_count: 0,
       created_at: Date.now(),
-    });
+    };
+    await setSession(sessionId, session, ttlSeconds);
+    await appendAudit({ timestamp_ms: timestamp, session_id: sessionId, decision: 'ALLOW', action: 'declare', stamp }, ttlSeconds);
 
     return NextResponse.json({
       ok: true,
       decision: 'ALLOW',
       declaration_stamp: stamp,
+      stamp_verifiable: verifyStamp(stamp, { sessionId, action: 'declare' }),
       session_id: sessionId,
       declared_actions: declaredActions,
       ttl_minutes: ttlMin,
@@ -158,12 +300,9 @@ export async function POST(request: Request) {
     }, { headers });
   }
 
-  // ── INSPECT: check a single action ──────────────────────────────────────────
-  if (typeof body.action === 'string') {
-    if (!sessionId) return NextResponse.json({ error: 'session_id required' }, { status: 400, headers });
-
-    const action = body.action.slice(0, 500);
-    const session = sessions.get(sessionId);
+  const action = parseAction(body.action);
+  if (action) {
+    const session = await getSession(sessionId);
 
     if (!session) {
       return NextResponse.json({
@@ -177,7 +316,7 @@ export async function POST(request: Request) {
     }
 
     if (Date.now() > session.expires_at) {
-      sessions.delete(sessionId);
+      await deleteSession(sessionId);
       return NextResponse.json({
         decision: 'BLOCK',
         reason: 'session_expired: TTL exceeded',
@@ -188,36 +327,34 @@ export async function POST(request: Request) {
       }, { status: 200, headers });
     }
 
-    // Always-block patterns — regardless of declaration
+    const ttlSeconds = Math.max(1, Math.ceil((session.expires_at - Date.now()) / 1000));
     const patternBlock = hasBlockedPattern(action);
     if (patternBlock) {
       session.blocked_count++;
-      return NextResponse.json(
-        buildBlockGuidance(patternBlock, session, action),
-        { status: 200, headers }
-      );
+      await setSession(sessionId, session, ttlSeconds);
+      await appendAudit({ timestamp_ms: Date.now(), session_id: sessionId, decision: 'BLOCK', action, reason: patternBlock, stamp: null }, ttlSeconds);
+      return NextResponse.json(buildBlockGuidance(patternBlock, session, action), { status: 200, headers });
     }
 
-    // Check declared actions
     if (!matchesDeclared(action, session.declared_actions)) {
       session.blocked_count++;
-      return NextResponse.json(
-        buildBlockGuidance(
-          `action_not_declared: "${action}" was not in your declared_actions list`,
-          session,
-          action
-        ),
-        { status: 200, headers }
-      );
+      const reason = `action_not_declared: "${action}" was not in your declared_actions list`;
+      await setSession(sessionId, session, ttlSeconds);
+      await appendAudit({ timestamp_ms: Date.now(), session_id: sessionId, decision: 'BLOCK', action, reason, stamp: null }, ttlSeconds);
+      return NextResponse.json(buildBlockGuidance(reason, session, action), { status: 200, headers });
     }
 
-    // ALLOW — stamp and record
-    const stamp = makeStamp();
+    const timestamp = Date.now();
+    const stamp = makeStamp({ sessionId, action, timestamp });
+    if (!stamp) return json('stamp_secret_required', 503, headers);
     session.stamps.push(stamp);
+    await setSession(sessionId, session, ttlSeconds);
+    await appendAudit({ timestamp_ms: timestamp, session_id: sessionId, decision: 'ALLOW', action, stamp }, ttlSeconds);
 
     return NextResponse.json({
       decision: 'ALLOW',
       stamp,
+      stamp_verifiable: verifyStamp(stamp, { sessionId, action }),
       action,
       session_id: sessionId,
       session_state: {
@@ -226,13 +363,12 @@ export async function POST(request: Request) {
         ttl_remaining_ms: Math.max(0, session.expires_at - Date.now()),
         declared_actions: session.declared_actions,
       },
-      timestamp_ms: Date.now(),
+      timestamp_ms: timestamp,
     }, { headers });
   }
 
-  // ── STATUS: check session state ──────────────────────────────────────────────
-  if (body.query === 'status' && sessionId) {
-    const session = sessions.get(sessionId);
+  if (body.query === 'status') {
+    const session = await getSession(sessionId);
     if (!session || Date.now() > session.expires_at) {
       return NextResponse.json({ session_id: sessionId, active: false }, { headers });
     }
@@ -247,12 +383,16 @@ export async function POST(request: Request) {
     }, { headers });
   }
 
-  return NextResponse.json({ error: 'provide declared_actions (declare), action (inspect), or query: "status"' }, { status: 400, headers });
+  return json('provide declared_actions (declare), action (inspect), or query: "status"', 400, headers);
 }
 
 export async function DELETE(request: Request) {
-  const body = await request.json().catch(() => null) as Record<string, unknown> | null;
-  const sessionId = typeof body?.session_id === 'string' ? body.session_id : null;
-  if (sessionId) sessions.delete(sessionId);
-  return NextResponse.json({ ok: true, cleared: Boolean(sessionId) });
+  const authResponse = authorizeTryGate(request);
+  if (authResponse) return authResponse;
+
+  const parsed = await readJsonBody<Record<string, unknown>>(request, { maxBytes: 4_000 });
+  if (!parsed.ok) return json(parsed.error, parsed.status);
+  const sessionId = parsed.value.session_id;
+  if (isValidSessionId(sessionId)) await deleteSession(sessionId);
+  return NextResponse.json({ ok: true, cleared: isValidSessionId(sessionId) });
 }

--- a/docs/PROOFGATE_PRODUCTION_HARDENING.md
+++ b/docs/PROOFGATE_PRODUCTION_HARDENING.md
@@ -1,0 +1,44 @@
+# ProofGate Production Hardening
+
+This branch hardens the public trial gate and related runtime surfaces against the issues found in the production-readiness review.
+
+## What changed
+
+- `/api/try/gate` no longer relies on process-local session state in production. It uses Upstash Redis when deployed with Redis environment variables.
+- Trial gate stamps are HMAC-signed and verifiable instead of being generated from `Math.random()`.
+- The trial gate requires an explicit production auth boundary unless public-trial mode is intentionally enabled for demo environments.
+- Trial gate request bodies are parsed with a bounded JSON reader.
+- DSG deterministic gate requests are runtime-validated instead of trusted through TypeScript assertions.
+- Rate limiting fails closed in production when Redis is unavailable.
+- Cron endpoints migrated to a fail-closed auth helper. Per-job secrets are supported and preferred over a shared cron secret.
+- Supabase admin requests now use a 5-second fetch timeout and an application header.
+- CORS now logs blocked origins and enforces strict production behavior.
+
+## Required production configuration
+
+Set these in the deployment secret manager before promoting this branch:
+
+- Upstash Redis URL and token for rate limiting and trial-gate session storage.
+- A 32+ byte DSG stamp secret for signed ProofGate stamps.
+- A trial gate API key or SHA-256 hash unless the deployment is explicitly public-demo only.
+- Cron bearer secrets, preferably one per cron job.
+- Strict CORS allowed origins.
+
+## Claim boundary
+
+After this patch, the branch is a production-hardening candidate, not an automatic production certification.
+
+Do not claim SOC 2, WORM-certified audit storage, third-party audit completion, GDPR residency coverage, or full cryptographic certification unless those controls are verified outside this code patch.
+
+## Minimum verification before merge
+
+Run:
+
+```bash
+npm run typecheck
+npm test
+npm run build
+npm run go:no-go
+```
+
+If production Redis or Supabase credentials are not available in CI, run the required live DB tests in staging before release.

--- a/lib/dsg/deterministic/request-validation.ts
+++ b/lib/dsg/deterministic/request-validation.ts
@@ -6,27 +6,36 @@ const SAFE_ID_RE = /^[A-Za-z0-9_.:-]+$/;
 const SAFE_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
 const HEX_HASH_RE = /^[a-fA-F0-9]{32,128}$/;
 
-export type ValidationResult =
-  | { ok: true; value: DeterministicProofRequest }
-  | { ok: false; error: string; details?: Array<{ field: string; message: string }> };
+type Issue = { field: string; message: string };
 
-function issue(field: string, message: string) {
+export type ValidationResult = {
+  ok: boolean;
+  value: DeterministicProofRequest | null;
+  error: string | null;
+  details: Issue[];
+};
+
+function issue(field: string, message: string): Issue {
   return { field, message };
 }
 
-function optionalSafeString(value: unknown, field: string, max = 255): { ok: true; value?: string } | { ok: false; detail: { field: string; message: string } } {
-  if (value === undefined || value === null || value === '') return { ok: true };
-  if (typeof value !== 'string') return { ok: false, detail: issue(field, 'must be a string') };
+function fail(details: Issue[]): ValidationResult {
+  return { ok: false, value: null, error: 'validation_failed', details };
+}
+
+function optionalSafeString(value: unknown, field: string, max = 255): { value?: string; detail?: Issue } {
+  if (value === undefined || value === null || value === '') return {};
+  if (typeof value !== 'string') return { detail: issue(field, 'must be a string') };
   const trimmed = value.trim();
-  if (trimmed.length > max) return { ok: false, detail: issue(field, `must be <= ${max} chars`) };
-  if (!SAFE_ID_RE.test(trimmed)) return { ok: false, detail: issue(field, 'contains unsupported characters') };
-  return { ok: true, value: trimmed };
+  if (trimmed.length > max) return { detail: issue(field, `must be <= ${max} chars`) };
+  if (!SAFE_ID_RE.test(trimmed)) return { detail: issue(field, 'contains unsupported characters') };
+  return { value: trimmed };
 }
 
 export function validateDeterministicProofRequest(raw: unknown): ValidationResult {
-  const details: Array<{ field: string; message: string }> = [];
+  const details: Issue[] = [];
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return { ok: false, error: 'validation_failed', details: [issue('body', 'must be an object')] };
+    return fail([issue('body', 'must be an object')]);
   }
 
   const body = raw as Record<string, unknown>;
@@ -56,7 +65,7 @@ export function validateDeterministicProofRequest(raw: unknown): ValidationResul
   const policyRef = optionalSafeString(body.policyRef, 'policyRef', 255);
   const policyVersion = optionalSafeString(body.policyVersion, 'policyVersion', 50);
   for (const parsed of [planId, policyRef, policyVersion]) {
-    if (!parsed.ok) details.push(parsed.detail);
+    if (parsed.detail) details.push(parsed.detail);
   }
 
   let riskLevel: DeterministicRiskLevel | undefined;
@@ -77,14 +86,16 @@ export function validateDeterministicProofRequest(raw: unknown): ValidationResul
     }
   }
 
-  if (details.length > 0) return { ok: false, error: 'validation_failed', details };
+  if (details.length > 0) return fail(details);
 
   return {
     ok: true,
+    error: null,
+    details: [],
     value: {
-      planId: planId.ok ? planId.value : undefined,
-      policyRef: policyRef.ok ? policyRef.value : undefined,
-      policyVersion: policyVersion.ok ? policyVersion.value : undefined,
+      planId: planId.value,
+      policyRef: policyRef.value,
+      policyVersion: policyVersion.value,
       riskLevel,
       previousProofHash,
       nonce,

--- a/lib/dsg/deterministic/request-validation.ts
+++ b/lib/dsg/deterministic/request-validation.ts
@@ -1,0 +1,95 @@
+import type { DeterministicProofRequest, DeterministicRiskLevel } from './types';
+import { jsonSizeBytes, maxObjectDepth } from '../../security/request-json';
+
+const RISK_LEVELS = new Set<DeterministicRiskLevel>(['low', 'medium', 'high', 'critical']);
+const SAFE_ID_RE = /^[A-Za-z0-9_.:-]+$/;
+const SAFE_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
+const HEX_HASH_RE = /^[a-fA-F0-9]{32,128}$/;
+
+export type ValidationResult =
+  | { ok: true; value: DeterministicProofRequest }
+  | { ok: false; error: string; details?: Array<{ field: string; message: string }> };
+
+function issue(field: string, message: string) {
+  return { field, message };
+}
+
+function optionalSafeString(value: unknown, field: string, max = 255): { ok: true; value?: string } | { ok: false; detail: { field: string; message: string } } {
+  if (value === undefined || value === null || value === '') return { ok: true };
+  if (typeof value !== 'string') return { ok: false, detail: issue(field, 'must be a string') };
+  const trimmed = value.trim();
+  if (trimmed.length > max) return { ok: false, detail: issue(field, `must be <= ${max} chars`) };
+  if (!SAFE_ID_RE.test(trimmed)) return { ok: false, detail: issue(field, 'contains unsupported characters') };
+  return { ok: true, value: trimmed };
+}
+
+export function validateDeterministicProofRequest(raw: unknown): ValidationResult {
+  const details: Array<{ field: string; message: string }> = [];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'validation_failed', details: [issue('body', 'must be an object')] };
+  }
+
+  const body = raw as Record<string, unknown>;
+  const context = body.context;
+  if (!context || typeof context !== 'object' || Array.isArray(context)) {
+    details.push(issue('context', 'must be an object'));
+  } else {
+    const keys = Object.keys(context as Record<string, unknown>);
+    if (keys.length > 50) details.push(issue('context', 'max 50 keys'));
+    if (jsonSizeBytes(context) > 10_000) details.push(issue('context', 'max 10KB'));
+    if (!maxObjectDepth(context, 8)) details.push(issue('context', 'max depth exceeded'));
+  }
+
+  const nonce = typeof body.nonce === 'string' ? body.nonce.trim() : '';
+  if (!nonce) details.push(issue('nonce', 'required'));
+  else if (nonce.length < 16 || nonce.length > 96 || !SAFE_TOKEN_RE.test(nonce)) {
+    details.push(issue('nonce', 'must be 16-96 chars using A-Z, a-z, 0-9, _, -'));
+  }
+
+  const idempotencyKey = typeof body.idempotencyKey === 'string' ? body.idempotencyKey.trim() : '';
+  if (!idempotencyKey) details.push(issue('idempotencyKey', 'required'));
+  else if (idempotencyKey.length < 16 || idempotencyKey.length > 128 || !SAFE_TOKEN_RE.test(idempotencyKey)) {
+    details.push(issue('idempotencyKey', 'must be 16-128 chars using A-Z, a-z, 0-9, _, -'));
+  }
+
+  const planId = optionalSafeString(body.planId, 'planId', 128);
+  const policyRef = optionalSafeString(body.policyRef, 'policyRef', 255);
+  const policyVersion = optionalSafeString(body.policyVersion, 'policyVersion', 50);
+  for (const parsed of [planId, policyRef, policyVersion]) {
+    if (!parsed.ok) details.push(parsed.detail);
+  }
+
+  let riskLevel: DeterministicRiskLevel | undefined;
+  if (body.riskLevel !== undefined && body.riskLevel !== null && body.riskLevel !== '') {
+    if (typeof body.riskLevel !== 'string' || !RISK_LEVELS.has(body.riskLevel as DeterministicRiskLevel)) {
+      details.push(issue('riskLevel', 'must be low, medium, high, or critical'));
+    } else {
+      riskLevel = body.riskLevel as DeterministicRiskLevel;
+    }
+  }
+
+  let previousProofHash: string | undefined;
+  if (body.previousProofHash !== undefined && body.previousProofHash !== null && body.previousProofHash !== '') {
+    if (typeof body.previousProofHash !== 'string' || !HEX_HASH_RE.test(body.previousProofHash)) {
+      details.push(issue('previousProofHash', 'must be a hex hash'));
+    } else {
+      previousProofHash = body.previousProofHash;
+    }
+  }
+
+  if (details.length > 0) return { ok: false, error: 'validation_failed', details };
+
+  return {
+    ok: true,
+    value: {
+      planId: planId.ok ? planId.value : undefined,
+      policyRef: policyRef.ok ? policyRef.value : undefined,
+      policyVersion: policyVersion.ok ? policyVersion.value : undefined,
+      riskLevel,
+      previousProofHash,
+      nonce,
+      idempotencyKey,
+      context: context as Record<string, unknown>,
+    },
+  };
+}

--- a/lib/security/cors.ts
+++ b/lib/security/cors.ts
@@ -21,6 +21,17 @@ function unique(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.filter(Boolean) as string[]));
 }
 
+function isStrictCors() {
+  return process.env.NODE_ENV === 'production' || process.env.DSG_CORS_STRICT === 'true';
+}
+
+function logBlockedOrigin(origin: string, request: Request) {
+  console.warn('[CORS] Blocked origin', {
+    origin,
+    path: new URL(request.url).pathname,
+  });
+}
+
 export function getAllowedCorsOrigins(): string[] {
   const explicit = String(process.env.DSG_ALLOWED_ORIGINS || '')
     .split(',')
@@ -35,7 +46,13 @@ export function getAllowedCorsOrigins(): string[] {
     ? parseOrigin(`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`)
     : null;
 
-  return unique([...explicit, appOrigin, vercelOrigin]);
+  const origins = unique([...explicit, appOrigin, vercelOrigin]);
+
+  if (isStrictCors() && origins.length === 0) {
+    console.warn('[CORS] No allowed origins configured in strict mode');
+  }
+
+  return origins;
 }
 
 export function resolveAllowedOrigin(request: Request): string | null {
@@ -43,7 +60,9 @@ export function resolveAllowedOrigin(request: Request): string | null {
   if (!requestOrigin) return null;
 
   const allowed = getAllowedCorsOrigins();
-  return allowed.includes(requestOrigin) ? requestOrigin : null;
+  const allowedOrigin = allowed.find((origin) => origin === requestOrigin) ?? null;
+  if (!allowedOrigin && isStrictCors()) logBlockedOrigin(requestOrigin, request);
+  return allowedOrigin;
 }
 
 export function buildCorsHeaders(

--- a/lib/security/cron-auth.ts
+++ b/lib/security/cron-auth.ts
@@ -1,9 +1,15 @@
 import { NextResponse } from 'next/server';
 import { verifyBearerSecret } from './secure-token';
 
-export type CronAuthResult =
-  | { ok: true; headers: HeadersInit }
-  | { ok: false; response: NextResponse };
+export type CronAuthResult = {
+  ok: boolean;
+  headers: HeadersInit;
+  response: NextResponse;
+};
+
+function noOpResponse() {
+  return new NextResponse(null, { status: 204, headers: { 'Cache-Control': 'no-store' } });
+}
 
 export function requireCronAuth(request: Request, jobName: string): CronAuthResult {
   const normalized = jobName.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
@@ -11,15 +17,17 @@ export function requireCronAuth(request: Request, jobName: string): CronAuthResu
   const jobSecretHash = process.env[`CRON_${normalized}_SECRET_SHA256`];
   const sharedSecret = process.env.CRON_SECRET;
   const sharedSecretHash = process.env.CRON_SECRET_SHA256;
+  const headers = { 'Cache-Control': 'no-store' };
 
   const hasAnySecret = Boolean(jobSecret || jobSecretHash || sharedSecret || sharedSecretHash);
   if (!hasAnySecret) {
     const status = process.env.NODE_ENV === 'production' ? 503 : 401;
     return {
       ok: false,
+      headers,
       response: NextResponse.json(
         { error: 'cron_secret_required' },
-        { status, headers: { 'Cache-Control': 'no-store' } },
+        { status, headers },
       ),
     };
   }
@@ -31,12 +39,13 @@ export function requireCronAuth(request: Request, jobName: string): CronAuthResu
   if (!allowed) {
     return {
       ok: false,
+      headers,
       response: NextResponse.json(
         { error: 'Unauthorized' },
-        { status: 401, headers: { 'Cache-Control': 'no-store' } },
+        { status: 401, headers },
       ),
     };
   }
 
-  return { ok: true, headers: { 'Cache-Control': 'no-store' } };
+  return { ok: true, headers, response: noOpResponse() };
 }

--- a/lib/security/cron-auth.ts
+++ b/lib/security/cron-auth.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { verifyBearerSecret } from './secure-token';
+
+export type CronAuthResult =
+  | { ok: true; headers: HeadersInit }
+  | { ok: false; response: NextResponse };
+
+export function requireCronAuth(request: Request, jobName: string): CronAuthResult {
+  const normalized = jobName.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
+  const jobSecret = process.env[`CRON_${normalized}_SECRET`];
+  const jobSecretHash = process.env[`CRON_${normalized}_SECRET_SHA256`];
+  const sharedSecret = process.env.CRON_SECRET;
+  const sharedSecretHash = process.env.CRON_SECRET_SHA256;
+
+  const hasAnySecret = Boolean(jobSecret || jobSecretHash || sharedSecret || sharedSecretHash);
+  if (!hasAnySecret) {
+    const status = process.env.NODE_ENV === 'production' ? 503 : 401;
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'cron_secret_required' },
+        { status, headers: { 'Cache-Control': 'no-store' } },
+      ),
+    };
+  }
+
+  const allowed =
+    verifyBearerSecret(request, { expected: jobSecret, expectedSha256: jobSecretHash }) ||
+    verifyBearerSecret(request, { expected: sharedSecret, expectedSha256: sharedSecretHash });
+
+  if (!allowed) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: { 'Cache-Control': 'no-store' } },
+      ),
+    };
+  }
+
+  return { ok: true, headers: { 'Cache-Control': 'no-store' } };
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -17,6 +17,14 @@ type Bucket = { count: number; resetAt: number };
 const memBuckets = new Map<string, Bucket>();
 const MAX_MEM_BUCKETS = 10_000;
 
+function isProduction() {
+  return process.env.NODE_ENV === 'production';
+}
+
+function blockedResult(windowMs: number): RateLimitResult {
+  return { allowed: false, remaining: 0, resetAt: Date.now() + windowMs };
+}
+
 function applyMemoryRateLimit(options: RateLimitOptions): RateLimitResult {
   const now = Date.now();
 
@@ -80,8 +88,13 @@ export async function applyRateLimit(options: RateLimitOptions): Promise<RateLim
   const limiter = getLimiter(prefix, options.limit, options.windowMs);
 
   if (!limiter) {
+    if (isProduction()) {
+      console.error('[rate-limit] Redis rate limiter is required in production; blocking request');
+      return blockedResult(options.windowMs);
+    }
+
     if (!warnedNoRedis) {
-      console.warn('[rate-limit] UPSTASH_REDIS_REST_URL not set — using in-memory fallback (not effective on serverless)');
+      console.warn('[rate-limit] UPSTASH_REDIS_REST_URL not set — using in-memory fallback (dev/test only)');
       warnedNoRedis = true;
     }
     return applyMemoryRateLimit(options);
@@ -90,7 +103,11 @@ export async function applyRateLimit(options: RateLimitOptions): Promise<RateLim
   try {
     const { success, remaining, reset } = await limiter.limit(options.key);
     return { allowed: success, remaining, resetAt: reset };
-  } catch {
+  } catch (error) {
+    if (isProduction()) {
+      console.error('[rate-limit] Redis rate limiter failed in production; blocking request', error);
+      return blockedResult(options.windowMs);
+    }
     return applyMemoryRateLimit(options);
   }
 }

--- a/lib/security/request-json.ts
+++ b/lib/security/request-json.ts
@@ -1,0 +1,50 @@
+export type JsonParseResult<T = unknown> =
+  | { ok: true; value: T }
+  | { ok: false; status: number; error: string };
+
+export async function readJsonBody<T = unknown>(
+  request: Request,
+  options?: { maxBytes?: number },
+): Promise<JsonParseResult<T>> {
+  const maxBytes = options?.maxBytes ?? 64_000;
+  const contentLength = request.headers.get('content-length');
+  if (contentLength && Number(contentLength) > maxBytes) {
+    return { ok: false, status: 413, error: 'payload_too_large' };
+  }
+
+  let raw = '';
+  try {
+    raw = await request.text();
+  } catch {
+    return { ok: false, status: 400, error: 'invalid_body' };
+  }
+
+  if (raw.length === 0) {
+    return { ok: false, status: 400, error: 'empty_body' };
+  }
+
+  if (Buffer.byteLength(raw, 'utf8') > maxBytes) {
+    return { ok: false, status: 413, error: 'payload_too_large' };
+  }
+
+  try {
+    return { ok: true, value: JSON.parse(raw) as T };
+  } catch {
+    return { ok: false, status: 400, error: 'invalid_json' };
+  }
+}
+
+export function jsonSizeBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+export function maxObjectDepth(value: unknown, maxDepth = 8): boolean {
+  function visit(node: unknown, depth: number): boolean {
+    if (depth > maxDepth) return false;
+    if (node === null || typeof node !== 'object') return true;
+    if (Array.isArray(node)) return node.every((item) => visit(item, depth + 1));
+    return Object.values(node as Record<string, unknown>).every((item) => visit(item, depth + 1));
+  }
+
+  return visit(value, 0);
+}

--- a/lib/security/request-json.ts
+++ b/lib/security/request-json.ts
@@ -1,6 +1,13 @@
-export type JsonParseResult<T = unknown> =
-  | { ok: true; value: T }
-  | { ok: false; status: number; error: string };
+export type JsonParseResult<T = unknown> = {
+  ok: boolean;
+  value: T | null;
+  status: number;
+  error: string | null;
+};
+
+function fail<T>(status: number, error: string): JsonParseResult<T> {
+  return { ok: false, value: null, status, error };
+}
 
 export async function readJsonBody<T = unknown>(
   request: Request,
@@ -9,28 +16,28 @@ export async function readJsonBody<T = unknown>(
   const maxBytes = options?.maxBytes ?? 64_000;
   const contentLength = request.headers.get('content-length');
   if (contentLength && Number(contentLength) > maxBytes) {
-    return { ok: false, status: 413, error: 'payload_too_large' };
+    return fail<T>(413, 'payload_too_large');
   }
 
   let raw = '';
   try {
     raw = await request.text();
   } catch {
-    return { ok: false, status: 400, error: 'invalid_body' };
+    return fail<T>(400, 'invalid_body');
   }
 
   if (raw.length === 0) {
-    return { ok: false, status: 400, error: 'empty_body' };
+    return fail<T>(400, 'empty_body');
   }
 
   if (Buffer.byteLength(raw, 'utf8') > maxBytes) {
-    return { ok: false, status: 413, error: 'payload_too_large' };
+    return fail<T>(413, 'payload_too_large');
   }
 
   try {
-    return { ok: true, value: JSON.parse(raw) as T };
+    return { ok: true, value: JSON.parse(raw) as T, status: 200, error: null };
   } catch {
-    return { ok: false, status: 400, error: 'invalid_json' };
+    return fail<T>(400, 'invalid_json');
   }
 }
 

--- a/lib/security/secure-token.ts
+++ b/lib/security/secure-token.ts
@@ -1,0 +1,48 @@
+import { createHash, timingSafeEqual } from 'crypto';
+
+function digest(value: string): Buffer {
+  return createHash('sha256').update(value).digest();
+}
+
+export function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function timingSafeStringEqual(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false;
+  return timingSafeEqual(digest(provided), digest(expected));
+}
+
+export function extractBearerToken(authHeader: string | null): string {
+  if (!authHeader) return '';
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) return '';
+  return token.trim();
+}
+
+export function verifySecretValue(options: {
+  provided: string;
+  expected?: string | null;
+  expectedSha256?: string | null;
+}): boolean {
+  const provided = options.provided.trim();
+  if (!provided) return false;
+
+  const expected = options.expected?.trim();
+  if (expected && timingSafeStringEqual(provided, expected)) return true;
+
+  const expectedSha256 = options.expectedSha256?.trim().toLowerCase();
+  if (!expectedSha256) return false;
+  return timingSafeStringEqual(sha256Hex(provided), expectedSha256);
+}
+
+export function verifyBearerSecret(request: Request, options: {
+  expected?: string | null;
+  expectedSha256?: string | null;
+}): boolean {
+  return verifySecretValue({
+    provided: extractBearerToken(request.headers.get('authorization')),
+    expected: options.expected,
+    expectedSha256: options.expectedSha256,
+  });
+}

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -3,6 +3,18 @@ import type { Database } from './database.types';
 
 let adminClient: ReturnType<typeof createClient<Database>> | null = null;
 
+const SUPABASE_TIMEOUT_MS = 5_000;
+
+function withTimeoutFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SUPABASE_TIMEOUT_MS);
+
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? controller.signal,
+  }).finally(() => clearTimeout(timeout));
+}
+
 export function getSupabaseAdmin() {
   if (adminClient) {
     return adminClient;
@@ -19,6 +31,12 @@ export function getSupabaseAdmin() {
     auth: {
       autoRefreshToken: false,
       persistSession: false,
+    },
+    global: {
+      headers: {
+        'x-application-name': 'dsg-control-plane',
+      },
+      fetch: withTimeoutFetch,
     },
   });
 


### PR DESCRIPTION
## Summary

This PR hardens the ProofGate / DSG runtime surfaces identified in the production-readiness review, using the current GitHub `main` branch as source of truth.

### Key changes

- Replaces `/api/try/gate` process-local session behavior in production with Redis-backed sessions.
- Replaces `Math.random()` trial-gate stamps with HMAC-signed, verifiable DSG stamps.
- Adds an explicit production auth boundary for `/api/try/gate`; public trial mode must be intentionally enabled.
- Adds bounded JSON body parsing for critical request paths.
- Adds runtime validation for `/api/dsg/v1/gates/evaluate` instead of relying on TypeScript assertions.
- Changes rate limiting to fail closed in production if Redis is not configured or unavailable.
- Adds fail-closed cron authentication helper and applies it to Vercel cron routes.
- Adds Supabase admin fetch timeout and application header.
- Adds stricter CORS logging/behavior in production.
- Documents remaining production-hardening requirements and claim boundaries in `docs/PROOFGATE_PRODUCTION_HARDENING.md`.

## Files changed

- `app/api/try/gate/route.ts`
- `app/api/dsg/v1/gates/evaluate/route.ts`
- `app/api/cron/*/route.ts` for the configured cron jobs
- `lib/security/rate-limit.ts`
- `lib/security/cors.ts`
- `lib/supabase-server.ts`
- new security helpers under `lib/security/`
- new deterministic request validator under `lib/dsg/deterministic/`
- new hardening doc

## Important deployment requirements

Before production promotion, configure deployment secrets for:

- Upstash Redis URL/token
- DSG stamp secret, 32+ bytes
- Trial gate API key or SHA-256 hash, unless this is explicitly a public demo deployment
- Cron bearer secrets, preferably per job
- Strict CORS allowed origins

`/.env.example` was not updated in this PR because the write tool safety guard blocked the attempted env-template update containing many secret variable names. The required variables are documented in the hardening doc and should be mirrored into `.env.example` in a follow-up if the guard allows it.

## Claim boundary

This PR makes the repo a production-hardening candidate. It does not by itself certify SOC 2, WORM audit storage, GDPR residency, third-party audit status, or formal cryptographic certification.

## Verification needed

Run before merge:

```bash
npm run typecheck
npm test
npm run build
npm run go:no-go
```

I did not claim these passed because this environment has not run the repo CI/build locally after the GitHub patch.