### PR TITLE
test: +324 unit tests across 19 source files (874 passed / 886 total)

### DIFF
--- a/tests/integration/api/effect-callback.test.ts
+++ b/tests/integration/api/effect-callback.test.ts
@@ -1,12 +1,208 @@
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('/api/effect-callback', () => {
-  it('returns 403 when role is missing', async () => {
+const allowedAccess = {
+  ok: true as const,
+  orgId: 'org-test',
+  userId: 'user-test',
+  authUserId: 'auth-test',
+  grantedRoles: ['operator'] as const,
+};
+
+function makeAuthzMock(result: object) {
+  return { requireOrgRole: vi.fn(async () => result) };
+}
+
+function makeReconcileMock(result: object) {
+  return { reconcileEffectCallback: vi.fn(async () => result) };
+}
+
+function makeErrorMocks() {
+  return {
+    logServerError: vi.fn(),
+    serverErrorResponse: vi.fn(() => Response.json({ error: 'Internal Server Error' }, { status: 500 })),
+  };
+}
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost/api/effect-callback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/effect-callback', () => {
+  beforeEach(() => {
     vi.resetModules();
-    vi.doMock('../../../lib/authz', () => ({ requireOrgRole: vi.fn(async () => ({ ok: false, status: 403, error: 'Insufficient role' })) }));
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.doMock('../../../lib/authz', () =>
+      makeAuthzMock({ ok: false, status: 401, error: 'Unauthorized' })
+    );
+    vi.doMock('../../../lib/runtime/reconcile', () =>
+      makeReconcileMock({ found: true, alreadyFinal: false })
+    );
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
     const { POST } = await import('../../../app/api/effect-callback/route');
-    const req = new Request('http://localhost/api/effect-callback', { method: 'POST', body: JSON.stringify({}) });
-    const res = await POST(req);
+    const res = await POST(postRequest({ effect_id: 'eff-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when role is insufficient', async () => {
+    vi.doMock('../../../lib/authz', () =>
+      makeAuthzMock({ ok: false, status: 403, error: 'Insufficient role' })
+    );
+    vi.doMock('../../../lib/runtime/reconcile', () =>
+      makeReconcileMock({ found: true, alreadyFinal: false })
+    );
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const res = await POST(postRequest({ effect_id: 'eff-1' }));
+    const body = await res.json();
+
     expect(res.status).toBe(403);
+    expect(body.error).toBe('Insufficient role');
+  });
+
+  it('returns 400 when effect_id is missing', async () => {
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () =>
+      makeReconcileMock({ found: true, alreadyFinal: false })
+    );
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const res = await POST(postRequest({}));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/effect_id/);
+  });
+
+  it('returns 400 when body is not valid JSON', async () => {
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () =>
+      makeReconcileMock({ found: true, alreadyFinal: false })
+    );
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const badReq = new Request('http://localhost/api/effect-callback', {
+      method: 'POST',
+      body: 'not-json',
+    });
+    const res = await POST(badReq);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/effect_id/);
+  });
+
+  it('returns 404 when effect_id does not exist', async () => {
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () =>
+      makeReconcileMock({ found: false, alreadyFinal: false })
+    );
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const res = await POST(postRequest({ effect_id: 'unknown-eff' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it('returns 200 with idempotent:false for a fresh pending effect', async () => {
+    const reconcile = makeReconcileMock({ found: true, alreadyFinal: false });
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () => reconcile);
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const res = await POST(postRequest({ effect_id: 'eff-pending', status: 'succeeded' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, idempotent: false });
+  });
+
+  it('returns 200 with idempotent:true when already in final state', async () => {
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () =>
+      makeReconcileMock({ found: true, alreadyFinal: true })
+    );
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const res = await POST(postRequest({ effect_id: 'eff-done', status: 'succeeded' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true, idempotent: true });
+  });
+
+  it('accepts status:failed and passes it to reconcile', async () => {
+    const reconcile = makeReconcileMock({ found: true, alreadyFinal: false });
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () => reconcile);
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    await POST(postRequest({ effect_id: 'eff-1', status: 'failed' }));
+
+    const call = reconcile.reconcileEffectCallback.mock.calls[0][0];
+    expect(call.status).toBe('failed');
+  });
+
+  it('defaults to status:succeeded when status is omitted', async () => {
+    const reconcile = makeReconcileMock({ found: true, alreadyFinal: false });
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () => reconcile);
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    await POST(postRequest({ effect_id: 'eff-1' }));
+
+    const call = reconcile.reconcileEffectCallback.mock.calls[0][0];
+    expect(call.status).toBe('succeeded');
+  });
+
+  it('passes orgId from auth context to reconcile (cross-org isolation)', async () => {
+    const access = { ...allowedAccess, orgId: 'org-specific' };
+    const reconcile = makeReconcileMock({ found: true, alreadyFinal: false });
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(access));
+    vi.doMock('../../../lib/runtime/reconcile', () => reconcile);
+    vi.doMock('../../../lib/security/error-response', () => makeErrorMocks());
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    await POST(postRequest({ effect_id: 'eff-1' }));
+
+    const call = reconcile.reconcileEffectCallback.mock.calls[0][0];
+    expect(call.orgId).toBe('org-specific');
+  });
+
+  it('returns 500 when reconcile throws unexpectedly', async () => {
+    const errorMocks = makeErrorMocks();
+    vi.doMock('../../../lib/authz', () => makeAuthzMock(allowedAccess));
+    vi.doMock('../../../lib/runtime/reconcile', () => ({
+      reconcileEffectCallback: vi.fn(async () => { throw new Error('DB exploded'); }),
+    }));
+    vi.doMock('../../../lib/security/error-response', () => errorMocks);
+
+    const { POST } = await import('../../../app/api/effect-callback/route');
+    const res = await POST(postRequest({ effect_id: 'eff-1' }));
+
+    expect(res.status).toBe(500);
+    expect(errorMocks.logServerError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'effect-callback-post'
+    );
   });
 });

--- a/tests/unit/agent-governance/planner.test.ts
+++ b/tests/unit/agent-governance/planner.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { planMessage } from '../../../lib/agent-governance/planner';
+
+describe('planMessage', () => {
+  it('returns empty array for empty string', () => {
+    expect(planMessage('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(planMessage('   ')).toEqual([]);
+    expect(planMessage('\n\t')).toEqual([]);
+  });
+
+  it('returns an array with one step for a non-empty message', () => {
+    const steps = planMessage('check agent readiness');
+    expect(steps).toHaveLength(1);
+  });
+
+  it('step has step_index 0', () => {
+    expect(planMessage('hello')[0].step_index).toBe(0);
+  });
+
+  it('step uses readiness tool', () => {
+    expect(planMessage('hello')[0].tool).toBe('readiness');
+  });
+
+  it('step passes message in params', () => {
+    const msg = 'deploy to production';
+    expect(planMessage(msg)[0].params).toEqual({ message: msg });
+  });
+
+  it('step has policy_mode allow', () => {
+    expect(planMessage('hello')[0].policy_mode).toBe('allow');
+  });
+
+  it('step has status pending', () => {
+    expect(planMessage('hello')[0].status).toBe('pending');
+  });
+});

--- a/tests/unit/agent-governance/policy.test.ts
+++ b/tests/unit/agent-governance/policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePolicyDecision } from '../../../lib/agent-governance/policy';
+import type { AgentStep } from '../../../lib/agent-governance/types';
+
+function makeStep(policy_mode: AgentStep['policy_mode']): AgentStep {
+  return {
+    step_index: 0,
+    tool: 'readiness',
+    params: {},
+    policy_mode,
+    status: 'pending',
+  };
+}
+
+describe('resolvePolicyDecision', () => {
+  it('returns allow for an allow step', () => {
+    expect(resolvePolicyDecision(makeStep('allow'))).toBe('allow');
+  });
+
+  it('returns review_required for a review_required step', () => {
+    expect(resolvePolicyDecision(makeStep('review_required'))).toBe('review_required');
+  });
+
+  it('returns block for a block step', () => {
+    expect(resolvePolicyDecision(makeStep('block'))).toBe('block');
+  });
+
+  it('is a direct pass-through of policy_mode', () => {
+    const step = makeStep('allow');
+    expect(resolvePolicyDecision(step)).toBe(step.policy_mode);
+  });
+});

--- a/tests/unit/gateway/approvals.test.ts
+++ b/tests/unit/gateway/approvals.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockFrom, mockRecordGovernanceDecisionEvent } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockRecordGovernanceDecisionEvent: vi.fn(),
+}));
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+vi.mock('@/lib/governance/decision-recorder', () => ({
+  recordGovernanceDecisionEvent: mockRecordGovernanceDecisionEvent,
+}));
+
+import {
+  buildApprovalToken,
+  buildApprovalHash,
+  listPendingGatewayApprovals,
+  decideGatewayApproval,
+} from '../../../lib/gateway/approvals';
+
+function makeReadChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockResolvedValue(result);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+function makeUpdateChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  return Object.assign(chain, { then: (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRecordGovernanceDecisionEvent.mockResolvedValue(true);
+});
+
+// ─── buildApprovalToken ──────────────────────────────────────────────────
+
+describe('buildApprovalToken', () => {
+  it('starts with gap_ prefix', () => {
+    expect(buildApprovalToken()).toMatch(/^gap_/);
+  });
+
+  it('contains only hex chars after the prefix', () => {
+    const token = buildApprovalToken();
+    expect(token.slice(4)).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('is 52 characters long (gap_ + 48 hex chars from 24 bytes)', () => {
+    expect(buildApprovalToken()).toHaveLength(52);
+  });
+
+  it('generates a different token on each call', () => {
+    expect(buildApprovalToken()).not.toBe(buildApprovalToken());
+  });
+});
+
+// ─── buildApprovalHash ───────────────────────────────────────────────────
+
+describe('buildApprovalHash', () => {
+  it('returns a 64-char hex string (SHA-256)', () => {
+    expect(buildApprovalHash({ x: 1 })).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const h1 = buildApprovalHash({ orgId: 'org-1', decision: 'approved' });
+    const h2 = buildApprovalHash({ orgId: 'org-1', decision: 'approved' });
+    expect(h1).toBe(h2);
+  });
+
+  it('differs when input changes', () => {
+    const h1 = buildApprovalHash({ decision: 'approved' });
+    const h2 = buildApprovalHash({ decision: 'rejected' });
+    expect(h1).not.toBe(h2);
+  });
+});
+
+// ─── listPendingGatewayApprovals ─────────────────────────────────────────
+
+describe('listPendingGatewayApprovals', () => {
+  it('returns ok:false and missing_org_id when orgId is empty', async () => {
+    const result = await listPendingGatewayApprovals('');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_org_id');
+    expect(result.approvals).toEqual([]);
+  });
+
+  it('returns ok:false on DB error', async () => {
+    const chain = makeReadChain({ data: null, error: { message: 'connection refused' } });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await listPendingGatewayApprovals('org-1');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('connection refused');
+    expect(result.approvals).toEqual([]);
+  });
+
+  it('returns ok:true and approvals array on success', async () => {
+    const approvals = [{ id: 'ev-1', decision: 'review' }];
+    const chain = makeReadChain({ data: approvals, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await listPendingGatewayApprovals('org-1');
+    expect(result.ok).toBe(true);
+    expect(result.approvals).toEqual(approvals);
+  });
+
+  it('returns empty array when data is null', async () => {
+    const chain = makeReadChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await listPendingGatewayApprovals('org-1');
+    expect(result.ok).toBe(true);
+    expect(result.approvals).toEqual([]);
+  });
+});
+
+// ─── decideGatewayApproval — validation ──────────────────────────────────
+
+describe('decideGatewayApproval — input validation', () => {
+  const base = {
+    orgId: 'org-1',
+    auditToken: 'tok-abc',
+    decision: 'approved' as const,
+    reviewerId: 'user-1',
+    reviewerRole: 'finance_approver',
+  };
+
+  it('returns ok:false + missing_org_id when orgId is empty', async () => {
+    const result = await decideGatewayApproval({ ...base, orgId: '' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_org_id');
+  });
+
+  it('returns ok:false + missing_audit_token when auditToken is empty', async () => {
+    const result = await decideGatewayApproval({ ...base, auditToken: '' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_audit_token');
+  });
+
+  it('returns ok:false + missing_reviewer_id when reviewerId is empty', async () => {
+    const result = await decideGatewayApproval({ ...base, reviewerId: '' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_reviewer_id');
+  });
+
+  it('returns ok:false + missing_reviewer_role when reviewerRole is empty', async () => {
+    const result = await decideGatewayApproval({ ...base, reviewerRole: '' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_reviewer_role');
+  });
+});
+
+// ─── decideGatewayApproval — DB read failures ─────────────────────────────
+
+describe('decideGatewayApproval — DB read', () => {
+  const base = {
+    orgId: 'org-1',
+    auditToken: 'tok-abc',
+    decision: 'approved' as const,
+    reviewerId: 'user-1',
+    reviewerRole: 'finance_approver',
+  };
+
+  it('throws when DB read fails', async () => {
+    const chain = makeReadChain({ data: null, error: { message: 'db timeout' } });
+    mockFrom.mockReturnValue(chain);
+
+    await expect(decideGatewayApproval(base)).rejects.toThrow('failed_to_read_approval_event:db timeout');
+  });
+
+  it('returns ok:false + audit_token_not_found when event not found', async () => {
+    const chain = makeReadChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await decideGatewayApproval(base);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('audit_token_not_found');
+  });
+
+  it('returns ok:false + event_not_waiting_for_review when event decision is not review', async () => {
+    const chain = makeReadChain({
+      data: { id: 'ev-1', org_id: 'org-1', audit_token: 'tok-abc', decision: 'allow', request_hash: 'abc', constraints: null, input: null },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await decideGatewayApproval(base);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('event_not_waiting_for_review');
+  });
+});
+
+// ─── decideGatewayApproval — success paths ───────────────────────────────
+
+describe('decideGatewayApproval — approved', () => {
+  const base = {
+    orgId: 'org-1',
+    auditToken: 'tok-abc',
+    decision: 'approved' as const,
+    reviewerId: 'user-1',
+    reviewerRole: 'finance_approver',
+    note: 'LGTM',
+  };
+
+  const pendingEvent = {
+    id: 'ev-1',
+    org_id: 'org-1',
+    audit_token: 'tok-abc',
+    decision: 'review',
+    request_hash: 'req-hash-abc',
+    constraints: null,
+    input: null,
+  };
+
+  function setupMocks() {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeReadChain({ data: pendingEvent, error: null });
+      }
+      const updateChain: Record<string, unknown> = {};
+      updateChain.update = vi.fn().mockReturnValue(updateChain);
+      updateChain.eq = vi.fn().mockReturnValue(updateChain);
+      (updateChain as unknown as Promise<unknown>) as unknown;
+      return Object.assign(updateChain, {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }),
+      });
+    });
+  }
+
+  it('returns ok:true', async () => {
+    setupMocks();
+    const result = await decideGatewayApproval(base);
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns an approvalToken starting with gap_', async () => {
+    setupMocks();
+    const result = await decideGatewayApproval(base);
+    expect(result.approvalToken).toMatch(/^gap_/);
+  });
+
+  it('returns approvalHash as 64-char hex', async () => {
+    setupMocks();
+    const result = await decideGatewayApproval(base);
+    expect(result.approvalHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('calls recordGovernanceDecisionEvent with decision PASS', async () => {
+    setupMocks();
+    await decideGatewayApproval(base);
+    expect(mockRecordGovernanceDecisionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: 'PASS', action: 'approve' })
+    );
+  });
+});
+
+describe('decideGatewayApproval — rejected', () => {
+  const base = {
+    orgId: 'org-1',
+    auditToken: 'tok-abc',
+    decision: 'rejected' as const,
+    reviewerId: 'user-1',
+    reviewerRole: 'finance_approver',
+  };
+
+  const pendingEvent = {
+    id: 'ev-1',
+    org_id: 'org-1',
+    audit_token: 'tok-abc',
+    decision: 'review',
+    request_hash: 'req-hash-abc',
+    constraints: null,
+    input: null,
+  };
+
+  function setupMocks() {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeReadChain({ data: pendingEvent, error: null });
+      }
+      return {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }),
+      };
+    });
+  }
+
+  it('returns ok:true', async () => {
+    setupMocks();
+    const result = await decideGatewayApproval(base);
+    expect(result.ok).toBe(true);
+  });
+
+  it('does NOT return an approvalToken for rejection', async () => {
+    setupMocks();
+    const result = await decideGatewayApproval(base);
+    expect(result.approvalToken).toBeUndefined();
+  });
+
+  it('calls recordGovernanceDecisionEvent with decision BLOCK', async () => {
+    setupMocks();
+    await decideGatewayApproval(base);
+    expect(mockRecordGovernanceDecisionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ decision: 'BLOCK', action: 'reject' })
+    );
+  });
+});
+
+describe('decideGatewayApproval — governance event failure', () => {
+  it('returns ok:false when governance event recording returns false', async () => {
+    mockRecordGovernanceDecisionEvent.mockResolvedValue(false);
+    const pendingEvent = {
+      id: 'ev-1', org_id: 'org-1', audit_token: 'tok-abc', decision: 'review',
+      request_hash: 'abc', constraints: null, input: null,
+    };
+    mockFrom.mockReturnValue(makeReadChain({ data: pendingEvent, error: null }));
+
+    const result = await decideGatewayApproval({
+      orgId: 'org-1', auditToken: 'tok-abc', decision: 'approved',
+      reviewerId: 'user-1', reviewerRole: 'finance_approver',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('failed_to_record_governance_decision_event');
+  });
+});

--- a/tests/unit/gateway/audit.test.ts
+++ b/tests/unit/gateway/audit.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { hashGatewayValue, buildGatewayAuditProof } from '../../../lib/gateway/audit';
+import type { GatewayToolRequest, GatewayToolProviderResult } from '../../../lib/gateway/types';
+
+const validRequest: GatewayToolRequest = {
+  orgId: 'org-1',
+  actorId: 'user-1',
+  actorRole: 'owner',
+  orgPlan: 'pro',
+  toolName: 'zapier.slack.post_message',
+  action: 'post_message',
+  input: { channel: '#general', text: 'hello' },
+};
+
+const validProviderResult: GatewayToolProviderResult = {
+  ok: true,
+  provider: 'zapier',
+  toolName: 'zapier.slack.post_message',
+  action: 'post_message',
+  result: { ts: '12345' },
+};
+
+describe('hashGatewayValue', () => {
+  it('returns a 64-char hex string (SHA-256)', () => {
+    expect(hashGatewayValue('test')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const h1 = hashGatewayValue({ a: 1, b: 2 });
+    const h2 = hashGatewayValue({ a: 1, b: 2 });
+    expect(h1).toBe(h2);
+  });
+
+  it('produces same hash regardless of object key insertion order', () => {
+    const h1 = hashGatewayValue({ a: 1, b: 2 });
+    const h2 = hashGatewayValue({ b: 2, a: 1 });
+    expect(h1).toBe(h2);
+  });
+
+  it('sorts nested object keys recursively', () => {
+    const h1 = hashGatewayValue({ outer: { z: 9, a: 1 } });
+    const h2 = hashGatewayValue({ outer: { a: 1, z: 9 } });
+    expect(h1).toBe(h2);
+  });
+
+  it('preserves array element order (arrays are not sorted)', () => {
+    const h1 = hashGatewayValue([1, 2, 3]);
+    const h2 = hashGatewayValue([3, 2, 1]);
+    expect(h1).not.toBe(h2);
+  });
+
+  it('handles null correctly', () => {
+    expect(() => hashGatewayValue(null)).not.toThrow();
+    expect(hashGatewayValue(null)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('handles primitive string', () => {
+    expect(hashGatewayValue('hello')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('handles primitive number', () => {
+    expect(hashGatewayValue(42)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('produces different hashes for different values', () => {
+    expect(hashGatewayValue({ a: 1 })).not.toBe(hashGatewayValue({ a: 2 }));
+  });
+});
+
+describe('buildGatewayAuditProof', () => {
+  it('returns requestHash and recordHash as 64-char hex strings', () => {
+    const proof = buildGatewayAuditProof(validRequest, validProviderResult, 'allow');
+    expect(proof.requestHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(proof.recordHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('requestHash is deterministic for identical requests', () => {
+    const p1 = buildGatewayAuditProof(validRequest, null, 'allow');
+    const p2 = buildGatewayAuditProof(validRequest, null, 'allow');
+    expect(p1.requestHash).toBe(p2.requestHash);
+  });
+
+  it('recordHash is deterministic for identical inputs', () => {
+    const p1 = buildGatewayAuditProof(validRequest, validProviderResult, 'allow');
+    const p2 = buildGatewayAuditProof(validRequest, validProviderResult, 'allow');
+    expect(p1.recordHash).toBe(p2.recordHash);
+  });
+
+  it('requestHash differs when orgId changes', () => {
+    const p1 = buildGatewayAuditProof(validRequest, null, 'allow');
+    const p2 = buildGatewayAuditProof({ ...validRequest, orgId: 'org-2' }, null, 'allow');
+    expect(p1.requestHash).not.toBe(p2.requestHash);
+  });
+
+  it('recordHash differs when decision changes', () => {
+    const p1 = buildGatewayAuditProof(validRequest, null, 'allow');
+    const p2 = buildGatewayAuditProof(validRequest, null, 'block');
+    expect(p1.recordHash).not.toBe(p2.recordHash);
+  });
+
+  it('committed is true when providerResult.ok is true', () => {
+    const proof = buildGatewayAuditProof(validRequest, validProviderResult, 'allow');
+    expect(proof.committed).toBe(true);
+  });
+
+  it('committed is false when decision is allow and no providerResult', () => {
+    const proof = buildGatewayAuditProof(validRequest, null, 'allow');
+    expect(proof.committed).toBe(false);
+  });
+
+  it('committed is true when decision is block (non-allow = committed for audit)', () => {
+    const proof = buildGatewayAuditProof(validRequest, null, 'block');
+    expect(proof.committed).toBe(true);
+  });
+
+  it('committed is true when decision is review', () => {
+    const proof = buildGatewayAuditProof(validRequest, null, 'review');
+    expect(proof.committed).toBe(true);
+  });
+
+  it('recordHash changes when providerResult changes', () => {
+    const p1 = buildGatewayAuditProof(validRequest, null, 'allow');
+    const p2 = buildGatewayAuditProof(validRequest, validProviderResult, 'allow');
+    expect(p1.recordHash).not.toBe(p2.recordHash);
+  });
+
+  it('recordHash changes when reason changes', () => {
+    const p1 = buildGatewayAuditProof(validRequest, null, 'block', 'missing_org_id');
+    const p2 = buildGatewayAuditProof(validRequest, null, 'block', 'role_not_allowed');
+    expect(p1.recordHash).not.toBe(p2.recordHash);
+  });
+
+  it('undefined reason and absent reason produce same recordHash', () => {
+    const p1 = buildGatewayAuditProof(validRequest, null, 'block');
+    const p2 = buildGatewayAuditProof(validRequest, null, 'block', undefined);
+    expect(p1.recordHash).toBe(p2.recordHash);
+  });
+});

--- a/tests/unit/gateway/control-templates.test.ts
+++ b/tests/unit/gateway/control-templates.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { gatewayControlTemplates, listGatewayControlTemplates } from '../../../lib/gateway/control-templates';
+
+const VALID_CATEGORIES = ['identity', 'entitlement', 'risk', 'approval', 'evidence', 'runtime', 'deployment'] as const;
+const VALID_MODES = ['gateway', 'monitor', 'deploy_gate', 'any'] as const;
+const VALID_RISKS = ['low', 'medium', 'high', 'critical'] as const;
+const VALID_STATUSES = ['implemented', 'planned'] as const;
+
+describe('gatewayControlTemplates data integrity', () => {
+  it('contains at least one template', () => {
+    expect(gatewayControlTemplates.length).toBeGreaterThan(0);
+  });
+
+  it('every template has a non-empty id', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(t.id).toBeTruthy();
+    });
+  });
+
+  it('all ids are unique', () => {
+    const ids = gatewayControlTemplates.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every template has a non-empty name', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(t.name).toBeTruthy();
+    });
+  });
+
+  it('every category is a valid value', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(VALID_CATEGORIES).toContain(t.category);
+    });
+  });
+
+  it('every recommendedMode is a valid value', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(VALID_MODES).toContain(t.recommendedMode);
+    });
+  });
+
+  it('every defaultRisk is a valid value', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(VALID_RISKS).toContain(t.defaultRisk);
+    });
+  });
+
+  it('every status is a valid value', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(VALID_STATUSES).toContain(t.status);
+    });
+  });
+
+  it('every template has at least one requiredEvidence entry', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(t.requiredEvidence.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('requiresApproval is a boolean', () => {
+    gatewayControlTemplates.forEach((t) => {
+      expect(typeof t.requiresApproval).toBe('boolean');
+    });
+  });
+
+  it('high-risk-approval template requires approval and is high risk', () => {
+    const template = gatewayControlTemplates.find((t) => t.id === 'high-risk-approval');
+    expect(template).toBeDefined();
+    expect(template!.requiresApproval).toBe(true);
+    expect(template!.defaultRisk).toBe('high');
+  });
+
+  it('ci-cd-deploy-gate has deploy_gate mode', () => {
+    const template = gatewayControlTemplates.find((t) => t.id === 'ci-cd-deploy-gate');
+    expect(template).toBeDefined();
+    expect(template!.recommendedMode).toBe('deploy_gate');
+  });
+});
+
+describe('listGatewayControlTemplates', () => {
+  it('returns the full array', () => {
+    expect(listGatewayControlTemplates()).toBe(gatewayControlTemplates);
+  });
+
+  it('returns same reference on repeated calls', () => {
+    expect(listGatewayControlTemplates()).toBe(listGatewayControlTemplates());
+  });
+
+  it('result has the same length as the exported array', () => {
+    expect(listGatewayControlTemplates().length).toBe(gatewayControlTemplates.length);
+  });
+});

--- a/tests/unit/gateway/evidence-bundle.test.ts
+++ b/tests/unit/gateway/evidence-bundle.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildGatewayEvidenceBundle } from '../../../lib/gateway/evidence-bundle';
+
+const event1 = { type: 'tool_execute', toolName: 'slack.post', orgId: 'org-1' };
+const event2 = { type: 'tool_block', toolName: 'stripe.refund', orgId: 'org-1', reason: 'role_not_allowed' };
+
+describe('buildGatewayEvidenceBundle — structure', () => {
+  it('returns ok:true', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.ok).toBe(true);
+  });
+
+  it('sets type to dsg-gateway-signed-evidence-bundle', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.type).toBe('dsg-gateway-signed-evidence-bundle');
+  });
+
+  it('sets version to 1.0', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.version).toBe('1.0');
+  });
+
+  it('preserves orgId', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-specific', events: [] });
+    expect(bundle.orgId).toBe('org-specific');
+  });
+
+  it('count matches events array length', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1, event2] });
+    expect(bundle.count).toBe(2);
+  });
+
+  it('count is 0 for empty events', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.count).toBe(0);
+  });
+
+  it('eventHashes array length matches events length', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1, event2] });
+    expect(bundle.eventHashes).toHaveLength(2);
+  });
+
+  it('each eventHash is a 64-char hex string', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1] });
+    expect(bundle.eventHashes[0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('bundleHash is a 64-char hex string', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.bundleHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('preserves events array in output', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1] });
+    expect(bundle.events).toEqual([event1]);
+  });
+
+  it('auditToken is null when not provided', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.auditToken).toBeNull();
+  });
+
+  it('preserves auditToken when provided', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [], auditToken: 'tok_abc' });
+    expect(bundle.auditToken).toBe('tok_abc');
+  });
+
+  it('uses provided exportedAt timestamp', () => {
+    const ts = '2025-01-01T00:00:00.000Z';
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [], exportedAt: ts });
+    expect(bundle.exportedAt).toBe(ts);
+  });
+
+  it('defaults exportedAt to current ISO timestamp when not provided', () => {
+    const before = Date.now();
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    const after = Date.now();
+    const ts = new Date(bundle.exportedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('buildGatewayEvidenceBundle — evidenceBoundary', () => {
+  it('certificationClaim is false', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.evidenceBoundary.certificationClaim).toBe(false);
+  });
+
+  it('independentAuditClaim is false', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.evidenceBoundary.independentAuditClaim).toBe(false);
+  });
+
+  it('statement is non-empty string', () => {
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(typeof bundle.evidenceBoundary.statement).toBe('string');
+    expect(bundle.evidenceBoundary.statement.length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildGatewayEvidenceBundle — determinism', () => {
+  it('bundleHash is deterministic for identical inputs with fixed exportedAt', () => {
+    const input = { orgId: 'org-1', events: [event1], exportedAt: '2025-01-01T00:00:00.000Z' };
+    const b1 = buildGatewayEvidenceBundle(input);
+    const b2 = buildGatewayEvidenceBundle(input);
+    expect(b1.bundleHash).toBe(b2.bundleHash);
+  });
+
+  it('bundleHash changes when events change', () => {
+    const b1 = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [], exportedAt: '2025-01-01T00:00:00.000Z' });
+    const b2 = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1], exportedAt: '2025-01-01T00:00:00.000Z' });
+    expect(b1.bundleHash).not.toBe(b2.bundleHash);
+  });
+
+  it('bundleHash changes when orgId changes', () => {
+    const b1 = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [], exportedAt: '2025-01-01T00:00:00.000Z' });
+    const b2 = buildGatewayEvidenceBundle({ orgId: 'org-2', events: [], exportedAt: '2025-01-01T00:00:00.000Z' });
+    expect(b1.bundleHash).not.toBe(b2.bundleHash);
+  });
+
+  it('eventHash for same event is deterministic', () => {
+    const b1 = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1], exportedAt: '2025-01-01T00:00:00.000Z' });
+    const b2 = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [event1], exportedAt: '2025-01-01T00:00:00.000Z' });
+    expect(b1.eventHashes[0]).toBe(b2.eventHashes[0]);
+  });
+});
+
+describe('buildGatewayEvidenceBundle — signing', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses hash-only mode when DSG_EVIDENCE_SIGNING_SECRET is absent', () => {
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_SECRET', '');
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.signature.signatureMode).toBe('hash-only');
+    expect(bundle.signature.algorithm).toBe('sha256');
+    expect(bundle.signature.signature).toBe(bundle.bundleHash);
+    expect(bundle.signature.keyId).toBe('none');
+  });
+
+  it('uses HMAC mode when DSG_EVIDENCE_SIGNING_SECRET is set', () => {
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_SECRET', 'super-secret-key');
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.signature.signatureMode).toBe('hmac');
+    expect(bundle.signature.algorithm).toBe('hmac-sha256');
+    expect(bundle.signature.signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(bundle.signature.signature).not.toBe(bundle.bundleHash);
+  });
+
+  it('HMAC signature differs from bundleHash', () => {
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_SECRET', 'my-key');
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.signature.signature).not.toBe(bundle.bundleHash);
+  });
+
+  it('uses custom keyId from DSG_EVIDENCE_SIGNING_KEY_ID when set', () => {
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_SECRET', 'my-key');
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_KEY_ID', 'key-v2');
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.signature.keyId).toBe('key-v2');
+  });
+
+  it('falls back to env:DSG_EVIDENCE_SIGNING_SECRET as keyId when KEY_ID is not set', () => {
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_SECRET', 'my-key');
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_KEY_ID', '');
+    const bundle = buildGatewayEvidenceBundle({ orgId: 'org-1', events: [] });
+    expect(bundle.signature.keyId).toBe('env:DSG_EVIDENCE_SIGNING_SECRET');
+  });
+
+  it('HMAC signature is deterministic for same secret and input', () => {
+    vi.stubEnv('DSG_EVIDENCE_SIGNING_SECRET', 'stable-key');
+    const input = { orgId: 'org-1', events: [], exportedAt: '2025-01-01T00:00:00.000Z' };
+    const b1 = buildGatewayEvidenceBundle(input);
+    const b2 = buildGatewayEvidenceBundle(input);
+    expect(b1.signature.signature).toBe(b2.signature.signature);
+  });
+});

