### PR TITLE
fix: reduce production security config debt

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:live:db": "vitest run tests/integration/api/finance-governance-live-db.test.ts tests/integration/api/audit-evidence.test.ts",
     "test:live:db:required": "node scripts/verify-live-env.mjs live-db && vitest run tests/integration/api/finance-governance-live-db.test.ts tests/integration/api/audit-evidence.test.ts",
     "verify:live-env": "node scripts/verify-live-env.mjs all",
+    "verify:security-headers": "node scripts/verify-production-security-headers.mjs",
     "test:e2e": "./scripts/with-playwright-chromium.sh playwright test",
     "screenshot": "./scripts/with-playwright-chromium.sh node scripts/capture-screenshot.mjs",
     "test:e2e:install": "playwright install --with-deps chromium",

--- a/scripts/verify-production-security-headers.mjs
+++ b/scripts/verify-production-security-headers.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const target = process.env.SECURITY_HEADERS_URL || process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL;
+
+if (!target) {
+  console.error('[security-headers] Set SECURITY_HEADERS_URL, NEXT_PUBLIC_APP_URL, or APP_URL');
+  process.exit(1);
+}
+
+const url = new URL('/', target);
+const response = await fetch(url, { method: 'GET', redirect: 'manual' });
+const headers = response.headers;
+const failures = [];
+
+function requireHeader(name) {
+  const value = headers.get(name);
+  if (!value) failures.push(`${name}: missing`);
+  return value;
+}
+
+function forbidValue(name, forbidden) {
+  const value = headers.get(name);
+  if (value && value.trim() === forbidden) failures.push(`${name}: forbidden value ${forbidden}`);
+}
+
+const csp = requireHeader('content-security-policy');
+requireHeader('strict-transport-security');
+requireHeader('x-frame-options');
+requireHeader('x-content-type-options');
+requireHeader('referrer-policy');
+requireHeader('permissions-policy');
+forbidValue('access-control-allow-origin', '*');
+
+if (csp) {
+  for (const directive of ["default-src 'self'", "frame-ancestors 'none'", "object-src 'none'", "base-uri 'self'"]) {
+    if (!csp.includes(directive)) failures.push(`content-security-policy: missing ${directive}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('[security-headers] FAIL', { url: url.toString(), status: response.status, failures });
+  process.exit(1);
+}
+
+console.log('[security-headers] PASS', {
+  url: url.toString(),
+  status: response.status,
+  checked: [
+    'content-security-policy',
+    'strict-transport-security',
+    'x-frame-options',
+    'x-content-type-options',
+    'referrer-policy',
+    'permissions-policy',
+    'access-control-allow-origin',
+  ],
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "npm install",
+  "installCommand": "npm ci",
   "crons": [
     {
       "path": "/api/health",


### PR DESCRIPTION
## Summary

Follow-up security/config debt cleanup after production hardening PRs #556 and #557.

## Changes

- Changes Vercel install command from `npm install` to `npm ci` for deterministic production builds against `package-lock.json`.
- Adds `scripts/verify-production-security-headers.mjs` to verify live/staging response headers.
- Adds `npm run verify:security-headers` for explicit post-deploy/staging security header checks.

## Why

The current production deployment is serving successfully, but runtime evidence showed:

- `access-control-allow-origin: *` on the production alias response.
- Build log previously reported moderate npm audit debt.
- Vercel builds were configured with `npm install`, not `npm ci`.

The source code does not set `Access-Control-Allow-Origin: *` in `next.config.js` or `vercel.json`; API CORS remains route-level. This PR adds an explicit verification script rather than guessing an override that could conflict with Next/Vercel static behavior.

## Verification needed

Before merge:

```bash
npm run typecheck
npm test
npm run build
```

After preview deploy:

```bash
SECURITY_HEADERS_URL=<preview-or-production-url> npm run verify:security-headers
```

Expected current behavior: the security header verifier will fail while `access-control-allow-origin: *` remains present. That is intentional: it turns the observed debt into a hard evidence gate.