### PR TITLE
fix(ts): exclude packages/ from tsconfig.typecheck.json — fix CI typecheck

### DIFF
--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -2,11 +2,22 @@
   "extends": "./tsconfig.json",
   "include": [
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
+    "global.d.ts",
+    "middleware.ts",
+    "sentry.server.config.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "lib/**/*.ts",
+    "lib/**/*.tsx",
+    "components/**/*.ts",
+    "components/**/*.tsx",
+    "skills/**/*.ts",
+    "skills/**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",
+    "packages",
     ".next"
   ]
 }


### PR DESCRIPTION
## Goal

Fix `npm run typecheck` (and Vercel CI) which was failing because `tsconfig.typecheck.json` still used the `**/*.ts` glob that picks up `packages/dsg-mcp-workspace-agent/src/server.ts` — the same root cause that broke `tsconfig.json` previously.

## Root cause

`tsconfig.json` was already fixed (explicit directory list), but `tsconfig.typecheck.json` — used by `npm run typecheck` and Vercel's CI step — kept the old `**/*.ts` glob:

```json
// BEFORE (broken)
"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
"exclude": ["node_modules", ".next"]
```

This compiled `packages/dsg-mcp-workspace-agent/src/server.ts` which cannot find `@modelcontextprotocol/sdk` types.

## Fix

Replaced with the same explicit directory list as `tsconfig.json`:

```json
// AFTER (fixed)
"include": [
  "next-env.d.ts", "global.d.ts", "middleware.ts",
  "sentry.server.config.ts",
  "app/**/*.ts", "app/**/*.tsx",
  "lib/**/*.ts", "lib/**/*.tsx",
  "components/**/*.ts", "components/**/*.tsx",
  "skills/**/*.ts", "skills/**/*.tsx",
  ".next/types/**/*.ts"
],
"exclude": ["node_modules", "packages", ".next"]
```

## Verification

- [x] `npm run typecheck` → **0 errors** (was: 14 errors in packages/)
- [x] `npm test` → **874 passed / 886 total**, 0 failures

## Known limits

No production logic changed — typecheck config only.

## User-visible benefit

Vercel CI typecheck step passes. The compliance evidence pack and all other routes now deploy successfully on every push to main.

## Next step

Merge → Vercel auto-deploys → smoke test `/compliance-evidence-pack` and `/api/compliance-evidence-pack`.

https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F)_