--- a/tests/unit/gateway/managed-connectors.test.ts
+++ b/tests/unit/gateway/managed-connectors.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+import { findManagedGatewayTool } from '../../../lib/gateway/managed-connectors';
+
+function makeChain(result: { data: unknown; error: { message: string } | null }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+const connectedData = {
+  name: 'slack.send',
+  provider: 'custom_http',
+  action: 'send_message',
+  risk: 'medium',
+  execution_mode: 'gateway',
+  requires_approval: false,
+  description: 'Send a Slack message',
+  connector_id: 'conn-1',
+  gateway_connectors: { endpoint_url: 'https://hook.example.com', status: 'connected' },
+};
+
+describe('findManagedGatewayTool', () => {
+  it('returns null when orgId is empty', async () => {
+    const result = await findManagedGatewayTool('', 'slack.send');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when toolName is empty', async () => {
+    const result = await findManagedGatewayTool('org-1', '');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when data is null and no error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    expect(await findManagedGatewayTool('org-1', 'missing-tool')).toBeNull();
+  });
+
+  it('returns null silently when error message contains "relation"', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'relation "gateway_tools" does not exist' } }));
+    expect(await findManagedGatewayTool('org-1', 'some-tool')).toBeNull();
+  });
+
+  it('throws on non-relation DB error', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'connection refused' } }));
+    await expect(findManagedGatewayTool('org-1', 'tool')).rejects.toThrow('failed_to_read_gateway_tool:connection refused');
+  });
+
+  it('returns null when connector status is not connected', async () => {
+    const data = { ...connectedData, gateway_connectors: { endpoint_url: 'https://hook.example.com', status: 'disconnected' } };
+    mockFrom.mockReturnValue(makeChain({ data, error: null }));
+    expect(await findManagedGatewayTool('org-1', 'slack.send')).toBeNull();
+  });
+
+  it('returns null when gateway_connectors is null', async () => {
+    const data = { ...connectedData, gateway_connectors: null };
+    mockFrom.mockReturnValue(makeChain({ data, error: null }));
+    expect(await findManagedGatewayTool('org-1', 'slack.send')).toBeNull();
+  });
+
+  it('returns registry entry with correct fields on success (object connector)', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: connectedData, error: null }));
+    const result = await findManagedGatewayTool('org-1', 'slack.send');
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('slack.send');
+    expect(result!.provider).toBe('custom_http');
+    expect(result!.endpointUrl).toBe('https://hook.example.com');
+    expect(result!.requiresApproval).toBe(false);
+  });
+
+  it('returns registry entry when gateway_connectors is an array', async () => {
+    const data = {
+      ...connectedData,
+      gateway_connectors: [{ endpoint_url: 'https://hook2.example.com', status: 'connected' }],
+    };
+    mockFrom.mockReturnValue(makeChain({ data, error: null }));
+    const result = await findManagedGatewayTool('org-1', 'slack.send');
+    expect(result!.endpointUrl).toBe('https://hook2.example.com');
+  });
+
+  it('converts requires_approval to boolean', async () => {
+    const data = { ...connectedData, requires_approval: true };
+    mockFrom.mockReturnValue(makeChain({ data, error: null }));
+    const result = await findManagedGatewayTool('org-1', 'slack.send');
+    expect(result!.requiresApproval).toBe(true);
+  });
+
+  it('falls back to "Managed gateway tool" description when description is null', async () => {
+    const data = { ...connectedData, description: null };
+    mockFrom.mockReturnValue(makeChain({ data, error: null }));
+    const result = await findManagedGatewayTool('org-1', 'slack.send');
+    expect(result!.description).toBe('Managed gateway tool');
+  });
+});

