### PR TITLE
P0 revenue hardening: Stripe meter outbox, cron auth, analytics period

### DIFF
--- a/app/api/cron/flush-meter-outbox/route.ts
+++ b/app/api/cron/flush-meter-outbox/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { flushMeterOutbox } from '../../../../lib/billing/metered';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+function authorizeCron(request: Request): NextResponse | null {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 });
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return null;
+}
+
+export async function GET(request: Request) {
+  const authError = authorizeCron(request);
+  if (authError) return authError;
+
+  const { searchParams } = new URL(request.url);
+  const limitParam = Number(searchParams.get('limit') ?? '100');
+  const limit = Number.isFinite(limitParam) && limitParam > 0
+    ? Math.min(Math.floor(limitParam), 500)
+    : 100;
+
+  try {
+    const result = await flushMeterOutbox(limit);
+    const status = result.errors.length > 0 && result.sent === 0 ? 500 : 200;
+    return NextResponse.json({ ok: status === 200, ...result }, { status });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[flush-meter-outbox] cron failed:', message);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/cron/flush-meter-outbox/route.ts
+++ b/app/api/cron/flush-meter-outbox/route.ts
@@ -32,10 +32,16 @@ export async function GET(request: Request) {
   try {
     const result = await flushMeterOutbox(limit);
     const status = result.errors.length > 0 && result.sent === 0 ? 500 : 200;
-    return NextResponse.json({ ok: status === 200, ...result }, { status });
+    return NextResponse.json({
+      ok: status === 200,
+      scanned: result.scanned,
+      sent: result.sent,
+      failed: result.failed,
+      skipped: result.skipped,
+      errorCount: result.errors.length,
+    }, { status });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[flush-meter-outbox] cron failed:', message);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    console.error('[flush-meter-outbox] cron failed:', error);
+    return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/cron/usage-alerts/route.ts
+++ b/app/api/cron/usage-alerts/route.ts
@@ -94,13 +94,24 @@ async function getOrgAdminEmails(orgIds: string[]): Promise<Map<string, string[]
   return map;
 }
 
-export async function GET(request: Request) {
-  // Verify cron secret (Vercel sets this automatically for cron jobs)
+function authorizeCron(request: Request): NextResponse | null {
   const authHeader = request.headers.get('authorization');
   const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+
+  if (!cronSecret) {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 });
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  return null;
+}
+
+export async function GET(request: Request) {
+  const authError = authorizeCron(request);
+  if (authError) return authError;
 
   try {
     const snapshots = await scanOrgsForNudge(['soft', 'hard']);

--- a/app/api/usage/analytics/route.ts
+++ b/app/api/usage/analytics/route.ts
@@ -11,7 +11,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '../../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
-import { getOrgUsageSnapshot } from '../../../../lib/revenue/upgrade-nudge';
+import { getOrgUsageSnapshot, normalizeBillingPeriod } from '../../../../lib/revenue/upgrade-nudge';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
 import { handleApiError } from '../../../../lib/security/api-error';
 
@@ -50,11 +50,10 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const requestedPeriod = searchParams.get('period');
-    const currentPeriod   = new Date().toISOString().slice(0, 7);
-    const period          = requestedPeriod ?? currentPeriod;
+    const period          = normalizeBillingPeriod(requestedPeriod);
 
-    // Get current period snapshot (includes nudge level)
-    const snapshot = await getOrgUsageSnapshot(profile.org_id);
+    // Get requested period snapshot (includes nudge level)
+    const snapshot = await getOrgUsageSnapshot(profile.org_id, period);
 
     // Get historical usage for trend chart (last 6 months)
     const { data: history } = await admin
@@ -73,18 +72,18 @@ export async function GET(request: Request) {
       );
     }
 
-    // Top agents by usage in current period
+    // Top agents by usage in requested period
     const { data: agentUsage } = await admin
       .from('usage_counters')
       .select('agent_id, executions')
       .eq('org_id', profile.org_id)
-      .eq('billing_period', currentPeriod)
+      .eq('billing_period', period)
       .order('executions', { ascending: false })
       .limit(10);
 
     return NextResponse.json({
       ok: true,
-      period: currentPeriod,
+      period,
       quota: {
         plan:         snapshot.plan,
         used:         snapshot.used,

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -211,7 +211,7 @@ export async function reportMeterEvent(
     quantity: meteredQuantity,
   });
 
-  if (!outbox.ok) {
+  if ('error' in outbox) {
     return { ok: false, error: outbox.error };
   }
 

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -30,23 +30,36 @@ function getMeterEventName(): string | null {
   return process.env.STRIPE_METER_EVENT_NAME ?? null;
 }
 
+function normalizeExecutionId(executionId: string): string | null {
+  const normalized = executionId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 /**
  * Report a single execution event to Stripe Metering.
  *
  * Called after a successful /api/execute response.
- * Fire-and-forget safe — errors are logged but never thrown.
+ * Execution-level idempotency prevents same-second org activity from being
+ * silently deduped by Stripe while still making retries of the same execution safe.
  *
  * @param stripeCustomerId  The org's Stripe customer ID (from billing_customers table)
- * @param orgId             DSG org ID (used as idempotency key component)
- * @param quantity          Number of executions to meter (default: 1)
+ * @param orgId             DSG org ID
+ * @param quantity          Number of executions to meter
+ * @param executionId       Canonical execution/audit row ID for idempotency
  */
 export async function reportMeterEvent(
   stripeCustomerId: string,
   orgId: string,
-  quantity = 1
+  quantity: number,
+  executionId: string
 ): Promise<MeterEventResult> {
   const stripe = getStripe();
   const eventName = getMeterEventName();
+  const normalizedExecutionId = normalizeExecutionId(executionId);
+
+  if (!normalizedExecutionId) {
+    return { ok: false, error: 'executionId is required for Stripe meter idempotency' };
+  }
 
   if (!stripe || !eventName) {
     return { ok: false, error: 'Stripe metering not configured', skipped: true };
@@ -54,11 +67,12 @@ export async function reportMeterEvent(
 
   try {
     const timestamp = Math.floor(Date.now() / 1000);
-    const idempotencyKey = `dsg-meter-${orgId}-${timestamp}`;
+    const idempotencyKey = `dsg-meter-${normalizedExecutionId}`;
 
     const event = await stripe.billing.meterEvents.create(
       {
         event_name: eventName,
+        identifier: idempotencyKey,
         payload: {
           stripe_customer_id: stripeCustomerId,
           value: String(quantity),
@@ -97,10 +111,10 @@ export async function getStripeCustomerIdForOrg(orgId: string): Promise<string |
  * Combined: report meter event for an org if they have a Stripe customer.
  * Safe to call from /api/execute — never throws, skips gracefully if unconfigured.
  */
-export async function meterExecution(orgId: string, quantity = 1): Promise<void> {
+export async function meterExecution(orgId: string, quantity: number, executionId: string): Promise<void> {
   const customerId = await getStripeCustomerIdForOrg(orgId);
   if (!customerId) return;
-  void reportMeterEvent(customerId, orgId, quantity);
+  void reportMeterEvent(customerId, orgId, quantity, executionId);
 }
 
 /**

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -20,6 +20,27 @@ type MeterEventResult =
   | { ok: true; eventId: string }
   | { ok: false; error: string; skipped?: boolean };
 
+export type MeterOutboxFlushResult = {
+  scanned: number;
+  sent: number;
+  failed: number;
+  skipped: number;
+  errors: string[];
+};
+
+type OutboxRow = {
+  id: string;
+  execution_id: string;
+  org_id: string;
+  stripe_customer_id: string;
+  event_name: string;
+  quantity: number;
+  status: 'pending' | 'sent' | 'failed';
+  stripe_event_id: string | null;
+  error: string | null;
+  created_at: string;
+};
+
 function getStripe(): Stripe | null {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) return null;
@@ -35,12 +56,128 @@ function normalizeExecutionId(executionId: string): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+function positiveQuantity(quantity: number): number {
+  return Number.isFinite(quantity) && quantity > 0 ? Math.floor(quantity) : 1;
+}
+
+function idempotencyKeyForExecution(executionId: string): string {
+  return `dsg-meter-${executionId}`;
+}
+
+async function getOutboxClient() {
+  const { getSupabaseAdmin } = await import('../supabase-server');
+  // billing_meter_outbox is introduced by a new migration in this branch.
+  // Cast to any until lib/database.types.ts is regenerated from Supabase.
+  return getSupabaseAdmin() as any;
+}
+
+async function createOutboxRow(input: {
+  executionId: string;
+  orgId: string;
+  stripeCustomerId: string;
+  eventName: string;
+  quantity: number;
+}): Promise<{ ok: true; rowId: string; alreadySentEventId?: string } | { ok: false; error: string }> {
+  const supabase = await getOutboxClient();
+
+  const { data, error } = await supabase
+    .from('billing_meter_outbox')
+    .insert({
+      execution_id: input.executionId,
+      org_id: input.orgId,
+      stripe_customer_id: input.stripeCustomerId,
+      event_name: input.eventName,
+      quantity: input.quantity,
+      status: 'pending',
+    })
+    .select('id,status,stripe_event_id')
+    .maybeSingle();
+
+  if (!error && data?.id) {
+    return { ok: true, rowId: data.id };
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from('billing_meter_outbox')
+    .select('id,status,stripe_event_id')
+    .eq('execution_id', input.executionId)
+    .maybeSingle();
+
+  if (existing?.id) {
+    if (existing.status === 'sent' && existing.stripe_event_id) {
+      return { ok: true, rowId: existing.id, alreadySentEventId: existing.stripe_event_id };
+    }
+    return { ok: true, rowId: existing.id };
+  }
+
+  return {
+    ok: false,
+    error: existingError?.message ?? error?.message ?? 'failed to create billing meter outbox row',
+  };
+}
+
+async function markOutboxSent(rowId: string, stripeEventId: string): Promise<void> {
+  const supabase = await getOutboxClient();
+  await supabase
+    .from('billing_meter_outbox')
+    .update({
+      status: 'sent',
+      stripe_event_id: stripeEventId,
+      error: null,
+      flushed_at: new Date().toISOString(),
+    })
+    .eq('id', rowId);
+}
+
+async function markOutboxFailed(rowId: string, error: string): Promise<void> {
+  const supabase = await getOutboxClient();
+  await supabase
+    .from('billing_meter_outbox')
+    .update({
+      status: 'failed',
+      error,
+      flushed_at: new Date().toISOString(),
+    })
+    .eq('id', rowId);
+}
+
+async function deliverMeterEvent(input: {
+  stripe: Stripe;
+  stripeCustomerId: string;
+  eventName: string;
+  quantity: number;
+  executionId: string;
+}): Promise<MeterEventResult> {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const idempotencyKey = idempotencyKeyForExecution(input.executionId);
+
+  const meterEventPayload: any = {
+    event_name: input.eventName,
+    identifier: idempotencyKey,
+    payload: {
+      stripe_customer_id: input.stripeCustomerId,
+      value: String(input.quantity),
+    },
+    timestamp,
+  };
+
+  const event = await input.stripe.billing.meterEvents.create(
+    meterEventPayload,
+    { idempotencyKey }
+  );
+
+  return { ok: true, eventId: event.identifier };
+}
+
 /**
  * Report a single execution event to Stripe Metering.
  *
  * Called after a successful /api/execute response.
  * Execution-level idempotency prevents same-second org activity from being
  * silently deduped by Stripe while still making retries of the same execution safe.
+ *
+ * A durable outbox row is written before Stripe delivery. If Stripe fails,
+ * the failed row remains retryable by /api/cron/flush-meter-outbox.
  *
  * @param stripeCustomerId  The org's Stripe customer ID (from billing_customers table)
  * @param orgId             DSG org ID
@@ -56,6 +193,7 @@ export async function reportMeterEvent(
   const stripe = getStripe();
   const eventName = getMeterEventName();
   const normalizedExecutionId = normalizeExecutionId(executionId);
+  const meteredQuantity = positiveQuantity(quantity);
 
   if (!normalizedExecutionId) {
     return { ok: false, error: 'executionId is required for Stripe meter idempotency' };
@@ -65,29 +203,107 @@ export async function reportMeterEvent(
     return { ok: false, error: 'Stripe metering not configured', skipped: true };
   }
 
+  const outbox = await createOutboxRow({
+    executionId: normalizedExecutionId,
+    orgId,
+    stripeCustomerId,
+    eventName,
+    quantity: meteredQuantity,
+  });
+
+  if (!outbox.ok) {
+    return { ok: false, error: outbox.error };
+  }
+
+  if (outbox.alreadySentEventId) {
+    return { ok: true, eventId: outbox.alreadySentEventId };
+  }
+
   try {
-    const timestamp = Math.floor(Date.now() / 1000);
-    const idempotencyKey = `dsg-meter-${normalizedExecutionId}`;
+    const result = await deliverMeterEvent({
+      stripe,
+      stripeCustomerId,
+      eventName,
+      quantity: meteredQuantity,
+      executionId: normalizedExecutionId,
+    });
 
-    const event = await stripe.billing.meterEvents.create(
-      {
-        event_name: eventName,
-        identifier: idempotencyKey,
-        payload: {
-          stripe_customer_id: stripeCustomerId,
-          value: String(quantity),
-        },
-        timestamp,
-      },
-      { idempotencyKey }
-    );
+    if (result.ok) {
+      await markOutboxSent(outbox.rowId, result.eventId);
+    }
 
-    return { ok: true, eventId: event.identifier };
+    return result;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error('[metered] Stripe meter event failed:', message);
+    await markOutboxFailed(outbox.rowId, message);
     return { ok: false, error: message };
   }
+}
+
+/**
+ * Retry pending and failed billing meter outbox rows.
+ */
+export async function flushMeterOutbox(limit = 100): Promise<MeterOutboxFlushResult> {
+  const stripe = getStripe();
+  const result: MeterOutboxFlushResult = {
+    scanned: 0,
+    sent: 0,
+    failed: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  if (!stripe) {
+    return { ...result, errors: ['Stripe metering not configured'] };
+  }
+
+  const supabase = await getOutboxClient();
+  const cutoff = new Date(Date.now() - 5 * 60_000).toISOString();
+
+  const { data, error } = await supabase
+    .from('billing_meter_outbox')
+    .select('*')
+    .in('status', ['pending', 'failed'])
+    .lt('created_at', cutoff)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    return { ...result, errors: [error.message ?? 'failed to load billing meter outbox'] };
+  }
+
+  const rows = (data ?? []) as OutboxRow[];
+  result.scanned = rows.length;
+
+  for (const row of rows) {
+    if (!row.execution_id || !row.stripe_customer_id || !row.event_name) {
+      result.skipped++;
+      continue;
+    }
+
+    try {
+      const delivered = await deliverMeterEvent({
+        stripe,
+        stripeCustomerId: row.stripe_customer_id,
+        eventName: row.event_name,
+        quantity: positiveQuantity(row.quantity),
+        executionId: row.execution_id,
+      });
+
+      if (delivered.ok) {
+        await markOutboxSent(row.id, delivered.eventId);
+        result.sent++;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await markOutboxFailed(row.id, message);
+      result.failed++;
+      result.errors.push(`${row.execution_id}: ${message}`);
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -114,7 +330,7 @@ export async function getStripeCustomerIdForOrg(orgId: string): Promise<string |
 export async function meterExecution(orgId: string, quantity: number, executionId: string): Promise<void> {
   const customerId = await getStripeCustomerIdForOrg(orgId);
   if (!customerId) return;
-  void reportMeterEvent(customerId, orgId, quantity, executionId);
+  await reportMeterEvent(customerId, orgId, quantity, executionId);
 }
 
 /**

--- a/lib/revenue/upgrade-nudge.ts
+++ b/lib/revenue/upgrade-nudge.ts
@@ -31,6 +31,7 @@ export type UsageSnapshot = {
 
 const SOFT_THRESHOLD  = 0.80; // 80%
 const HARD_THRESHOLD  = 0.95; // 95%
+const BILLING_PERIOD_PATTERN = /^\d{4}-\d{2}$/;
 
 const PLAN_UPGRADE_PATH: Record<string, KnownPlan | null> = {
   free:       'trial',
@@ -39,6 +40,16 @@ const PLAN_UPGRADE_PATH: Record<string, KnownPlan | null> = {
   business:   'enterprise',
   enterprise: null,
 };
+
+function currentBillingPeriod(): string {
+  return new Date().toISOString().slice(0, 7);
+}
+
+export function normalizeBillingPeriod(period?: string | null): string {
+  if (!period) return currentBillingPeriod();
+  const normalized = period.trim();
+  return BILLING_PERIOD_PATTERN.test(normalized) ? normalized : currentBillingPeriod();
+}
 
 function appUrl(): string {
   return process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://app.dsg.pics';
@@ -68,11 +79,11 @@ function formatSavings(plan: string): string | null {
 }
 
 /**
- * Get current usage snapshot for a single org in the current billing period.
+ * Get usage snapshot for a single org in a target billing period.
  */
-export async function getOrgUsageSnapshot(orgId: string): Promise<UsageSnapshot> {
+export async function getOrgUsageSnapshot(orgId: string, period?: string | null): Promise<UsageSnapshot> {
   const supabase = getSupabaseAdmin();
-  const period = new Date().toISOString().slice(0, 7); // YYYY-MM
+  const billingPeriod = normalizeBillingPeriod(period);
 
   const [orgResult, usageResult] = await Promise.all([
     supabase.from('organizations').select('plan').eq('id', orgId).maybeSingle(),
@@ -80,7 +91,7 @@ export async function getOrgUsageSnapshot(orgId: string): Promise<UsageSnapshot>
       .from('usage_counters')
       .select('executions')
       .eq('org_id', orgId)
-      .eq('billing_period', period),
+      .eq('billing_period', billingPeriod),
   ]);
 
   const plan  = orgResult.data?.plan ?? 'free';
@@ -109,7 +120,7 @@ export async function getOrgUsageSnapshot(orgId: string): Promise<UsageSnapshot>
  */
 export async function scanOrgsForNudge(nudgeFilter: NudgeLevel[] = ['soft', 'hard', 'blocked']): Promise<UsageSnapshot[]> {
   const supabase = getSupabaseAdmin();
-  const period   = new Date().toISOString().slice(0, 7);
+  const period   = currentBillingPeriod();
 
   // Fetch all orgs with usage in the current period
   const { data: usageRows, error } = await supabase

--- a/supabase/migrations/20260523000000_billing_meter_outbox.sql
+++ b/supabase/migrations/20260523000000_billing_meter_outbox.sql
@@ -1,0 +1,29 @@
+-- Durable Stripe Billing Meter outbox.
+--
+-- P0 revenue-hardening goal:
+-- A successful paid execution must have a durable internal billing record
+-- before any best-effort Stripe delivery attempt is made.
+
+create table if not exists public.billing_meter_outbox (
+  id uuid primary key default gen_random_uuid(),
+  execution_id text not null unique,
+  org_id text not null references public.organizations(id) on delete cascade,
+  stripe_customer_id text not null,
+  event_name text not null,
+  quantity integer not null default 1 check (quantity > 0),
+  status text not null default 'pending' check (status in ('pending', 'sent', 'failed')),
+  stripe_event_id text,
+  error text,
+  created_at timestamptz not null default now(),
+  flushed_at timestamptz
+);
+
+create index if not exists idx_billing_meter_outbox_pending
+  on public.billing_meter_outbox(status, created_at)
+  where status = 'pending';
+
+create index if not exists idx_billing_meter_outbox_failed
+  on public.billing_meter_outbox(status, created_at)
+  where status = 'failed';
+
+alter table public.billing_meter_outbox enable row level security;

--- a/tests/proofs/README.md
+++ b/tests/proofs/README.md
@@ -1,0 +1,26 @@
+# DSG Proof Test Lanes
+
+This directory contains TypeScript proof-oriented tests for live product code.
+
+## TypeScript lane
+
+Files such as `billing-invariants.test.ts` and `quota-invariants.test.ts` run through Vitest and may use `z3-solver` WASM to verify behavioral invariants against the current TypeScript implementation.
+
+Use this lane to catch implementation drift in the billing and entitlement code that ships with the app.
+
+## Python lane — canonical mathematical proof path
+
+The canonical design-time proof lane is:
+
+```bash
+npm run proof:install
+npm run proof:revenue
+```
+
+That path runs the Python Z3 proof scripts under `tools/proofs/`, including `tools/proofs/prove_revenue_ready.py`.
+
+## Claim boundary
+
+Passing these proof tests does not mean the deployed SaaS is fully formally verified. It means the selected revenue and policy invariants checked by these scripts hold for the encoded model or implementation surface.
+
+Do not claim production-ready billing until the P0 revenue-hardening checks pass in CI and Stripe test-mode delivery confirms the outbox behavior.

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -10,29 +10,34 @@ vi.mock('stripe', () => ({
   })),
 }));
 
-const mockOutboxInsert = vi.fn();
-const mockOutboxUpdate = vi.fn();
+const mockOutboxInsertCall = vi.fn();
+const mockOutboxInsertMaybeSingle = vi.fn();
+const mockOutboxExistingMaybeSingle = vi.fn();
+const mockOutboxUpdateCall = vi.fn();
+const mockOutboxUpdateEq = vi.fn();
 const mockOutboxSelectAll = vi.fn();
 const mockCustomerMaybeSingle = vi.fn();
 
-function outboxInsertChain() {
+function outboxInsertChain(payload: Record<string, unknown>) {
+  mockOutboxInsertCall(payload);
   return {
     select: () => ({
-      maybeSingle: mockOutboxInsert,
+      maybeSingle: mockOutboxInsertMaybeSingle,
     }),
   };
 }
 
-function outboxUpdateChain() {
+function outboxUpdateChain(payload: Record<string, unknown>) {
+  mockOutboxUpdateCall(payload);
   return {
-    eq: mockOutboxUpdate,
+    eq: mockOutboxUpdateEq,
   };
 }
 
 function outboxSelectChain() {
   return {
     eq: () => ({
-      maybeSingle: () => Promise.resolve({ data: null, error: null }),
+      maybeSingle: mockOutboxExistingMaybeSingle,
     }),
     in: () => ({
       lt: () => ({
@@ -49,8 +54,8 @@ vi.mock('../../../lib/supabase-server', () => ({
     from: (table: string) => {
       if (table === 'billing_meter_outbox') {
         return {
-          insert: mockOutboxInsert.mockImplementationOnce(() => outboxInsertChain()),
-          update: mockOutboxUpdate.mockImplementationOnce(() => outboxUpdateChain()),
+          insert: outboxInsertChain,
+          update: outboxUpdateChain,
           select: () => outboxSelectChain(),
         };
       }
@@ -73,11 +78,12 @@ describe('Stripe metered billing', () => {
     vi.clearAllMocks();
     process.env.STRIPE_SECRET_KEY       = 'sk_test_xxx';
     process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution';
-    mockOutboxInsert.mockImplementation(() => Promise.resolve({
+    mockOutboxInsertMaybeSingle.mockResolvedValue({
       data: { id: 'outbox-001', status: 'pending', stripe_event_id: null },
       error: null,
-    }));
-    mockOutboxUpdate.mockResolvedValue({ data: null, error: null });
+    });
+    mockOutboxExistingMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockOutboxUpdateEq.mockResolvedValue({ data: null, error: null });
     mockOutboxSelectAll.mockResolvedValue({ data: [], error: null });
     mockCustomerMaybeSingle.mockResolvedValue({ data: { stripe_customer_id: 'cus_test123' }, error: null });
   });
@@ -96,7 +102,7 @@ describe('Stripe metered billing', () => {
 
     await reportMeterEvent('cus_test123', 'org-1', 1, 'exec-001');
 
-    expect(mockOutboxInsert).toHaveBeenCalledWith({
+    expect(mockOutboxInsertCall).toHaveBeenCalledWith({
       execution_id: 'exec-001',
       org_id: 'org-1',
       stripe_customer_id: 'cus_test123',
@@ -104,7 +110,7 @@ describe('Stripe metered billing', () => {
       quantity: 1,
       status: 'pending',
     });
-    expect(mockOutboxUpdate).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockOutboxUpdateCall).toHaveBeenCalledWith(expect.objectContaining({
       status: 'sent',
       stripe_event_id: 'mtr_evt_001',
       error: null,
@@ -149,7 +155,7 @@ describe('Stripe metered billing', () => {
     const result = await reportMeterEvent('cus_test', 'org-3', 1, 'exec-003');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).skipped).toBe(true);
-    expect(mockOutboxInsert).not.toHaveBeenCalled();
+    expect(mockOutboxInsertCall).not.toHaveBeenCalled();
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
@@ -167,7 +173,7 @@ describe('Stripe metered billing', () => {
     const result = await reportMeterEvent('cus_test', 'org-5', 1, 'exec-005');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).error).toContain('Stripe API error');
-    expect(mockOutboxUpdate).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockOutboxUpdateCall).toHaveBeenCalledWith(expect.objectContaining({
       status: 'failed',
       error: 'Stripe API error',
     }));

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -27,34 +27,54 @@ import { reportMeterEvent, isMeteredBillingConfigured } from '../../../lib/billi
 describe('Stripe metered billing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.STRIPE_SECRET_KEY      = 'sk_test_xxx';
+    process.env.STRIPE_SECRET_KEY       = 'sk_test_xxx';
     process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution';
   });
 
   it('reports meter event successfully', async () => {
     mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_001' });
 
-    const result = await reportMeterEvent('cus_test123', 'org-1', 1);
+    const result = await reportMeterEvent('cus_test123', 'org-1', 1, 'exec-001');
     expect(result.ok).toBe(true);
     if (result.ok) expect((result as any).eventId).toBe('mtr_evt_001');
     expect(mockMeterEventsCreate).toHaveBeenCalledOnce();
   });
 
-  it('passes correct payload to Stripe', async () => {
+  it('passes correct payload and execution idempotency key to Stripe', async () => {
     mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_002' });
 
-    await reportMeterEvent('cus_abc', 'org-2', 3);
+    await reportMeterEvent('cus_abc', 'org-2', 3, 'exec-abc-123');
 
-    const call = mockMeterEventsCreate.mock.calls[0][0];
-    expect(call.event_name).toBe('dsg_execution');
-    expect(call.payload.stripe_customer_id).toBe('cus_abc');
-    expect(call.payload.value).toBe('3');
+    const [payload, options] = mockMeterEventsCreate.mock.calls[0];
+    expect(payload.event_name).toBe('dsg_execution');
+    expect(payload.identifier).toBe('dsg-meter-exec-abc-123');
+    expect(payload.payload.stripe_customer_id).toBe('cus_abc');
+    expect(payload.payload.value).toBe('3');
+    expect(options.idempotencyKey).toBe('dsg-meter-exec-abc-123');
+  });
+
+  it('uses distinct idempotency keys for same-second executions from the same org', async () => {
+    mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_same_second' });
+    vi.spyOn(Date, 'now').mockReturnValue(1_777_000_000_000);
+
+    await reportMeterEvent('cus_abc', 'org-same', 1, 'exec-same-1');
+    await reportMeterEvent('cus_abc', 'org-same', 1, 'exec-same-2');
+
+    expect(mockMeterEventsCreate.mock.calls[0][1].idempotencyKey).toBe('dsg-meter-exec-same-1');
+    expect(mockMeterEventsCreate.mock.calls[1][1].idempotencyKey).toBe('dsg-meter-exec-same-2');
+  });
+
+  it('requires executionId to prevent unsafe timestamp-only metering', async () => {
+    const result = await reportMeterEvent('cus_test', 'org-missing-exec', 1, '   ');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect((result as any).error).toContain('executionId is required');
+    expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
   it('skips gracefully when STRIPE_METER_EVENT_NAME is not set', async () => {
     delete process.env.STRIPE_METER_EVENT_NAME;
 
-    const result = await reportMeterEvent('cus_test', 'org-3', 1);
+    const result = await reportMeterEvent('cus_test', 'org-3', 1, 'exec-003');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).skipped).toBe(true);
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
@@ -63,7 +83,7 @@ describe('Stripe metered billing', () => {
   it('skips gracefully when STRIPE_SECRET_KEY is not set', async () => {
     delete process.env.STRIPE_SECRET_KEY;
 
-    const result = await reportMeterEvent('cus_test', 'org-4', 1);
+    const result = await reportMeterEvent('cus_test', 'org-4', 1, 'exec-004');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).skipped).toBe(true);
   });
@@ -71,7 +91,7 @@ describe('Stripe metered billing', () => {
   it('returns error (not throw) when Stripe call fails', async () => {
     mockMeterEventsCreate.mockRejectedValue(new Error('Stripe API error'));
 
-    const result = await reportMeterEvent('cus_test', 'org-5', 1);
+    const result = await reportMeterEvent('cus_test', 'org-5', 1, 'exec-005');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).error).toContain('Stripe API error');
   });

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock stripe before imports
 const mockMeterEventsCreate = vi.fn();
@@ -10,25 +10,81 @@ vi.mock('stripe', () => ({
   })),
 }));
 
-vi.mock('../../../lib/supabase-server', () => ({
-  getSupabaseAdmin: () => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: () => Promise.resolve({ data: { stripe_customer_id: 'cus_test123' }, error: null }),
+const mockOutboxInsert = vi.fn();
+const mockOutboxUpdate = vi.fn();
+const mockOutboxSelectAll = vi.fn();
+const mockCustomerMaybeSingle = vi.fn();
+
+function outboxInsertChain() {
+  return {
+    select: () => ({
+      maybeSingle: mockOutboxInsert,
+    }),
+  };
+}
+
+function outboxUpdateChain() {
+  return {
+    eq: mockOutboxUpdate,
+  };
+}
+
+function outboxSelectChain() {
+  return {
+    eq: () => ({
+      maybeSingle: () => Promise.resolve({ data: null, error: null }),
+    }),
+    in: () => ({
+      lt: () => ({
+        order: () => ({
+          limit: mockOutboxSelectAll,
         }),
       }),
     }),
+  };
+}
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({
+    from: (table: string) => {
+      if (table === 'billing_meter_outbox') {
+        return {
+          insert: mockOutboxInsert.mockImplementationOnce(() => outboxInsertChain()),
+          update: mockOutboxUpdate.mockImplementationOnce(() => outboxUpdateChain()),
+          select: () => outboxSelectChain(),
+        };
+      }
+
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: mockCustomerMaybeSingle,
+          }),
+        }),
+      };
+    },
   }),
 }));
 
-import { reportMeterEvent, isMeteredBillingConfigured } from '../../../lib/billing/metered';
+import { reportMeterEvent, isMeteredBillingConfigured, flushMeterOutbox } from '../../../lib/billing/metered';
 
 describe('Stripe metered billing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     process.env.STRIPE_SECRET_KEY       = 'sk_test_xxx';
     process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution';
+    mockOutboxInsert.mockImplementation(() => Promise.resolve({
+      data: { id: 'outbox-001', status: 'pending', stripe_event_id: null },
+      error: null,
+    }));
+    mockOutboxUpdate.mockResolvedValue({ data: null, error: null });
+    mockOutboxSelectAll.mockResolvedValue({ data: [], error: null });
+    mockCustomerMaybeSingle.mockResolvedValue({ data: { stripe_customer_id: 'cus_test123' }, error: null });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('reports meter event successfully', async () => {
@@ -38,6 +94,26 @@ describe('Stripe metered billing', () => {
     expect(result.ok).toBe(true);
     if (result.ok) expect((result as any).eventId).toBe('mtr_evt_001');
     expect(mockMeterEventsCreate).toHaveBeenCalledOnce();
+  });
+
+  it('writes an outbox row before Stripe delivery and marks it sent on success', async () => {
+    mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_001' });
+
+    await reportMeterEvent('cus_test123', 'org-1', 1, 'exec-001');
+
+    expect(mockOutboxInsert).toHaveBeenCalledWith({
+      execution_id: 'exec-001',
+      org_id: 'org-1',
+      stripe_customer_id: 'cus_test123',
+      event_name: 'dsg_execution',
+      quantity: 1,
+      status: 'pending',
+    });
+    expect(mockOutboxUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'sent',
+      stripe_event_id: 'mtr_evt_001',
+      error: null,
+    }));
   });
 
   it('passes correct payload and execution idempotency key to Stripe', async () => {
@@ -77,6 +153,7 @@ describe('Stripe metered billing', () => {
     const result = await reportMeterEvent('cus_test', 'org-3', 1, 'exec-003');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).skipped).toBe(true);
+    expect(mockOutboxInsert).not.toHaveBeenCalled();
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
@@ -88,12 +165,44 @@ describe('Stripe metered billing', () => {
     if (!result.ok) expect((result as any).skipped).toBe(true);
   });
 
-  it('returns error (not throw) when Stripe call fails', async () => {
+  it('returns error and marks outbox failed when Stripe call fails', async () => {
     mockMeterEventsCreate.mockRejectedValue(new Error('Stripe API error'));
 
     const result = await reportMeterEvent('cus_test', 'org-5', 1, 'exec-005');
     expect(result.ok).toBe(false);
     if (!result.ok) expect((result as any).error).toContain('Stripe API error');
+    expect(mockOutboxUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error: 'Stripe API error',
+    }));
+  });
+
+  it('flushMeterOutbox retries pending rows', async () => {
+    mockOutboxSelectAll.mockResolvedValue({
+      data: [{
+        id: 'outbox-retry-1',
+        execution_id: 'exec-retry-1',
+        org_id: 'org-retry',
+        stripe_customer_id: 'cus_retry',
+        event_name: 'dsg_execution',
+        quantity: 1,
+        status: 'pending',
+        stripe_event_id: null,
+        error: null,
+        created_at: '2026-05-01T00:00:00.000Z',
+      }],
+      error: null,
+    });
+    mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_retry' });
+
+    const result = await flushMeterOutbox(10);
+
+    expect(result.scanned).toBe(1);
+    expect(result.sent).toBe(1);
+    expect(mockMeterEventsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ identifier: 'dsg-meter-exec-retry-1' }),
+      { idempotencyKey: 'dsg-meter-exec-retry-1' }
+    );
   });
 
   it('isMeteredBillingConfigured returns true when both env vars are set', () => {

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock stripe before imports
 const mockMeterEventsCreate = vi.fn();
@@ -71,7 +71,6 @@ import { reportMeterEvent, isMeteredBillingConfigured, flushMeterOutbox } from '
 describe('Stripe metered billing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.restoreAllMocks();
     process.env.STRIPE_SECRET_KEY       = 'sk_test_xxx';
     process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution';
     mockOutboxInsert.mockImplementation(() => Promise.resolve({
@@ -81,10 +80,6 @@ describe('Stripe metered billing', () => {
     mockOutboxUpdate.mockResolvedValue({ data: null, error: null });
     mockOutboxSelectAll.mockResolvedValue({ data: [], error: null });
     mockCustomerMaybeSingle.mockResolvedValue({ data: { stripe_customer_id: 'cus_test123' }, error: null });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it('reports meter event successfully', async () => {
@@ -131,13 +126,14 @@ describe('Stripe metered billing', () => {
 
   it('uses distinct idempotency keys for same-second executions from the same org', async () => {
     mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_same_second' });
-    vi.spyOn(Date, 'now').mockReturnValue(1_777_000_000_000);
+    const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(1_777_000_000_000);
 
     await reportMeterEvent('cus_abc', 'org-same', 1, 'exec-same-1');
     await reportMeterEvent('cus_abc', 'org-same', 1, 'exec-same-2');
 
     expect(mockMeterEventsCreate.mock.calls[0][1].idempotencyKey).toBe('dsg-meter-exec-same-1');
     expect(mockMeterEventsCreate.mock.calls[1][1].idempotencyKey).toBe('dsg-meter-exec-same-2');
+    dateSpy.mockRestore();
   });
 
   it('requires executionId to prevent unsafe timestamp-only metering', async () => {

--- a/tests/unit/revenue/upgrade-nudge-period.test.ts
+++ b/tests/unit/revenue/upgrade-nudge-period.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getOrgUsageSnapshot, normalizeBillingPeriod } from '../../../lib/revenue/upgrade-nudge';
+
+const eqCalls: Array<[string, unknown]> = [];
+
+function makeChain(data: unknown) {
+  const chain: any = {
+    select: () => chain,
+    eq: (column: string, value: unknown) => {
+      eqCalls.push([column, value]);
+      return chain;
+    },
+    maybeSingle: () => Promise.resolve({ data, error: null }),
+    then: (resolve: any, reject: any) => Promise.resolve({ data, error: null }).then(resolve, reject),
+    catch: (reject: any) => Promise.resolve({ data, error: null }).catch(reject),
+  };
+  return chain;
+}
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'organizations') return makeChain({ plan: 'pro' });
+  if (table === 'usage_counters') return makeChain([{ executions: 4200 }]);
+  return makeChain(null);
+});
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+describe('upgrade-nudge explicit billing period', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eqCalls.length = 0;
+  });
+
+  it('uses the requested billing period for usage_counters queries', async () => {
+    const snapshot = await getOrgUsageSnapshot('org-period', '2026-04');
+
+    expect(snapshot.used).toBe(4200);
+    expect(eqCalls).toContainEqual(['org_id', 'org-period']);
+    expect(eqCalls).toContainEqual(['billing_period', '2026-04']);
+  });
+
+  it('normalizes invalid period values to a safe YYYY-MM fallback', () => {
+    const normalized = normalizeBillingPeriod('not-a-period');
+    expect(normalized).toMatch(/^\d{4}-\d{2}$/);
+    expect(normalized).not.toBe('not-a-period');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
   "ignoreCommand": "exit 1",
   "crons": [
     {
+      "path": "/api/cron/flush-meter-outbox",
+      "schedule": "0 * * * *"
+    },
+    {
       "path": "/api/cron/usage-alerts",
       "schedule": "0 7 * * *"
     },


### PR DESCRIPTION
## Summary

Closes the core implementation work for Issue #577 revenue hardening.

This PR makes the paid execution metering path safer by:

- using execution-level Stripe meter idempotency instead of org+timestamp keys
- adding a durable `billing_meter_outbox` table for retryable Stripe meter delivery
- adding a protected `/api/cron/flush-meter-outbox` route
- making `/api/cron/usage-alerts` fail closed when `CRON_SECRET` is missing
- fixing `/api/usage/analytics?period=YYYY-MM` so snapshot, top agents, and response period use the requested period
- adding an explicit-period unit test for `getOrgUsageSnapshot('org-id', '2026-04')`
- documenting the TypeScript vs Python Z3 proof lanes

## Changes

### P0-1 Stripe meter idempotency

- `reportMeterEvent(stripeCustomerId, orgId, quantity, executionId)` now requires `executionId`.
- Stripe idempotency now uses `dsg-meter-${executionId}`.
- Meter payload includes `identifier` with the same deterministic key.
- Unit tests cover same-second executions from the same org.

### P0-2 Billing outbox

- Adds `supabase/migrations/20260523000000_billing_meter_outbox.sql`.
- Writes an outbox row before Stripe delivery.
- Marks rows `sent` with `stripe_event_id` on success.
- Marks rows `failed` with error details on delivery failure.
- Adds `flushMeterOutbox(limit)` and `/api/cron/flush-meter-outbox`.

### P0-3 Cron auth fail-closed

- Missing `CRON_SECRET` returns 503.
- Wrong bearer token returns 401.
- Correct bearer token proceeds.

### P1-1 Analytics period correctness

- Adds `normalizeBillingPeriod(period?)`.
- `getOrgUsageSnapshot(orgId, period?)` uses the requested billing period.
- `/api/usage/analytics` uses one normalized `period` for response, snapshot, and top agents.
- Adds `tests/unit/revenue/upgrade-nudge-period.test.ts`.

### P1-2 Proof lane documentation

- Adds `tests/proofs/README.md` with clear claim boundary.

## Manual follow-up before production merge

The ChatGPT GitHub connector blocked updating `vercel.json` payload twice. Add this cron entry manually before production deploy:

```json
{
  "path": "/api/cron/flush-meter-outbox",
  "schedule": "0 * * * *"
}
```

## Verification required

Run before marking ready:

```bash
npm run typecheck
npm run test -- tests/unit/billing/metered.test.ts
npm run test -- tests/unit/revenue/upgrade-nudge-period.test.ts
npm run test
npm run verify:policy
npm run proof:install && npm run proof:revenue
npm run go:no-go
```

Manual smoke after deploy:

```text
GET /api/cron/usage-alerts without CRON_SECRET => 503
GET /api/cron/usage-alerts with wrong Bearer => 401
GET /api/cron/usage-alerts with correct Bearer => 200
GET /api/cron/flush-meter-outbox with wrong Bearer => 401
GET /api/usage/analytics?period=2026-04 => response.period === "2026-04"
Stripe test dashboard: each execution has a distinct meter event identifier
```

## Claim boundary

Do not claim production-ready billing until CI passes, Supabase migration is applied, the Vercel cron is configured, and Stripe test-mode meter delivery confirms outbox retry behavior.