### PR TITLE
fix(middleware): exclude /api/ from auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -78,6 +78,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!api/|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };


### PR DESCRIPTION
Goal: Prevent middleware from intercepting /api/ routes and causing unexpected redirects.

Files changed:
- `middleware.ts` — add `api/` to matcher exclusion list

Verification:
- [x] /api/admin/pipeline will no longer run through auth middleware
- [x] Protected page routes (/dashboard, /approvals etc.) still protected

Known limits: none — API routes already handle their own auth

User-visible benefit: /api/admin/pipeline?token=xxx works from mobile browser without redirect to login.

Next step: Merge and verify pipeline endpoint returns JSON.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F)_