--- a/tests/unit/gateway/monitor.test.ts
+++ b/tests/unit/gateway/monitor.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const {
+  mockFrom,
+  mockFindGatewayTool,
+  mockEvaluateGatewayToolRequest,
+  mockBuildGatewayAuditProof,
+  mockHashGatewayValue,
+} = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockFindGatewayTool: vi.fn(),
+  mockEvaluateGatewayToolRequest: vi.fn(),
+  mockBuildGatewayAuditProof: vi.fn(),
+  mockHashGatewayValue: vi.fn(),
+}));
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+vi.mock('../../../lib/gateway/tool-registry', () => ({
+  findGatewayTool: mockFindGatewayTool,
+}));
+
+vi.mock('../../../lib/gateway/policy', () => ({
+  evaluateGatewayToolRequest: mockEvaluateGatewayToolRequest,
+}));
+
+vi.mock('../../../lib/gateway/audit', () => ({
+  buildGatewayAuditProof: mockBuildGatewayAuditProof,
+  hashGatewayValue: mockHashGatewayValue,
+}));
+
+import { createMonitorPlanCheck, commitMonitorAudit } from '../../../lib/gateway/monitor';
+import type { GatewayToolRequest } from '../../../lib/gateway/types';
+
+const baseRequest: GatewayToolRequest = {
+  orgId: 'org-1',
+  actorId: 'actor-1',
+  actorRole: 'admin',
+  toolName: 'slack.send',
+  action: 'send_message',
+  input: { text: 'hello' },
+};
+
+function makeInsertChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.insert = vi.fn().mockReturnValue(chain);
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+function makeReadChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+function makeUpdateChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  // vitest resolves the final `.eq()` call as a Promise
+  chain.eq = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFindGatewayTool.mockResolvedValue(null);
+  mockEvaluateGatewayToolRequest.mockReturnValue({ decision: 'allow', reason: null });
+  mockBuildGatewayAuditProof.mockReturnValue({ requestHash: 'req-hash-123', recordHash: 'rec-hash-123' });
+  mockHashGatewayValue.mockReturnValue('decision-hash-abc');
+});
+
+// ─── createMonitorPlanCheck ──────────────────────────────────────────────────
+
+describe('createMonitorPlanCheck', () => {
+  it('throws when DB insert fails', async () => {
+    mockFrom.mockReturnValue(makeInsertChain({ data: null, error: { message: 'insert error' } }));
+
+    await expect(createMonitorPlanCheck(baseRequest)).rejects.toThrow('failed_to_record_monitor_event:insert error');
+  });
+
+  it('throws when insert returns no event id', async () => {
+    mockFrom.mockReturnValue(makeInsertChain({ data: {}, error: null }));
+
+    await expect(createMonitorPlanCheck(baseRequest)).rejects.toThrow('failed_to_record_monitor_event:no_inserted_event');
+  });
+
+  it('returns ok:true when decision is allow', async () => {
+    mockFrom.mockReturnValue(makeInsertChain({ data: { id: 'ev-1', audit_token: 'gat_abc' }, error: null }));
+
+    const result = await createMonitorPlanCheck(baseRequest);
+    expect(result.ok).toBe(true);
+    expect(result.decision).toBe('allow');
+    expect(result.mode).toBe('monitor');
+  });
+
+  it('returns ok:false when decision is block', async () => {
+    mockEvaluateGatewayToolRequest.mockReturnValue({ decision: 'block', reason: 'tool not registered' });
+    mockFrom.mockReturnValue(makeInsertChain({ data: { id: 'ev-2', audit_token: 'gat_def' }, error: null }));
+
+    const result = await createMonitorPlanCheck(baseRequest);
+    expect(result.ok).toBe(false);
+    expect(result.decision).toBe('block');
+    expect(result.reason).toBe('tool not registered');
+  });
+
+  it('auditToken starts with gat_', async () => {
+    mockFrom.mockReturnValue(makeInsertChain({ data: { id: 'ev-3', audit_token: 'gat_xyz' }, error: null }));
+
+    const result = await createMonitorPlanCheck(baseRequest);
+    expect(result.auditToken).toMatch(/^gat_/);
+  });
+
+  it('includes requestHash and decisionHash in result', async () => {
+    mockFrom.mockReturnValue(makeInsertChain({ data: { id: 'ev-4', audit_token: 'gat_123' }, error: null }));
+
+    const result = await createMonitorPlanCheck(baseRequest);
+    expect(result.requestHash).toBe('req-hash-123');
+    expect(result.decisionHash).toBe('decision-hash-abc');
+  });
+
+  it('passes constraints with 300s expiry to insert', async () => {
+    const insertChain = makeInsertChain({ data: { id: 'ev-5', audit_token: 'gat_abc' }, error: null });
+    mockFrom.mockReturnValue(insertChain);
+
+    await createMonitorPlanCheck(baseRequest);
+
+    const insertCall = (insertChain.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(insertCall.constraints.expiresInSeconds).toBe(300);
+    expect(insertCall.constraints.allowedTool).toBe('slack.send');
+  });
+});
+
+// ─── commitMonitorAudit ──────────────────────────────────────────────────────
+
+describe('commitMonitorAudit', () => {
+  it('returns ok:false + missing_org_id when orgId is empty', async () => {
+    const result = await commitMonitorAudit('', 'tok-abc', {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_org_id');
+  });
+
+  it('returns ok:false + missing_audit_token when auditToken is empty', async () => {
+    const result = await commitMonitorAudit('org-1', '', {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing_audit_token');
+  });
+
+  it('throws when DB read fails', async () => {
+    mockFrom.mockReturnValue(makeReadChain({ data: null, error: { message: 'db timeout' } }));
+
+    await expect(commitMonitorAudit('org-1', 'tok-abc', {})).rejects.toThrow('failed_to_read_monitor_event:db timeout');
+  });
+
+  it('returns ok:false + audit_token_not_found when event not found', async () => {
+    mockFrom.mockReturnValue(makeReadChain({ data: null, error: null }));
+
+    const result = await commitMonitorAudit('org-1', 'tok-abc', {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('audit_token_not_found');
+  });
+
+  it('returns ok:false + decision_not_allowed when event decision is not allow', async () => {
+    mockFrom.mockReturnValue(makeReadChain({
+      data: { id: 'ev-1', org_id: 'org-1', request_hash: 'rh-1', decision: 'block', status: 'rejected' },
+      error: null,
+    }));
+
+    const result = await commitMonitorAudit('org-1', 'tok-abc', {});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('decision_not_allowed');
+  });
+
+  it('throws when update fails', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeReadChain({
+          data: { id: 'ev-1', org_id: 'org-1', request_hash: 'rh-1', decision: 'allow', status: 'recorded' },
+          error: null,
+        });
+      }
+      const chain: Record<string, unknown> = {};
+      chain.update = vi.fn().mockReturnValue(chain);
+      chain.eq = vi.fn().mockResolvedValue({ error: { message: 'update failed' } });
+      return chain;
+    });
+
+    await expect(commitMonitorAudit('org-1', 'tok-abc', {})).rejects.toThrow('failed_to_commit_monitor_event:update failed');
+  });
+
+  it('returns ok:true with committed:true and recordHash on success', async () => {
+    mockHashGatewayValue.mockReturnValue('committed-record-hash');
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeReadChain({
+          data: { id: 'ev-1', org_id: 'org-1', request_hash: 'rh-1', decision: 'allow', status: 'recorded' },
+          error: null,
+        });
+      }
+      const chain: Record<string, unknown> = {};
+      chain.update = vi.fn().mockReturnValue(chain);
+      chain.eq = vi.fn().mockResolvedValue({ error: null });
+      return chain;
+    });
+
+    const result = await commitMonitorAudit('org-1', 'tok-abc', { executionResult: 'done' });
+    expect(result.ok).toBe(true);
+    expect(result.committed).toBe(true);
+    expect(result.recordHash).toBe('committed-record-hash');
+  });
+});

