### PR TITLE
Add OpenClaw bridge and lock native Android agent target

### DIFF
--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -1,0 +1,46 @@
+name: Android Agent
+
+on:
+  pull_request:
+    paths:
+      - "apps/android/**"
+      - ".github/workflows/android-agent.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-debug-apk:
+    name: Build debug APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Build debug APK
+        working-directory: apps/android
+        run: gradle assembleDebug --no-daemon --stacktrace
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-agent-debug-apk
+          path: apps/android/app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -41,7 +41,26 @@ jobs:
 
       - name: Build debug APK
         working-directory: apps/android
-        run: gradle assembleDebug --no-daemon --stacktrace --warning-mode all
+        shell: bash
+        run: |
+          set +e
+          gradle assembleDebug --no-daemon --stacktrace --warning-mode all 2>&1 | tee android-build.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -ne 0 ]; then
+            echo ""
+            echo "==== Android build root-error hints ===="
+            grep -n -E "FAILURE:|What went wrong:|Execution failed for task|Android resource linking failed|Unresolved reference|Manifest merger failed|Compilation error" android-build.log || true
+            echo "==== End Android build root-error hints ===="
+            exit "$status"
+          fi
+
+      - name: Upload Android build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-agent-android-build-log
+          path: apps/android/android-build.log
+          if-no-files-found: ignore
 
       - name: Upload debug APK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -29,14 +29,19 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Install required Android SDK packages
+        run: |
+          yes | sdkmanager --licenses
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: "8.11.1"
+          gradle-version: "8.10.2"
 
       - name: Build debug APK
         working-directory: apps/android
-        run: gradle assembleDebug --no-daemon --stacktrace
+        run: gradle assembleDebug --no-daemon --stacktrace --warning-mode all
 
       - name: Upload debug APK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -48,8 +48,11 @@ jobs:
           status=${PIPESTATUS[0]}
           if [ "$status" -ne 0 ]; then
             echo ""
+            echo "==== Android build root-error context ===="
+            sed -n '/What went wrong:/,/Try:/p' android-build.log | sed -n '1,160p' || true
+            echo ""
             echo "==== Android build root-error hints ===="
-            grep -n -E "FAILURE:|What went wrong:|Execution failed for task|Android resource linking failed|Unresolved reference|Manifest merger failed|Compilation error" android-build.log || true
+            grep -n -E "FAILURE:|What went wrong:|Execution failed for task|Android resource linking failed|Unresolved reference|Manifest merger failed|Compilation error|Inconsistent JVM-target|e: file:|error:" android-build.log || true
             echo "==== End Android build root-error hints ===="
             exit "$status"
           fi
@@ -60,6 +63,16 @@ jobs:
         with:
           name: dsg-agent-android-build-log
           path: apps/android/android-build.log
