### PR TITLE
fix(ts): exclude packages/ from root tsconfig — fix build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "packages"
   ]
 }


### PR DESCRIPTION
Goal: Fix Vercel build failure blocking production deploy.

Files changed:
- `tsconfig.json` — add `packages` to exclude list

Verification:
- [x] packages/dsg-mcp-workspace-agent has its own TS config/build
- [x] Excluding it prevents root build from picking up deprecated options

Known limits: none

User-visible benefit: Vercel build goes green, /api/admin/pipeline becomes accessible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F)_