### PR TITLE
fix: replace wildcard CORS header on rendered pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,21 @@ function resolveRemoteApiOrigin() {
   return parseOrigin(process.env.DSG_REMOTE_API_URL || process.env.NEXT_PUBLIC_DSG_REMOTE_API_URL);
 }
 
+function resolveCanonicalResponseOrigin() {
+  const appOrigin = parseOrigin(process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL);
+  const vercelProductionOrigin = process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? parseOrigin(`https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`)
+    : null;
+  const vercelDeploymentOrigin = process.env.VERCEL_URL
+    ? parseOrigin(`https://${process.env.VERCEL_URL}`)
+    : null;
+
+  return appOrigin
+    || vercelProductionOrigin
+    || vercelDeploymentOrigin
+    || 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
+}
+
 function buildConnectSrc() {
   const coreOrigin = parseOrigin(process.env.DSG_CORE_URL);
   const remoteApiOrigin = resolveRemoteApiOrigin();
@@ -52,7 +67,16 @@ const nextConfig = {
 
   async headers() {
     // API CORS is intentionally handled at route level via lib/security/cors.ts.
+    // Non-API document/static responses should never expose wildcard CORS.
+    const canonicalResponseOrigin = resolveCanonicalResponseOrigin();
+
     return [
+      {
+        source: '/((?!api/).*)',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: canonicalResponseOrigin },
+        ],
+      },
       {
         source: '/(.*)',
         headers: [


### PR DESCRIPTION
## Summary

Attempts to close the observed production security debt where rendered page responses include:

```text
access-control-allow-origin: *
```

## Change

- Adds an explicit non-API Next.js header rule for rendered/static page responses:
  - `Access-Control-Allow-Origin: <canonical app origin>`
- Leaves `/api/*` out of this page-level override because API CORS is intentionally handled by `lib/security/cors.ts` at route level.

## Why this approach

Vercel docs support setting response headers through project config / Next headers. The source repo does not currently set `Access-Control-Allow-Origin: *` in `next.config.js` or `vercel.json`, so this PR avoids a broad Vercel route transform/delete and instead sets a deterministic page-level origin.

## Verification required

After preview deploy:

```bash
SECURITY_HEADERS_URL=<preview-url> npm run verify:security-headers
```

Then after production deploy:

```bash
SECURITY_HEADERS_URL=https://tdealer01-crypto-dsg-control-plane.vercel.app npm run verify:security-headers
```

Expected result: `access-control-allow-origin` must no longer be `*` on `/`.

## Boundary

This PR only targets rendered/static page responses. API CORS remains governed by `lib/security/cors.ts` and should be tested separately with allowed and blocked origins.