### PR TITLE
ci: allow manual DSG gate runs

### DIFF
--- a/.github/workflows/dsg-secure-deploy-gate.yml
+++ b/.github/workflows/dsg-secure-deploy-gate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   dsg-gate:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to the DSG Secure Deploy Gate workflow.
- Keeps existing pull_request and push triggers.

## Why
After PR #567, we need a manual post-merge DSG evidence run on `main`. Without `workflow_dispatch`, GitHub UI cannot run this workflow manually.

## Validation
- Workflow-only change.
- Existing strict preset config already includes `protected_url` and `protected_expected`.