--- a/tests/unit/gateway/providers.test.ts
+++ b/tests/unit/gateway/providers.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeGatewayProvider } from '../../../lib/gateway/providers';
+import type { GatewayToolRequest, GatewayToolRegistryEntry } from '../../../lib/gateway/types';
+
+const baseRequest: GatewayToolRequest = {
+  orgId: 'org-1',
+  actorId: 'actor-1',
+  actorRole: 'admin',
+  toolName: 'mock.echo',
+  action: 'execute',
+  input: { key: 'value' },
+};
+
+function makeFetchResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: vi.fn().mockResolvedValue(typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+describe('executeGatewayProvider — mock provider', () => {
+  it('returns ok:true for mock. prefix tool', async () => {
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'mock.echo' });
+    expect(result.ok).toBe(true);
+    expect(result.provider).toBe('mock');
+  });
+
+  it('echoes the input in result', async () => {
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'mock.test', input: { x: 42 } });
+    expect(result.result).toMatchObject({ echoed: { x: 42 } });
+  });
+
+  it('sets deterministic:true in mock result', async () => {
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'mock.test' });
+    expect((result.result as Record<string, unknown>).deterministic).toBe(true);
+  });
+});
+
+describe('executeGatewayProvider — unknown provider', () => {
+  it('returns ok:false for unrecognised toolName with no registryEntry', async () => {
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'some.unknown.tool' });
+    expect(result.ok).toBe(false);
+    expect(result.provider).toBe('unknown');
+    expect(result.error).toBe('provider_not_supported');
+  });
+});
+
+describe('executeGatewayProvider — zapier provider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns provider_not_configured when no webhook URL env var set', async () => {
+    vi.stubEnv('ZAPIER_WEBHOOK_URL', '');
+    vi.stubEnv('ZAPIER_WEBHOOK_ZAPIER_NOTIFY', '');
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'zapier.notify' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('provider_not_configured');
+    expect(result.provider).toBe('zapier');
+  });
+
+  it('uses tool-specific env key ZAPIER_WEBHOOK_{NORMALIZED_TOOL_NAME}', async () => {
+    vi.stubEnv('ZAPIER_WEBHOOK_ZAPIER_SEND_EMAIL', 'https://hooks.zapier.com/specific');
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(makeFetchResponse(200, { status: 'success' }));
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'zapier.send_email' });
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledWith('https://hooks.zapier.com/specific', expect.any(Object));
+  });
+
+  it('falls back to ZAPIER_WEBHOOK_URL when specific key not set', async () => {
+    vi.stubEnv('ZAPIER_WEBHOOK_ZAPIER_OTHER', '');
+    vi.stubEnv('ZAPIER_WEBHOOK_URL', 'https://hooks.zapier.com/fallback');
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(makeFetchResponse(200, { ok: true }));
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'zapier.other' });
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledWith('https://hooks.zapier.com/fallback', expect.any(Object));
+  });
+
+  it('returns ok:false and error code on HTTP error response', async () => {
+    vi.stubEnv('ZAPIER_WEBHOOK_URL', 'https://hooks.zapier.com/fallback');
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(makeFetchResponse(503, 'service unavailable'));
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'zapier.alert' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('provider_http_503');
+  });
+
+  it('handles non-JSON response body gracefully', async () => {
+    vi.stubEnv('ZAPIER_WEBHOOK_URL', 'https://hooks.zapier.com/fallback');
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(makeFetchResponse(200, 'plain text response'));
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'zapier.test' });
+    expect(result.ok).toBe(true);
+    expect((result.result as Record<string, unknown>).raw).toBe('plain text response');
+  });
+});
+
+describe('executeGatewayProvider — custom_http provider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns provider_not_configured when no endpointUrl and no env var', async () => {
+    vi.stubEnv('CUSTOM_HTTP_WEBHOOK_URL', '');
+    const registryEntry: GatewayToolRegistryEntry = {
+      name: 'custom.tool',
+      provider: 'custom_http',
+      action: 'run',
+      risk: 'low',
+      executionMode: 'gateway',
+      requiresApproval: false,
+      description: 'test',
+    };
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'custom.tool' }, registryEntry);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('provider_not_configured');
+  });
+
+  it('uses registryEntry.endpointUrl when set', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(makeFetchResponse(200, { done: true }));
+    const registryEntry: GatewayToolRegistryEntry = {
+      name: 'custom.action',
+      provider: 'custom_http',
+      action: 'execute',
+      risk: 'medium',
+      executionMode: 'gateway',
+      requiresApproval: false,
+      description: 'test',
+      endpointUrl: 'https://my-webhook.example.com/hook',
+    };
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'custom.action' }, registryEntry);
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledWith('https://my-webhook.example.com/hook', expect.any(Object));
+  });
+
+  it('activates custom_http path via toolName prefix custom_http.', async () => {
+    vi.stubEnv('CUSTOM_HTTP_WEBHOOK_URL', 'https://custom-fallback.example.com');
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(makeFetchResponse(200, {}));
+
+    const result = await executeGatewayProvider({ ...baseRequest, toolName: 'custom_http.my_action' });
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledWith('https://custom-fallback.example.com', expect.any(Object));
+  });
+});

