### PR TITLE
fix(vercel): downgrade agent crons to daily — unblock Hobby plan deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -32,11 +32,11 @@
     },
     {
       "path": "/api/cron/agent-orchestrator",
-      "schedule": "*/15 * * * *"
+      "schedule": "0 6 * * *"
     },
     {
       "path": "/api/cron/agent-health-check",
-      "schedule": "0 * * * *"
+      "schedule": "0 12 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Goal

Unblock Vercel deployment blocked by cron schedules incompatible with Hobby plan.

## Root cause

Vercel Hobby plan enforces: **crons must run at most once per day.**

Two crons violated this:

| Route | Old schedule | Violation |
|---|---|---|
| `/api/cron/agent-orchestrator` | `*/15 * * * *` | runs 96×/day |
| `/api/cron/agent-health-check` | `0 * * * *` | runs 24×/day |

Both blocked the Vercel build/deploy on merge commit `0f4c800`.

## Fix

| Route | Before | After |
|---|---|---|
| `/api/cron/agent-orchestrator` | `*/15 * * * *` | `0 6 * * *` (daily 06:00 UTC) |
| `/api/cron/agent-health-check` | `0 * * * *` | `0 12 * * *` (daily 12:00 UTC) |

## Verification

- [x] `vercel.json` — all crons now run once per day max
- [x] `npm run typecheck` → 0 errors
- [x] `npm test` → 874 passed / 886 total

## Known limits

Agent orchestrator and health-check will trigger daily instead of every 15 min / every hour. Re-enable sub-daily schedules after upgrading to Vercel Pro.

## User-visible benefit

Vercel deployment unblocked → compliance evidence pack, homepage, and all routes go live.

## Next step

Merge → Vercel redeploys → smoke test `GET /api/compliance-evidence-pack` and `GET /compliance-evidence-pack`.

https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYqCkcpSviLfNCn8sNeE3F)_