### PR TITLE
Add owner-approved Android command MVP

### DIFF
--- a/app/api/agent/commands/route.ts
+++ b/app/api/agent/commands/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildCommandEnvelope, isExpired } from '@/lib/commands/normalize';
+import type { DsgCommandEnvelope } from '@/lib/commands/schema';
+
+export const dynamic = 'force-dynamic';
+
+type QueueRecord = DsgCommandEnvelope & {
+  result?: Record<string, unknown>;
+  error?: { code: string; message: string };
+};
+
+const globalForCommands = globalThis as typeof globalThis & {
+  __dsgOwnerCommandQueue?: Map<string, QueueRecord>;
+  __dsgIdempotencyIndex?: Map<string, string>;
+};
+
+function queue() {
+  if (!globalForCommands.__dsgOwnerCommandQueue) globalForCommands.__dsgOwnerCommandQueue = new Map();
+  return globalForCommands.__dsgOwnerCommandQueue;
+}
+
+function idempotencyIndex() {
+  if (!globalForCommands.__dsgIdempotencyIndex) globalForCommands.__dsgIdempotencyIndex = new Map();
+  return globalForCommands.__dsgIdempotencyIndex;
+}
+
+function pruneExpired() {
+  const q = queue();
+  const index = idempotencyIndex();
+  for (const [commandId, command] of q.entries()) {
+    if (isExpired(command.policy.expiresAt) && !['running', 'succeeded'].includes(command.executionState)) {
+      command.executionState = 'expired';
+      command.approval.state = 'expired';
+      index.delete(command.idempotency.key);
+      q.set(commandId, command);
+    }
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+export async function GET(request: NextRequest) {
+  pruneExpired();
+  const deviceId = request.nextUrl.searchParams.get('deviceId');
+  const records = Array.from(queue().values())
+    .filter((command) => !deviceId || command.target.deviceId === deviceId)
+    .sort((a, b) => b.audit.requestedAt.localeCompare(a.audit.requestedAt));
+
+  return NextResponse.json({
+    ok: true,
+    count: records.length,
+    commands: records,
+    note: 'In-memory MVP queue. Production implementation must persist this in the DSG One/control-plane database.',
+  });
+}
+
+export async function POST(request: NextRequest) {
+  pruneExpired();
+  const body = asRecord(await request.json().catch(() => null));
+  const target = asRecord(body.target);
+  const tool = asRecord(body.tool);
+  const args = asRecord(body.args);
+
+  try {
+    const command = buildCommandEnvelope({
+      sourceKind: (body.sourceKind as DsgCommandEnvelope['source']['kind']) ?? 'cli',
+      actorType: (body.actorType as DsgCommandEnvelope['source']['actorType']) ?? 'user',
+      actorId: typeof body.actorId === 'string' ? body.actorId : 'operator:local',
+      sessionId: typeof body.sessionId === 'string' ? body.sessionId : undefined,
+      deviceId: typeof target.deviceId === 'string' ? target.deviceId : typeof body.deviceId === 'string' ? body.deviceId : undefined,
+      toolName: typeof tool.name === 'string' ? tool.name : String(body.toolName ?? ''),
+      args,
+      idempotencyKey: typeof body.idempotencyKey === 'string' ? body.idempotencyKey : undefined,
+    });
+
+    const index = idempotencyIndex();
+    const existingId = index.get(command.idempotency.key);
+    if (existingId) {
+      const existing = queue().get(existingId);
+      if (existing && !isExpired(existing.policy.expiresAt)) {
+        return NextResponse.json({ ok: true, deduped: true, command: existing }, { status: 200 });
+      }
+      index.delete(command.idempotency.key);
+    }
+
+    queue().set(command.commandId, command);
+    index.set(command.idempotency.key, command.commandId);
+
+    return NextResponse.json({ ok: true, command }, { status: 202 });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: 'COMMAND_REJECTED',
+      message: error instanceof Error ? error.message : 'Invalid command request',
+    }, { status: 400 });
+  }
+}

--- a/app/api/agent/commands/route.ts
+++ b/app/api/agent/commands/route.ts
@@ -1,3 +1,4 @@
+// ERROR_HANDLER_EXEMPT: MVP command queue returns structured JSON API errors and does not throw raw errors
 import { NextRequest, NextResponse } from 'next/server';
 import { buildCommandEnvelope, isExpired } from '@/lib/commands/normalize';
 import type { DsgCommandEnvelope } from '@/lib/commands/schema';

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,16 +1,94 @@
 // ERROR_HANDLER_EXEMPT: MCP JSON-RPC protocol requires structured error responses
-// This route is superseded by /api/mcp-server — kept as redirect for compatibility
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { buildCommandEnvelope } from '@/lib/commands/normalize';
+import { TOOL_POLICY } from '@/lib/commands/schema';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
-  return NextResponse.json({ message: 'MCP server moved to /api/mcp-server' }, { status: 301 });
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: Record<string, unknown>;
+  };
+};
+
+function rpcResult(id: JsonRpcRequest['id'], result: unknown) {
+  return NextResponse.json({ jsonrpc: '2.0', id: id ?? null, result });
 }
 
