### PR TITLE
feat(admin): PIPELINE_TOKEN for mobile pipeline access

### DIFF
--- a/app/api/admin/pipeline/route.ts
+++ b/app/api/admin/pipeline/route.ts
@@ -4,12 +4,12 @@ import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
   const { searchParams } = new URL(request.url);
   const token = searchParams.get('token')
     ?? request.headers.get('authorization')?.replace('Bearer ', '');
 
-  if (!secret || token !== secret) {
+  const validTokens = [process.env.CRON_SECRET, process.env.PIPELINE_TOKEN].filter(Boolean);
+  if (!validTokens.length || !validTokens.includes(token ?? '')) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 


### PR DESCRIPTION
Goal: Set PIPELINE_TOKEN to a simple memorable value, open pipeline from mobile without login.

Files changed:
- `app/api/admin/pipeline/route.ts` — accept PIPELINE_TOKEN OR CRON_SECRET

Next step: Set PIPELINE_TOKEN in Vercel, deploy, open URL from mobile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F)_