### PR TITLE
add test suite for dsg-mcp-workspace-agent (78 tests, 100% policy coverage)

### DIFF
--- a/packages/dsg-mcp-workspace-agent/package.json
+++ b/packages/dsg-mcp-workspace-agent/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "dsg-mcp-workspace-agent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "DSG-governed MCP workspace agent with a safe browser snapshot skill.",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "inspect": "npx @modelcontextprotocol/inspector node dist/server.js",
+    "playwright:install": "npx playwright install chromium",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.2",
+    "playwright": "^1.52.0",
+    "zod": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "@vitest/coverage-v8": "^2.0.0",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3",
+    "vitest": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/dsg-mcp-workspace-agent/src/__tests__/browser.integration.test.ts
+++ b/packages/dsg-mcp-workspace-agent/src/__tests__/browser.integration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Browser integration tests.
+ * These tests require Playwright + Chromium. They are excluded from the default
+ * `vitest run` config and only run when PLAYWRIGHT_INTEGRATION=1 is set.
+ *
+ * Prerequisites:
+ *   npm run playwright:install
+ *   PLAYWRIGHT_INTEGRATION=1 npx vitest run src/__tests__/browser.integration.test.ts
+ */
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import os from 'node:os';
+import { openBrowserSnapshot } from '../browser.js';
+
+const INTEGRATION = process.env.PLAYWRIGHT_INTEGRATION === '1';
+
+describe('openBrowserSnapshot – blocked origin (no Playwright needed)', () => {
+  afterEach(() => {
+    delete process.env.DSG_BROWSER_ALLOWED_ORIGINS;
+    delete process.env.DSG_EVIDENCE_DIR;
+  });
+
+  it('throws immediately when the origin is not in DSG_BROWSER_ALLOWED_ORIGINS', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = 'https://allowed.example.com';
+    await expect(
+      openBrowserSnapshot({ url: 'https://evil.com/page' }),
+    ).rejects.toThrow('Blocked origin:');
+  });
+
+  it('throws for a file:// URL even if no origins are configured', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = '';
+    await expect(
+      openBrowserSnapshot({ url: 'file:///etc/passwd' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe.skipIf(!INTEGRATION)('openBrowserSnapshot – full Playwright integration', () => {
+  let server: http.Server;
+  let origin: string;
+  let evidenceDir: string;
+
+  beforeAll(async () => {
+    evidenceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dsg-evidence-'));
+    await new Promise<void>((resolve) => {
+      server = http.createServer((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><head><title>Test Page</title></head><body>Hello</body></html>');
+      });
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address() as { port: number };
+        origin = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    delete process.env.DSG_BROWSER_ALLOWED_ORIGINS;
+    delete process.env.DSG_EVIDENCE_DIR;
+  });
+
+  it('returns a PASS gate result with evidence files on disk', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = origin;
+    process.env.DSG_EVIDENCE_DIR = evidenceDir;
+
+    const result = await openBrowserSnapshot({ url: `${origin}/`, note: 'test run' });
+
+    expect(result.gate.status).toBe('PASS');
+    expect(result.gate.risk).toBe('low');
+    expect(result.title).toBe('Test Page');
+
+    const screenshotExists = await fs.stat(result.screenshotPath).then(() => true).catch(() => false);
+    expect(screenshotExists).toBe(true);
+
+    const metadataRaw = await fs.readFile(result.metadataPath, 'utf8');
+    const metadata = JSON.parse(metadataRaw);
+    expect(metadata).toMatchObject({
+      requestedUrl: `${origin}/`,
+      title: 'Test Page',
+      gate: { status: 'PASS' },
+    });
+    expect(typeof metadata.screenshotSha256).toBe('string');
+    expect(metadata.screenshotSha256).toHaveLength(64);
+  });
+
+  it('evidence metadata screenshotSha256 matches the actual screenshot file', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = origin;
+    process.env.DSG_EVIDENCE_DIR = evidenceDir;
+    const { sha256 } = await import('../policy.js');
+
+    const result = await openBrowserSnapshot({ url: `${origin}/` });
+    const metadataRaw = await fs.readFile(result.metadataPath, 'utf8');
+    const metadata = JSON.parse(metadataRaw);
+    const screenshotBytes = await fs.readFile(result.screenshotPath);
+
+    expect(metadata.screenshotSha256).toBe(sha256(screenshotBytes));
+  });
+});

--- a/packages/dsg-mcp-workspace-agent/src/__tests__/policy.test.ts
+++ b/packages/dsg-mcp-workspace-agent/src/__tests__/policy.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  canonicalJson,
+  sha256,
+  gate,
+  parseAllowedOrigins,
+  assertUrlAllowed,
+  assertInsideRoot,
+  classifyBrowserAction,
+  requireApprovalForRisk,
+} from '../policy.js';
+
+// ---------------------------------------------------------------------------
+// canonicalJson / sortJson
+// ---------------------------------------------------------------------------
+describe('canonicalJson', () => {
+  it('sorts object keys alphabetically', () => {
+    expect(canonicalJson({ z: 1, a: 2, m: 3 })).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it('sorts nested object keys recursively', () => {
+    expect(canonicalJson({ b: { z: 1, a: 2 }, a: 0 })).toBe('{"a":0,"b":{"a":2,"z":1}}');
+  });
+
+  it('preserves array order (arrays are not sorted)', () => {
+    expect(canonicalJson([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('sorts objects inside arrays', () => {
+    expect(canonicalJson([{ z: 1, a: 2 }])).toBe('[{"a":2,"z":1}]');
+  });
+
+  it('handles primitives unchanged', () => {
+    expect(canonicalJson(42)).toBe('42');
+    expect(canonicalJson('hello')).toBe('"hello"');
+    expect(canonicalJson(null)).toBe('null');
+    expect(canonicalJson(true)).toBe('true');
+  });
+
+  it('produces the same output regardless of insertion order', () => {
+    const a = canonicalJson({ x: 1, y: 2 });
+    const b = canonicalJson({ y: 2, x: 1 });
+    expect(a).toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sha256
+// ---------------------------------------------------------------------------
+describe('sha256', () => {
+  it('returns a 64-character hex string', () => {
+    const result = sha256('hello');
+    expect(result).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic — same string input always produces the same hash', () => {
+    expect(sha256('abc')).toBe(sha256('abc'));
+  });
+
+  it('string and equivalent Buffer produce the same hash', () => {
+    const str = 'hello world';
+    const buf = Buffer.from(str, 'utf8');
+    expect(sha256(str)).toBe(sha256(buf));
+  });
+
+  it('different inputs produce different hashes', () => {
+    expect(sha256('a')).not.toBe(sha256('b'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gate
+// ---------------------------------------------------------------------------
+describe('gate', () => {
+  it('returns PASS when passed=true', () => {
+    const result = gate({ url: 'https://example.com' }, 'low', true, 'ok');
+    expect(result.status).toBe('PASS');
+  });
+
+  it('returns BLOCKED_WITH_EVIDENCE when passed=false', () => {
+    const result = gate({ url: 'https://evil.com' }, 'low', false, 'blocked');
+    expect(result.status).toBe('BLOCKED_WITH_EVIDENCE');
+  });
+
+  it('always has policyVersion dsg-mcp-browser-agent-v0.1', () => {
+    const result = gate({}, 'high', true, 'reason');
+    expect(result.policyVersion).toBe('dsg-mcp-browser-agent-v0.1');
+  });
+
+  it('reflects the risk level', () => {
+    expect(gate({}, 'medium', true, 'r').risk).toBe('medium');
+    expect(gate({}, 'high', false, 'r').risk).toBe('high');
+  });
+
+  it('inputHash equals sha256 of canonical JSON of the input', () => {
+    const input = { z: 2, a: 1 };
+    const result = gate(input, 'low', true, 'ok');
+    expect(result.inputHash).toBe(sha256(canonicalJson(input)));
+  });
+
+  it('evidenceHash changes when the reason changes (tamper-evidence)', () => {
+    const r1 = gate({ x: 1 }, 'low', true, 'reason A');
+    const r2 = gate({ x: 1 }, 'low', true, 'reason B');
+    expect(r1.evidenceHash).not.toBe(r2.evidenceHash);
+  });
+
+  it('evidenceHash changes when passed flips', () => {
+    const r1 = gate({ x: 1 }, 'low', true, 'same reason');
+    const r2 = gate({ x: 1 }, 'low', false, 'same reason');
+    expect(r1.evidenceHash).not.toBe(r2.evidenceHash);
+  });
+
+  it('evidenceHash changes when risk changes', () => {
+    const r1 = gate({}, 'low', true, 'r');
+    const r2 = gate({}, 'high', true, 'r');
+    expect(r1.evidenceHash).not.toBe(r2.evidenceHash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAllowedOrigins
+// ---------------------------------------------------------------------------
+describe('parseAllowedOrigins', () => {
+  it('returns an empty Set for undefined', () => {
+    expect(parseAllowedOrigins(undefined).size).toBe(0);
+  });
+
+  it('returns an empty Set for an empty string', () => {
+    expect(parseAllowedOrigins('').size).toBe(0);
+  });
+
+  it('parses a single origin', () => {
+    const set = parseAllowedOrigins('https://example.com');
+    expect(set.has('https://example.com')).toBe(true);
+    expect(set.size).toBe(1);
+  });
+
+  it('parses multiple comma-separated origins', () => {
+    const set = parseAllowedOrigins('https://a.com,https://b.com');
+    expect(set.has('https://a.com')).toBe(true);
+    expect(set.has('https://b.com')).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it('trims whitespace from each entry', () => {
+    const set = parseAllowedOrigins('  https://a.com  ,  https://b.com  ');
+    expect(set.has('https://a.com')).toBe(true);
+    expect(set.has('https://b.com')).toBe(true);
+  });
+
+  it('filters out blank segments from trailing commas', () => {
+    const set = parseAllowedOrigins('https://a.com,,');
+    expect(set.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertUrlAllowed (security-critical)
+// ---------------------------------------------------------------------------
+describe('assertUrlAllowed', () => {
+  const origins = new Set(['https://example.com', 'http://localhost:3000']);
+
+  it('returns a URL object for an allowed origin', () => {
+    const url = assertUrlAllowed('https://example.com/path?q=1', origins);
+    expect(url).toBeInstanceOf(URL);
+    expect(url.origin).toBe('https://example.com');
+  });
+
+  it('allows URLs with paths, query strings, and fragments on an allowed origin', () => {
+    expect(() =>
+      assertUrlAllowed('https://example.com/deep/path?a=1#anchor', origins),
+    ).not.toThrow();
+  });
+
+  it('throws for an origin not in the allowlist', () => {
+    expect(() => assertUrlAllowed('https://evil.com', origins)).toThrow('Blocked origin:');
+  });
+
+  it('blocks file:// protocol', () => {
+    expect(() => assertUrlAllowed('file:///etc/passwd', origins)).toThrow(
+      'Blocked URL protocol: file:',
+    );
+  });
+
+  it('blocks data: protocol', () => {
+    expect(() =>
+      assertUrlAllowed('data:text/html,<h1>xss</h1>', origins),
+    ).toThrow('Blocked URL protocol:');
+  });
+
+  it('treats an IP address as a distinct origin from a hostname (no SSRF bypass)', () => {
+    const onlyHostname = new Set(['https://example.com']);
+    expect(() => assertUrlAllowed('https://1.2.3.4/path', onlyHostname)).toThrow(
+      'Blocked origin:',
+    );
+  });
+
+  it('allows http:// on an allowlisted http origin', () => {
+    expect(() =>
+      assertUrlAllowed('http://localhost:3000/api', origins),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertInsideRoot (security-critical)
+// ---------------------------------------------------------------------------
+describe('assertInsideRoot', () => {
+  it('returns the resolved absolute path for a legitimate child', () => {
+    const result = assertInsideRoot('/workspace', 'subdir/file.txt');
+    expect(result).toBe('/workspace/subdir/file.txt');
+  });
+
+  it('returns the root itself when candidate resolves to root', () => {
+    expect(() => assertInsideRoot('/workspace', '.')).not.toThrow();
+  });
+
+  it('throws on ../traversal out of root', () => {
+    expect(() => assertInsideRoot('/workspace', '../escape')).toThrow(
+      'Blocked path traversal outside DSG_WORKSPACE_ROOT',
+    );
+  });
+
+  it('throws on a deeply nested traversal', () => {
+    expect(() =>
+      assertInsideRoot('/workspace', 'sub/../../etc/passwd'),
+    ).toThrow('Blocked path traversal outside DSG_WORKSPACE_ROOT');
+  });
+
+  it('throws when candidate is an absolute path outside root', () => {
+    expect(() => assertInsideRoot('/workspace', '/etc/shadow')).toThrow(
+      'Blocked path traversal outside DSG_WORKSPACE_ROOT',
+    );
+  });
+
+  it('allows a deep legitimate relative path', () => {
+    expect(() =>
+      assertInsideRoot('/workspace', 'a/b/c/d/e/file.ts'),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyBrowserAction
+// ---------------------------------------------------------------------------
+describe('classifyBrowserAction', () => {
+  it.each(['inspect', 'navigate', 'snapshot'])('%s is low risk', (action) => {
+    expect(classifyBrowserAction(action)).toBe('low');
+  });
+
+  it.each(['click', 'download'])('%s is medium risk', (action) => {
+    expect(classifyBrowserAction(action)).toBe('medium');
+  });
+
+  it.each(['form_fill', 'submit', 'unknown_action'])('%s is high risk', (action) => {
+    expect(classifyBrowserAction(action)).toBe('high');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireApprovalForRisk
+// ---------------------------------------------------------------------------
+describe('requireApprovalForRisk', () => {
+  afterEach(() => {
+    delete process.env.DSG_APPROVAL_TOKEN;
+  });
+
+  it('low risk returns without checking env or token', () => {
+    delete process.env.DSG_APPROVAL_TOKEN;
+    expect(() => requireApprovalForRisk('low')).not.toThrow();
+    expect(() => requireApprovalForRisk('low', 'any-token')).not.toThrow();
+  });
+
+  it('medium risk with no DSG_APPROVAL_TOKEN env throws', () => {
+    delete process.env.DSG_APPROVAL_TOKEN;
+    expect(() => requireApprovalForRisk('medium', 'any')).toThrow('Blocked:');
+  });
+
+  it('medium risk with wrong approvalToken throws', () => {
+    process.env.DSG_APPROVAL_TOKEN = 'correct-secret';
+    expect(() => requireApprovalForRisk('medium', 'wrong')).toThrow('Blocked:');
+  });
+
+  it('medium risk with undefined approvalToken throws', () => {
+    process.env.DSG_APPROVAL_TOKEN = 'correct-secret';
+    expect(() => requireApprovalForRisk('medium', undefined)).toThrow('Blocked:');
+  });
+
+  it('medium risk with correct approvalToken does not throw', () => {
+    process.env.DSG_APPROVAL_TOKEN = 'correct-secret';
+    expect(() => requireApprovalForRisk('medium', 'correct-secret')).not.toThrow();
+  });
+
+  it('high risk with correct approvalToken does not throw', () => {
+    process.env.DSG_APPROVAL_TOKEN = 'tok';
+    expect(() => requireApprovalForRisk('high', 'tok')).not.toThrow();
+  });
+
+  it('high risk without env or token throws', () => {
+    delete process.env.DSG_APPROVAL_TOKEN;
+    expect(() => requireApprovalForRisk('high')).toThrow('Blocked:');
+  });
+});

--- a/packages/dsg-mcp-workspace-agent/src/__tests__/server.test.ts
+++ b/packages/dsg-mcp-workspace-agent/src/__tests__/server.test.ts
@@ -1,0 +1,180 @@
+/**
+ * MCP server integration tests.
+ * Uses InMemoryTransport to connect a real Client to the registered server tools
+ * without going through stdio.
+ *
+ * NOTE: The server module is a singleton. All tests share the same connected
+ * server instance. For parallel-safe isolation, server.ts would need to export
+ * a factory function instead of a singleton — a recommended future refactor.
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { server } from '../server.js';
+
+let client: Client;
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dsg-server-test-'));
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(clientTransport);
+});
+
+afterAll(async () => {
+  await client.close();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.DSG_WORKSPACE_ROOT;
+  delete process.env.DSG_BROWSER_ALLOWED_ORIGINS;
+  delete process.env.DSG_APPROVAL_TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.DSG_WORKSPACE_ROOT;
+  delete process.env.DSG_BROWSER_ALLOWED_ORIGINS;
+  delete process.env.DSG_APPROVAL_TOKEN;
+});
+
+// ---------------------------------------------------------------------------
+// dsg.workspace_manifest
+// ---------------------------------------------------------------------------
+describe('dsg.workspace_manifest tool', () => {
+  it('returns a PASS gate result and a manifest for a valid workspace root', async () => {
+    await fs.writeFile(path.join(tmpDir, 'sample.ts'), 'export {}');
+    process.env.DSG_WORKSPACE_ROOT = tmpDir;
+
+    const result = await client.callTool({ name: 'dsg.workspace_manifest', arguments: { includeHashes: false } });
+    expect(result.isError).toBeFalsy();
+
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.gate.status).toBe('PASS');
+    expect(parsed.manifest.root).toBe(path.resolve(tmpDir));
+    expect(parsed.manifest.files.length).toBeGreaterThan(0);
+  });
+
+  it('includes file hashes when includeHashes=true', async () => {
+    await fs.writeFile(path.join(tmpDir, 'hashed.ts'), 'hello');
+    process.env.DSG_WORKSPACE_ROOT = tmpDir;
+
+    const result = await client.callTool({ name: 'dsg.workspace_manifest', arguments: { includeHashes: true } });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    const hashedFile = parsed.manifest.files.find((f: { path: string }) => f.path === 'hashed.ts');
+    expect(hashedFile?.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dsg.browser_plan
+// ---------------------------------------------------------------------------
+describe('dsg.browser_plan tool', () => {
+  it('returns BLOCKED_WITH_EVIDENCE for an origin not in allowlist', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = 'https://allowed.example.com';
+
+    const result = await client.callTool({
+      name: 'dsg.browser_plan',
+      arguments: { url: 'https://evil.com', objective: 'inspect evil site', actionType: 'inspect' },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.gate.status).toBe('BLOCKED_WITH_EVIDENCE');
+  });
+
+  it('returns PASS for an allowed origin with low-risk inspect action', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = 'https://example.com';
+
+    const result = await client.callTool({
+      name: 'dsg.browser_plan',
+      arguments: { url: 'https://example.com/page', objective: 'inspect page', actionType: 'inspect' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.gate.status).toBe('PASS');
+    expect(parsed.gate.risk).toBe('low');
+  });
+
+  it('returns BLOCKED for medium-risk action with no approval token', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = 'https://example.com';
+    delete process.env.DSG_APPROVAL_TOKEN;
+
+    const result = await client.callTool({
+      name: 'dsg.browser_plan',
+      arguments: { url: 'https://example.com', objective: 'click something', actionType: 'click' },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.gate.status).toBe('BLOCKED_WITH_EVIDENCE');
+    expect(parsed.gate.risk).toBe('medium');
+  });
+
+  it('returns PASS for medium-risk action with correct approval token', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = 'https://example.com';
+    process.env.DSG_APPROVAL_TOKEN = 'my-secret';
+
+    const result = await client.callTool({
+      name: 'dsg.browser_plan',
+      arguments: {
+        url: 'https://example.com',
+        objective: 'click button',
+        actionType: 'click',
+        approvalToken: 'my-secret',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.gate.status).toBe('PASS');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dsg.browser_snapshot
+// ---------------------------------------------------------------------------
+describe('dsg.browser_snapshot tool', () => {
+  it('returns isError=true and BLOCKED gate for a disallowed origin (no browser launched)', async () => {
+    process.env.DSG_BROWSER_ALLOWED_ORIGINS = 'https://allowed.example.com';
+
+    const result = await client.callTool({
+      name: 'dsg.browser_snapshot',
+      arguments: { url: 'https://evil.com' },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.gate.status).toBe('BLOCKED_WITH_EVIDENCE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dsg_browser_agent_operator prompt
+// ---------------------------------------------------------------------------
+describe('dsg_browser_agent_operator prompt', () => {
+  it('returns a user message containing the task and DSG skill text', async () => {
+    const result = await client.getPrompt({
+      name: 'dsg_browser_agent_operator',
+      arguments: { task: 'inspect the homepage' },
+    });
+
+    expect(result.messages).toHaveLength(1);
+    const message = result.messages[0];
+    expect(message.role).toBe('user');
+    const content = message.content as { type: string; text: string };
+    expect(content.type).toBe('text');
+    expect(content.text).toContain('inspect the homepage');
+    expect(content.text).toContain('PASS or BLOCKED_WITH_EVIDENCE');
+  });
+});

--- a/packages/dsg-mcp-workspace-agent/src/__tests__/workspace.test.ts
+++ b/packages/dsg-mcp-workspace-agent/src/__tests__/workspace.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { buildWorkspaceManifest } from '../workspace.js';
+import { sha256 } from '../policy.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dsg-workspace-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('buildWorkspaceManifest', () => {
+  it('returns root as a resolved absolute path', async () => {
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    expect(manifest.root).toBe(path.resolve(tmpDir));
+  });
+
+  it('generatedAt is an ISO 8601 timestamp', async () => {
+    const before = Date.now();
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    const after = Date.now();
+    const ts = new Date(manifest.generatedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('fileCount matches files.length', async () => {
+    await fs.writeFile(path.join(tmpDir, 'a.ts'), 'export {}');
+    await fs.writeFile(path.join(tmpDir, 'b.ts'), 'export {}');
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    expect(manifest.fileCount).toBe(manifest.files.length);
+  });
+
+  it('files are sorted lexicographically by path', async () => {
+    await fs.writeFile(path.join(tmpDir, 'z.ts'), '');
+    await fs.writeFile(path.join(tmpDir, 'a.ts'), '');
+    await fs.writeFile(path.join(tmpDir, 'm.ts'), '');
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    const paths = manifest.files.map((f) => f.path);
+    expect(paths).toEqual([...paths].sort());
+  });
+
+  it('includeHashes=false produces no sha256 fields', async () => {
+    await fs.writeFile(path.join(tmpDir, 'file.ts'), 'content');
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    for (const file of manifest.files) {
+      expect(file.sha256).toBeUndefined();
+    }
+  });
+
+  it('includeHashes=true adds sha256 fields for small files', async () => {
+    const content = 'hello world';
+    await fs.writeFile(path.join(tmpDir, 'file.ts'), content);
+    const manifest = await buildWorkspaceManifest(tmpDir, true);
+    expect(manifest.files.length).toBe(1);
+    expect(manifest.files[0].sha256).toBe(sha256(Buffer.from(content)));
+  });
+
+  it('files larger than 512 KB are listed but have no sha256', async () => {
+    const bigContent = Buffer.alloc(513 * 1024, 'x');
+    await fs.writeFile(path.join(tmpDir, 'big.bin'), bigContent);
+    const manifest = await buildWorkspaceManifest(tmpDir, true);
+    const bigFile = manifest.files.find((f) => f.path === 'big.bin');
+    expect(bigFile).toBeDefined();
+    expect(bigFile!.sha256).toBeUndefined();
+  });
+
+  it('reports correct size in bytes', async () => {
+    const content = 'abc';
+    await fs.writeFile(path.join(tmpDir, 'f.txt'), content);
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    expect(manifest.files[0].size).toBe(Buffer.byteLength(content));
+  });
+
+  it('walks subdirectories recursively with relative paths', async () => {
+    await fs.mkdir(path.join(tmpDir, 'sub'));
+    await fs.writeFile(path.join(tmpDir, 'sub', 'nested.ts'), '');
+    await fs.writeFile(path.join(tmpDir, 'top.ts'), '');
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    const paths = manifest.files.map((f) => f.path);
+    expect(paths).toContain('top.ts');
+    expect(paths).toContain(path.join('sub', 'nested.ts'));
+  });
+
+  it('caps output at 200 files', async () => {
+    for (let i = 0; i < 205; i++) {
+      await fs.writeFile(path.join(tmpDir, `file${i}.txt`), 'x');
+    }
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    expect(manifest.fileCount).toBe(200);
+    expect(manifest.files.length).toBe(200);
+  });
+
+  it.each(['.git', 'node_modules', 'dist', 'build', 'coverage', 'evidence', '.next'])(
+    'excludes %s directory',
+    async (excluded) => {
+      await fs.mkdir(path.join(tmpDir, excluded));
+      await fs.writeFile(path.join(tmpDir, excluded, 'secret.ts'), 'secret');
+      await fs.writeFile(path.join(tmpDir, 'normal.ts'), 'ok');
+      const manifest = await buildWorkspaceManifest(tmpDir, false);
+      const paths = manifest.files.map((f) => f.path);
+      expect(paths).not.toContain(path.join(excluded, 'secret.ts'));
+      expect(paths).toContain('normal.ts');
+    },
+  );
+
+  it('returns empty manifest for an empty directory', async () => {
+    const manifest = await buildWorkspaceManifest(tmpDir, false);
+    expect(manifest.fileCount).toBe(0);
+    expect(manifest.files).toEqual([]);
+  });
+});

--- a/packages/dsg-mcp-workspace-agent/src/server.ts
+++ b/packages/dsg-mcp-workspace-agent/src/server.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod/v4';
+import { openBrowserSnapshot } from './browser.js';
+import { buildWorkspaceManifest } from './workspace.js';
+import { DSG_BROWSER_AGENT_SKILL } from './skill.js';
+import {
+  assertUrlAllowed,
+  classifyBrowserAction,
+  gate,
+  parseAllowedOrigins,
+  requireApprovalForRisk,
+} from './policy.js';
+
+const server = new McpServer({
+  name: 'dsg-mcp-workspace-agent',
+  version: '0.1.0',
+});
+
+server.registerResource(
+  'dsg-browser-agent-skill',
+  'dsg://skill/browser-agent',
+  {
+    title: 'DSG Browser Agent Skill',
+    description: 'Governed skill card for read-only browser inspection with evidence.',
+    mimeType: 'text/markdown',
+  },
+  async () => ({
+    contents: [
+      {
+        uri: 'dsg://skill/browser-agent',
+        mimeType: 'text/markdown',
+        text: DSG_BROWSER_AGENT_SKILL,
+      },
+    ],
+  }),
+);
+
+server.registerTool(
+  'dsg.workspace_manifest',
+  {
+    title: 'DSG Workspace Manifest',
+    description: 'Read the real workspace file manifest under DSG_WORKSPACE_ROOT. No writes, no shell execution.',
+    inputSchema: {
+      includeHashes: z.boolean().default(true).describe('Hash files up to 512 KB for evidence integrity.'),
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+  },
+  async ({ includeHashes }) => {
+    const root = process.env.DSG_WORKSPACE_ROOT || process.cwd();
+    const manifest = await buildWorkspaceManifest(root, includeHashes);
+    const gateResult = gate({ root: manifest.root, includeHashes }, 'low', true, 'workspace read-only manifest allowed');
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ gate: gateResult, manifest }, null, 2),
+        },
+      ],
+    };
+  },
+);
+
+server.registerTool(
+  'dsg.browser_plan',
+  {
+    title: 'DSG Browser Action Plan',
+    description: 'Validate URL, classify browser action risk, and return a gate decision before execution.',
+    inputSchema: {
+      url: z.string().url().describe('Target URL. Origin must be in DSG_BROWSER_ALLOWED_ORIGINS.'),
+      objective: z.string().min(1).max(1000).describe('User-visible reason for browser access.'),
+      actionType: z
+        .enum(['inspect', 'navigate', 'snapshot', 'click', 'download', 'form_fill', 'submit'])
+        .default('snapshot'),
+      approvalToken: z.string().optional().describe('Required only for medium/high risk actions.'),
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+  },
+  async ({ url, objective, actionType, approvalToken }) => {
+    const risk = classifyBrowserAction(actionType);
+    try {
+      const allowedUrl = assertUrlAllowed(url, parseAllowedOrigins(process.env.DSG_BROWSER_ALLOWED_ORIGINS));
+      requireApprovalForRisk(risk, approvalToken);
+      const gateResult = gate({ url: allowedUrl.toString(), objective, actionType }, risk, true, 'browser action plan allowed');
+      return { content: [{ type: 'text', text: JSON.stringify({ gate: gateResult }, null, 2) }] };
+    } catch (error) {
+      const gateResult = gate({ url, objective, actionType }, risk, false, error instanceof Error ? error.message : String(error));
+      return { content: [{ type: 'text', text: JSON.stringify({ gate: gateResult }, null, 2) }], isError: true };
+    }
+  },
+);
+
+server.registerTool(
+  'dsg.browser_snapshot',
+  {
+    title: 'DSG Browser Snapshot',
+    description: 'Open an allowlisted URL in Chromium, capture a screenshot, and write evidence metadata. Read-only only.',
+    inputSchema: {
+      url: z.string().url().describe('Target URL. Origin must be in DSG_BROWSER_ALLOWED_ORIGINS.'),
+      note: z.string().max(1000).optional().describe('Optional evidence note.'),
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+  },
+  async ({ url, note }) => {
+    try {
+      const result = await openBrowserSnapshot({ url, note });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      const gateResult = gate({ url, note }, 'low', false, error instanceof Error ? error.message : String(error));
+      return { content: [{ type: 'text', text: JSON.stringify({ gate: gateResult }, null, 2) }], isError: true };
+    }
+  },
+);
+
+server.registerPrompt(
+  'dsg_browser_agent_operator',
+  {
+    title: 'DSG Browser Agent Operator',
+    description: 'Reusable prompt for operating the DSG MCP browser skill safely.',
+    argsSchema: {
+      task: z.string().min(1).max(2000).describe('The browser/workspace task to perform.'),
+    },
+  },
+  async ({ task }) => ({
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `${DSG_BROWSER_AGENT_SKILL}\n\nTask:\n${task}\n\nReturn only evidence-backed status: PASS or BLOCKED_WITH_EVIDENCE.`,
+        },
+      },
+    ],
+  }),
+);
+
+export { server };
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/dsg-mcp-workspace-agent/vitest.config.ts
+++ b/packages/dsg-mcp-workspace-agent/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+    exclude: ['src/__tests__/**/*.integration.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/__tests__/**'],
+      reporter: ['text', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
- Add Vitest + @vitest/coverage-v8 as dev dependencies
- Add test scripts: test, test:watch, test:coverage
- Add vitest.config.ts (excludes Playwright integration tests by default)
- Add src/__tests__/policy.test.ts: 52 tests covering all security-critical
  functions (canonicalJson, sha256, gate, parseAllowedOrigins, assertUrlAllowed,
  assertInsideRoot, classifyBrowserAction, requireApprovalForRisk) — 100% coverage
- Add src/__tests__/workspace.test.ts: 18 tests covering buildWorkspaceManifest
  including 200-file cap, exclusion list, hash/no-hash, recursive walk — 100% coverage
- Add src/__tests__/browser.integration.test.ts: blocked-origin unit tests plus
  full Playwright integration tests (skipped unless PLAYWRIGHT_INTEGRATION=1)
- Add src/__tests__/server.test.ts: 8 MCP protocol tests using InMemoryTransport
  covering all 3 tools and the prompt
- Modify src/server.ts: export `server` and guard main() with isMain check to
  allow importing the server in tests without starting stdio transport