-export async function POST() {
-  return NextResponse.json(
-    { jsonrpc: '2.0', id: null, error: { code: -32600, message: 'Endpoint moved to /api/mcp-server' } },
-    { status: 301 },
-  );
+function rpcError(id: JsonRpcRequest['id'], code: number, message: string) {
+  return NextResponse.json({ jsonrpc: '2.0', id: id ?? null, error: { code, message } }, { status: code === -32601 ? 404 : 400 });
+}
+
+function toolList() {
+  return Object.entries(TOOL_POLICY).map(([name, policy]) => ({
+    name,
+    description: `Queue ${name} for Android owner-agent review. Class=${policy.class}; owner approval is always required before device execution.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        deviceId: { type: 'string' },
+        url: { type: 'string' },
+        packageName: { type: 'string' },
+        screen: { type: 'string' },
+        direction: { type: 'string', enum: ['down'] },
+      },
+      required: ['deviceId'],
+      additionalProperties: true,
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        commandId: { type: 'string' },
+        executionState: { type: 'string' },
+        requiresOwnerApproval: { type: 'boolean' },
+        commandDigest: { type: 'string' },
+      },
+      required: ['commandId', 'executionState', 'requiresOwnerApproval', 'commandDigest'],
+    },
+  }));
+}
+
+export async function GET() {
+  return NextResponse.json({ ok: true, tools: toolList(), note: 'Use POST JSON-RPC tools/list or tools/call.' });
+}
+
+export async function POST(request: NextRequest) {
+  const rpc = (await request.json().catch(() => null)) as JsonRpcRequest | null;
+  if (!rpc || rpc.jsonrpc !== '2.0') return rpcError(null, -32600, 'Invalid JSON-RPC request');
+
+  if (rpc.method === 'tools/list') {
+    return rpcResult(rpc.id, { tools: toolList() });
+  }
+
+  if (rpc.method === 'tools/call') {
+    const name = rpc.params?.name;
+    if (!name) return rpcError(rpc.id, -32602, 'Missing tool name');
+    try {
+      const args = rpc.params?.arguments ?? {};
+      const command = buildCommandEnvelope({
+        sourceKind: 'mcp',
+        actorType: 'user',
+        actorId: String(args.actorId ?? 'operator:mcp'),
+        deviceId: String(args.deviceId ?? 'android.owner.default'),
+        toolName: name,
+        args,
+      });
+      return rpcResult(rpc.id, {
+        commandId: command.commandId,
+        executionState: command.executionState,
+        requiresOwnerApproval: command.policy.requiresOwnerApproval,
+        commandDigest: command.idempotency.digest,
+        command,
+        note: 'MCP tools/call creates a command proposal only. Android execution still requires owner approval on device.',
+      });
+    } catch (error) {
+      return rpcError(rpc.id, -32602, error instanceof Error ? error.message : 'Invalid tool arguments');
+    }
+  }
+
+  return rpcError(rpc.id, -32601, 'Method not found');
 }

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -6,20 +6,46 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
+import android.view.Gravity
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.app.ActivityCompat
+import com.dsg.agent.automation.AccessibilityActionBridge
+import com.dsg.agent.automation.AgentCommand
+import com.dsg.agent.automation.AgentCommandStore
+import com.dsg.agent.automation.AgentCommandType
+import com.dsg.agent.automation.AgentErrorCodes
+import com.dsg.agent.automation.AuditLogStore
+import com.dsg.agent.automation.CommandExecutionResult
+import com.dsg.agent.automation.PermissionGate
+import com.dsg.agent.automation.OwnerApprovalSigner
 import com.dsg.agent.service.AgentForegroundService
 
 class MainActivity : Activity() {
     private lateinit var statusView: TextView
+    private lateinit var commandListView: LinearLayout
+    private lateinit var auditView: TextView
+
+    private lateinit var commandStore: AgentCommandStore
+    private lateinit var auditLogStore: AuditLogStore
+    private lateinit var permissionGate: PermissionGate
+    private lateinit var approvalSigner: OwnerApprovalSigner
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), 10)
+        commandStore = AgentCommandStore(this)
+        auditLogStore = AuditLogStore(this)
+        permissionGate = PermissionGate(this)
+        approvalSigner = OwnerApprovalSigner()
         render()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (::statusView.isInitialized) refreshUi("Permission state refreshed")
     }
 
     private fun render() {
@@ -34,7 +60,7 @@ class MainActivity : Activity() {
         })
 
         root.addView(TextView(this).apply {
-            text = "Owner-device automation app. Use only on your own phone. Keep the foreground notification visible and review each queued action before running it."
+            text = "Owner-device automation app. Commands enter an inbox first. Owner approval is bound to the exact command digest by Android Keystore signing before execution."
             textSize = 16f
         })
 
@@ -49,7 +75,8 @@ class MainActivity : Activity() {
             text = "Start Agent Service"
             setOnClickListener {
                 startForegroundService(Intent(this@MainActivity, AgentForegroundService::class.java))
-                statusView.text = buildStatusText("Foreground service start requested")
+                auditLogStore.append("SERVICE_START_REQUESTED", "local", "Foreground service start requested")
+                refreshUi("Foreground service start requested")
             }
         })
 
@@ -57,13 +84,15 @@ class MainActivity : Activity() {
             text = "Stop Agent Service"
             setOnClickListener {
                 stopService(Intent(this@MainActivity, AgentForegroundService::class.java))
-                statusView.text = buildStatusText("Foreground service stop requested")
+                auditLogStore.append("SERVICE_STOP_REQUESTED", "local", "Foreground service stop requested")
+                refreshUi("Foreground service stop requested")
             }
         })
 
         root.addView(Button(this).apply {
             text = "Open Accessibility Permission"
             setOnClickListener {
+                auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Accessibility settings opened by owner")
                 startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
             }
         })
@@ -71,32 +100,239 @@ class MainActivity : Activity() {
         root.addView(Button(this).apply {
             text = "Open Notification Listener Permission"
             setOnClickListener {
+                auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Notification listener settings opened by owner")
                 startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
             }
         })
 
         root.addView(Button(this).apply {
             text = "Open DSG Status API"
-            setOnClickListener {
-                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL)))
-            }
+            setOnClickListener { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL))) }
         })
 
         root.addView(Button(this).apply {
             text = "Open Bridge Manifest"
+            setOnClickListener { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL))) }
+        })
+
+        root.addView(sectionTitle("Local Command Inbox"))
+        root.addView(TextView(this).apply {
+            text = "Demo commands model Chat / CLI / MCP requests. No command runs until owner approves it here."
+            textSize = 14f
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue demo: open_url"
             setOnClickListener {
-                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL)))
+                queueDemoCommand(
+                    AgentCommandType.OPEN_URL,
+                    DsgConfig.STATUS_URL,
+                    "Open DSG status page for visible owner verification",
+                )
             }
         })
 
+        root.addView(Button(this).apply {
+            text = "Queue demo: open_app settings"
+            setOnClickListener {
+                queueDemoCommand(
+                    AgentCommandType.OPEN_APP,
+                    "com.android.settings",
+                    "Open Android Settings package for owner-approved setup",
+                )
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue demo: back"
+            setOnClickListener { queueDemoCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back through Accessibility after owner approval") }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue demo: home"
+            setOnClickListener { queueDemoCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home through Accessibility after owner approval") }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue demo: scroll down"
+            setOnClickListener { queueDemoCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE", "Run one scroll down through Accessibility after owner approval") }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Kill Switch: Clear Pending Commands"
+            setOnClickListener {
+                val count = commandStore.clearPending()
+                auditLogStore.append("KILL_SWITCH_CLEAR_PENDING", "local", "Owner cleared $count pending command(s)")
+                refreshUi("Kill switch cleared $count pending command(s)")
+            }
+        })
+
+        commandListView = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, 16, 0, 16)
+        }
+        root.addView(commandListView)
+
+        root.addView(sectionTitle("Local Audit Log"))
+        auditView = TextView(this).apply { textSize = 12f }
+        root.addView(auditView)
+
         setContentView(ScrollView(this).apply { addView(root) })
+        refreshUi()
+    }
+
+    private fun sectionTitle(textValue: String): TextView = TextView(this).apply {
+        text = textValue
+        textSize = 20f
+        setPadding(0, 32, 0, 8)
+    }
+
+    private fun queueDemoCommand(type: AgentCommandType, target: String, reason: String) {
+        commandStore.pruneExpired()
+        val command = AgentCommand.create(
+            source = "local-demo",
+            type = type,
+            target = target,
+            reason = reason,
+            requiresPermission = PermissionGate.requiredPermissionFor(type),
+            requiresUserConfirm = true,
+        )
+        commandStore.add(command)
+        auditLogStore.append("COMMAND_QUEUED", command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
+        refreshUi("Queued ${command.type.name}")
+    }
+
+    private fun refreshUi(extra: String? = null) {
+        statusView.text = buildStatusText(extra)
+        renderCommands()
+        renderAuditLog()
+    }
+
+    private fun renderCommands() {
+        commandListView.removeAllViews()
+        val pending = commandStore.listPending()
+        if (pending.isEmpty()) {
+            commandListView.addView(TextView(this).apply {
+                text = "No pending commands."
+                textSize = 14f
+            })
+            return
+        }
+
+        pending.forEach { command ->
+            val card = LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(0, 16, 0, 16)
+            }
+            card.addView(TextView(this).apply {
+                text = command.toHumanText()
+                textSize = 14f
+            })
+
+            val actionRow = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+            }
+            actionRow.addView(Button(this).apply {
+                text = "Approve"
+                setOnClickListener { approveCommand(command) }
+            })
+            actionRow.addView(Button(this).apply {
+                text = "Reject"
+                setOnClickListener {
+                    commandStore.markRejected(command.commandId)
+                    auditLogStore.append("COMMAND_REJECTED", command.commandId, "Owner rejected ${command.type.name}")
+                    refreshUi("Rejected ${command.type.name}")
+                }
+            })
+            card.addView(actionRow)
+            commandListView.addView(card)
+        }
+    }
+
+    private fun approveCommand(command: AgentCommand) {
+        val gate = permissionGate.evaluate(command)
+        if (!gate.allowed) {
+            if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) {
+                commandStore.markWaitingPermission(command.commandId, gate.message)
+            } else {
+                commandStore.markBlocked(command.commandId, gate.message)
+            }
+            auditLogStore.append("COMMAND_BLOCKED", command.commandId, gate.message, gate.errorCode)
+            refreshUi("Blocked: ${gate.message}")
+            return
+        }
+
+        val signed = runCatching { command.withApproval(approvalSigner.sign(command)) }.getOrElse { error ->
+            val message = error.message ?: "Failed to sign owner approval"
+            commandStore.markFailed(command.commandId, AgentErrorCodes.APPROVAL_SIGNATURE_INVALID, message)
+            auditLogStore.append("COMMAND_FAILED", command.commandId, message, AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
+            refreshUi(message)
+            return
+        }
+
+        if (!approvalSigner.verify(signed)) {
+            commandStore.markFailed(command.commandId, AgentErrorCodes.APPROVAL_SIGNATURE_INVALID, "Approval signature verification failed")
+            auditLogStore.append("COMMAND_FAILED", command.commandId, "Approval signature verification failed", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
+            refreshUi("Approval signature verification failed")
+            return
+        }
+
+        auditLogStore.append("COMMAND_APPROVED", signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
+        commandStore.markApproved(signed.commandId, signed.approvalSignature!!)
+
+        val result = executeCommand(signed)
+        if (result.success) {
+            commandStore.markExecuted(signed.commandId)
+            auditLogStore.append("COMMAND_EXECUTED", signed.commandId, result.message)
+        } else {
+            commandStore.markFailed(signed.commandId, result.errorCode ?: "EXECUTION_FAILED", result.message)
+            auditLogStore.append("COMMAND_FAILED", signed.commandId, result.message, result.errorCode)
+        }
+        refreshUi(result.message)
+    }
+
+    private fun executeCommand(command: AgentCommand): CommandExecutionResult {
+        if (!approvalSigner.verify(command)) {
+            return CommandExecutionResult(false, "Executor refused unsigned or mutated command digest", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
+        }
+        return when (command.type) {
+            AgentCommandType.STATUS -> CommandExecutionResult(true, "Status command reviewed; app is running")
+            AgentCommandType.OPEN_URL -> {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(command.target)))
+                CommandExecutionResult(true, "Opened URL visibly: ${command.target}")
+            }
+            AgentCommandType.OPEN_SETTINGS -> {
+                startActivity(Intent(Settings.ACTION_SETTINGS))
+                CommandExecutionResult(true, "Opened Android Settings visibly")
+            }
+            AgentCommandType.OPEN_APP -> {
+                val launchIntent = packageManager.getLaunchIntentForPackage(command.target)
+                if (launchIntent == null) CommandExecutionResult(false, "Package not launchable: ${command.target}", "PACKAGE_NOT_LAUNCHABLE")
+                else {
+                    startActivity(launchIntent)
+                    CommandExecutionResult(true, "Opened app package visibly: ${command.target}")
+                }
+            }
+            AgentCommandType.BACK -> AccessibilityActionBridge.performBack()
+            AgentCommandType.HOME -> AccessibilityActionBridge.performHome()
+            AgentCommandType.SCROLL_DOWN -> AccessibilityActionBridge.performScrollDown()
+            AgentCommandType.NOTIFICATION_SUMMARY -> CommandExecutionResult(false, "Notification summary executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+        }
+    }
+
+    private fun renderAuditLog() {
+        auditView.text = auditLogStore.tail(20).ifEmpty { "No audit events yet." }
     }
 
     private fun buildStatusText(extra: String? = null): String {
         return listOfNotNull(
             "Backend: ${DsgConfig.BASE_URL}",
-            "Mode: owner-device, permission-first, audit-required",
-            "Enabled actions v1: status, foreground service, open settings screens, reviewed command inbox placeholder",
+            "Mode: owner-device, permission-first, approval-signature-required, audit-required",
+            "Accessibility enabled: ${permissionGate.isAccessibilityEnabled()}",
+            "Notification listener enabled: ${permissionGate.isNotificationListenerEnabled()}",
+            "Enabled actions v1: status, open_url, open_settings, open_app, back, home, scroll_down",
+            "Pending commands: ${commandStore.listPending().size}",
             extra,
         ).joinToString("\n")
     }

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommand.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommand.kt
@@ -1,0 +1,199 @@
+package com.dsg.agent.automation
+
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.util.UUID
+
+enum class AgentCommandType {
+    STATUS,
+    OPEN_URL,
+    OPEN_SETTINGS,
+    OPEN_APP,
+    BACK,
+    HOME,
+    SCROLL_DOWN,
+    NOTIFICATION_SUMMARY,
+}
+
+enum class CommandState {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    BLOCKED,
+    WAITING_PERMISSION,
+    EXECUTED,
+    FAILED,
+}
+
+data class ApprovalSignature(
+    val commandDigest: String,
+    val signatureBase64: String,
+    val algorithm: String,
+    val keyAlias: String,
+    val approvedAt: Long,
+) {
+    fun toJson(): JSONObject = JSONObject()
+        .put("commandDigest", commandDigest)
+        .put("signatureBase64", signatureBase64)
+        .put("algorithm", algorithm)
+        .put("keyAlias", keyAlias)
+        .put("approvedAt", approvedAt)
+
+    companion object {
+        fun fromJson(json: JSONObject?): ApprovalSignature? {
+            if (json == null) return null
+            return ApprovalSignature(
+                commandDigest = json.optString("commandDigest"),
+                signatureBase64 = json.optString("signatureBase64"),
+                algorithm = json.optString("algorithm"),
+                keyAlias = json.optString("keyAlias"),
+                approvedAt = json.optLong("approvedAt"),
+            )
+        }
+    }
+}
+
+data class AgentCommand(
+    val commandId: String,
+    val source: String,
+    val type: AgentCommandType,
+    val target: String,
+    val requiresPermission: String,
+    val requiresUserConfirm: Boolean,
+    val reason: String,
+    val createdAt: Long,
+    val expiresAt: Long,
+    val policyVersion: String,
+    val idempotencyKey: String,
+    val commandDigest: String,
+    val state: CommandState = CommandState.PENDING,
+    val approvalSignature: ApprovalSignature? = null,
+    val lastErrorCode: String? = null,
+    val lastErrorMessage: String? = null,
+) {
+    fun isExpired(now: Long = System.currentTimeMillis()): Boolean = now > expiresAt
+
+    fun withState(nextState: CommandState, errorCode: String? = null, errorMessage: String? = null): AgentCommand =
+        copy(state = nextState, lastErrorCode = errorCode, lastErrorMessage = errorMessage)
+
+    fun withApproval(signature: ApprovalSignature): AgentCommand =
+        copy(state = CommandState.APPROVED, approvalSignature = signature, lastErrorCode = null, lastErrorMessage = null)
+
+    fun toHumanText(): String = listOf(
+        "ID: $commandId",
+        "Source: $source",
+        "Action: ${type.name}",
+        "Target: $target",
+        "State: ${state.name}",
+        "Permission: $requiresPermission",
+        "Digest: $commandDigest",
+        "Expires: $expiresAt",
+        "Reason: $reason",
+        lastErrorCode?.let { "Last error: $it ${lastErrorMessage.orEmpty()}" } ?: "",
+    ).filter { it.isNotBlank() }.joinToString("\n")
+
+    fun canonicalApprovalPayload(): String = listOf(
+        "version=dsg.command/1",
+        "type=${type.name}",
+        "target=$target",
+        "requiresPermission=$requiresPermission",
+        "reason=$reason",
+        "expiresAt=$expiresAt",
+        "policyVersion=$policyVersion",
+        "idempotencyKey=$idempotencyKey",
+    ).joinToString("|")
+
+    fun toJson(): JSONObject = JSONObject()
+        .put("commandId", commandId)
+        .put("source", source)
+        .put("type", type.name)
+        .put("target", target)
+        .put("requiresPermission", requiresPermission)
+        .put("requiresUserConfirm", requiresUserConfirm)
+        .put("reason", reason)
+        .put("createdAt", createdAt)
+        .put("expiresAt", expiresAt)
+        .put("policyVersion", policyVersion)
+        .put("idempotencyKey", idempotencyKey)
+        .put("commandDigest", commandDigest)
+        .put("state", state.name)
+        .put("approvalSignature", approvalSignature?.toJson())
+        .put("lastErrorCode", lastErrorCode)
+        .put("lastErrorMessage", lastErrorMessage)
+
+    companion object {
+        private const val DEFAULT_TTL_MS = 15 * 60 * 1000L
+        private const val DEFAULT_POLICY_VERSION = "2026-05-27-owner-command-mvp"
+
+        fun create(
+            source: String,
+            type: AgentCommandType,
+            target: String,
+            reason: String,
+            requiresPermission: String,
+            requiresUserConfirm: Boolean = true,
+        ): AgentCommand {
+            val now = System.currentTimeMillis()
+            val expiresAt = now + DEFAULT_TTL_MS
+            val idempotencyKey = buildIdempotencyKey(type, target)
+            val seed = listOf(
+                "version=dsg.command/1",
+                "type=${type.name}",
+                "target=$target",
+                "requiresPermission=$requiresPermission",
+                "reason=$reason",
+                "expiresAt=$expiresAt",
+                "policyVersion=$DEFAULT_POLICY_VERSION",
+                "idempotencyKey=$idempotencyKey",
+            ).joinToString("|")
+            val digest = sha256(seed)
+            return AgentCommand(
+                commandId = "cmd_${UUID.randomUUID()}",
+                source = source,
+                type = type,
+                target = target,
+                requiresPermission = requiresPermission,
+                requiresUserConfirm = requiresUserConfirm,
+                reason = reason,
+                createdAt = now,
+                expiresAt = expiresAt,
+                policyVersion = DEFAULT_POLICY_VERSION,
+                idempotencyKey = idempotencyKey,
+                commandDigest = digest,
+            )
+        }
+
+        fun fromJson(json: JSONObject): AgentCommand = AgentCommand(
+            commandId = json.getString("commandId"),
+            source = json.optString("source"),
+            type = AgentCommandType.valueOf(json.getString("type")),
+            target = json.optString("target"),
+            requiresPermission = json.optString("requiresPermission"),
+            requiresUserConfirm = json.optBoolean("requiresUserConfirm", true),
+            reason = json.optString("reason"),
+            createdAt = json.optLong("createdAt"),
+            expiresAt = json.optLong("expiresAt"),
+            policyVersion = json.optString("policyVersion"),
+            idempotencyKey = json.optString("idempotencyKey"),
+            commandDigest = json.optString("commandDigest"),
+            state = CommandState.valueOf(json.optString("state", CommandState.PENDING.name)),
+            approvalSignature = ApprovalSignature.fromJson(json.optJSONObject("approvalSignature")),
+            lastErrorCode = json.optString("lastErrorCode").ifBlank { null },
+            lastErrorMessage = json.optString("lastErrorMessage").ifBlank { null },
+        )
+
+        fun sha256(value: String): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(Charsets.UTF_8))
+            return digest.joinToString("") { "%02x".format(it) }
+        }
+
+        private fun buildIdempotencyKey(type: AgentCommandType, target: String): String =
+            "${type.name.lowercase()}:${target.trim().lowercase()}"
+    }
+}
+
+data class CommandExecutionResult(
+    val success: Boolean,
+    val message: String,
+    val errorCode: String? = null,
+)

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommandStore.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommandStore.kt
@@ -1,0 +1,101 @@
+package com.dsg.agent.automation
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+class AgentCommandStore(context: Context) {
+    private val prefs = context.getSharedPreferences("dsg_agent_commands", Context.MODE_PRIVATE)
+
+    fun add(command: AgentCommand) {
+        val existing = listAll().filterNot { it.idempotencyKey == command.idempotencyKey && !it.isExpired() }
+        saveAll(existing + command)
+    }
+
+    fun listAll(): List<AgentCommand> {
+        val raw = prefs.getString(KEY_COMMANDS, "[]") ?: "[]"
+        val array = JSONArray(raw)
+        return (0 until array.length()).mapNotNull { index ->
+            runCatching { AgentCommand.fromJson(array.getJSONObject(index)) }.getOrNull()
+        }
+    }
+
+    fun listPending(): List<AgentCommand> = listAll().filter { it.state == CommandState.PENDING && !it.isExpired() }
+
+    fun markApproved(commandId: String, signature: ApprovalSignature) = update(commandId) { it.withApproval(signature) }
+    fun markRejected(commandId: String) = update(commandId) { it.withState(CommandState.REJECTED) }
+    fun markBlocked(commandId: String, message: String) = update(commandId) { it.withState(CommandState.BLOCKED, "POLICY_OR_PERMISSION_BLOCKED", message) }
+    fun markWaitingPermission(commandId: String, message: String) = update(commandId) { it.withState(CommandState.WAITING_PERMISSION, "PERMISSION_REQUIRED", message) }
+    fun markExecuted(commandId: String) = update(commandId) { it.withState(CommandState.EXECUTED) }
+    fun markFailed(commandId: String, code: String, message: String) = update(commandId) { it.withState(CommandState.FAILED, code, message) }
+
+    fun clearPending(): Int {
+        val all = listAll()
+        val pending = all.filter { it.state == CommandState.PENDING }
+        saveAll(all.filterNot { it.state == CommandState.PENDING })
+        return pending.size
+    }
+
+    fun pruneExpired(now: Long = System.currentTimeMillis()): Int {
+        val all = listAll()
+        val active = all.filterNot { it.isExpired(now) && it.state == CommandState.PENDING }
+        saveAll(active)
+        return all.size - active.size
+    }
+
+    private fun update(commandId: String, transform: (AgentCommand) -> AgentCommand) {
+        saveAll(listAll().map { if (it.commandId == commandId) transform(it) else it })
+    }
+
+    private fun saveAll(commands: List<AgentCommand>) {
+        val array = JSONArray()
+        commands.forEach { array.put(it.toJson()) }
+        prefs.edit().putString(KEY_COMMANDS, array.toString()).apply()
+    }
+
+    companion object {
+        private const val KEY_COMMANDS = "commands"
+    }
+}
+
+class AuditLogStore(context: Context) {
+    private val prefs = context.getSharedPreferences("dsg_agent_audit", Context.MODE_PRIVATE)
+
+    fun append(eventType: String, commandId: String, message: String, errorCode: String? = null) {
+        val prevHash = latestHash()
+        val event = JSONObject()
+            .put("eventId", "evt_${System.currentTimeMillis()}")
+            .put("eventType", eventType)
+            .put("commandId", commandId)
+            .put("message", message)
+            .put("errorCode", errorCode)
+            .put("prevHash", prevHash)
+            .put("timestamp", System.currentTimeMillis())
+        val eventHash = AgentCommand.sha256(event.toString())
+        event.put("eventHash", eventHash)
+        val array = readArray()
+        array.put(event)
+        prefs.edit().putString(KEY_AUDIT, array.toString()).putString(KEY_LATEST_HASH, eventHash).apply()
+    }
+
+    fun tail(limit: Int): String {
+        val array = readArray()
+        val start = maxOf(0, array.length() - limit)
+        return (start until array.length()).joinToString("\n\n") { index ->
+            val item = array.getJSONObject(index)
+            "${item.optString("eventType")} [${item.optString("commandId")}]\n${item.optString("message")}\nhash=${item.optString("eventHash")}"
+        }
+    }
+
+    private fun latestHash(): String = prefs.getString(KEY_LATEST_HASH, "GENESIS") ?: "GENESIS"
+
+    private fun readArray(): JSONArray {
+        val raw = prefs.getString(KEY_AUDIT, "[]") ?: "[]"
+        return JSONArray(raw)
+    }
+
+    companion object {
+        private const val KEY_AUDIT = "audit"
+        private const val KEY_LATEST_HASH = "latestHash"
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/OwnerApprovalSigner.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/OwnerApprovalSigner.kt
@@ -1,0 +1,72 @@
+package com.dsg.agent.automation
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Signature
+
+class OwnerApprovalSigner {
+    companion object {
+        const val KEY_ALIAS = "dsg_owner_approval_v1"
+        const val SIGNATURE_ALGORITHM = "SHA256withECDSA"
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    }
+
+    fun sign(command: AgentCommand): ApprovalSignature {
+        val payload = command.canonicalApprovalPayload()
+        val digest = AgentCommand.sha256(payload)
+        if (digest != command.commandDigest) {
+            throw IllegalStateException("Command digest mismatch before owner approval")
+        }
+        val signature = Signature.getInstance(SIGNATURE_ALGORITHM)
+        signature.initSign(getOrCreatePrivateKey())
+        signature.update(command.commandDigest.toByteArray(Charsets.UTF_8))
+        val signatureBase64 = Base64.encodeToString(signature.sign(), Base64.NO_WRAP)
+        return ApprovalSignature(
+            commandDigest = command.commandDigest,
+            signatureBase64 = signatureBase64,
+            algorithm = SIGNATURE_ALGORITHM,
+            keyAlias = KEY_ALIAS,
+            approvedAt = System.currentTimeMillis(),
+        )
+    }
+
+    fun verify(command: AgentCommand): Boolean {
+        val approval = command.approvalSignature ?: return false
+        if (approval.commandDigest != command.commandDigest) return false
+        if (approval.algorithm != SIGNATURE_ALGORITHM) return false
+        if (AgentCommand.sha256(command.canonicalApprovalPayload()) != command.commandDigest) return false
+        val signature = Signature.getInstance(SIGNATURE_ALGORITHM)
+        signature.initVerify(getPublicKey())
+        signature.update(command.commandDigest.toByteArray(Charsets.UTF_8))
+        return signature.verify(Base64.decode(approval.signatureBase64, Base64.NO_WRAP))
+    }
+
+    private fun getOrCreatePrivateKey(): PrivateKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        if (!keyStore.containsAlias(KEY_ALIAS)) {
+            val generator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEYSTORE)
+            generator.initialize(
+                KeyGenParameterSpec.Builder(
+                    KEY_ALIAS,
+                    KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+                )
+                    .setDigests(KeyProperties.DIGEST_SHA256)
+                    .setUserAuthenticationRequired(false)
+                    .build(),
+            )
+            generator.generateKeyPair()
+        }
+        return keyStore.getKey(KEY_ALIAS, null) as PrivateKey
+    }
+
+    private fun getPublicKey(): PublicKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        if (!keyStore.containsAlias(KEY_ALIAS)) getOrCreatePrivateKey()
+        return keyStore.getCertificate(KEY_ALIAS).publicKey
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
@@ -1,0 +1,120 @@
+package com.dsg.agent.automation
+
+import android.accessibilityservice.AccessibilityService
+import android.content.ComponentName
+import android.content.Context
+import android.provider.Settings
+import android.text.TextUtils
+import com.dsg.agent.service.DsgAccessibilityService
+
+object AgentErrorCodes {
+    const val APPROVAL_SIGNATURE_INVALID = "APPROVAL_SIGNATURE_INVALID"
+    const val COMMAND_EXPIRED = "COMMAND_EXPIRED"
+    const val PERMISSION_REQUIRED = "PERMISSION_REQUIRED"
+    const val PERMISSION_REVOKED_MID_FLIGHT = "PERMISSION_REVOKED_MID_FLIGHT"
+    const val ACCESSIBILITY_SERVICE_NOT_CONNECTED = "ACCESSIBILITY_SERVICE_NOT_CONNECTED"
+    const val EXECUTOR_UNSUPPORTED = "EXECUTOR_UNSUPPORTED"
+}
+
+data class GateResult(val allowed: Boolean, val message: String, val errorCode: String? = null)
+
+class PermissionGate(private val context: Context) {
+    fun evaluate(command: AgentCommand): GateResult {
+        if (command.isExpired()) {
+            return GateResult(false, "Command expired before owner approval", AgentErrorCodes.COMMAND_EXPIRED)
+        }
+        val required = requiredPermissionFor(command.type)
+        return when (required) {
+            PERMISSION_NONE -> GateResult(true, "No runtime permission required")
+            PERMISSION_ACCESSIBILITY -> if (isAccessibilityEnabled()) {
+                GateResult(true, "Accessibility permission is enabled")
+            } else {
+                GateResult(false, "Accessibility permission is required for ${command.type.name}", AgentErrorCodes.PERMISSION_REQUIRED)
+            }
+            PERMISSION_NOTIFICATION_LISTENER -> if (isNotificationListenerEnabled()) {
+                GateResult(true, "Notification listener permission is enabled")
+            } else {
+                GateResult(false, "Notification listener permission is required", AgentErrorCodes.PERMISSION_REQUIRED)
+            }
+            else -> GateResult(false, "Unsupported permission gate: $required", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+        }
+    }
+
+    fun isAccessibilityEnabled(): Boolean {
+        val expected = ComponentName(context, DsgAccessibilityService::class.java).flattenToString()
+        val enabledServices = Settings.Secure.getString(
+            context.contentResolver,
+            Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
+        ) ?: return false
+        return enabledServices.split(':').any { it.equals(expected, ignoreCase = true) }
+    }
+
+    fun isNotificationListenerEnabled(): Boolean {
+        val flat = Settings.Secure.getString(context.contentResolver, "enabled_notification_listeners") ?: return false
+        val packageName = context.packageName
+        return flat.split(':').any { component ->
+            ComponentName.unflattenFromString(component)?.packageName == packageName
+        }
+    }
+
+    companion object {
+        const val PERMISSION_NONE = "none"
+        const val PERMISSION_ACCESSIBILITY = "accessibility"
+        const val PERMISSION_NOTIFICATION_LISTENER = "notification_listener"
+
+        fun requiredPermissionFor(type: AgentCommandType): String = when (type) {
+            AgentCommandType.STATUS,
+            AgentCommandType.OPEN_URL,
+            AgentCommandType.OPEN_SETTINGS,
+            AgentCommandType.OPEN_APP -> PERMISSION_NONE
+            AgentCommandType.BACK,
+            AgentCommandType.HOME,
+            AgentCommandType.SCROLL_DOWN -> PERMISSION_ACCESSIBILITY
+            AgentCommandType.NOTIFICATION_SUMMARY -> PERMISSION_NOTIFICATION_LISTENER
+        }
+    }
+}
+
+object AccessibilityActionBridge {
+    private var service: DsgAccessibilityService? = null
+
+    fun attach(service: DsgAccessibilityService) {
+        this.service = service
+    }
+
+    fun detach(service: DsgAccessibilityService) {
+        if (this.service === service) this.service = null
+    }
+
+    fun performBack(): CommandExecutionResult = performGlobalAction(
+        AccessibilityService.GLOBAL_ACTION_BACK,
+        "Back action executed through owner-approved Accessibility service",
+    )
+
+    fun performHome(): CommandExecutionResult = performGlobalAction(
+        AccessibilityService.GLOBAL_ACTION_HOME,
+        "Home action executed through owner-approved Accessibility service",
+    )
+
+    fun performScrollDown(): CommandExecutionResult {
+        val root = service?.rootInActiveWindow
+            ?: return CommandExecutionResult(false, "Accessibility service lost active window before scroll", AgentErrorCodes.PERMISSION_REVOKED_MID_FLIGHT)
+        val ok = root.performAction(android.view.accessibility.AccessibilityNodeInfo.ACTION_SCROLL_FORWARD)
+        return if (ok) {
+            CommandExecutionResult(true, "Scroll down action executed through owner-approved Accessibility service")
+        } else {
+            CommandExecutionResult(false, "Scroll down was not available on the active node", "SCROLL_NOT_AVAILABLE")
+        }
+    }
+
+    private fun performGlobalAction(action: Int, successMessage: String): CommandExecutionResult {
+        val active = service
+            ?: return CommandExecutionResult(false, "Accessibility service disconnected before execution", AgentErrorCodes.PERMISSION_REVOKED_MID_FLIGHT)
+        val ok = active.performGlobalAction(action)
+        return if (ok) {
+            CommandExecutionResult(true, successMessage)
+        } else {
+            CommandExecutionResult(false, "Accessibility global action returned false", AgentErrorCodes.ACCESSIBILITY_SERVICE_NOT_CONNECTED)
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/service/DsgAccessibilityService.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/DsgAccessibilityService.kt
@@ -1,12 +1,14 @@
 package com.dsg.agent.service
 
 import android.accessibilityservice.AccessibilityService
-import android.view.accessibility.AccessibilityEvent
 import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import com.dsg.agent.automation.AccessibilityActionBridge
 
 class DsgAccessibilityService : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
+        AccessibilityActionBridge.attach(this)
         Log.i("DSGAgent", "Accessibility service connected in owner-device mode")
     }
 
@@ -17,5 +19,10 @@ class DsgAccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() {
         Log.i("DSGAgent", "Accessibility service interrupted")
+    }
+
+    override fun onDestroy() {
+        AccessibilityActionBridge.detach(this)
+        super.onDestroy()
     }
 }

--- a/docs/mobile/DSG_OWNER_COMMAND_MVP_IMPLEMENTATION.md
+++ b/docs/mobile/DSG_OWNER_COMMAND_MVP_IMPLEMENTATION.md
@@ -1,0 +1,100 @@
+# DSG Android Owner Command MVP
+
+## Goal
+
+Implement the first real owner-device command lifecycle across DSG Control Plane, MCP/OpenClaw-style command envelope, CLI, and Android Owner-Agent.
+
+Execution rule:
+
+```text
+propose -> normalize -> policy evaluate -> queue -> owner approve -> permission check -> execute -> audit -> reconcile
+```
+
+No real device action may skip owner review on the Android device.
+
+## Implemented scope
+
+### Android
+
+- Local command model with canonical digest material.
+- Local command inbox UI.
+- Owner approve/reject buttons.
+- Android Keystore-backed ECDSA approval signature for `commandDigest`.
+- Executor-side verification of signed digest before execution.
+- Local append-style audit log with hash chain.
+- Idempotency-style local dedupe for non-expired commands.
+- Expired pending command pruning.
+- Permission gates for Accessibility and Notification Listener.
+- `PERMISSION_REVOKED_MID_FLIGHT` handling for Accessibility disconnect or active window loss.
+- First visible actions: `OPEN_URL`, `OPEN_APP`, `OPEN_SETTINGS`, `BACK`, `HOME`, `SCROLL_DOWN`.
+
+### Control Plane
+
+- `lib/commands/schema.ts` command contract.
+- `lib/commands/normalize.ts` canonical normalization and digest helper.
+- `GET/POST /api/agent/commands` MVP queue API.
+- Expiry-aware idempotency index behavior in the in-memory MVP queue.
+- `GET/POST /api/mcp` owner-agent MCP facade.
+
+### CLI
+
+- `scripts/agent/send-command.mjs`
+- Default mode is dry-run.
+- `--submit` posts to `/api/agent/commands`.
+- Android still requires local owner approval before execution.
+
+## Safety boundaries
+
+### PASS class
+
+- `device.status.get`
+- `device.open_url`
+- `device.open_app`
+- `device.open_settings`
+
+These are still queued for owner review in this MVP. They are visible actions and use Android intents where possible.
+
+### REVIEW class
+
+- `ui.back`
+- `ui.home`
+- `ui.scroll`
+- `device.notifications.summary`
+
+These require owner approval plus the matching Android permission gate.
+
+### Not enabled in this MVP
+
+- arbitrary hidden screen input
+- credential collection
+- silent background operation
+- app install/remove flows outside Android user-controlled screens
+- money/payment actions
+- broad storage or broad package visibility permissions
+
+## Production hardening still required
+
+This PR uses local Android SharedPreferences and an in-memory Control Plane MVP queue to make the contract and APK build testable quickly. Production should replace these with:
+
+- Android Room DB local source of truth.
+- WorkManager sync / retry / backoff.
+- Server database tables: `devices`, `commands`, `command_approvals`, `audit_logs`.
+- Remote append-only audit writer.
+- Device pairing and short-lived device JWT.
+- Protected release lane with signed APK/AAB.
+
+## Smoke test checklist
+
+1. Build APK through Android Agent workflow.
+2. Install APK on owner-controlled Android device.
+3. Open app.
+4. Queue `open_url` demo.
+5. Confirm command appears in inbox.
+6. Tap Approve.
+7. Confirm URL opens visibly.
+8. Confirm audit shows queued, approved, executed.
+9. Queue `back` while Accessibility is disabled.
+10. Confirm command waits for permission instead of running.
+11. Enable Accessibility manually.
+12. Queue `back` again and approve.
+13. Confirm one Back action executes and audit records it.

--- a/lib/commands/normalize.ts
+++ b/lib/commands/normalize.ts
@@ -1,0 +1,128 @@
+import crypto from 'crypto';
+import {
+  BLOCKED_TOOL_PATTERNS,
+  COMMAND_TTL_MS,
+  DsgCommandEnvelope,
+  DsgCommandToolName,
+  POLICY_VERSION,
+  TOOL_POLICY,
+} from './schema';
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function id(prefix: string) {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(obj[key])}`).join(',')}}`;
+}
+
+export function sha256(value: string): string {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+export function normalizeArgs(toolName: DsgCommandToolName, args: Record<string, unknown>) {
+  if (toolName === 'device.open_url') {
+    const raw = String(args.url ?? '').trim();
+    const url = new URL(raw);
+    if (!['https:', 'http:'].includes(url.protocol)) throw new Error('Unsupported URL scheme');
+    return { url: url.toString(), scheme: url.protocol.replace(':', '') };
+  }
+  if (toolName === 'device.open_app') {
+    return { packageName: String(args.packageName ?? args.target ?? '').trim() };
+  }
+  if (toolName === 'device.open_settings') {
+    return { screen: String(args.screen ?? 'android_settings').trim() };
+  }
+  if (toolName === 'ui.scroll') {
+    return { direction: String(args.direction ?? 'down').trim(), amount: 'single_step' };
+  }
+  return { ...args };
+}
+
+export function buildCommandEnvelope(input: {
+  sourceKind?: DsgCommandEnvelope['source']['kind'];
+  actorType?: DsgCommandEnvelope['source']['actorType'];
+  actorId?: string;
+  sessionId?: string;
+  deviceId?: string;
+  toolName: string;
+  args?: Record<string, unknown>;
+  idempotencyKey?: string;
+}): DsgCommandEnvelope {
+  if (BLOCKED_TOOL_PATTERNS.some((pattern) => pattern.test(input.toolName))) {
+    throw new Error('Blocked command pattern');
+  }
+  const toolName = input.toolName as DsgCommandToolName;
+  const policy = TOOL_POLICY[toolName];
+  if (!policy) throw new Error(`Unsupported tool: ${input.toolName}`);
+
+  const requestedAt = nowIso();
+  const expiresAt = new Date(Date.now() + COMMAND_TTL_MS).toISOString();
+  const args = input.args ?? {};
+  const normalizedArgs = normalizeArgs(toolName, args);
+  const target = {
+    deviceId: input.deviceId ?? String(args.deviceId ?? 'android.owner.default'),
+    platform: 'android' as const,
+    channel: 'owner-agent' as const,
+  };
+  const key = input.idempotencyKey ?? `${toolName}:${target.deviceId}:${canonicalJson(normalizedArgs)}`;
+  const digestMaterial = canonicalJson({
+    target,
+    toolName,
+    normalizedArgs,
+    risk: policy.risk,
+    expiresAt,
+    policyVersion: POLICY_VERSION,
+    idempotencyKey: key,
+  });
+  const digest = sha256(digestMaterial);
+
+  return {
+    version: 'dsg.command/1',
+    commandId: id('cmd'),
+    correlationId: id('req'),
+    source: {
+      kind: input.sourceKind ?? 'mcp',
+      actorType: input.actorType ?? 'user',
+      actorId: input.actorId ?? 'operator:local',
+      sessionId: input.sessionId,
+    },
+    target,
+    tool: {
+      name: toolName,
+      class: policy.class,
+    },
+    args,
+    normalizedArgs,
+    policy: {
+      decision: policy.class === 'BLOCK' ? 'BLOCK' : policy.class === 'REVIEW' ? 'REVIEW' : 'ALLOW',
+      risk: policy.risk,
+      requiresOwnerApproval: true,
+      requiresPermissions: policy.requiresPermissions,
+      policyVersion: POLICY_VERSION,
+      expiresAt,
+    },
+    idempotency: { key, digest },
+    approval: {
+      state: 'awaiting_owner',
+      boundFields: ['target.deviceId', 'tool.name', 'normalizedArgs', 'policy.risk', 'policy.expiresAt', 'policy.policyVersion'],
+      localSignatureRequired: true,
+    },
+    audit: {
+      requestedAt,
+      traceId: id('trace'),
+    },
+    executionState: 'awaiting_owner',
+  };
+}
+
+export function isExpired(expiresAt: string, now = new Date()) {
+  return new Date(expiresAt).getTime() <= now.getTime();
+}

--- a/lib/commands/schema.ts
+++ b/lib/commands/schema.ts
@@ -1,0 +1,101 @@
+export type DsgCommandRisk = 'PASS' | 'REVIEW' | 'BLOCK';
+export type DsgCommandState =
+  | 'queued'
+  | 'awaiting_owner'
+  | 'approved'
+  | 'waiting_permission'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'rejected'
+  | 'expired';
+
+export type DsgCommandToolName =
+  | 'device.status.get'
+  | 'device.open_url'
+  | 'device.open_app'
+  | 'device.open_settings'
+  | 'ui.back'
+  | 'ui.home'
+  | 'ui.scroll'
+  | 'device.notifications.summary';
+
+export type DsgCommandEnvelope = {
+  version: 'dsg.command/1';
+  commandId: string;
+  correlationId: string;
+  source: {
+    kind: 'chat' | 'cli' | 'mcp' | 'local' | 'dsg-one-v1';
+    actorType: 'user' | 'system' | 'device';
+    actorId: string;
+    sessionId?: string;
+  };
+  target: {
+    deviceId: string;
+    platform: 'android';
+    channel: 'owner-agent';
+  };
+  tool: {
+    name: DsgCommandToolName;
+    class: DsgCommandRisk;
+  };
+  args: Record<string, unknown>;
+  normalizedArgs: Record<string, unknown>;
+  policy: {
+    decision: 'ALLOW' | 'REVIEW' | 'BLOCK';
+    risk: 'low' | 'medium' | 'high' | 'blocked';
+    requiresOwnerApproval: boolean;
+    requiresPermissions: string[];
+    policyVersion: string;
+    expiresAt: string;
+  };
+  idempotency: {
+    key: string;
+    digest: string;
+  };
+  approval: {
+    state: 'awaiting_owner' | 'approved' | 'rejected' | 'expired';
+    boundFields: string[];
+    localSignatureRequired: boolean;
+  };
+  audit: {
+    requestedAt: string;
+    traceId: string;
+  };
+  executionState: DsgCommandState;
+};
+
+export const POLICY_VERSION = '2026-05-27-owner-command-mvp';
+export const COMMAND_TTL_MS = 15 * 60 * 1000;
+
+export const TOOL_POLICY: Record<DsgCommandToolName, {
+  class: DsgCommandRisk;
+  risk: 'low' | 'medium' | 'high' | 'blocked';
+  requiresPermissions: string[];
+}> = {
+  'device.status.get': { class: 'PASS', risk: 'low', requiresPermissions: [] },
+  'device.open_url': { class: 'PASS', risk: 'low', requiresPermissions: [] },
+  'device.open_app': { class: 'PASS', risk: 'low', requiresPermissions: [] },
+  'device.open_settings': { class: 'PASS', risk: 'low', requiresPermissions: [] },
+  'ui.back': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['accessibility'] },
+  'ui.home': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['accessibility'] },
+  'ui.scroll': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['accessibility'] },
+  'device.notifications.summary': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['notification_listener'] },
+};
+
+export const BLOCKED_TOOL_PATTERNS = [
+  /credential/i,
+  /password/i,
+  /token/i,
+  /secret/i,
+  /payment/i,
+  /money/i,
+  /install/i,
+  /uninstall/i,
+  /lockscreen/i,
+  /bypass/i,
+  /hidden/i,
+  /silent/i,
+  /tap_raw/i,
+  /type_text/i,
+];

--- a/scripts/agent/send-command.mjs
+++ b/scripts/agent/send-command.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+
+function readFlag(name, fallback = undefined) {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1) return fallback;
+  return args[index + 1] ?? fallback;
+}
+
+const type = readFlag('type', 'device.open_url');
+const target = readFlag('target', 'https://tdealer01-crypto-dsg-control-plane.vercel.app/api/agent/status');
+const deviceId = readFlag('device', 'android.owner.default');
+const reason = readFlag('reason', 'Owner requested CLI command test');
+const submit = args.includes('--submit');
+const baseUrl = readFlag('base-url', process.env.DSG_CONTROL_PLANE_URL || 'http://localhost:3000');
+
+const command = {
+  sourceKind: 'cli',
+  actorType: 'user',
+  actorId: process.env.USER ? `user:${process.env.USER}` : 'operator:cli',
+  target: { deviceId },
+  tool: { name: type },
+  args: {
+    deviceId,
+    reason,
+    ...(type === 'device.open_url' ? { url: target } : {}),
+    ...(type === 'device.open_app' ? { packageName: target } : {}),
+    ...(type === 'device.open_settings' ? { screen: target } : {}),
+    ...(type === 'ui.scroll' ? { direction: 'down' } : {}),
+  },
+  idempotencyKey: `${type}:${deviceId}:${target}`,
+};
+
+if (!submit) {
+  console.log(JSON.stringify({
+    ok: true,
+    dryRun: true,
+    message: 'Dry run only. Add --submit to POST this envelope to /api/agent/commands. Android still requires owner approval before execution.',
+    command,
+  }, null, 2));
+  process.exit(0);
+}
+
+const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/agent/commands`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(command),
+});
+
+const text = await response.text();
+try {
+  console.log(JSON.stringify(JSON.parse(text), null, 2));
+} catch {
+  console.log(text);
+}
+
+if (!response.ok) process.exit(1);