--- a/tests/unit/gateway/smt2-invariants.test.ts
+++ b/tests/unit/gateway/smt2-invariants.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSmt2InvariantInput,
+  evaluateSmt2InvariantInput,
+  renderGatewayInvariantSmt2,
+} from '../../../lib/gateway/invariants/smt2';
+import type { GatewayToolRequest } from '../../../lib/gateway/types';
+
+const validRequest: GatewayToolRequest = {
+  orgId: 'org-1',
+  actorId: 'user-1',
+  actorRole: 'owner',
+  orgPlan: 'pro',
+  toolName: 'zapier.slack.post_message',
+  action: 'post_message',
+  input: {},
+};
+
+const validTool = {
+  action: 'post_message',
+  risk: 'low',
+  requiresApproval: false,
+};
+
+const fullyValidInput = {
+  hasOrg: true,
+  hasActor: true,
+  hasActorRole: true,
+  hasOrgPlan: true,
+  isRegisteredTool: true,
+  actionMatchesTool: true,
+  actorRoleAllowed: true,
+  planEntitled: true,
+  risk: 0 as const,
+  requiresApproval: false,
+  hasApproval: false,
+  evidenceWritable: true,
+};
+
+// ─── buildSmt2InvariantInput ────────────────────────────────────────────
+
+describe('buildSmt2InvariantInput', () => {
+  it('maps a fully valid request to all-true flags', () => {
+    const input = buildSmt2InvariantInput(validRequest, validTool);
+    expect(input.hasOrg).toBe(true);
+    expect(input.hasActor).toBe(true);
+    expect(input.hasActorRole).toBe(true);
+    expect(input.hasOrgPlan).toBe(true);
+    expect(input.isRegisteredTool).toBe(true);
+    expect(input.actionMatchesTool).toBe(true);
+    expect(input.actorRoleAllowed).toBe(true);
+    expect(input.planEntitled).toBe(true);
+    expect(input.evidenceWritable).toBe(true);
+  });
+
+  it('sets hasOrg:false when orgId is empty', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, orgId: '' }, validTool);
+    expect(input.hasOrg).toBe(false);
+  });
+
+  it('sets hasActor:false when actorId is empty', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, actorId: '' }, validTool);
+    expect(input.hasActor).toBe(false);
+  });
+
+  it('sets hasActorRole:false when actorRole is empty', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, actorRole: '' }, validTool);
+    expect(input.hasActorRole).toBe(false);
+  });
+
+  it('sets hasOrgPlan:false when orgPlan is empty', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, orgPlan: '' }, validTool);
+    expect(input.hasOrgPlan).toBe(false);
+  });
+
+  it('sets isRegisteredTool:false and actionMatchesTool:false when tool is null', () => {
+    const input = buildSmt2InvariantInput(validRequest, null);
+    expect(input.isRegisteredTool).toBe(false);
+    expect(input.actionMatchesTool).toBe(false);
+  });
+
+  it('sets actionMatchesTool:false when tool action does not match request action', () => {
+    const input = buildSmt2InvariantInput(
+      { ...validRequest, action: 'delete' },
+      { ...validTool, action: 'post_message' }
+    );
+    expect(input.actionMatchesTool).toBe(false);
+  });
+
+  it.each(['owner', 'admin', 'finance_admin', 'finance_approver', 'agent_operator'])(
+    'sets actorRoleAllowed:true for allowed role "%s"',
+    (role) => {
+      const input = buildSmt2InvariantInput({ ...validRequest, actorRole: role }, validTool);
+      expect(input.actorRoleAllowed).toBe(true);
+    }
+  );
+
+  it.each(['viewer', 'guest', 'auditor', 'readonly'])(
+    'sets actorRoleAllowed:false for disallowed role "%s"',
+    (role) => {
+      const input = buildSmt2InvariantInput({ ...validRequest, actorRole: role }, validTool);
+      expect(input.actorRoleAllowed).toBe(false);
+    }
+  );
+
+  it('is case-insensitive for actorRole', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, actorRole: 'OWNER' }, validTool);
+    expect(input.actorRoleAllowed).toBe(true);
+  });
+
+  it.each(['pro', 'business', 'enterprise'])(
+    'sets planEntitled:true for entitled plan "%s"',
+    (plan) => {
+      const input = buildSmt2InvariantInput({ ...validRequest, orgPlan: plan }, validTool);
+      expect(input.planEntitled).toBe(true);
+    }
+  );
+
+  it('sets planEntitled:false for free plan', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, orgPlan: 'free' }, validTool);
+    expect(input.planEntitled).toBe(false);
+  });
+
+  it('is case-insensitive for orgPlan', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, orgPlan: 'PRO' }, validTool);
+    expect(input.planEntitled).toBe(true);
+  });
+
+  it.each([
+    ['critical', 3],
+    ['high', 2],
+    ['medium', 1],
+    ['low', 0],
+  ] as const)('maps risk "%s" to integer %d', (riskStr, expected) => {
+    const input = buildSmt2InvariantInput(validRequest, { ...validTool, risk: riskStr });
+    expect(input.risk).toBe(expected);
+  });
+
+  it('defaults risk to 0 when tool has unknown risk value', () => {
+    const input = buildSmt2InvariantInput(validRequest, { ...validTool, risk: 'unknown' });
+    expect(input.risk).toBe(0);
+  });
+
+  it('sets hasApproval:true when approvalToken is present', () => {
+    const input = buildSmt2InvariantInput({ ...validRequest, approvalToken: 'tok_abc' }, validTool);
+    expect(input.hasApproval).toBe(true);
+  });
+
+  it('sets hasApproval:false when approvalToken is absent', () => {
+    const input = buildSmt2InvariantInput(validRequest, validTool);
+    expect(input.hasApproval).toBe(false);
+  });
+
+  it('defaults evidenceWritable to true', () => {
+    const input = buildSmt2InvariantInput(validRequest, validTool);
+    expect(input.evidenceWritable).toBe(true);
+  });
+
+  it('respects explicit evidenceWritable:false', () => {
+    const input = buildSmt2InvariantInput(validRequest, validTool, false);
+    expect(input.evidenceWritable).toBe(false);
+  });
+});
+
+// ─── evaluateSmt2InvariantInput ──────────────────────────────────────────
+
+describe('evaluateSmt2InvariantInput', () => {
+  it('returns ok:true and allow with no violations for fully valid input', () => {
+    const result = evaluateSmt2InvariantInput(fullyValidInput);
+    expect(result.ok).toBe(true);
+    expect(result.decision).toBe('allow');
+    expect(result.violated).toEqual([]);
+  });
+
+  it.each([
+    ['missing_org_id', { hasOrg: false }],
+    ['missing_actor_id', { hasActor: false }],
+    ['missing_actor_role', { hasActorRole: false }],
+    ['missing_org_plan', { hasOrgPlan: false }],
+    ['tool_not_registered', { isRegisteredTool: false }],
+    ['tool_action_mismatch', { actionMatchesTool: false }],
+    ['role_not_allowed', { actorRoleAllowed: false }],
+    ['plan_not_entitled', { planEntitled: false }],
+    ['evidence_not_writable', { evidenceWritable: false }],
+  ] as const)('reports violation "%s" when flag is false', (violation, override) => {
+    const result = evaluateSmt2InvariantInput({ ...fullyValidInput, ...override });
+    expect(result.ok).toBe(false);
+    expect(result.decision).toBe('block');
+    expect(result.violated).toContain(violation);
+  });
+
+  it('reports approval_required when requiresApproval:true and no token', () => {
+    const result = evaluateSmt2InvariantInput({
+      ...fullyValidInput,
+      requiresApproval: true,
+      hasApproval: false,
+    });
+    expect(result.violated).toContain('approval_required');
+  });
+
+  it('reports approval_required when risk >= 2 (high) and no token', () => {
+    const result = evaluateSmt2InvariantInput({
+      ...fullyValidInput,
+      risk: 2,
+      hasApproval: false,
+    });
+    expect(result.violated).toContain('approval_required');
+  });
+
+  it('reports approval_required when risk == 3 (critical) and no token', () => {
+    const result = evaluateSmt2InvariantInput({
+      ...fullyValidInput,
+      risk: 3,
+      hasApproval: false,
+    });
+    expect(result.violated).toContain('approval_required');
+  });
+
+  it('does NOT report approval_required when risk == 1 (medium) and requiresApproval:false', () => {
+    const result = evaluateSmt2InvariantInput({
+      ...fullyValidInput,
+      risk: 1,
+      requiresApproval: false,
+      hasApproval: false,
+    });
+    expect(result.violated).not.toContain('approval_required');
+    expect(result.ok).toBe(true);
+  });
+
+  it('allows high-risk action when approval token is present', () => {
+    const result = evaluateSmt2InvariantInput({
+      ...fullyValidInput,
+      risk: 2,
+      hasApproval: true,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.violated).not.toContain('approval_required');
+  });
+
+  it('collects multiple violations at once', () => {
+    const result = evaluateSmt2InvariantInput({
+      ...fullyValidInput,
+      hasOrg: false,
+      hasActor: false,
+      planEntitled: false,
+    });
+    expect(result.violated).toContain('missing_org_id');
+    expect(result.violated).toContain('missing_actor_id');
+    expect(result.violated).toContain('plan_not_entitled');
+    expect(result.violated.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('produces deterministic smt2Hash for identical inputs', () => {
+    const r1 = evaluateSmt2InvariantInput(fullyValidInput);
+    const r2 = evaluateSmt2InvariantInput(fullyValidInput);
+    expect(r1.smt2Hash).toBe(r2.smt2Hash);
+  });
+
+  it('produces deterministic resultHash for identical inputs', () => {
+    const r1 = evaluateSmt2InvariantInput(fullyValidInput);
+    const r2 = evaluateSmt2InvariantInput(fullyValidInput);
+    expect(r1.resultHash).toBe(r2.resultHash);
+  });
+
+  it('resultHash differs when violations differ', () => {
+    const r1 = evaluateSmt2InvariantInput(fullyValidInput);
+    const r2 = evaluateSmt2InvariantInput({ ...fullyValidInput, hasOrg: false });
+    expect(r1.resultHash).not.toBe(r2.resultHash);
+  });
+
+  it('smt2Hash differs when input differs', () => {
+    const r1 = evaluateSmt2InvariantInput(fullyValidInput);
+    const r2 = evaluateSmt2InvariantInput({ ...fullyValidInput, risk: 2 });
+    expect(r1.smt2Hash).not.toBe(r2.smt2Hash);
+  });
+
+  it('smt2 string contains (check-sat)', () => {
+    const result = evaluateSmt2InvariantInput(fullyValidInput);
+    expect(result.smt2).toContain('(check-sat)');
+  });
+
+  it('smt2Hash is a 64-char hex string (SHA-256)', () => {
+    const result = evaluateSmt2InvariantInput(fullyValidInput);
+    expect(result.smt2Hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('resultHash is a 64-char hex string (SHA-256)', () => {
+    const result = evaluateSmt2InvariantInput(fullyValidInput);
+    expect(result.resultHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ─── renderGatewayInvariantSmt2 ───────────────────────────────────────────
+
+describe('renderGatewayInvariantSmt2', () => {
+  it('includes (set-logic QF_UFLIA)', () => {
+    const smt2 = renderGatewayInvariantSmt2(fullyValidInput);
+    expect(smt2).toContain('(set-logic QF_UFLIA)');
+  });
+
+  it('includes (check-sat) and (get-model)', () => {
+    const smt2 = renderGatewayInvariantSmt2(fullyValidInput);
+    expect(smt2).toContain('(check-sat)');
+    expect(smt2).toContain('(get-model)');
+  });
+
+  it('asserts true for all flags when input is fully valid', () => {
+    const smt2 = renderGatewayInvariantSmt2(fullyValidInput);
+    expect(smt2).toContain('(assert (= has_org true))');
+    expect(smt2).toContain('(assert (= has_actor true))');
+    expect(smt2).toContain('(assert (= evidence_writable true))');
+  });
+
+  it('asserts false for missing flags', () => {
+    const smt2 = renderGatewayInvariantSmt2({ ...fullyValidInput, hasOrg: false });
+    expect(smt2).toContain('(assert (= has_org false))');
+  });
+
+  it('renders risk as the correct integer', () => {
+    const smt2 = renderGatewayInvariantSmt2({ ...fullyValidInput, risk: 3 });
+    expect(smt2).toContain('(assert (= risk 3))');
+  });
+
+  it('renders risk 0 for low-risk input', () => {
+    const smt2 = renderGatewayInvariantSmt2(fullyValidInput);
+    expect(smt2).toContain('(assert (= risk 0))');
+  });
+
+  it('is deterministic — same input produces identical output', () => {
+    const s1 = renderGatewayInvariantSmt2(fullyValidInput);
+    const s2 = renderGatewayInvariantSmt2(fullyValidInput);
+    expect(s1).toBe(s2);
+  });
+
+  it('includes the approval implication assertion', () => {
+    const smt2 = renderGatewayInvariantSmt2(fullyValidInput);
+    expect(smt2).toContain('(assert (=> (or requires_approval (>= risk 2)) has_approval))');
+  });
+
+  it('declares all 12 constants', () => {
+    const smt2 = renderGatewayInvariantSmt2(fullyValidInput);
+    const expected = [
+      'has_org', 'has_actor', 'has_actor_role', 'has_org_plan',
+      'is_registered_tool', 'action_matches_tool', 'actor_role_allowed',
+      'plan_entitled', 'risk', 'requires_approval', 'has_approval', 'evidence_writable',
+    ];
+    for (const name of expected) {
+      expect(smt2).toContain(`declare-const ${name}`);
+    }
+  });
+});

--- a/tests/unit/runtime/checkpoint.test.ts
+++ b/tests/unit/runtime/checkpoint.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildCheckpointHash } from '../../../lib/runtime/checkpoint';
+
+const baseInput = {
+  truthCanonicalHash: 'abc123def456abc123def456abc123def456abc123def456abc123def456abcd',
+  latestLedgerId: 'ledger-001',
+  latestLedgerSequence: 42,
+  latestTruthSequence: 7,
+};
+
+describe('buildCheckpointHash', () => {
+  it('returns a 64-char hex string (SHA-256)', () => {
+    expect(buildCheckpointHash(baseInput)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const h1 = buildCheckpointHash(baseInput);
+    const h2 = buildCheckpointHash(baseInput);
+    expect(h1).toBe(h2);
+  });
+
+  it('changes when truthCanonicalHash changes', () => {
+    const h1 = buildCheckpointHash(baseInput);
+    const h2 = buildCheckpointHash({ ...baseInput, truthCanonicalHash: 'deadbeef' + 'a'.repeat(56) });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('changes when latestLedgerId changes', () => {
+    const h1 = buildCheckpointHash(baseInput);
+    const h2 = buildCheckpointHash({ ...baseInput, latestLedgerId: 'ledger-002' });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('changes when latestLedgerSequence changes', () => {
+    const h1 = buildCheckpointHash(baseInput);
+    const h2 = buildCheckpointHash({ ...baseInput, latestLedgerSequence: 43 });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('changes when latestTruthSequence changes', () => {
+    const h1 = buildCheckpointHash(baseInput);
+    const h2 = buildCheckpointHash({ ...baseInput, latestTruthSequence: 8 });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('sequence 0 and sequence 1 produce different hashes', () => {
+    const h1 = buildCheckpointHash({ ...baseInput, latestLedgerSequence: 0 });
+    const h2 = buildCheckpointHash({ ...baseInput, latestLedgerSequence: 1 });
+    expect(h1).not.toBe(h2);
+  });
+});

--- a/tests/unit/runtime/commit-rpc.test.ts
+++ b/tests/unit/runtime/commit-rpc.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { invokeRuntimeCommitRpc } from '../../../lib/runtime/commit-rpc';
+import type { RuntimeCommitRpcArgs } from '../../../lib/runtime/commit-rpc';
+
+const baseArgs: RuntimeCommitRpcArgs = {
+  p_org_id: 'org-1',
+  p_agent_id: 'agent-1',
+  p_request_id: 'req-1',
+  p_decision: 'allow',
+  p_reason: 'policy pass',
+  p_canonical_hash: 'abc123',
+  p_canonical_json: { key: 'value' },
+  p_agent_monthly_limit: 1000,
+  p_org_plan_limit: 5000,
+};
+
+function makeClient(responses: Array<{ data: unknown; error: { message: string } | null }>) {
+  let callCount = 0;
+  return {
+    rpc: vi.fn().mockImplementation(() => {
+      const result = responses[callCount] ?? responses[responses.length - 1];
+      callCount++;
+      return Promise.resolve(result);
+    }),
+  };
+}
+
+describe('invokeRuntimeCommitRpc', () => {
+  it('returns first call result with mode:latest when no error', async () => {
+    const client = makeClient([{ data: { id: 'exec-1' }, error: null }]);
+    const result = await invokeRuntimeCommitRpc(client, baseArgs);
+    expect(result.mode).toBe('latest');
+    expect(result.data).toEqual({ id: 'exec-1' });
+    expect(result.error).toBeNull();
+  });
+
+  it('calls rpc exactly once when first call succeeds', async () => {
+    const client = makeClient([{ data: {}, error: null }]);
+    await invokeRuntimeCommitRpc(client, baseArgs);
+    expect(client.rpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns first result with mode:latest when error is non-signature-mismatch', async () => {
+    const client = makeClient([{ data: null, error: { message: 'permission denied' } }]);
+    const result = await invokeRuntimeCommitRpc(client, baseArgs);
+    expect(result.mode).toBe('latest');
+    expect(result.error?.message).toBe('permission denied');
+    expect(client.rpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to legacy call when error is schema cache mismatch', async () => {
+    const signatureMismatch = {
+      data: null,
+      error: { message: 'runtime_commit_execution function schema cache miss' },
+    };
+    const legacyResult = { data: { id: 'exec-fallback' }, error: null };
+    const client = makeClient([signatureMismatch, legacyResult]);
+
+    const result = await invokeRuntimeCommitRpc(client, baseArgs);
+    expect(result.mode).toBe('legacy');
+    expect(result.data).toEqual({ id: 'exec-fallback' });
+    expect(client.rpc).toHaveBeenCalledTimes(2);
+  });
+
+  it('strips p_agent_monthly_limit and p_org_plan_limit in the legacy call', async () => {
+    const signatureMismatch = {
+      data: null,
+      error: { message: 'runtime_commit_execution function schema cache miss' },
+    };
+    const client = makeClient([signatureMismatch, { data: {}, error: null }]);
+
+    await invokeRuntimeCommitRpc(client, baseArgs);
+
+    const legacyCallArgs = client.rpc.mock.calls[1][1] as Record<string, unknown>;
+    expect(legacyCallArgs.p_agent_monthly_limit).toBeUndefined();
+    expect(legacyCallArgs.p_org_plan_limit).toBeUndefined();
+    expect(legacyCallArgs.p_org_id).toBe('org-1');
+  });
+
+  it('first call always passes full args including limits', async () => {
+    const client = makeClient([{ data: {}, error: null }]);
+    await invokeRuntimeCommitRpc(client, baseArgs);
+
+    const firstCallArgs = client.rpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(firstCallArgs.p_agent_monthly_limit).toBe(1000);
+    expect(firstCallArgs.p_org_plan_limit).toBe(5000);
+  });
+
+  it('first call uses function name runtime_commit_execution', async () => {
+    const client = makeClient([{ data: {}, error: null }]);
+    await invokeRuntimeCommitRpc(client, baseArgs);
+    expect(client.rpc.mock.calls[0][0]).toBe('runtime_commit_execution');
+  });
+
+  it('handles args without optional limit fields', async () => {
+    const argsNoLimits: RuntimeCommitRpcArgs = {
+      p_org_id: 'org-2',
+      p_agent_id: 'agent-2',
+      p_request_id: 'req-2',
+      p_decision: 'block',
+      p_reason: 'policy block',
+      p_canonical_hash: 'def456',
+      p_canonical_json: {},
+    };
+    const client = makeClient([{ data: { id: 'exec-2' }, error: null }]);
+    const result = await invokeRuntimeCommitRpc(client, argsNoLimits);
+    expect(result.mode).toBe('latest');
+    expect(result.data).toEqual({ id: 'exec-2' });
+  });
+});

--- a/tests/unit/runtime/reconcile-effect-callback.test.ts
+++ b/tests/unit/runtime/reconcile-effect-callback.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+const mockFrom = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockEq = vi.fn();
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({
+    from: mockFrom,
+  }),
+}));
+
+import { reconcileEffectCallback } from '../../../lib/runtime/reconcile';
+
+function makeChain(finalValue: unknown) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.maybeSingle = vi.fn().mockResolvedValue(finalValue);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reconcileEffectCallback — unit', () => {
+  const base = {
+    effectId: 'effect-001',
+    orgId: 'org-test',
+    status: 'succeeded' as const,
+    payload: { result: 'ok' },
+  };
+
+  it('returns found:false when effect does not exist', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await reconcileEffectCallback(base);
+
+    expect(result).toEqual({ found: false, alreadyFinal: false });
+  });
+
+  it('returns alreadyFinal:true when status is succeeded (idempotent)', async () => {
+    const readChain = makeChain({ data: { id: 'effect-001', status: 'succeeded', callback_count: 1 }, error: null });
+    mockFrom.mockReturnValue(readChain);
+
+    const result = await reconcileEffectCallback(base);
+
+    expect(result).toEqual({ found: true, alreadyFinal: true });
+  });
+
+  it('returns alreadyFinal:true when status is failed (immutable)', async () => {
+    const readChain = makeChain({ data: { id: 'effect-001', status: 'failed', callback_count: 1 }, error: null });
+    mockFrom.mockReturnValue(readChain);
+
+    const result = await reconcileEffectCallback({ ...base, status: 'succeeded' });
+
+    expect(result).toEqual({ found: true, alreadyFinal: true });
+  });
+
+  it('updates status and increments callback_count when pending', async () => {
+    const readChain = makeChain({ data: { id: 'effect-001', status: 'pending', callback_count: 0 }, error: null });
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockResolvedValue({ error: null }),
+    };
+    updateChain.eq.mockReturnValue(updateChain);
+    updateChain.update.mockReturnValue(updateChain);
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return readChain;
+      return {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }),
+        }),
+      };
+    });
+
+    const result = await reconcileEffectCallback(base);
+
+    expect(result).toEqual({ found: true, alreadyFinal: false });
+  });
+
+  it('throws when DB read fails', async () => {
+    const chain = makeChain({ data: null, error: { message: 'connection timeout' } });
+    mockFrom.mockReturnValue(chain);
+
+    await expect(reconcileEffectCallback(base)).rejects.toThrow('connection timeout');
+  });
+
+  it('accepts failed status', async () => {
+    const readChain = makeChain({ data: { id: 'effect-001', status: 'pending', callback_count: 2 }, error: null });
+    mockFrom.mockImplementationOnce(() => readChain).mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }),
+      }),
+    });
+
+    const result = await reconcileEffectCallback({ ...base, status: 'failed' });
+    expect(result).toEqual({ found: true, alreadyFinal: false });
+  });
+
+  it('scopes read query by org_id to prevent cross-org access', async () => {
+    const chain = makeChain({ data: null, error: null });
+    const eqSpy = vi.fn().mockReturnValue(chain);
+    chain.eq = eqSpy;
+    mockFrom.mockReturnValue(chain);
+
+    await reconcileEffectCallback({ ...base, orgId: 'org-specific' });
+
+    const eqCalls = eqSpy.mock.calls.map(([col]) => col);
+    expect(eqCalls).toContain('org_id');
+  });
+});

--- a/tests/unit/security/audit-export.test.ts
+++ b/tests/unit/security/audit-export.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+import { fetchAuditLogsForExport } from '../../../lib/security/audit-export';
+
+function makeChain(result: { data: unknown; error: { message?: string; code?: string } | null }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+describe('fetchAuditLogsForExport', () => {
+  it('returns ok:true with rows on success', async () => {
+    const rows = [{ id: 'log-1', decision: 'allow' }];
+    mockFrom.mockReturnValue(makeChain({ data: rows, error: null }));
+
+    const result = await fetchAuditLogsForExport('org-1', 50);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.rows).toEqual(rows);
+    }
+  });
+
+  it('returns empty rows when data is null', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+
+    const result = await fetchAuditLogsForExport('org-1', 50);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.rows).toEqual([]);
+    }
+  });
+
+  it('returns relation-missing when error contains "relation"', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'relation does not exist' } }));
+
+    const result = await fetchAuditLogsForExport('org-1', 50);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('relation-missing');
+    }
+  });
+
+  it('returns relation-missing when error contains "does not exist"', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'table does not exist' } }));
+
+    const result = await fetchAuditLogsForExport('org-1', 50);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('relation-missing');
+    }
+  });
+
+  it('returns relation-missing when error code is PGRST205', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'query error', code: 'PGRST205' } }));
+
+    const result = await fetchAuditLogsForExport('org-1', 50);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('relation-missing');
+    }
+  });
+
+  it('returns query-error for generic DB errors', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'connection timeout' } }));
+
+    const result = await fetchAuditLogsForExport('org-1', 50);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('query-error');
+    }
+  });
+
+  it('passes orgId filter to query', async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await fetchAuditLogsForExport('org-42', 10);
+    expect(chain.eq as ReturnType<typeof vi.fn>).toHaveBeenCalledWith('org_id', 'org-42');
+  });
+});

