### PR TITLE
chore: trigger production deployment after gate fixes

### DIFF
--- a/qa-logs/production-deploy-trigger-2026-05-20.md
+++ b/qa-logs/production-deploy-trigger-2026-05-20.md
@@ -1,0 +1,13 @@
+# Production deploy trigger — 2026-05-20
+
+Purpose: create a GitHub merge commit after the latest production-readiness and E2E-gate fixes so Vercel Git integration can build a verified main commit.
+
+Included fixes already on main before this trigger:
+
+- `fix(e2e): keep staging specs out of default Docker pipeline`
+- `fix(readiness): avoid false failures on skipped management checks and health rate limits`
+
+Validation boundary:
+
+- This file does not change runtime code.
+- Production readiness must still be verified by Vercel deployment status and `/api/readiness` after the merge.


### PR DESCRIPTION
## Summary
- Adds a QA evidence note so this branch produces a normal GitHub PR merge commit after the latest gate fixes on `main`.
- Runtime code is unchanged.

## Why
Recent direct commits to `main` produced Vercel deployments with `githubCommitVerification: unverified` and Vercel canceled them before build logs were emitted. The previous successful production deployment came from a verified merged PR commit.

## Validation after merge
- Confirm Vercel production deployment reaches READY.
- Confirm `/api/readiness` returns `ok: true`.
- Confirm default Docker E2E no longer runs staging-only auth specs.
- Confirm production-readiness treats `/api/health` HTTP 429 as rate-limited/non-fatal while `/api/readiness` remains authoritative.