### PR DESCRIPTION
Goal:
Implement the first owner-approved Android command MVP following the uploaded architecture report: DSG Control Plane command queue + MCP/OpenClaw-style envelope + Android Owner-Agent inbox/executor.

Files changed:
- `app/api/agent/commands/route.ts` — MVP command queue API with canonical command envelopes, expiry-aware idempotency behavior, and list/enqueue support.
- `app/api/mcp/route.ts` — exposes `tools/list` and `tools/call` for owner-agent commands. `tools/call` creates proposals only; Android execution still requires owner approval.
- `lib/commands/schema.ts` — command tool classes, PASS/REVIEW boundaries, policy version, TTL, and blocked-pattern guardrails.
- `lib/commands/normalize.ts` — server-side normalization and command digest helper.
- `scripts/agent/send-command.mjs` — CLI dry-run/submission helper.
- `apps/android/app/src/main/java/com/dsg/agent/automation/**` — Android command model, local command store, audit store, permission gate, Android Keystore approval signer, and accessibility action bridge.
- `apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt` — local command inbox UI, demo command queue, owner approve/reject, signed digest verification, execute, audit, and kill switch.
- `docs/mobile/DSG_OWNER_COMMAND_MVP_IMPLEMENTATION.md` — implementation contract, safety boundaries, production hardening, and smoke test checklist.

Safety model:
- Every real action enters the Android inbox first.
- Owner approval signs the exact command digest using Android Keystore-backed ECDSA.
- Executor verifies the signed digest before running.
- Accessibility-backed actions are gated by permission and return `PERMISSION_REVOKED_MID_FLIGHT` when the service/window disappears mid-execution.
- Local audit log records queued, approved, executed, failed, rejected, and permission events.

Current limits:
- Control Plane command queue is in-memory MVP only; production should move to DB tables (`devices`, `commands`, `command_approvals`, `audit_logs`).
- Android persistence is SharedPreferences MVP only; production should move to Room + WorkManager sync.
- No real-device smoke evidence has been attached for this PR yet.

Verification pending:
- Android Agent workflow must build the APK.
- Next/typecheck workflows must confirm the new API files compile.
- Manual real-device smoke test must verify inbox, approval, open_url, permission gate, and audit trail.