### PR TITLE
docs: add ProofGate demo repo link

### DIFF
--- a/app/proofgate-github-action/page.tsx
+++ b/app/proofgate-github-action/page.tsx
@@ -83,6 +83,12 @@ export default function ProofGateGitHubActionPage() {
               >
                 View source
               </a>
+              <a
+                href="https://github.com/tdealer01-crypto/dsg-gate-demo-nextjs"
+                className="dsg-btn-blue"
+              >
+                View demo repo
+              </a>
               <Link href="/quickstart" className="dsg-btn-red">
                 Control Plane quickstart
               </Link>


### PR DESCRIPTION
## Summary
- Adds a View demo repo button to /proofgate-github-action.
- Links to tdealer01-crypto/dsg-gate-demo-nextjs after the demo workflow passed.

## Validation
- Demo repo PR comment and evidence artifact already verified.
- Page-only link update.