+          if-no-files-found: ignore
+
+      - name: Upload Android build reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-agent-android-build-reports
+          path: |
+            apps/android/app/build/reports/**
+            apps/android/build/reports/**
           if-no-files-found: ignore
 
       - name: Upload debug APK artifact

--- a/app/api/agent/openclaw/route.ts
+++ b/app/api/agent/openclaw/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+type AgentDecision = 'PASS' | 'REVIEW' | 'BLOCK' | 'UNSUPPORTED';
+
+type CommandDecision = {
+  decision: AgentDecision;
+  httpStatus: number;
+  reason: string;
+  nextAction: string;
+};
+
+const OPENCLAW_APP = {
+  id: 'openclaw-android',
+  displayName: 'OpenClaw Android',
+  mappedLike: 'Kimi Claw Android one-click setup',
+  setupStep: 'Configure API Key',
+  configureButton: 'Configure',
+} as const;
+
+const ALLOWED_READ_ONLY_COMMANDS = [
+  'configure',
+  'openclaw.configure',
+  'setup_preview',
+  'status_check',
+] as const;
+
+const BLOCKED_COMMAND_PATTERNS = [
+  /deploy/i,
+  /merge/i,
+  /release/i,
+  /env/i,
+  /secret/i,
+  /token/i,
+  /api[_-]?key/i,
+  /service[_-]?role/i,
+  /write/i,
+  /delete/i,
+  /database[_-]?mutation/i,
+  /supabase[_-]?admin/i,
+] as const;
+
+const SECRET_VALUE_PATTERNS = [
+  /sk-[a-z0-9_-]{12,}/i,
+  /ghp_[a-z0-9_]{12,}/i,
+  /github_pat_[a-z0-9_]{12,}/i,
+  /xox[baprs]-[a-z0-9-]{12,}/i,
+  /service[_-]?role/i,
+  /private[_-]?key/i,
+  /vercel[_-]?token/i,
+  /supabase[_-]?service[_-]?role[_-]?key/i,
+] as const;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function sanitizeString(value: unknown, fallback = ''): string {
+  if (typeof value !== 'string') return fallback;
+  return value.trim().slice(0, 160);
+}
+
+function payloadContainsSecretLikeValue(payload: unknown): boolean {
+  const raw = JSON.stringify(payload ?? {});
+  return SECRET_VALUE_PATTERNS.some((pattern) => pattern.test(raw));
+}
+
+function classifyCommand(command: string, payload: Record<string, unknown>): CommandDecision {
+  if (payloadContainsSecretLikeValue(payload)) {
+    return {
+      decision: 'BLOCK',
+      httpStatus: 403,
+      reason: 'Mobile setup must not send or store production secrets, API keys, tokens, or service-role credentials.',
+      nextAction: 'Remove secrets from the mobile payload and use a backend-managed connector key.',
+    };
+  }
+
+  if (!command) {
+    return {
+      decision: 'REVIEW',
+      httpStatus: 400,
+      reason: 'Missing command.',
+      nextAction: 'Send command=status_check or command=openclaw.configure for the first mobile smoke test.',
+    };
+  }
+
+  if (ALLOWED_READ_ONLY_COMMANDS.includes(command as (typeof ALLOWED_READ_ONLY_COMMANDS)[number])) {
+    return {
+      decision: 'PASS',
+      httpStatus: 200,
+      reason: 'Read-only OpenClaw mobile command accepted.',
+      nextAction: 'Call /api/agent/status and display the repo/env/db status in the Android app.',
+    };
+  }
+
+  if (BLOCKED_COMMAND_PATTERNS.some((pattern) => pattern.test(command))) {
+    return {
+      decision: 'BLOCK',
+      httpStatus: 403,
+      reason: 'This mobile bridge is read-only. Deploy, merge, env, secret, write, delete, and database mutation commands are blocked.',
+      nextAction: 'Route privileged actions through the normal DSG review gate with explicit approval and audit evidence.',
+    };
+  }
+
+  return {
+    decision: 'REVIEW',
+    httpStatus: 202,
+    reason: 'Unknown OpenClaw command. It was not executed.',
+    nextAction: 'Add an explicit allow-list entry and tests before enabling this command.',
+  };
+}
+
+function setupManifest() {
+  return {
+    ok: true,
+    app: OPENCLAW_APP,
+    oneClickSetup: {
+      label: 'OpenClaw one-click setup',
+      apiKeyMode: 'backend-managed',
+      mobileShouldStoreSecrets: false,
+      configureEndpoint: '/api/agent/openclaw',
+      statusEndpoint: '/api/agent/status',
+      allowedCommands: ALLOWED_READ_ONLY_COMMANDS,
+    },
+    decisionPolicy: {
+      pass: 'read-only configure/status commands only',
+      review: 'unknown commands or malformed command requests',
+      block: 'secrets, API keys, tokens, deploy, merge, env, write, delete, and database mutation commands',
+    },
+    checks: {
+      writeEnabled: false,
+      deployEnabled: false,
+      mobileSecretStorageEnabled: false,
+    },
+    ts: nowIso(),
+  };
+}
+
+export async function GET() {
+  return NextResponse.json(setupManifest());
+}
+
+export async function POST(request: Request) {
+  const payload = asRecord(await request.json().catch(() => null));
+
+  if (!payload) {
+    return NextResponse.json(
+      {
+        ok: false,
+        app: OPENCLAW_APP,
+        decision: 'REVIEW',
+        reason: 'Request body must be a JSON object.',
+        nextAction: 'Send a JSON body with source, target, and command.',
+        ts: nowIso(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const source = sanitizeString(payload.source, OPENCLAW_APP.id) || OPENCLAW_APP.id;
+  const target = sanitizeString(payload.target, 'dsg-control-plane') || 'dsg-control-plane';
+  const command = sanitizeString(payload.command ?? payload.action);
+  const commandDecision = classifyCommand(command, payload);
+
+  return NextResponse.json(
+    {
+      ok: commandDecision.decision === 'PASS',
+      app: OPENCLAW_APP,
+      source,
+      target,
+      command,
+      decision: commandDecision.decision,
+      reason: commandDecision.reason,
+      nextAction: commandDecision.nextAction,
+      statusUrl: '/api/agent/status',
+      checks: {
+        readOnly: true,
+        secretAccepted: false,
+        writeEnabled: false,
+        deployEnabled: false,
+      },
+      ts: nowIso(),
+    },
+    { status: commandDecision.httpStatus },
+  );
+}

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -19,6 +19,11 @@ android {
         buildConfig = true
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     kotlinOptions {
         jvmTarget = "17"
     }
@@ -26,6 +31,4 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
 }

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.dsg.agent"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.dsg.agent"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+}

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
+    <application
+        android:allowBackup="false"
+        android:usesCleartextTraffic="false"
+        android:label="DSG Agent"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".service.AgentForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
+        <service
+            android:name=".service.DsgNotificationListenerService"
+            android:exported="true"
+            android:label="DSG Agent Notification Listener"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".service.DsgAccessibilityService"
+            android:exported="true"
+            android:label="DSG Agent Owner Automation"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/dsg_accessibility_service" />
+        </service>
+    </application>
+</manifest>

--- a/apps/android/app/src/main/java/com/dsg/agent/DsgConfig.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/DsgConfig.kt
@@ -1,0 +1,9 @@
+package com.dsg.agent
+
+object DsgConfig {
+    const val BASE_URL = "https://tdealer01-crypto-dsg-control-plane.vercel.app"
+    const val STATUS_URL = "$BASE_URL/api/agent/status"
+    const val OPENCLAW_URL = "$BASE_URL/api/agent/openclaw"
+    const val NOTIFICATION_CHANNEL_ID = "dsg_agent_status"
+    const val NOTIFICATION_ID = 1001
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -1,0 +1,103 @@
+package com.dsg.agent
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.core.app.ActivityCompat
+import com.dsg.agent.service.AgentForegroundService
+
+class MainActivity : Activity() {
+    private lateinit var statusView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), 10)
+        render()
+    }
+
+    private fun render() {
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(32, 32, 32, 32)
+        }
+
+        root.addView(TextView(this).apply {
+            text = "DSG Agent"
+            textSize = 28f
+        })
+
+        root.addView(TextView(this).apply {
+            text = "Owner-device automation app. Use only on your own phone. Keep the foreground notification visible and review each queued action before running it."
+            textSize = 16f
+        })
+
+        statusView = TextView(this).apply {
+            text = buildStatusText()
+            textSize = 14f
+            setPadding(0, 24, 0, 24)
+        }
+        root.addView(statusView)
+
+        root.addView(Button(this).apply {
+            text = "Start Agent Service"
+            setOnClickListener {
+                startForegroundService(Intent(this@MainActivity, AgentForegroundService::class.java))
+                statusView.text = buildStatusText("Foreground service start requested")
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Stop Agent Service"
+            setOnClickListener {
+                stopService(Intent(this@MainActivity, AgentForegroundService::class.java))
+                statusView.text = buildStatusText("Foreground service stop requested")
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Open Accessibility Permission"
+            setOnClickListener {
+                startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Open Notification Listener Permission"
+            setOnClickListener {
+                startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Open DSG Status API"
+            setOnClickListener {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL)))
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Open Bridge Manifest"
+            setOnClickListener {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL)))
+            }
+        })
+
+        setContentView(ScrollView(this).apply { addView(root) })
+    }
+
+    private fun buildStatusText(extra: String? = null): String {
+        return listOfNotNull(
+            "Backend: ${DsgConfig.BASE_URL}",
+            "Mode: owner-device, permission-first, audit-required",
+            "Enabled actions v1: status, foreground service, open settings screens, reviewed command inbox placeholder",
+            extra,
+        ).joinToString("\n")
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/service/AgentForegroundService.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/AgentForegroundService.kt
@@ -1,0 +1,45 @@
+package com.dsg.agent.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import com.dsg.agent.DsgConfig
+
+class AgentForegroundService : Service() {
+    override fun onCreate() {
+        super.onCreate()
+        ensureChannel()
+        startForeground(DsgConfig.NOTIFICATION_ID, buildNotification("DSG Agent running — owner-device mode"))
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(DsgConfig.NOTIFICATION_ID, buildNotification("DSG Agent active. Open app to review or stop."))
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun ensureChannel() {
+        val manager = getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            DsgConfig.NOTIFICATION_CHANNEL_ID,
+            "DSG Agent Status",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Visible status for the DSG owner-device automation agent."
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(text: String): Notification {
+        return Notification.Builder(this, DsgConfig.NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("DSG Agent")
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .build()
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/service/DsgAccessibilityService.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/DsgAccessibilityService.kt
@@ -1,0 +1,21 @@
+package com.dsg.agent.service
+
+import android.accessibilityservice.AccessibilityService
+import android.view.accessibility.AccessibilityEvent
+import android.util.Log
+
+class DsgAccessibilityService : AccessibilityService() {
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        Log.i("DSGAgent", "Accessibility service connected in owner-device mode")
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        val packageName = event?.packageName?.toString() ?: return
+        Log.i("DSGAgent", "Accessibility event from current visible app: $packageName")
+    }
+
+    override fun onInterrupt() {
+        Log.i("DSGAgent", "Accessibility service interrupted")
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/service/DsgNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/DsgNotificationListenerService.kt
@@ -1,0 +1,17 @@
+package com.dsg.agent.service
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+
+class DsgNotificationListenerService : NotificationListenerService() {
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        val packageName = sbn?.packageName ?: return
+        Log.i("DSGAgent", "Notification observed from allowed runtime permission channel: $packageName")
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+        val packageName = sbn?.packageName ?: return
+        Log.i("DSGAgent", "Notification removed from: $packageName")
+    }
+}

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">DSG Agent</string>
+    <string name="accessibility_service_description">DSG Agent owner-device automation. Enable only on your own device. Actions require visible approval and audit logging.</string>
+</resources>

--- a/apps/android/app/src/main/res/values/styles.xml
+++ b/apps/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">#FFFFFF</item>
+    </style>
+</resources>

--- a/apps/android/app/src/main/res/xml/dsg_accessibility_service.xml
+++ b/apps/android/app/src/main/res/xml/dsg_accessibility_service.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="true"
+    android:description="@string/accessibility_service_description"
+    android:notificationTimeout="100" />

--- a/apps/android/build.gradle.kts
+++ b/apps/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}

--- a/apps/android/gradle.properties
+++ b/apps/android/gradle.properties
@@ -1,0 +1,3 @@
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8

--- a/apps/android/settings.gradle.kts
+++ b/apps/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "DSGAgentAndroid"
+include(":app")

--- a/docs/mobile/DSG_NATIVE_ANDROID_AGENT_LOCKED_TARGET.md
+++ b/docs/mobile/DSG_NATIVE_ANDROID_AGENT_LOCKED_TARGET.md
@@ -1,0 +1,40 @@
+# DSG Native Android Agent — Locked Target
+
+Status: target locked, production status not verified.
+
+## Goal
+
+Build a DSG-owned Android app that pairs with the DSG Control Plane and gives the device owner a visible, auditable agent console.
+
+## Locked scope for v1
+
+- Native Android app source under `apps/android/`.
+- Device pairing screen.
+- Agent status screen.
+- Visible foreground service status.
+- Permission checklist screen.
+- Local command inbox that requires the device owner to confirm actions.
+- Local and server audit event contract.
+- Kill switch visible in the app.
+
+## Non-goals for v1
+
+- No hidden background control.
+- No credential storage in the mobile app.
+- No silent access to private app content.
+- No production release claim until APK build and real-device smoke evidence exist.
+
+## User-visible result
+
+The user should be able to install the app, pair the device, see live DSG status, see whether the agent service is running, approve or reject queued actions, and stop the agent at any time.
+
+## Verification required before release
+
+- Android project opens in Android Studio.
+- Debug APK builds.
+- App launches on a real Android device.
+- Pairing screen works.
+- Status call to DSG Control Plane works.
+- Foreground service notification is visible.
+- Kill switch stops the service.
+- Audit event is recorded for every approved or rejected action.


### PR DESCRIPTION
Goal:
Add the first OpenClaw-compatible mobile agent bridge and native Android owner-device automation skeleton so the project has one clear direction for the DSG-owned Android agent.

Files changed:
- `app/api/agent/openclaw/route.ts` — adds GET/POST bridge for OpenClaw-style mobile setup. Current bridge is intentionally read-only and returns PASS/REVIEW/BLOCK decisions for safe setup/status commands.
- `docs/mobile/DSG_NATIVE_ANDROID_AGENT_LOCKED_TARGET.md` — locks the target for DSG Native Android Agent as an owner-device automation app with visible service, permission checklist, command inbox, audit log, and kill switch.
- `apps/android/**` — adds Native Android project skeleton with launcher activity, endpoint config, foreground service, notification listener service stub, accessibility service stub, permission entry buttons, and app resources.
- `apps/android/gradle.properties` — enables AndroidX and Android build JVM settings.
- `.github/workflows/android-agent.yml` — adds CI workflow to build a debug APK, upload build logs, and upload the debug APK artifact.

Verification:
- [x] GitHub compare inspected: branch is ahead of `main` and not behind.
- [x] Existing repo workflows visible on head commit: DSG Secure Deploy Gate success, CI Security Checks success, launch-readiness success, E2E success.
- [x] Android Agent workflow on head commit `14d771823da9ca30f1de351dea45cd1bc7144bf1`: success.
- [x] Android debug APK artifact uploaded: `dsg-agent-debug-apk`.
- [x] Android build log artifact uploaded: `dsg-agent-android-build-log`.

Known limits:
- Native Android source is included and CI debug APK build now passes, but no real-device smoke evidence has been provided yet.
- Production endpoint is not live until this PR is merged and deployed.
- The OpenClaw bridge is read-only; privileged commands remain blocked by design.

User-visible benefit:
This creates a concrete backend entrypoint and first native Android app skeleton for DSG owner-device automation while preserving truth boundaries: APK CI build is verified, but real-device behavior still requires manual smoke testing.

Next step:
Download the `dsg-agent-debug-apk` artifact, install on an owner-controlled Android test device, and record smoke evidence: app opens, foreground service starts/stops, permission screens open, status/bridge links open, and no privileged automation runs without owner approval.