### PR TITLE
fix: close remaining API error leakage findings

### DIFF
--- a/app/api/enterprise-proof/route.ts
+++ b/app/api/enterprise-proof/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireActiveProfile } from '../../../lib/auth/require-active-profile';
 import { buildEnterpriseProofReport } from '../../../lib/enterprise/proof';
+import { internalErrorMessage, logApiError } from '../../../lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -20,9 +21,10 @@ export async function GET(request: Request) {
   try {
     const report = await buildEnterpriseProofReport({ orgId: access.orgId, agentId });
     return NextResponse.json(report);
-  } catch (err) {
+  } catch (error) {
+    logApiError('api/enterprise-proof', error, { orgId: access.orgId, agentId });
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : 'Failed to generate report' },
+      { error: internalErrorMessage() },
       { status: 500 }
     );
   }

--- a/app/api/route-qa/route.ts
+++ b/app/api/route-qa/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireOrgRole } from '../../../lib/authz';
+import { internalErrorMessage, logApiError } from '../../../lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,6 +19,10 @@ const PUBLIC_ROUTES = [
   '/login',
 ];
 
+class RouteQaInputError extends Error {
+  status = 400;
+}
+
 function normalizeTarget(input: unknown, origin: string) {
   const value = String(input || '').trim();
   if (!value) return '';
@@ -25,7 +30,7 @@ function normalizeTarget(input: unknown, origin: string) {
   if (value.startsWith('http://') || value.startsWith('https://')) {
     const url = new URL(value);
     if (url.origin !== origin) {
-      throw new Error('ROUTE_QA_EXTERNAL_URL_BLOCKED');
+      throw new RouteQaInputError('external URL blocked');
     }
     return url.toString();
   }
@@ -113,8 +118,11 @@ export async function POST(request: Request) {
       truthBoundary: 'Route QA checks server-rendered route status and HTML basics. Browser console and visual layout still require browser runtime evidence.',
     });
   } catch (error) {
-    const code = error instanceof Error ? error.message : 'ROUTE_QA_FAILED';
-    const status = code === 'ROUTE_QA_EXTERNAL_URL_BLOCKED' ? 400 : 500;
-    return NextResponse.json({ ok: false, error: code }, { status });
+    if (error instanceof RouteQaInputError) {
+      return NextResponse.json({ ok: false, error: 'invalid_route_qa_target' }, { status: error.status });
+    }
+
+    logApiError('api/route-qa', error);
+    return NextResponse.json({ ok: false, error: internalErrorMessage() }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary

Hotfix for the CI Security Checks failure after PR #556 was merged.

The security workflow failed at `Enforce central error handler on API routes` with two concrete leakage findings:

- `app/api/enterprise-proof/route.ts`
- `app/api/route-qa/route.ts`

This PR changes those routes to return stable public errors and log internal details through the centralized API error helper.

## Changes

- `enterprise-proof`: stops returning `err.message` to clients; uses `logApiError` + `internalErrorMessage`.
- `route-qa`: stops returning arbitrary thrown `error.message`; returns `invalid_route_qa_target` for expected bad input and centralized internal error for unexpected failures.

## Verification needed

Required before merge:

```bash
npm run typecheck
npm test
npm run build
npm run go:no-go
```

Most importantly, rerun `CI Security Checks` and confirm `Enforce central error handler on API routes` passes.