--- a/tests/unit/security/cron-auth.test.ts
+++ b/tests/unit/security/cron-auth.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { sha256Hex } from '../../../lib/security/secure-token';
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function makeRequest(token: string | null) {
+  const headers: Record<string, string> = {};
+  if (token !== null) headers['authorization'] = `Bearer ${token}`;
+  return new Request('http://localhost/api/cron/test', { headers });
+}
+
+describe('requireCronAuth — no secret configured', () => {
+  it('returns 503 in production when no secret is set', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('CRON_SECRET', '');
+    vi.stubEnv('CRON_SECRET_SHA256', '');
+
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('any-token'), 'flush-meter-outbox');
+
+    expect(result.ok).toBe(false);
+    expect(result.response.status).toBe(503);
+  });
+
+  it('returns 401 in development when no secret is set', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('CRON_SECRET', '');
+    vi.stubEnv('CRON_SECRET_SHA256', '');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('any-token'), 'flush-meter-outbox');
+
+    expect(result.ok).toBe(false);
+    expect(result.response.status).toBe(401);
+  });
+
+  it('includes cron_secret_required error when no secret configured', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('CRON_SECRET', '');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('tok'), 'test-job');
+    const body = await result.response.json();
+
+    expect(body.error).toBe('cron_secret_required');
+  });
+});
+
+describe('requireCronAuth — shared CRON_SECRET', () => {
+  it('returns ok:true when Bearer token matches CRON_SECRET', async () => {
+    vi.stubEnv('CRON_SECRET', 'shared-secret-value');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('shared-secret-value'), 'any-job');
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns 401 when Bearer token does not match CRON_SECRET', async () => {
+    vi.stubEnv('CRON_SECRET', 'shared-secret-value');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('wrong-token'), 'any-job');
+
+    expect(result.ok).toBe(false);
+    expect(result.response.status).toBe(401);
+  });
+
+  it('returns ok:true when Bearer token sha256 matches CRON_SECRET_SHA256', async () => {
+    const secret = 'hashed-cron-secret';
+    vi.stubEnv('CRON_SECRET_SHA256', sha256Hex(secret));
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest(secret), 'any-job');
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('requireCronAuth — job-specific secret', () => {
+  it('returns ok:true when token matches job-specific CRON_<JOB>_SECRET', async () => {
+    vi.stubEnv('CRON_FLUSH_METER_OUTBOX_SECRET', 'job-specific-secret');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('job-specific-secret'), 'flush-meter-outbox');
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('normalizes job name: lowercase with dashes → uppercase with underscores', async () => {
+    vi.stubEnv('CRON_AGENT_HEALTH_CHECK_SECRET', 'health-tok');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('health-tok'), 'agent-health-check');
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('job-specific secret takes precedence over shared CRON_SECRET mismatch', async () => {
+    vi.stubEnv('CRON_SECRET', 'shared-wrong');
+    vi.stubEnv('CRON_MY_JOB_SECRET', 'job-correct');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('job-correct'), 'my-job');
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('requireCronAuth — response headers', () => {
+  it('always sets Cache-Control: no-store header', async () => {
+    vi.stubEnv('CRON_SECRET', 'tok');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('tok'), 'any-job');
+
+    expect(result.headers).toMatchObject({ 'Cache-Control': 'no-store' });
+  });
+
+  it('sets Cache-Control: no-store even on auth failure', async () => {
+    vi.stubEnv('CRON_SECRET', 'tok');
+
+    vi.resetModules();
+    const { requireCronAuth } = await import('../../../lib/security/cron-auth');
+    const result = requireCronAuth(makeRequest('wrong'), 'any-job');
+
+    expect(result.headers).toMatchObject({ 'Cache-Control': 'no-store' });
+  });
+});

--- a/tests/unit/security/request-json.test.ts
+++ b/tests/unit/security/request-json.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { readJsonBody, jsonSizeBytes, maxObjectDepth } from '../../../lib/security/request-json';
+
+function makeRequest(body: string, contentLength?: number, contentType = 'application/json') {
+  const headers: Record<string, string> = { 'content-type': contentType };
+  if (contentLength !== undefined) {
+    headers['content-length'] = String(contentLength);
+  }
+  return new Request('http://localhost/', {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+// ─── readJsonBody ─────────────────────────────────────────────────────────────
+
+describe('readJsonBody', () => {
+  it('returns ok:true and parsed value for valid JSON', async () => {
+    const result = await readJsonBody(makeRequest('{"key":"value"}'));
+    expect(result.ok).toBe(true);
+    expect(result.value).toEqual({ key: 'value' });
+    expect(result.status).toBe(200);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns 400 empty_body for empty body', async () => {
+    const result = await readJsonBody(makeRequest(''));
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toBe('empty_body');
+    expect(result.value).toBeNull();
+  });
+
+  it('returns 400 invalid_json for non-JSON body', async () => {
+    const result = await readJsonBody(makeRequest('not json'));
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toBe('invalid_json');
+  });
+
+  it('returns 413 payload_too_large when content-length header exceeds default maxBytes', async () => {
+    const result = await readJsonBody(makeRequest('{}', 65_000));
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(413);
+    expect(result.error).toBe('payload_too_large');
+  });
+
+  it('returns 413 payload_too_large when content-length header exceeds custom maxBytes', async () => {
+    const result = await readJsonBody(makeRequest('{"x":1}', 500), { maxBytes: 100 });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(413);
+    expect(result.error).toBe('payload_too_large');
+  });
+
+  it('accepts body at default maxBytes boundary', async () => {
+    const result = await readJsonBody(makeRequest('{"x":1}', 100));
+    expect(result.ok).toBe(true);
+  });
+
+  it('parses arrays at top level', async () => {
+    const result = await readJsonBody(makeRequest('[1,2,3]'));
+    expect(result.ok).toBe(true);
+    expect(result.value).toEqual([1, 2, 3]);
+  });
+
+  it('parses primitive JSON values', async () => {
+    const result = await readJsonBody(makeRequest('"hello"'));
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe('hello');
+  });
+
+  it('returns generic type when T is specified', async () => {
+    type Payload = { orgId: string };
+    const result = await readJsonBody<Payload>(makeRequest('{"orgId":"org-1"}'));
+    expect(result.ok).toBe(true);
+    expect(result.value?.orgId).toBe('org-1');
+  });
+});
+
+// ─── jsonSizeBytes ────────────────────────────────────────────────────────────
+
+describe('jsonSizeBytes', () => {
+  it('returns byte size of a JSON-serialized object', () => {
+    const value = { a: 1 };
+    const expected = Buffer.byteLength(JSON.stringify(value), 'utf8');
+    expect(jsonSizeBytes(value)).toBe(expected);
+  });
+
+  it('handles empty object', () => {
+    expect(jsonSizeBytes({})).toBe(2); // "{}"
+  });
+
+  it('handles null', () => {
+    expect(jsonSizeBytes(null)).toBe(4); // "null"
+  });
+
+  it('handles multi-byte unicode characters', () => {
+    const value = { emoji: '🔒' };
+    const expected = Buffer.byteLength(JSON.stringify(value), 'utf8');
+    expect(jsonSizeBytes(value)).toBe(expected);
+  });
+});
+
+// ─── maxObjectDepth ──────────────────────────────────────────────────────────
+
+describe('maxObjectDepth', () => {
+  it('returns true for a flat object (depth 1)', () => {
+    expect(maxObjectDepth({ a: 1, b: 2 })).toBe(true);
+  });
+
+  it('returns true for null', () => {
+    expect(maxObjectDepth(null)).toBe(true);
+  });
+
+  it('returns true for a primitive', () => {
+    expect(maxObjectDepth(42)).toBe(true);
+    expect(maxObjectDepth('str')).toBe(true);
+  });
+
+  it('returns true for an array of primitives', () => {
+    expect(maxObjectDepth([1, 2, 3])).toBe(true);
+  });
+
+  it('returns true for nested object within default maxDepth (8)', () => {
+    const deep = { a: { b: { c: { d: { e: { f: { g: { h: 1 } } } } } } } };
+    expect(maxObjectDepth(deep)).toBe(true);
+  });
+
+  it('returns false for object deeper than maxDepth', () => {
+    const tooDeep = { a: { b: { c: { d: { e: { f: { g: { h: { i: 1 } } } } } } } } };
+    expect(maxObjectDepth(tooDeep)).toBe(false);
+  });
+
+  it('returns false when custom maxDepth is exceeded', () => {
+    expect(maxObjectDepth({ a: { b: { c: 1 } } }, 2)).toBe(false);
+  });
+
+  it('returns true when nested array depth is within limit', () => {
+    expect(maxObjectDepth([[1, 2], [3, 4]], 2)).toBe(true);
+  });
+});

--- a/tests/unit/security/safe-log.test.ts
+++ b/tests/unit/security/safe-log.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toSafeErrorInfo, logSecurityEvent } from '../../../lib/security/safe-log';
+
+// ─── toSafeErrorInfo ─────────────────────────────────────────────────────────
+
+describe('toSafeErrorInfo', () => {
+  it('returns UnknownError when error is null', () => {
+    expect(toSafeErrorInfo(null)).toEqual({ name: 'UnknownError', code: null });
+  });
+
+  it('returns UnknownError when error is undefined', () => {
+    expect(toSafeErrorInfo(undefined)).toEqual({ name: 'UnknownError', code: null });
+  });
+
+  it('returns UnknownError when error is a string', () => {
+    expect(toSafeErrorInfo('something went wrong')).toEqual({ name: 'UnknownError', code: null });
+  });
+
+  it('returns UnknownError when error is a number', () => {
+    expect(toSafeErrorInfo(42)).toEqual({ name: 'UnknownError', code: null });
+  });
+
+  it('extracts name and code from a typed error object', () => {
+    expect(toSafeErrorInfo({ name: 'TypeError', code: 'ERR_INVALID' })).toEqual({
+      name: 'TypeError',
+      code: 'ERR_INVALID',
+    });
+  });
+
+  it('falls back to Error when name is missing', () => {
+    expect(toSafeErrorInfo({ code: 'ERR_X' })).toEqual({ name: 'Error', code: 'ERR_X' });
+  });
+
+  it('falls back to Error when name is empty string', () => {
+    expect(toSafeErrorInfo({ name: '', code: 'ERR_X' })).toEqual({ name: 'Error', code: 'ERR_X' });
+  });
+
+  it('falls back to Error when name is whitespace', () => {
+    expect(toSafeErrorInfo({ name: '   ', code: 'ERR_X' })).toEqual({ name: 'Error', code: 'ERR_X' });
+  });
+
+  it('returns null code when code is missing', () => {
+    expect(toSafeErrorInfo({ name: 'NetworkError' })).toEqual({ name: 'NetworkError', code: null });
+  });
+
+  it('returns null code when code is empty string', () => {
+    expect(toSafeErrorInfo({ name: 'NetworkError', code: '' })).toEqual({ name: 'NetworkError', code: null });
+  });
+
+  it('returns null code when code is whitespace', () => {
+    expect(toSafeErrorInfo({ name: 'NetworkError', code: '   ' })).toEqual({ name: 'NetworkError', code: null });
+  });
+
+  it('ignores non-string name and code fields', () => {
+    expect(toSafeErrorInfo({ name: 42, code: { nested: true } })).toEqual({ name: 'Error', code: null });
+  });
+});
+
+// ─── logSecurityEvent ────────────────────────────────────────────────────────
+
+describe('logSecurityEvent', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls console.info for level info', () => {
+    logSecurityEvent('info', 'test_event');
+    expect(console.info).toHaveBeenCalledWith({ event: 'test_event' });
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('calls console.warn for level warn', () => {
+    logSecurityEvent('warn', 'rate_limit_exceeded');
+    expect(console.warn).toHaveBeenCalledWith({ event: 'rate_limit_exceeded' });
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it('calls console.error for level error', () => {
+    logSecurityEvent('error', 'auth_failure');
+    expect(console.error).toHaveBeenCalledWith({ event: 'auth_failure' });
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it('spreads details into the payload when provided', () => {
+    logSecurityEvent('info', 'token_verified', { orgId: 'org-1', userId: 'u-1' });
+    expect(console.info).toHaveBeenCalledWith({ event: 'token_verified', orgId: 'org-1', userId: 'u-1' });
+  });
+
+  it('does not include extra keys when details is undefined', () => {
+    logSecurityEvent('warn', 'suspicious_request');
+    const call = (console.warn as ReturnType<typeof vi.spyOn>).mock.calls[0][0];
+    expect(Object.keys(call)).toEqual(['event']);
+  });
+});

--- a/tests/unit/security/secure-token.test.ts
+++ b/tests/unit/security/secure-token.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  sha256Hex,
+  timingSafeStringEqual,
+  extractBearerToken,
+  verifySecretValue,
+  verifyBearerSecret,
+} from '../../../lib/security/secure-token';
+
+describe('sha256Hex', () => {
+  it('returns a 64-char hex string', () => {
+    expect(sha256Hex('hello')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    expect(sha256Hex('test-value')).toBe(sha256Hex('test-value'));
+  });
+
+  it('produces different hashes for different inputs', () => {
+    expect(sha256Hex('a')).not.toBe(sha256Hex('b'));
+  });
+
+  it('handles empty string', () => {
+    expect(sha256Hex('')).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('timingSafeStringEqual', () => {
+  it('returns false when provided is empty', () => {
+    expect(timingSafeStringEqual('', 'secret')).toBe(false);
+  });
+
+  it('returns false when expected is empty', () => {
+    expect(timingSafeStringEqual('provided', '')).toBe(false);
+  });
+
+  it('returns true for equal strings', () => {
+    expect(timingSafeStringEqual('my-secret', 'my-secret')).toBe(true);
+  });
+
+  it('returns false for unequal strings', () => {
+    expect(timingSafeStringEqual('my-secret', 'other-secret')).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(timingSafeStringEqual('Secret', 'secret')).toBe(false);
+  });
+});
+
+describe('extractBearerToken', () => {
+  it('returns empty string when header is null', () => {
+    expect(extractBearerToken(null)).toBe('');
+  });
+
+  it('returns empty string when header is empty', () => {
+    expect(extractBearerToken('')).toBe('');
+  });
+
+  it('returns token from valid Bearer header', () => {
+    expect(extractBearerToken('Bearer my-token-123')).toBe('my-token-123');
+  });
+
+  it('returns empty string when scheme is not Bearer', () => {
+    expect(extractBearerToken('Basic dXNlcjpwYXNz')).toBe('');
+  });
+
+  it('is case-insensitive for Bearer scheme', () => {
+    expect(extractBearerToken('bearer my-token')).toBe('my-token');
+    expect(extractBearerToken('BEARER my-token')).toBe('my-token');
+  });
+
+  it('returns empty string when no token follows Bearer', () => {
+    expect(extractBearerToken('Bearer')).toBe('');
+  });
+
+  it('trims trailing whitespace from the token', () => {
+    expect(extractBearerToken('Bearer my-token   ')).toBe('my-token');
+  });
+});
+
+describe('verifySecretValue', () => {
+  it('returns false when provided is empty', () => {
+    expect(verifySecretValue({ provided: '', expected: 'secret' })).toBe(false);
+  });
+
+  it('returns false when provided is only whitespace', () => {
+    expect(verifySecretValue({ provided: '   ', expected: 'secret' })).toBe(false);
+  });
+
+  it('returns true when provided matches expected exactly', () => {
+    expect(verifySecretValue({ provided: 'correct-secret', expected: 'correct-secret' })).toBe(true);
+  });
+
+  it('returns false when provided does not match expected', () => {
+    expect(verifySecretValue({ provided: 'wrong-secret', expected: 'correct-secret' })).toBe(false);
+  });
+
+  it('returns true when sha256(provided) matches expectedSha256', () => {
+    const secret = 'my-secret';
+    const hash = sha256Hex(secret);
+    expect(verifySecretValue({ provided: secret, expectedSha256: hash })).toBe(true);
+  });
+
+  it('returns false when sha256 does not match expectedSha256', () => {
+    expect(verifySecretValue({ provided: 'wrong', expectedSha256: sha256Hex('correct') })).toBe(false);
+  });
+
+  it('returns false when both expected and expectedSha256 are absent', () => {
+    expect(verifySecretValue({ provided: 'something' })).toBe(false);
+  });
+
+  it('matches expected before falling back to sha256', () => {
+    const secret = 'my-secret';
+    expect(verifySecretValue({ provided: secret, expected: secret, expectedSha256: 'wrong-hash' })).toBe(true);
+  });
+
+  it('trims whitespace from provided before comparison', () => {
+    expect(verifySecretValue({ provided: '  my-secret  ', expected: 'my-secret' })).toBe(true);
+  });
+
+  it('returns false when expected is null', () => {
+    expect(verifySecretValue({ provided: 'secret', expected: null })).toBe(false);
+  });
+});
+
+describe('verifyBearerSecret', () => {
+  function makeRequest(authHeader: string | null) {
+    const headers: Record<string, string> = {};
+    if (authHeader !== null) headers['authorization'] = authHeader;
+    return new Request('http://localhost/', { headers });
+  }
+
+  it('returns false when no Authorization header', () => {
+    expect(verifyBearerSecret(makeRequest(null), { expected: 'secret' })).toBe(false);
+  });
+
+  it('returns false when token does not match expected', () => {
+    expect(verifyBearerSecret(makeRequest('Bearer wrong'), { expected: 'correct' })).toBe(false);
+  });
+
+  it('returns true when token matches expected', () => {
+    expect(verifyBearerSecret(makeRequest('Bearer my-token'), { expected: 'my-token' })).toBe(true);
+  });
+
+  it('returns true when token sha256 matches expectedSha256', () => {
+    const secret = 'my-cron-secret';
+    expect(verifyBearerSecret(
+      makeRequest(`Bearer ${secret}`),
+      { expectedSha256: sha256Hex(secret) }
+    )).toBe(true);
+  });
+
+  it('returns false when Authorization is not Bearer scheme', () => {
+    expect(verifyBearerSecret(makeRequest('Basic abc123'), { expected: 'abc123' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Goal
Add unit test coverage for all previously untested P0 and P1 source files.

## Files changed

**P0 — 9 files, 207 tests**
- `tests/unit/runtime/reconcile-effect-callback.test.ts` — WORM idempotency
- `tests/integration/api/effect-callback.test.ts` — auth/validation/WORM route
- `tests/unit/gateway/smt2-invariants.test.ts` — SMT2 invariant evaluation (63 tests)
- `tests/unit/gateway/audit.test.ts` — hash determinism + audit proof
- `tests/unit/gateway/evidence-bundle.test.ts` — HMAC signing + bundle structure
- `tests/unit/runtime/checkpoint.test.ts` — SHA-256 checkpoint hash
- `tests/unit/security/secure-token.test.ts` — timing-safe auth primitives
- `tests/unit/security/cron-auth.test.ts` — cron auth gating
- `tests/unit/gateway/approvals.test.ts` — approval token lifecycle

**P1 — 10 files, 117 tests**
- `tests/unit/gateway/control-templates.test.ts`
- `tests/unit/gateway/providers.test.ts`
- `tests/unit/gateway/monitor.test.ts`
- `tests/unit/gateway/managed-connectors.test.ts`
- `tests/unit/runtime/commit-rpc.test.ts`
- `tests/unit/security/safe-log.test.ts`
- `tests/unit/security/audit-export.test.ts`
- `tests/unit/security/request-json.test.ts`
- `tests/unit/agent-governance/policy.test.ts`
- `tests/unit/agent-governance/planner.test.ts`

## Verification
- [x] `npm test` — **874 passed / 886 total** (125 files passed, 4 skipped)
- [x] All new tests green, zero regressions vs main

## Known limits
Test files only — no production source code changed.

## User-visible benefit
874 tests vs 550 before (+59%). All P0 security, gateway audit, and approval paths have explicit regression guards.

## Next step
Merge → Vercel auto-deploy (docs/test only, no runtime changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F)_