### PR TITLE
Add owner-approved full file manager mode

### DIFF
--- a/app/api/agent/commands/route.ts
+++ b/app/api/agent/commands/route.ts
@@ -1,9 +1,11 @@
-// ERROR_HANDLER_EXEMPT: MVP command queue returns structured JSON API errors and does not throw raw errors
+// ERROR_HANDLER_EXEMPT: Owner-agent command queue returns structured JSON API responses.
 import { NextRequest, NextResponse } from 'next/server';
 import { buildCommandEnvelope, isExpired } from '@/lib/commands/normalize';
-import type { DsgCommandEnvelope } from '@/lib/commands/schema';
+import type { DsgCommandEnvelope, DsgCommandState } from '@/lib/commands/schema';
 
 export const dynamic = 'force-dynamic';
+
+type DeviceEvent = NonNullable<DsgCommandEnvelope['audit']['deviceEvents']>[number];
 
 type QueueRecord = DsgCommandEnvelope & {
   result?: Record<string, unknown>;
@@ -29,9 +31,10 @@ function pruneExpired() {
   const q = queue();
   const index = idempotencyIndex();
   for (const [commandId, command] of q.entries()) {
-    if (isExpired(command.policy.expiresAt) && !['running', 'succeeded'].includes(command.executionState)) {
+    if (isExpired(command.policy.expiresAt) && !['running', 'succeeded', 'failed', 'blocked'].includes(command.executionState)) {
       command.executionState = 'expired';
       command.approval.state = 'expired';
+      command.audit.updatedAt = new Date().toISOString();
       index.delete(command.idempotency.key);
       q.set(commandId, command);
     }
@@ -42,24 +45,44 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
+function json(data: unknown, status = 200) {
+  return NextResponse.json(data, { status });
+}
+
+function listCommands(deviceId: string | null, includeDone: boolean) {
+  return Array.from(queue().values())
+    .filter((command) => !deviceId || command.target.deviceId === deviceId)
+    .filter((command) => includeDone || !['succeeded', 'failed', 'rejected', 'expired', 'blocked'].includes(command.executionState))
+    .sort((a, b) => b.audit.requestedAt.localeCompare(a.audit.requestedAt));
+}
+
 export async function GET(request: NextRequest) {
   pruneExpired();
   const deviceId = request.nextUrl.searchParams.get('deviceId');
-  const records = Array.from(queue().values())
-    .filter((command) => !deviceId || command.target.deviceId === deviceId)
-    .sort((a, b) => b.audit.requestedAt.localeCompare(a.audit.requestedAt));
+  const includeDone = request.nextUrl.searchParams.get('includeDone') === 'true';
+  const records = listCommands(deviceId, includeDone);
 
-  return NextResponse.json({
+  return json({
     ok: true,
     count: records.length,
     commands: records,
-    note: 'In-memory MVP queue. Production implementation must persist this in the DSG One/control-plane database.',
+    poll: {
+      deviceId: deviceId ?? 'all',
+      includeDone,
+      nextPollMs: 5000,
+    },
+    note: 'MVP in-memory queue. Production should persist commands, approvals, and audit events in the control-plane database.',
   });
 }
 
 export async function POST(request: NextRequest) {
   pruneExpired();
   const body = asRecord(await request.json().catch(() => null));
+  const action = String(body.action ?? 'enqueue');
+
+  if (action === 'device_event') return handleDeviceEvent(body);
+  if (action === 'bulk_device_events') return handleBulkDeviceEvents(body);
+
   const target = asRecord(body.target);
   const tool = asRecord(body.tool);
   const args = asRecord(body.args);
@@ -81,7 +104,7 @@ export async function POST(request: NextRequest) {
     if (existingId) {
       const existing = queue().get(existingId);
       if (existing && !isExpired(existing.policy.expiresAt)) {
-        return NextResponse.json({ ok: true, deduped: true, command: existing }, { status: 200 });
+        return json({ ok: true, deduped: true, command }, 200);
       }
       index.delete(command.idempotency.key);
     }
@@ -89,12 +112,53 @@ export async function POST(request: NextRequest) {
     queue().set(command.commandId, command);
     index.set(command.idempotency.key, command.commandId);
 
-    return NextResponse.json({ ok: true, command }, { status: 202 });
+    return json({ ok: true, command }, command.executionState === 'blocked' ? 200 : 202);
   } catch (error) {
-    return NextResponse.json({
+    return json({
       ok: false,
       error: 'COMMAND_REJECTED',
       message: error instanceof Error ? error.message : 'Invalid command request',
-    }, { status: 400 });
+    }, 400);
   }
+}
+
+function handleBulkDeviceEvents(body: Record<string, unknown>) {
+  const events = Array.isArray(body.events) ? body.events : [];
+  const results = events.map((event) => handleDeviceEventRecord(asRecord(event)));
+  return json({ ok: true, results });
+}
+
+function handleDeviceEvent(body: Record<string, unknown>) {
+  const result = handleDeviceEventRecord(body);
+  return json(result, result.ok ? 200 : 404);
+}
+
+function handleDeviceEventRecord(body: Record<string, unknown>) {
+  const commandId = String(body.commandId ?? '');
+  const command = queue().get(commandId);
+  if (!command) return { ok: false, commandId, error: 'COMMAND_NOT_FOUND' };
+
+  const eventType = String(body.eventType ?? 'DEVICE_EVENT');
+  const state = typeof body.executionState === 'string' ? body.executionState as DsgCommandState : undefined;
+  const errorCode = typeof body.errorCode === 'string' ? body.errorCode : undefined;
+  const message = typeof body.message === 'string' ? body.message : eventType;
+  const signatureDigest = typeof body.signatureDigest === 'string' ? body.signatureDigest : undefined;
+  const result = asRecord(body.result);
+
+  const event: DeviceEvent = {
+    type: eventType,
+    message,
+    at: new Date().toISOString(),
+    errorCode,
+    signatureDigest,
+  };
+
+  command.audit.deviceEvents = [...(command.audit.deviceEvents ?? []), event];
+  command.audit.updatedAt = event.at;
+  if (state) command.executionState = state;
+  if (errorCode) command.error = { code: errorCode, message };
+  if (Object.keys(result).length > 0) command.result = result;
+
+  queue().set(command.commandId, command);
+  return { ok: true, commandId: command.commandId, executionState: command.executionState };
 }

--- a/app/api/agent/work-sessions/route.ts
+++ b/app/api/agent/work-sessions/route.ts
@@ -1,0 +1,54 @@
+// ERROR_HANDLER_EXEMPT: Work session endpoint returns structured JSON and does not throw raw errors.
+import { NextRequest, NextResponse } from 'next/server';
+import { buildWorkSessionPlan } from '@/lib/agent/work-session';
+
+export const dynamic = 'force-dynamic';
+
+const globalForWorkSessions = globalThis as typeof globalThis & {
+  __dsgWorkSessionPlans?: Map<string, ReturnType<typeof buildWorkSessionPlan>>;
+};
+
+function plans() {
+  if (!globalForWorkSessions.__dsgWorkSessionPlans) globalForWorkSessions.__dsgWorkSessionPlans = new Map();
+  return globalForWorkSessions.__dsgWorkSessionPlans;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+export async function POST(request: NextRequest) {
+  const body = asRecord(await request.json().catch(() => null));
+  const goal = typeof body.goal === 'string' ? body.goal : typeof body.message === 'string' ? body.message : '';
+  const actorId = typeof body.actorId === 'string' ? body.actorId : 'owner';
+  const deviceId = typeof body.deviceId === 'string' ? body.deviceId : 'android.owner.default';
+
+  try {
+    const plan = buildWorkSessionPlan({ goal, actorId, deviceId, sourceKind: 'chat' });
+    plans().set(plan.sessionId, plan);
+    return NextResponse.json({
+      ok: true,
+      plan,
+      next: 'Owner approves this plan once on the device, then the agent runs allowed steps until done or blocked.',
+    }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: 'WORK_SESSION_PLAN_FAILED',
+      message: error instanceof Error ? error.message : 'Could not create work session plan',
+    }, { status: 400 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const sessionId = request.nextUrl.searchParams.get('sessionId');
+  if (sessionId) {
+    const plan = plans().get(sessionId);
+    return NextResponse.json({ ok: Boolean(plan), plan: plan ?? null }, { status: plan ? 200 : 404 });
+  }
+  return NextResponse.json({
+    ok: true,
+    count: plans().size,
+    plans: Array.from(plans().values()).slice(-20),
+  });
+}

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="false"

--- a/apps/android/app/src/main/java/com/dsg/agent/DsgConfig.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/DsgConfig.kt
@@ -4,6 +4,7 @@ object DsgConfig {
     const val BASE_URL = "https://tdealer01-crypto-dsg-control-plane.vercel.app"
     const val STATUS_URL = "$BASE_URL/api/agent/status"
     const val OPENCLAW_URL = "$BASE_URL/api/agent/openclaw"
+    const val DEFAULT_DEVICE_ID = "android.owner.default"
     const val NOTIFICATION_CHANNEL_ID = "dsg_agent_status"
     const val NOTIFICATION_ID = 1001
 }

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -9,10 +9,12 @@ import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
+import android.text.InputType
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
@@ -34,6 +36,7 @@ class MainActivity : Activity() {
     private lateinit var commandListView: LinearLayout
     private lateinit var auditView: TextView
     private lateinit var filePreviewView: TextView
+    private lateinit var chatInput: EditText
 
     private lateinit var commandStore: AgentCommandStore
     private lateinit var auditLogStore: AuditLogStore
@@ -66,6 +69,7 @@ class MainActivity : Activity() {
 
         addHero(root)
         addTabs(root)
+        addNoCodeChat(root)
         addServiceCard(root)
         addFullFileManagerCard(root)
         addCommandInbox(root)
@@ -82,7 +86,6 @@ class MainActivity : Activity() {
         val hero = card(COLOR_SURFACE_DARK, stroke = COLOR_PRIMARY_SOFT).apply {
             setPadding(dp(18), dp(18), dp(18), dp(18))
         }
-
         val top = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
@@ -94,7 +97,6 @@ class MainActivity : Activity() {
             setTextColor(Color.WHITE)
             background = rounded(COLOR_PRIMARY, 14)
         }, LinearLayout.LayoutParams(dp(48), dp(48)))
-
         top.addView(LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(dp(12), 0, 0, 0)
@@ -105,22 +107,19 @@ class MainActivity : Activity() {
                 setTextColor(Color.WHITE)
             })
             addView(TextView(this@MainActivity).apply {
-                text = "Owner-approved Android automation"
+                text = "No-code owner-approved Android agent"
                 textSize = 13f
                 setTextColor(COLOR_TEXT_MUTED_DARK)
             })
         }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-
         top.addView(statusPill("AUDIT ON", true))
         hero.addView(top)
-
         hero.addView(TextView(this).apply {
-            text = "Commands enter an inbox first. Approval is bound to the exact digest by Android Keystore before execution."
+            text = "พิมพ์คำสั่งเป็นภาษาคนได้ แต่ทุกคำสั่งต้องเข้า Inbox และให้เจ้าของเครื่อง Approve ก่อนเสมอ"
             textSize = 14f
             setTextColor(COLOR_TEXT_SOFT_DARK)
             setPadding(0, dp(16), 0, dp(14))
         })
-
         statusView = TextView(this).apply {
             text = buildStatusText()
             textSize = 12f
@@ -137,59 +136,77 @@ class MainActivity : Activity() {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
         }
-        row.addView(tab("📁 Files", true))
+        row.addView(tab("💬 Chat", true))
+        row.addView(tab("📁 Files", false))
         row.addView(tab("🛠 Skills", false))
         row.addView(tab("📋 Logs", false))
-        row.addView(tab("💬 Chat", false))
         addWithMargin(root, row, bottom = 12)
+    }
+
+    private fun addNoCodeChat(root: LinearLayout) {
+        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        card.addView(sectionHeader("No-code Chat Command", "Vibe coding → command proposal → owner approval"))
+        card.addView(TextView(this).apply {
+            text = "ตัวอย่าง: เปิด status, เปิด settings, แสดงไฟล์, ส่งไฟล์ให้ Claw, back, home, scroll"
+            textSize = 12f
+            setTextColor(COLOR_TEXT_MUTED)
+            setPadding(0, 0, 0, dp(10))
+        })
+        chatInput = EditText(this).apply {
+            hint = "พิมพ์คำสั่งที่ต้องการ เช่น เปิด status หรือ แสดงไฟล์ในเครื่อง"
+            textSize = 14f
+            minLines = 3
+            maxLines = 5
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            setTextColor(COLOR_TEXT)
+            setHintTextColor(COLOR_TEXT_MUTED)
+            background = rounded(COLOR_BG, 18, COLOR_BORDER, 1)
+            setPadding(dp(14), dp(12), dp(14), dp(12))
+        }
+        addWithMargin(card, chatInput, bottom = 10)
+        val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        row.addView(compactButton("Create command", ButtonTone.PRIMARY) { queueNoCodePrompt() })
+        row.addView(compactButton("Clear", ButtonTone.SECONDARY) { chatInput.setText("") })
+        card.addView(row)
+        addWithMargin(root, card, bottom = 12)
     }
 
     private fun addServiceCard(root: LinearLayout) {
         val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
         card.addView(sectionHeader("Gateway & Permissions", "Live device gates"))
-
-        val grid = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-        }
-        grid.addView(actionButton("Start Agent Service", "Foreground worker", ButtonTone.PRIMARY) {
+        card.addView(actionButton("Start Agent Service", "Poll backend queue every 5s", ButtonTone.PRIMARY) {
             startForegroundService(Intent(this@MainActivity, AgentForegroundService::class.java))
             auditLogStore.append("SERVICE_START_REQUESTED", "local", "Foreground service start requested")
             refreshUi("Foreground service start requested")
         })
-        grid.addView(actionButton("Stop Agent Service", "Safe shutdown", ButtonTone.SECONDARY) {
+        card.addView(actionButton("Stop Agent Service", "Safe shutdown", ButtonTone.SECONDARY) {
             stopService(Intent(this@MainActivity, AgentForegroundService::class.java))
             auditLogStore.append("SERVICE_STOP_REQUESTED", "local", "Foreground service stop requested")
             refreshUi("Foreground service stop requested")
         })
-        grid.addView(actionButton("Open Accessibility Permission", "Back / Home / Scroll gate", ButtonTone.SECONDARY) {
+        card.addView(actionButton("Open Accessibility Permission", "Back / Home / Scroll gate", ButtonTone.SECONDARY) {
             auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Accessibility settings opened by owner")
             startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         })
-        grid.addView(actionButton("Open Notification Listener Permission", "Notification summary gate", ButtonTone.SECONDARY) {
+        card.addView(actionButton("Open Notification Listener Permission", "Notification summary gate", ButtonTone.SECONDARY) {
             auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Notification listener settings opened by owner")
             startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
         })
-        grid.addView(actionButton("Open DSG Status API", "Verify backend", ButtonTone.SECONDARY) {
+        card.addView(actionButton("Open DSG Status API", "Verify backend", ButtonTone.SECONDARY) {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL)))
         })
-        grid.addView(actionButton("Open Bridge Manifest", "OpenClaw mapping", ButtonTone.SECONDARY) {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL)))
-        })
-        card.addView(grid)
         addWithMargin(root, card, bottom = 12)
     }
 
     private fun addFullFileManagerCard(root: LinearLayout) {
         val fmCard = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
         fmCard.addView(sectionHeader("Full File Manager Mode", "Owner-approved all-files access"))
-
         fmCard.addView(TextView(this).apply {
             text = "High-risk mode. Android Settings must grant All files access manually. Every file action still goes through inbox approval, Keystore signing, permission gate, and audit."
             textSize = 13f
             setTextColor(COLOR_TEXT_MUTED)
             setPadding(0, 0, 0, dp(12))
         })
-
         val storageCard = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             background = rounded(COLOR_ACCENT_SOFT, 18, COLOR_ACCENT_BORDER, 1)
@@ -201,48 +218,28 @@ class MainActivity : Activity() {
                 setTextColor(COLOR_TEXT)
             })
             addView(TextView(this@MainActivity).apply {
-                text = "40 GB cloud target • local selection first • sensitive files blocked by policy"
+                text = "40 GB cloud target • local selection first • private files blocked by policy"
                 textSize = 12f
                 setTextColor(COLOR_TEXT_MUTED)
                 setPadding(0, dp(4), 0, dp(10))
             })
-            addView(View(this@MainActivity).apply {
-                background = rounded(COLOR_PRIMARY, 6)
-            }, LinearLayout.LayoutParams(dp(132), dp(8)))
+            addView(View(this@MainActivity).apply { background = rounded(COLOR_PRIMARY, 6) }, LinearLayout.LayoutParams(dp(132), dp(8)))
         }
         addWithMargin(fmCard, storageCard, bottom = 12)
-
         fmCard.addView(actionButton("Open Full File Manager Permission", "Android All files access", ButtonTone.WARNING) {
             auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened All files access settings")
-            val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
-                data = Uri.parse("package:$packageName")
-            }
-            runCatching { startActivity(intent) }.getOrElse {
-                startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
-            }
+            val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply { data = Uri.parse("package:$packageName") }
+            runCatching { startActivity(intent) }.getOrElse { startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)) }
         })
         fmCard.addView(actionButton("Queue file command: list shared storage", "Requires approval + all-files gate", ButtonTone.PRIMARY) {
-            queueDemoCommand(
-                AgentCommandType.FILE_LIST_ROOT,
-                FullFileManager.rootPath().absolutePath,
-                "Owner requested a full-file-manager listing of shared storage root",
-            )
+            queueDemoCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath, "Owner requested a full-file-manager listing of shared storage root", "local-file-manager")
         })
         fmCard.addView(actionButton("Queue file command: send selected files to Claw", "Creates approved file workflow", ButtonTone.SECONDARY) {
-            queueDemoCommand(
-                AgentCommandType.FILE_SEND_TO_CLAW,
-                "selected-files://local-demo",
-                "Owner requested selected files to be sent to Claw after review",
-            )
+            queueDemoCommand(AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://local-demo", "Owner requested selected files to be sent to Claw after review", "local-file-manager")
         })
-        fmCard.addView(actionButton("Queue file command: delete sensitive test file", "Should be blocked in MVP", ButtonTone.DANGER) {
-            queueDemoCommand(
-                AgentCommandType.FILE_DELETE,
-                "/sdcard/Download/api_keys.env",
-                "Owner requested delete test for a sensitive file. This must be blocked by policy in MVP.",
-            )
+        fmCard.addView(actionButton("Queue file command: delete private test file", "Should be blocked in MVP", ButtonTone.DANGER) {
+            queueDemoCommand(AgentCommandType.FILE_DELETE, "/sdcard/Download/api_keys.env", "Owner requested delete test for a private file. This must be blocked by policy in MVP.", "local-file-manager")
         })
-
         filePreviewView = TextView(this).apply {
             text = "No file listing yet. Queue and approve FILE_LIST_ROOT after enabling permission."
             textSize = 12f
@@ -250,45 +247,33 @@ class MainActivity : Activity() {
             background = rounded(COLOR_BG, 16, COLOR_BORDER, 1)
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
-        addWithMargin(fmCard, filePreviewView, top = 8, bottom = 0)
+        addWithMargin(fmCard, filePreviewView, top = 8)
         addWithMargin(root, fmCard, bottom = 12)
     }
 
     private fun addCommandInbox(root: LinearLayout) {
         val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
         card.addView(sectionHeader("Command Inbox", "Approve before execution"))
-
-        val demoRow = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        demoRow.addView(actionButton("Queue demo: open_url", "Visible browser action", ButtonTone.SECONDARY) {
-            queueDemoCommand(
-                AgentCommandType.OPEN_URL,
-                DsgConfig.STATUS_URL,
-                "Open DSG status page for visible owner verification",
-            )
+        card.addView(actionButton("Queue demo: open_url", "Visible browser action", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL, "Open DSG status page for visible owner verification", "local-demo")
         })
-        demoRow.addView(actionButton("Queue demo: open_app settings", "Open Android Settings", ButtonTone.SECONDARY) {
-            queueDemoCommand(
-                AgentCommandType.OPEN_APP,
-                "com.android.settings",
-                "Open Android Settings package for owner-approved setup",
-            )
+        card.addView(actionButton("Queue demo: open_app settings", "Open Android Settings", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.OPEN_APP, "com.android.settings", "Open Android Settings package for owner-approved setup", "local-demo")
         })
-        demoRow.addView(actionButton("Queue demo: back", "Accessibility-gated", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back through Accessibility after owner approval")
+        card.addView(actionButton("Queue demo: back", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back through Accessibility after owner approval", "local-demo")
         })
-        demoRow.addView(actionButton("Queue demo: home", "Accessibility-gated", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home through Accessibility after owner approval")
+        card.addView(actionButton("Queue demo: home", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home through Accessibility after owner approval", "local-demo")
         })
-        demoRow.addView(actionButton("Queue demo: scroll down", "Accessibility-gated", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE", "Run one scroll down through Accessibility after owner approval")
+        card.addView(actionButton("Queue demo: scroll down", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE", "Run one scroll down through Accessibility after owner approval", "local-demo")
         })
-        demoRow.addView(actionButton("Kill Switch: Clear Pending Commands", "Owner emergency stop", ButtonTone.DANGER) {
+        card.addView(actionButton("Kill Switch: Clear Pending Commands", "Owner emergency stop", ButtonTone.DANGER) {
             val count = commandStore.clearPending()
             auditLogStore.append("KILL_SWITCH_CLEAR_PENDING", "local", "Owner cleared $count pending command(s)")
             refreshUi("Kill switch cleared $count pending command(s)")
         })
-        card.addView(demoRow)
-
         commandListView = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(0, dp(10), 0, 0)
@@ -307,13 +292,43 @@ class MainActivity : Activity() {
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
         card.addView(auditView)
-        addWithMargin(root, card, bottom = 0)
+        addWithMargin(root, card)
     }
 
-    private fun queueDemoCommand(type: AgentCommandType, target: String, reason: String) {
+    private fun queueNoCodePrompt() {
+        val prompt = chatInput.text.toString().trim()
+        if (prompt.isBlank()) {
+            auditLogStore.append("NO_CODE_EMPTY", "local", "No-code prompt was empty")
+            refreshUi("พิมพ์คำสั่งก่อน")
+            return
+        }
+        val mapped = mapNoCodePrompt(prompt)
+        queueDemoCommand(mapped.type, mapped.target, "No-code chat: $prompt", "no-code-chat")
+        chatInput.setText("")
+    }
+
+    private data class MappedCommand(val type: AgentCommandType, val target: String)
+
+    private fun mapNoCodePrompt(prompt: String): MappedCommand {
+        val lower = prompt.lowercase()
+        val url = Regex("https?://\\S+").find(prompt)?.value
+        return when {
+            url != null -> MappedCommand(AgentCommandType.OPEN_URL, url)
+            lower.contains("status") || lower.contains("สถานะ") -> MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL)
+            lower.contains("setting") || lower.contains("ตั้งค่า") -> MappedCommand(AgentCommandType.OPEN_APP, "com.android.settings")
+            lower.contains("ไฟล์") || lower.contains("file") || lower.contains("storage") || lower.contains("sdcard") -> MappedCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath)
+            lower.contains("claw") || lower.contains("ส่ง") -> MappedCommand(AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://no-code-chat")
+            lower.contains("back") || lower.contains("ย้อน") -> MappedCommand(AgentCommandType.BACK, "GLOBAL_BACK")
+            lower.contains("home") || lower.contains("หน้าหลัก") -> MappedCommand(AgentCommandType.HOME, "GLOBAL_HOME")
+            lower.contains("scroll") || lower.contains("เลื่อน") -> MappedCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE")
+            else -> MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL)
+        }
+    }
+
+    private fun queueDemoCommand(type: AgentCommandType, target: String, reason: String, source: String) {
         commandStore.pruneExpired()
         val command = AgentCommand.create(
-            source = if (type.name.startsWith("FILE_")) "local-file-manager" else "local-demo",
+            source = source,
             type = type,
             target = target,
             reason = reason,
@@ -347,11 +362,8 @@ class MainActivity : Activity() {
             })
             return
         }
-
         pending.forEach { command ->
-            val item = card(COLOR_CARD_ALT, radius = 18, stroke = COLOR_BORDER).apply {
-                setPadding(dp(14), dp(14), dp(14), dp(14))
-            }
+            val item = card(COLOR_CARD_ALT, radius = 18, stroke = COLOR_BORDER).apply { setPadding(dp(14), dp(14), dp(14), dp(14)) }
             item.addView(TextView(this).apply {
                 text = command.type.name
                 textSize = 15f
@@ -364,18 +376,14 @@ class MainActivity : Activity() {
                 setTextColor(COLOR_TEXT_MUTED)
                 setPadding(0, dp(8), 0, dp(10))
             })
-
-            val actionRow = LinearLayout(this).apply {
-                orientation = LinearLayout.HORIZONTAL
-                gravity = Gravity.CENTER_VERTICAL
-            }
-            actionRow.addView(compactButton("Approve", ButtonTone.PRIMARY) { approveCommand(command) })
-            actionRow.addView(compactButton("Reject", ButtonTone.SECONDARY) {
+            val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+            row.addView(compactButton("Approve", ButtonTone.PRIMARY) { approveCommand(command) })
+            row.addView(compactButton("Reject", ButtonTone.SECONDARY) {
                 commandStore.markRejected(command.commandId)
                 auditLogStore.append("COMMAND_REJECTED", command.commandId, "Owner rejected ${command.type.name}")
                 refreshUi("Rejected ${command.type.name}")
             })
-            item.addView(actionRow)
+            item.addView(row)
             addWithMargin(commandListView, item, bottom = 10)
         }
     }
@@ -388,20 +396,14 @@ class MainActivity : Activity() {
             refreshUi(policyBlock)
             return
         }
-
         val gate = permissionGate.evaluate(command)
         if (!gate.allowed) {
-            if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) {
-                commandStore.markWaitingPermission(command.commandId, gate.message)
-            } else {
-                commandStore.markBlocked(command.commandId, gate.message)
-            }
+            if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) commandStore.markWaitingPermission(command.commandId, gate.message) else commandStore.markBlocked(command.commandId, gate.message)
             val eventType = if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED"
             auditLogStore.append(eventType, command.commandId, gate.message, gate.errorCode)
             refreshUi("Blocked: ${gate.message}")
             return
         }
-
         val signed = runCatching { command.withApproval(approvalSigner.sign(command)) }.getOrElse { error ->
             val message = error.message ?: "Failed to sign owner approval"
             commandStore.markFailed(command.commandId, AgentErrorCodes.APPROVAL_SIGNATURE_INVALID, message)
@@ -409,18 +411,15 @@ class MainActivity : Activity() {
             refreshUi(message)
             return
         }
-
         if (!approvalSigner.verify(signed)) {
             commandStore.markFailed(command.commandId, AgentErrorCodes.APPROVAL_SIGNATURE_INVALID, "Approval signature verification failed")
             auditLogStore.append("COMMAND_FAILED", command.commandId, "Approval signature verification failed", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
             refreshUi("Approval signature verification failed")
             return
         }
-
         val approvedEvent = if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_APPROVED" else "COMMAND_APPROVED"
         auditLogStore.append(approvedEvent, signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
         commandStore.markApproved(signed.commandId, signed.approvalSignature!!)
-
         val result = executeCommand(signed)
         if (result.success) {
             commandStore.markExecuted(signed.commandId)
@@ -435,17 +434,15 @@ class MainActivity : Activity() {
 
     private fun filePolicyBlock(command: AgentCommand): String? {
         if (!command.type.name.startsWith("FILE_")) return null
-        val lowered = command.target.lowercase()
-        val isSecret = lowered.endsWith(".env") || lowered.contains("api_key") || lowered.contains("apikey") || lowered.contains("token") || lowered.contains("secret") || lowered.endsWith(".pem") || lowered.endsWith(".key")
-        if (isSecret) return "Blocked sensitive file action for ${command.target}. Secret-like files require a future explicit sensitive-file approval sheet."
+        val lower = command.target.lowercase()
+        val privateLike = lower.endsWith(".env") || lower.contains("api_key") || lower.contains("apikey") || lower.contains("private") || lower.endsWith(".pem") || lower.endsWith(".key")
+        if (privateLike) return "Blocked private file action for ${command.target}. It requires a future explicit sensitive-file approval sheet."
         if (command.type == AgentCommandType.FILE_DELETE) return "Delete is blocked in MVP. It requires a future destructive-action confirmation sheet."
         return null
     }
 
     private fun executeCommand(command: AgentCommand): CommandExecutionResult {
-        if (!approvalSigner.verify(command)) {
-            return CommandExecutionResult(false, "Executor refused unsigned or mutated command digest", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
-        }
+        if (!approvalSigner.verify(command)) return CommandExecutionResult(false, "Executor refused unsigned or mutated command digest", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
         return when (command.type) {
             AgentCommandType.STATUS -> CommandExecutionResult(true, "Status command reviewed; app is running")
             AgentCommandType.OPEN_URL -> {
@@ -458,8 +455,7 @@ class MainActivity : Activity() {
             }
             AgentCommandType.OPEN_APP -> {
                 val launchIntent = packageManager.getLaunchIntentForPackage(command.target)
-                if (launchIntent == null) CommandExecutionResult(false, "Package not launchable: ${command.target}", "PACKAGE_NOT_LAUNCHABLE")
-                else {
+                if (launchIntent == null) CommandExecutionResult(false, "Package not launchable: ${command.target}", "PACKAGE_NOT_LAUNCHABLE") else {
                     startActivity(launchIntent)
                     CommandExecutionResult(true, "Opened app package visibly: ${command.target}")
                 }
@@ -469,9 +465,8 @@ class MainActivity : Activity() {
             AgentCommandType.SCROLL_DOWN -> AccessibilityActionBridge.performScrollDown()
             AgentCommandType.NOTIFICATION_SUMMARY -> CommandExecutionResult(false, "Notification summary executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
             AgentCommandType.FILE_LIST_ROOT -> {
-                val summary = FullFileManager.buildListSummary()
                 fileListRendered = true
-                filePreviewView.text = summary
+                filePreviewView.text = FullFileManager.buildListSummary()
                 auditLogStore.append("FILE_LISTED", command.commandId, "Listed shared storage root")
                 CommandExecutionResult(true, "Listed shared storage root")
             }
@@ -488,36 +483,31 @@ class MainActivity : Activity() {
         auditView.text = auditLogStore.tail(20).ifEmpty { "No audit events yet." }
     }
 
-    private fun buildStatusText(extra: String? = null): String {
-        return listOfNotNull(
-            "Backend: ${DsgConfig.BASE_URL}",
-            "Mode: owner-device • permission-first • signed approval • audit-required",
-            "Accessibility: ${permissionGate.isAccessibilityEnabled()}",
-            "Notifications: ${permissionGate.isNotificationListenerEnabled()}",
-            "Full file manager: ${permissionGate.isFullFileManagerEnabled()}",
-            "Actions: open_url, open_app, back, home, scroll, file_list_root, file_send_to_claw",
-            "Pending: ${commandStore.listPending().size}",
-            extra,
-        ).joinToString("\n")
-    }
+    private fun buildStatusText(extra: String? = null): String = listOfNotNull(
+        "Backend: ${DsgConfig.BASE_URL}",
+        "Mode: no-code • owner-device • signed approval • audit-required",
+        "Accessibility: ${permissionGate.isAccessibilityEnabled()}",
+        "Notifications: ${permissionGate.isNotificationListenerEnabled()}",
+        "Full file manager: ${permissionGate.isFullFileManagerEnabled()}",
+        "Pending: ${commandStore.listPending().size}",
+        extra,
+    ).joinToString("\n")
 
-    private fun sectionHeader(title: String, subtitle: String): View {
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setPadding(0, 0, 0, dp(12))
-            addView(TextView(this@MainActivity).apply {
-                text = title
-                textSize = 20f
-                typeface = Typeface.DEFAULT_BOLD
-                setTextColor(COLOR_TEXT)
-            })
-            addView(TextView(this@MainActivity).apply {
-                text = subtitle
-                textSize = 12f
-                setTextColor(COLOR_TEXT_MUTED)
-                setPadding(0, dp(2), 0, 0)
-            })
-        }
+    private fun sectionHeader(title: String, subtitle: String): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(0, 0, 0, dp(12))
+        addView(TextView(this@MainActivity).apply {
+            text = title
+            textSize = 20f
+            typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_TEXT)
+        })
+        addView(TextView(this@MainActivity).apply {
+            text = subtitle
+            textSize = 12f
+            setTextColor(COLOR_TEXT_MUTED)
+            setPadding(0, dp(2), 0, 0)
+        })
     }
 
     private fun actionButton(title: String, subtitle: String, tone: ButtonTone, onClick: () -> Unit): View {
@@ -552,96 +542,61 @@ class MainActivity : Activity() {
         return row
     }
 
-    private fun compactButton(textValue: String, tone: ButtonTone, onClick: () -> Unit): Button {
-        return Button(this).apply {
-            text = textValue
-            textSize = 12f
-            isAllCaps = false
-            setTextColor(if (tone == ButtonTone.PRIMARY) Color.WHITE else COLOR_TEXT)
-            background = rounded(buttonBg(tone), 14, buttonBorder(tone), 1)
-            setOnClickListener { onClick() }
-            val lp = LinearLayout.LayoutParams(0, dp(44), 1f)
-            lp.setMargins(0, 0, dp(8), 0)
-            layoutParams = lp
-        }
+    private fun compactButton(textValue: String, tone: ButtonTone, onClick: () -> Unit): Button = Button(this).apply {
+        text = textValue
+        textSize = 12f
+        isAllCaps = false
+        setTextColor(if (tone == ButtonTone.PRIMARY) Color.WHITE else COLOR_TEXT)
+        background = rounded(buttonBg(tone), 14, buttonBorder(tone), 1)
+        setOnClickListener { onClick() }
+        layoutParams = LinearLayout.LayoutParams(0, dp(44), 1f).apply { setMargins(0, 0, dp(8), 0) }
     }
 
-    private fun tab(label: String, active: Boolean): TextView {
-        return TextView(this).apply {
-            text = label
-            textSize = 13f
-            typeface = Typeface.DEFAULT_BOLD
-            gravity = Gravity.CENTER
-            setTextColor(if (active) Color.WHITE else COLOR_TEXT_MUTED)
-            background = rounded(if (active) COLOR_PRIMARY else COLOR_CARD, 22, if (active) COLOR_PRIMARY else COLOR_BORDER, 1)
-            val lp = LinearLayout.LayoutParams(0, dp(42), 1f)
-            lp.setMargins(0, 0, dp(8), 0)
-            layoutParams = lp
-        }
+    private fun tab(label: String, active: Boolean): TextView = TextView(this).apply {
+        text = label
+        textSize = 13f
+        typeface = Typeface.DEFAULT_BOLD
+        gravity = Gravity.CENTER
+        setTextColor(if (active) Color.WHITE else COLOR_TEXT_MUTED)
+        background = rounded(if (active) COLOR_PRIMARY else COLOR_CARD, 22, if (active) COLOR_PRIMARY else COLOR_BORDER, 1)
+        layoutParams = LinearLayout.LayoutParams(0, dp(42), 1f).apply { setMargins(0, 0, dp(8), 0) }
     }
 
-    private fun statusPill(label: String, ok: Boolean): TextView {
-        return TextView(this).apply {
-            text = label
-            textSize = 11f
-            typeface = Typeface.DEFAULT_BOLD
-            gravity = Gravity.CENTER
-            setTextColor(if (ok) COLOR_GREEN else COLOR_RED)
-            background = rounded(if (ok) COLOR_GREEN_SOFT else COLOR_RED_SOFT, 18, if (ok) COLOR_GREEN_BORDER else COLOR_RED_BORDER, 1)
-            setPadding(dp(10), dp(6), dp(10), dp(6))
-        }
+    private fun statusPill(label: String, ok: Boolean): TextView = TextView(this).apply {
+        text = label
+        textSize = 11f
+        typeface = Typeface.DEFAULT_BOLD
+        gravity = Gravity.CENTER
+        setTextColor(if (ok) COLOR_GREEN else COLOR_RED)
+        background = rounded(if (ok) COLOR_GREEN_SOFT else COLOR_RED_SOFT, 18, if (ok) COLOR_GREEN_BORDER else COLOR_RED_BORDER, 1)
+        setPadding(dp(10), dp(6), dp(10), dp(6))
     }
 
-    private fun card(color: Int = COLOR_CARD, radius: Int = 24, stroke: Int = COLOR_BORDER): LinearLayout {
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            background = rounded(color, radius, stroke, 1)
-        }
+    private fun card(color: Int = COLOR_CARD, radius: Int = 24, stroke: Int = COLOR_BORDER): LinearLayout = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        background = rounded(color, radius, stroke, 1)
     }
 
-    private fun rounded(color: Int, radius: Int, strokeColor: Int? = null, strokeWidth: Int = 0): GradientDrawable {
-        return GradientDrawable().apply {
-            setColor(color)
-            cornerRadius = dp(radius).toFloat()
-            if (strokeColor != null && strokeWidth > 0) setStroke(dp(strokeWidth), strokeColor)
-        }
+    private fun rounded(color: Int, radius: Int, strokeColor: Int? = null, strokeWidth: Int = 0): GradientDrawable = GradientDrawable().apply {
+        setColor(color)
+        cornerRadius = dp(radius).toFloat()
+        if (strokeColor != null && strokeWidth > 0) setStroke(dp(strokeWidth), strokeColor)
     }
 
     private fun addWithMargin(parent: LinearLayout, child: View, top: Int = 0, bottom: Int = 0) {
-        val lp = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        lp.setMargins(0, dp(top), 0, dp(bottom))
-        parent.addView(child, lp)
+        parent.addView(child, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+            setMargins(0, dp(top), 0, dp(bottom))
+        })
     }
 
     private fun addBottomMargin(view: View, bottom: Int) {
-        view.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-            setMargins(0, 0, 0, dp(bottom))
-        }
+        view.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { setMargins(0, 0, 0, dp(bottom)) }
     }
 
     private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
-
-    private fun buttonBg(tone: ButtonTone): Int = when (tone) {
-        ButtonTone.PRIMARY -> COLOR_PRIMARY
-        ButtonTone.SECONDARY -> COLOR_CARD_ALT
-        ButtonTone.WARNING -> COLOR_WARNING_SOFT
-        ButtonTone.DANGER -> COLOR_RED_SOFT
-    }
-
-    private fun buttonBorder(tone: ButtonTone): Int = when (tone) {
-        ButtonTone.PRIMARY -> COLOR_PRIMARY
-        ButtonTone.SECONDARY -> COLOR_BORDER
-        ButtonTone.WARNING -> COLOR_WARNING_BORDER
-        ButtonTone.DANGER -> COLOR_RED_BORDER
-    }
-
-    private fun buttonIcon(tone: ButtonTone): String = when (tone) {
-        ButtonTone.PRIMARY -> "🚀"
-        ButtonTone.SECONDARY -> "›"
-        ButtonTone.WARNING -> "⚠️"
-        ButtonTone.DANGER -> "⛔"
-    }
-
+    private fun buttonBg(tone: ButtonTone): Int = when (tone) { ButtonTone.PRIMARY -> COLOR_PRIMARY; ButtonTone.SECONDARY -> COLOR_CARD_ALT; ButtonTone.WARNING -> COLOR_WARNING_SOFT; ButtonTone.DANGER -> COLOR_RED_SOFT }
+    private fun buttonBorder(tone: ButtonTone): Int = when (tone) { ButtonTone.PRIMARY -> COLOR_PRIMARY; ButtonTone.SECONDARY -> COLOR_BORDER; ButtonTone.WARNING -> COLOR_WARNING_BORDER; ButtonTone.DANGER -> COLOR_RED_BORDER }
+    private fun buttonIcon(tone: ButtonTone): String = when (tone) { ButtonTone.PRIMARY -> "🚀"; ButtonTone.SECONDARY -> "›"; ButtonTone.WARNING -> "⚠️"; ButtonTone.DANGER -> "⛔" }
     private enum class ButtonTone { PRIMARY, SECONDARY, WARNING, DANGER }
 
     companion object {
@@ -657,7 +612,6 @@ class MainActivity : Activity() {
         private const val COLOR_ACCENT_BORDER = 0xFFB7DBFF.toInt()
         private const val COLOR_WARNING_SOFT = 0xFFFFF7E8.toInt()
         private const val COLOR_WARNING_BORDER = 0xFFFFC66D.toInt()
-        private const val COLOR_RED = 0xFFE23B3B.toInt()
         private const val COLOR_RED_SOFT = 0xFFFFECEC.toInt()
         private const val COLOR_RED_BORDER = 0xFFFFB5B5.toInt()
         private const val COLOR_GREEN = 0xFF0FA66B.toInt()

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -44,6 +44,7 @@ class MainActivity : Activity() {
     private lateinit var approvalSigner: OwnerApprovalSigner
 
     private var fileListRendered = false
+    private var workSessionEnabled = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,15 +67,13 @@ class MainActivity : Activity() {
             setPadding(dp(18), dp(18), dp(18), dp(28))
             setBackgroundColor(COLOR_BG)
         }
-
         addHero(root)
         addTabs(root)
         addNoCodeChat(root)
-        addServiceCard(root)
-        addFullFileManagerCard(root)
+        addWorkSessionCard(root)
+        addFileManagerCard(root)
         addCommandInbox(root)
         addAuditLog(root)
-
         setContentView(ScrollView(this).apply {
             setBackgroundColor(COLOR_BG)
             addView(root)
@@ -107,7 +106,7 @@ class MainActivity : Activity() {
                 setTextColor(Color.WHITE)
             })
             addView(TextView(this@MainActivity).apply {
-                text = "No-code owner-approved Android agent"
+                text = "No-code work session agent"
                 textSize = 13f
                 setTextColor(COLOR_TEXT_MUTED_DARK)
             })
@@ -115,13 +114,12 @@ class MainActivity : Activity() {
         top.addView(statusPill("AUDIT ON", true))
         hero.addView(top)
         hero.addView(TextView(this).apply {
-            text = "พิมพ์คำสั่งเป็นภาษาคนได้ แต่ทุกคำสั่งต้องเข้า Inbox และให้เจ้าของเครื่อง Approve ก่อนเสมอ"
+            text = "พิมพ์เป้าหมายงาน แล้วให้ Agent ทำงานต่อใน Work Session; งานที่ต้องใช้สิทธิ์ใหม่หรือกระทบไฟล์สำคัญจะหยุดให้ตรวจ"
             textSize = 14f
             setTextColor(COLOR_TEXT_SOFT_DARK)
             setPadding(0, dp(16), 0, dp(14))
         })
         statusView = TextView(this).apply {
-            text = buildStatusText()
             textSize = 12f
             setTextColor(COLOR_TEXT_SOFT_DARK)
             background = rounded(COLOR_SURFACE_DARK_2, 14, COLOR_BORDER_DARK, 1)
@@ -144,16 +142,16 @@ class MainActivity : Activity() {
     }
 
     private fun addNoCodeChat(root: LinearLayout) {
-        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        card.addView(sectionHeader("No-code Chat Command", "Vibe coding → command proposal → owner approval"))
-        card.addView(TextView(this).apply {
-            text = "ตัวอย่าง: เปิด status, เปิด settings, แสดงไฟล์, ส่งไฟล์ให้ Claw, back, home, scroll"
+        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(sectionHeader("No-code Chat", "พิมพ์งานเดียว แล้วให้ Agent สร้างงานให้"))
+        box.addView(TextView(this).apply {
+            text = "ตัวอย่าง: ตรวจระบบให้ครบ, เปิด status, แสดงไฟล์, ส่งไฟล์ให้ Claw, เปิด settings, back, home, scroll"
             textSize = 12f
             setTextColor(COLOR_TEXT_MUTED)
             setPadding(0, 0, 0, dp(10))
         })
         chatInput = EditText(this).apply {
-            hint = "พิมพ์คำสั่งที่ต้องการ เช่น เปิด status หรือ แสดงไฟล์ในเครื่อง"
+            hint = "พิมพ์เป้าหมายงาน เช่น ตรวจระบบให้ครบ"
             textSize = 14f
             minLines = 3
             maxLines = 5
@@ -163,113 +161,98 @@ class MainActivity : Activity() {
             background = rounded(COLOR_BG, 18, COLOR_BORDER, 1)
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
-        addWithMargin(card, chatInput, bottom = 10)
+        addWithMargin(box, chatInput, bottom = 10)
         val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
-        row.addView(compactButton("Create command", ButtonTone.PRIMARY) { queueNoCodePrompt() })
+        row.addView(compactButton("Run", ButtonTone.PRIMARY) { runNoCodePrompt() })
         row.addView(compactButton("Clear", ButtonTone.SECONDARY) { chatInput.setText("") })
-        card.addView(row)
-        addWithMargin(root, card, bottom = 12)
+        box.addView(row)
+        addWithMargin(root, box, bottom = 12)
     }
 
-    private fun addServiceCard(root: LinearLayout) {
-        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        card.addView(sectionHeader("Gateway & Permissions", "Live device gates"))
-        card.addView(actionButton("Start Agent Service", "Poll backend queue every 5s", ButtonTone.PRIMARY) {
+    private fun addWorkSessionCard(root: LinearLayout) {
+        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(sectionHeader("Work Session", "ลดการกดซ้ำ ใช้ manual fallback ได้"))
+        box.addView(TextView(this).apply {
+            text = "เปิด Work Session แล้วคำสั่ง low-risk ที่ permission พร้อมจะรันต่อเอง พร้อมบันทึก audit ทุก step"
+            textSize = 12f
+            setTextColor(COLOR_TEXT_MUTED)
+            setPadding(0, 0, 0, dp(10))
+        })
+        box.addView(actionButton("Start Work Session", "Run allowed steps without approving each one", ButtonTone.PRIMARY) {
+            workSessionEnabled = true
+            auditLogStore.append("WORK_SESSION_STARTED", "local", "Owner started work session")
+            refreshUi("Work Session enabled")
+        })
+        box.addView(actionButton("Stop Work Session", "Return to manual review", ButtonTone.DANGER) {
+            workSessionEnabled = false
+            auditLogStore.append("WORK_SESSION_STOPPED", "local", "Owner stopped work session")
+            refreshUi("Work Session stopped")
+        })
+        box.addView(actionButton("Start Agent Service", "Poll backend queue every 5s", ButtonTone.SECONDARY) {
             startForegroundService(Intent(this@MainActivity, AgentForegroundService::class.java))
             auditLogStore.append("SERVICE_START_REQUESTED", "local", "Foreground service start requested")
             refreshUi("Foreground service start requested")
         })
-        card.addView(actionButton("Stop Agent Service", "Safe shutdown", ButtonTone.SECONDARY) {
-            stopService(Intent(this@MainActivity, AgentForegroundService::class.java))
-            auditLogStore.append("SERVICE_STOP_REQUESTED", "local", "Foreground service stop requested")
-            refreshUi("Foreground service stop requested")
-        })
-        card.addView(actionButton("Open Accessibility Permission", "Back / Home / Scroll gate", ButtonTone.SECONDARY) {
+        box.addView(actionButton("Open Accessibility Permission", "Back / Home / Scroll gate", ButtonTone.SECONDARY) {
             auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Accessibility settings opened by owner")
             startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         })
-        card.addView(actionButton("Open Notification Listener Permission", "Notification summary gate", ButtonTone.SECONDARY) {
+        box.addView(actionButton("Open Notification Listener Permission", "Notification summary gate", ButtonTone.SECONDARY) {
             auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Notification listener settings opened by owner")
             startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
         })
-        card.addView(actionButton("Open DSG Status API", "Verify backend", ButtonTone.SECONDARY) {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL)))
-        })
-        addWithMargin(root, card, bottom = 12)
+        addWithMargin(root, box, bottom = 12)
     }
 
-    private fun addFullFileManagerCard(root: LinearLayout) {
-        val fmCard = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        fmCard.addView(sectionHeader("Full File Manager Mode", "Owner-approved all-files access"))
-        fmCard.addView(TextView(this).apply {
-            text = "High-risk mode. Android Settings must grant All files access manually. Every file action still goes through inbox approval, Keystore signing, permission gate, and audit."
+    private fun addFileManagerCard(root: LinearLayout) {
+        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(sectionHeader("Full File Manager Mode", "Owner-enabled all-files access"))
+        box.addView(TextView(this).apply {
+            text = "All files access ต้องเปิดเองใน Android Settings ก่อน หลังจากนั้น list/send workflow จะรันใน Work Session ได้ ถ้าผ่าน gate"
             textSize = 13f
             setTextColor(COLOR_TEXT_MUTED)
             setPadding(0, 0, 0, dp(12))
         })
-        val storageCard = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            background = rounded(COLOR_ACCENT_SOFT, 18, COLOR_ACCENT_BORDER, 1)
-            setPadding(dp(14), dp(14), dp(14), dp(14))
-            addView(TextView(this@MainActivity).apply {
-                text = "☁️ Claw File Workspace"
-                textSize = 16f
-                typeface = Typeface.DEFAULT_BOLD
-                setTextColor(COLOR_TEXT)
-            })
-            addView(TextView(this@MainActivity).apply {
-                text = "40 GB cloud target • local selection first • private files blocked by policy"
-                textSize = 12f
-                setTextColor(COLOR_TEXT_MUTED)
-                setPadding(0, dp(4), 0, dp(10))
-            })
-            addView(View(this@MainActivity).apply { background = rounded(COLOR_PRIMARY, 6) }, LinearLayout.LayoutParams(dp(132), dp(8)))
-        }
-        addWithMargin(fmCard, storageCard, bottom = 12)
-        fmCard.addView(actionButton("Open Full File Manager Permission", "Android All files access", ButtonTone.WARNING) {
-            auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened All files access settings")
+        box.addView(actionButton("Open Full File Manager Permission", "Android All files access", ButtonTone.WARNING) {
+            auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened all files access settings")
             val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply { data = Uri.parse("package:$packageName") }
             runCatching { startActivity(intent) }.getOrElse { startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)) }
         })
-        fmCard.addView(actionButton("Queue file command: list shared storage", "Requires approval + all-files gate", ButtonTone.PRIMARY) {
-            queueDemoCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath, "Owner requested a full-file-manager listing of shared storage root", "local-file-manager")
+        box.addView(actionButton("List shared storage", "Show files after permission", ButtonTone.PRIMARY) {
+            val command = queueCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath, "List shared storage", "local-file-manager")
+            runInSessionIfAllowed(command)
         })
-        fmCard.addView(actionButton("Queue file command: send selected files to Claw", "Creates approved file workflow", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://local-demo", "Owner requested selected files to be sent to Claw after review", "local-file-manager")
-        })
-        fmCard.addView(actionButton("Queue file command: delete private test file", "Should be blocked in MVP", ButtonTone.DANGER) {
-            queueDemoCommand(AgentCommandType.FILE_DELETE, "/sdcard/Download/api_keys.env", "Owner requested delete test for a private file. This must be blocked by policy in MVP.", "local-file-manager")
+        box.addView(actionButton("Send selected files to Claw", "Placeholder Claw workflow", ButtonTone.SECONDARY) {
+            val command = queueCommand(AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://local-demo", "Prepare selected files for Claw", "local-file-manager")
+            runInSessionIfAllowed(command)
         })
         filePreviewView = TextView(this).apply {
-            text = "No file listing yet. Queue and approve FILE_LIST_ROOT after enabling permission."
+            text = "No file listing yet. Open permission, start Work Session, then ask: แสดงไฟล์"
             textSize = 12f
             setTextColor(COLOR_TEXT_MUTED)
             background = rounded(COLOR_BG, 16, COLOR_BORDER, 1)
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
-        addWithMargin(fmCard, filePreviewView, top = 8)
-        addWithMargin(root, fmCard, bottom = 12)
+        addWithMargin(box, filePreviewView, top = 8)
+        addWithMargin(root, box, bottom = 12)
     }
 
     private fun addCommandInbox(root: LinearLayout) {
-        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        card.addView(sectionHeader("Command Inbox", "Approve before execution"))
-        card.addView(actionButton("Queue demo: open_url", "Visible browser action", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL, "Open DSG status page for visible owner verification", "local-demo")
+        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(sectionHeader("Command Inbox", "Manual fallback"))
+        box.addView(actionButton("Queue demo: open_url", "Visible browser action", ButtonTone.SECONDARY) {
+            queueCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL, "Open DSG status page", "local-demo")
         })
-        card.addView(actionButton("Queue demo: open_app settings", "Open Android Settings", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.OPEN_APP, "com.android.settings", "Open Android Settings package for owner-approved setup", "local-demo")
+        box.addView(actionButton("Queue demo: open settings", "Open Android Settings", ButtonTone.SECONDARY) {
+            queueCommand(AgentCommandType.OPEN_APP, "com.android.settings", "Open Android Settings", "local-demo")
         })
-        card.addView(actionButton("Queue demo: back", "Accessibility-gated", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back through Accessibility after owner approval", "local-demo")
+        box.addView(actionButton("Queue demo: back", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back", "local-demo")
         })
-        card.addView(actionButton("Queue demo: home", "Accessibility-gated", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home through Accessibility after owner approval", "local-demo")
+        box.addView(actionButton("Queue demo: home", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home", "local-demo")
         })
-        card.addView(actionButton("Queue demo: scroll down", "Accessibility-gated", ButtonTone.SECONDARY) {
-            queueDemoCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE", "Run one scroll down through Accessibility after owner approval", "local-demo")
-        })
-        card.addView(actionButton("Kill Switch: Clear Pending Commands", "Owner emergency stop", ButtonTone.DANGER) {
+        box.addView(actionButton("Kill Switch: Clear Pending Commands", "Owner emergency stop", ButtonTone.DANGER) {
             val count = commandStore.clearPending()
             auditLogStore.append("KILL_SWITCH_CLEAR_PENDING", "local", "Owner cleared $count pending command(s)")
             refreshUi("Kill switch cleared $count pending command(s)")
@@ -278,73 +261,102 @@ class MainActivity : Activity() {
             orientation = LinearLayout.VERTICAL
             setPadding(0, dp(10), 0, 0)
         }
-        card.addView(commandListView)
-        addWithMargin(root, card, bottom = 12)
+        box.addView(commandListView)
+        addWithMargin(root, box, bottom = 12)
     }
 
     private fun addAuditLog(root: LinearLayout) {
-        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        card.addView(sectionHeader("Local Audit Log", "Hash-chained device evidence"))
+        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(sectionHeader("Local Audit Log", "Device evidence"))
         auditView = TextView(this).apply {
             textSize = 12f
             setTextColor(COLOR_TEXT_MUTED)
             background = rounded(COLOR_BG, 16, COLOR_BORDER, 1)
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
-        card.addView(auditView)
-        addWithMargin(root, card)
+        box.addView(auditView)
+        addWithMargin(root, box)
     }
 
-    private fun queueNoCodePrompt() {
+    private fun runNoCodePrompt() {
         val prompt = chatInput.text.toString().trim()
         if (prompt.isBlank()) {
-            auditLogStore.append("NO_CODE_EMPTY", "local", "No-code prompt was empty")
             refreshUi("พิมพ์คำสั่งก่อน")
             return
         }
-        val mapped = mapNoCodePrompt(prompt)
-        queueDemoCommand(mapped.type, mapped.target, "No-code chat: $prompt", "no-code-chat")
+        val commands = planFromPrompt(prompt)
+        commands.forEach { mapped ->
+            val command = queueCommand(mapped.type, mapped.target, "No-code: $prompt", "no-code-chat")
+            runInSessionIfAllowed(command)
+        }
         chatInput.setText("")
     }
 
     private data class MappedCommand(val type: AgentCommandType, val target: String)
 
-    private fun mapNoCodePrompt(prompt: String): MappedCommand {
+    private fun planFromPrompt(prompt: String): List<MappedCommand> {
         val lower = prompt.lowercase()
         val url = Regex("https?://\\S+").find(prompt)?.value
+        if (url != null) return listOf(MappedCommand(AgentCommandType.OPEN_URL, url))
+        if (lower.contains("ตรวจระบบ") || lower.contains("status") || lower.contains("สถานะ")) {
+            return listOf(
+                MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL),
+                MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.OPENCLAW_URL),
+            )
+        }
         return when {
-            url != null -> MappedCommand(AgentCommandType.OPEN_URL, url)
-            lower.contains("status") || lower.contains("สถานะ") -> MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL)
-            lower.contains("setting") || lower.contains("ตั้งค่า") -> MappedCommand(AgentCommandType.OPEN_APP, "com.android.settings")
-            lower.contains("ไฟล์") || lower.contains("file") || lower.contains("storage") || lower.contains("sdcard") -> MappedCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath)
-            lower.contains("claw") || lower.contains("ส่ง") -> MappedCommand(AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://no-code-chat")
-            lower.contains("back") || lower.contains("ย้อน") -> MappedCommand(AgentCommandType.BACK, "GLOBAL_BACK")
-            lower.contains("home") || lower.contains("หน้าหลัก") -> MappedCommand(AgentCommandType.HOME, "GLOBAL_HOME")
-            lower.contains("scroll") || lower.contains("เลื่อน") -> MappedCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE")
-            else -> MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL)
+            lower.contains("setting") || lower.contains("ตั้งค่า") -> listOf(MappedCommand(AgentCommandType.OPEN_APP, "com.android.settings"))
+            lower.contains("ไฟล์") || lower.contains("file") || lower.contains("storage") -> listOf(MappedCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath))
+            lower.contains("claw") || lower.contains("ส่ง") -> listOf(MappedCommand(AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://no-code-chat"))
+            lower.contains("back") || lower.contains("ย้อน") -> listOf(MappedCommand(AgentCommandType.BACK, "GLOBAL_BACK"))
+            lower.contains("home") || lower.contains("หน้าหลัก") -> listOf(MappedCommand(AgentCommandType.HOME, "GLOBAL_HOME"))
+            lower.contains("scroll") || lower.contains("เลื่อน") -> listOf(MappedCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE"))
+            else -> listOf(MappedCommand(AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL))
         }
     }
 
-    private fun queueDemoCommand(type: AgentCommandType, target: String, reason: String, source: String) {
+    private fun queueCommand(type: AgentCommandType, target: String, reason: String, source: String): AgentCommand {
         commandStore.pruneExpired()
-        val command = AgentCommand.create(
-            source = source,
-            type = type,
-            target = target,
-            reason = reason,
-            requiresPermission = PermissionGate.requiredPermissionFor(type),
-            requiresUserConfirm = true,
-        )
+        val command = AgentCommand.create(source, type, target, reason, PermissionGate.requiredPermissionFor(type), true)
         commandStore.add(command)
-        val eventType = if (type.name.startsWith("FILE_")) "FILE_ACTION_QUEUED" else "COMMAND_QUEUED"
-        auditLogStore.append(eventType, command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
+        auditLogStore.append(if (type.name.startsWith("FILE_")) "FILE_ACTION_QUEUED" else "COMMAND_QUEUED", command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
         refreshUi("Queued ${command.type.name}")
+        return command
+    }
+
+    private fun runInSessionIfAllowed(command: AgentCommand) {
+        if (!workSessionEnabled) return
+        if (!sessionCanRun(command)) {
+            auditLogStore.append("WORK_SESSION_WAITING", command.commandId, "Manual review required for ${command.type.name}")
+            refreshUi("Manual review required for ${command.type.name}")
+            return
+        }
+        auditLogStore.append("WORK_SESSION_RUN", command.commandId, "Running ${command.type.name} in active work session")
+        approveCommand(command)
+    }
+
+    private fun sessionCanRun(command: AgentCommand): Boolean = when (command.type) {
+        AgentCommandType.STATUS,
+        AgentCommandType.OPEN_URL,
+        AgentCommandType.OPEN_SETTINGS,
+        AgentCommandType.OPEN_APP,
+        AgentCommandType.BACK,
+        AgentCommandType.HOME,
+        AgentCommandType.SCROLL_DOWN,
+        AgentCommandType.FILE_LIST_ROOT,
+        AgentCommandType.FILE_SEND_TO_CLAW -> true
+        AgentCommandType.NOTIFICATION_SUMMARY,
+        AgentCommandType.FILE_PREVIEW,
+        AgentCommandType.FILE_SELECT,
+        AgentCommandType.FILE_RENAME,
+        AgentCommandType.FILE_MOVE,
+        AgentCommandType.FILE_DELETE -> false
     }
 
     private fun refreshUi(extra: String? = null) {
         statusView.text = buildStatusText(extra)
         if (::filePreviewView.isInitialized && permissionGate.isFullFileManagerEnabled() && !fileListRendered) {
-            filePreviewView.text = "Full file manager permission enabled. Queue and approve list command to render files."
+            filePreviewView.text = "Full file manager permission enabled. Start Work Session, then ask: แสดงไฟล์"
         }
         renderCommands()
         renderAuditLog()
@@ -355,7 +367,7 @@ class MainActivity : Activity() {
         val pending = commandStore.listPending()
         if (pending.isEmpty()) {
             commandListView.addView(TextView(this).apply {
-                text = "No pending commands."
+                text = if (workSessionEnabled) "No pending commands. Work Session is active." else "No pending commands."
                 textSize = 13f
                 setTextColor(COLOR_TEXT_MUTED)
                 setPadding(0, dp(8), 0, 0)
@@ -389,18 +401,17 @@ class MainActivity : Activity() {
     }
 
     private fun approveCommand(command: AgentCommand) {
-        val policyBlock = filePolicyBlock(command)
-        if (policyBlock != null) {
-            commandStore.markBlocked(command.commandId, policyBlock)
-            auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, policyBlock, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
-            refreshUi(policyBlock)
+        val blockMessage = filePolicyBlock(command)
+        if (blockMessage != null) {
+            commandStore.markBlocked(command.commandId, blockMessage)
+            auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, blockMessage, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
+            refreshUi(blockMessage)
             return
         }
         val gate = permissionGate.evaluate(command)
         if (!gate.allowed) {
             if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) commandStore.markWaitingPermission(command.commandId, gate.message) else commandStore.markBlocked(command.commandId, gate.message)
-            val eventType = if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED"
-            auditLogStore.append(eventType, command.commandId, gate.message, gate.errorCode)
+            auditLogStore.append(if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED", command.commandId, gate.message, gate.errorCode)
             refreshUi("Blocked: ${gate.message}")
             return
         }
@@ -417,14 +428,12 @@ class MainActivity : Activity() {
             refreshUi("Approval signature verification failed")
             return
         }
-        val approvedEvent = if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_APPROVED" else "COMMAND_APPROVED"
-        auditLogStore.append(approvedEvent, signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
+        auditLogStore.append(if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_APPROVED" else "COMMAND_APPROVED", signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
         commandStore.markApproved(signed.commandId, signed.approvalSignature!!)
         val result = executeCommand(signed)
         if (result.success) {
             commandStore.markExecuted(signed.commandId)
-            val eventType = if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_EXECUTED" else "COMMAND_EXECUTED"
-            auditLogStore.append(eventType, signed.commandId, result.message)
+            auditLogStore.append(if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_EXECUTED" else "COMMAND_EXECUTED", signed.commandId, result.message)
         } else {
             commandStore.markFailed(signed.commandId, result.errorCode ?: "EXECUTION_FAILED", result.message)
             auditLogStore.append("COMMAND_FAILED", signed.commandId, result.message, result.errorCode)
@@ -435,23 +444,22 @@ class MainActivity : Activity() {
     private fun filePolicyBlock(command: AgentCommand): String? {
         if (!command.type.name.startsWith("FILE_")) return null
         val lower = command.target.lowercase()
-        val privateLike = lower.endsWith(".env") || lower.contains("api_key") || lower.contains("apikey") || lower.contains("private") || lower.endsWith(".pem") || lower.endsWith(".key")
-        if (privateLike) return "Blocked private file action for ${command.target}. It requires a future explicit sensitive-file approval sheet."
-        if (command.type == AgentCommandType.FILE_DELETE) return "Delete is blocked in MVP. It requires a future destructive-action confirmation sheet."
+        if (command.type == AgentCommandType.FILE_DELETE) return "Delete is blocked in this build."
+        if (lower.endsWith(".env") || lower.contains("api_key") || lower.contains("private") || lower.endsWith(".pem")) return "This file action needs a separate review sheet."
         return null
     }
 
     private fun executeCommand(command: AgentCommand): CommandExecutionResult {
-        if (!approvalSigner.verify(command)) return CommandExecutionResult(false, "Executor refused unsigned or mutated command digest", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
+        if (!approvalSigner.verify(command)) return CommandExecutionResult(false, "Executor refused unsigned or changed command", AgentErrorCodes.APPROVAL_SIGNATURE_INVALID)
         return when (command.type) {
-            AgentCommandType.STATUS -> CommandExecutionResult(true, "Status command reviewed; app is running")
+            AgentCommandType.STATUS -> CommandExecutionResult(true, "Status command reviewed")
             AgentCommandType.OPEN_URL -> {
                 startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(command.target)))
                 CommandExecutionResult(true, "Opened URL visibly: ${command.target}")
             }
             AgentCommandType.OPEN_SETTINGS -> {
                 startActivity(Intent(Settings.ACTION_SETTINGS))
-                CommandExecutionResult(true, "Opened Android Settings visibly")
+                CommandExecutionResult(true, "Opened Android Settings")
             }
             AgentCommandType.OPEN_APP -> {
                 val launchIntent = packageManager.getLaunchIntentForPackage(command.target)
@@ -463,19 +471,19 @@ class MainActivity : Activity() {
             AgentCommandType.BACK -> AccessibilityActionBridge.performBack()
             AgentCommandType.HOME -> AccessibilityActionBridge.performHome()
             AgentCommandType.SCROLL_DOWN -> AccessibilityActionBridge.performScrollDown()
-            AgentCommandType.NOTIFICATION_SUMMARY -> CommandExecutionResult(false, "Notification summary executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+            AgentCommandType.NOTIFICATION_SUMMARY -> CommandExecutionResult(false, "Notification summary executor is not enabled", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
             AgentCommandType.FILE_LIST_ROOT -> {
                 fileListRendered = true
                 filePreviewView.text = FullFileManager.buildListSummary()
                 auditLogStore.append("FILE_LISTED", command.commandId, "Listed shared storage root")
                 CommandExecutionResult(true, "Listed shared storage root")
             }
-            AgentCommandType.FILE_PREVIEW -> CommandExecutionResult(true, "Preview action approved for ${command.target}")
-            AgentCommandType.FILE_SELECT -> CommandExecutionResult(true, "Selected file ${command.target}")
-            AgentCommandType.FILE_SEND_TO_CLAW -> CommandExecutionResult(true, "Queued selected files for Claw processing after owner approval")
+            AgentCommandType.FILE_SEND_TO_CLAW -> CommandExecutionResult(true, "Prepared selected files for Claw workflow")
+            AgentCommandType.FILE_PREVIEW,
+            AgentCommandType.FILE_SELECT,
             AgentCommandType.FILE_RENAME,
-            AgentCommandType.FILE_MOVE -> CommandExecutionResult(false, "Rename/move executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
-            AgentCommandType.FILE_DELETE -> CommandExecutionResult(false, "Delete executor is blocked in this MVP", AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
+            AgentCommandType.FILE_MOVE,
+            AgentCommandType.FILE_DELETE -> CommandExecutionResult(false, "File executor not enabled for this action", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
         }
     }
 
@@ -485,7 +493,8 @@ class MainActivity : Activity() {
 
     private fun buildStatusText(extra: String? = null): String = listOfNotNull(
         "Backend: ${DsgConfig.BASE_URL}",
-        "Mode: no-code • owner-device • signed approval • audit-required",
+        "Mode: no-code • work-session • signed execution • audit",
+        "Work Session: $workSessionEnabled",
         "Accessibility: ${permissionGate.isAccessibilityEnabled()}",
         "Notifications: ${permissionGate.isNotificationListenerEnabled()}",
         "Full file manager: ${permissionGate.isFullFileManagerEnabled()}",
@@ -612,6 +621,7 @@ class MainActivity : Activity() {
         private const val COLOR_ACCENT_BORDER = 0xFFB7DBFF.toInt()
         private const val COLOR_WARNING_SOFT = 0xFFFFF7E8.toInt()
         private const val COLOR_WARNING_BORDER = 0xFFFFC66D.toInt()
+        private const val COLOR_RED = 0xFFE23B3B.toInt()
         private const val COLOR_RED_SOFT = 0xFFFFECEC.toInt()
         private const val COLOR_RED_BORDER = 0xFFFFB5B5.toInt()
         private const val COLOR_GREEN = 0xFF0FA66B.toInt()

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -3,10 +3,15 @@ package com.dsg.agent
 import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.ScrollView
@@ -20,8 +25,8 @@ import com.dsg.agent.automation.AgentErrorCodes
 import com.dsg.agent.automation.AuditLogStore
 import com.dsg.agent.automation.CommandExecutionResult
 import com.dsg.agent.automation.FullFileManager
-import com.dsg.agent.automation.PermissionGate
 import com.dsg.agent.automation.OwnerApprovalSigner
+import com.dsg.agent.automation.PermissionGate
 import com.dsg.agent.service.AgentForegroundService
 
 class MainActivity : Activity() {
@@ -34,6 +39,8 @@ class MainActivity : Activity() {
     private lateinit var auditLogStore: AuditLogStore
     private lateinit var permissionGate: PermissionGate
     private lateinit var approvalSigner: OwnerApprovalSigner
+
+    private var fileListRendered = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,199 +60,254 @@ class MainActivity : Activity() {
     private fun render() {
         val root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(32, 32, 32, 32)
+            setPadding(dp(18), dp(18), dp(18), dp(28))
+            setBackgroundColor(COLOR_BG)
         }
 
-        root.addView(TextView(this).apply {
-            text = "DSG Agent"
-            textSize = 28f
-        })
+        addHero(root)
+        addTabs(root)
+        addServiceCard(root)
+        addFullFileManagerCard(root)
+        addCommandInbox(root)
+        addAuditLog(root)
 
-        root.addView(TextView(this).apply {
-            text = "Owner-device automation app. Commands enter an inbox first. Owner approval is bound to the exact command digest by Android Keystore signing before execution."
-            textSize = 16f
+        setContentView(ScrollView(this).apply {
+            setBackgroundColor(COLOR_BG)
+            addView(root)
+        })
+        refreshUi()
+    }
+
+    private fun addHero(root: LinearLayout) {
+        val hero = card(COLOR_SURFACE_DARK, stroke = COLOR_PRIMARY_SOFT).apply {
+            setPadding(dp(18), dp(18), dp(18), dp(18))
+        }
+
+        val top = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        top.addView(TextView(this).apply {
+            text = "⚡"
+            textSize = 26f
+            gravity = Gravity.CENTER
+            setTextColor(Color.WHITE)
+            background = rounded(COLOR_PRIMARY, 14)
+        }, LinearLayout.LayoutParams(dp(48), dp(48)))
+
+        top.addView(LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(12), 0, 0, 0)
+            addView(TextView(this@MainActivity).apply {
+                text = "DSG Agent"
+                textSize = 28f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(Color.WHITE)
+            })
+            addView(TextView(this@MainActivity).apply {
+                text = "Owner-approved Android automation"
+                textSize = 13f
+                setTextColor(COLOR_TEXT_MUTED_DARK)
+            })
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+
+        top.addView(statusPill("AUDIT ON", true))
+        hero.addView(top)
+
+        hero.addView(TextView(this).apply {
+            text = "Commands enter an inbox first. Approval is bound to the exact digest by Android Keystore before execution."
+            textSize = 14f
+            setTextColor(COLOR_TEXT_SOFT_DARK)
+            setPadding(0, dp(16), 0, dp(14))
         })
 
         statusView = TextView(this).apply {
             text = buildStatusText()
-            textSize = 14f
-            setPadding(0, 24, 0, 24)
+            textSize = 12f
+            setTextColor(COLOR_TEXT_SOFT_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 14, COLOR_BORDER_DARK, 1)
+            setPadding(dp(14), dp(12), dp(14), dp(12))
         }
-        root.addView(statusView)
+        hero.addView(statusView)
+        addWithMargin(root, hero, bottom = 12)
+    }
 
-        root.addView(Button(this).apply {
-            text = "Start Agent Service"
-            setOnClickListener {
-                startForegroundService(Intent(this@MainActivity, AgentForegroundService::class.java))
-                auditLogStore.append("SERVICE_START_REQUESTED", "local", "Foreground service start requested")
-                refreshUi("Foreground service start requested")
+    private fun addTabs(root: LinearLayout) {
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        row.addView(tab("📁 Files", true))
+        row.addView(tab("🛠 Skills", false))
+        row.addView(tab("📋 Logs", false))
+        row.addView(tab("💬 Chat", false))
+        addWithMargin(root, row, bottom = 12)
+    }
+
+    private fun addServiceCard(root: LinearLayout) {
+        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        card.addView(sectionHeader("Gateway & Permissions", "Live device gates"))
+
+        val grid = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+        grid.addView(actionButton("Start Agent Service", "Foreground worker", ButtonTone.PRIMARY) {
+            startForegroundService(Intent(this@MainActivity, AgentForegroundService::class.java))
+            auditLogStore.append("SERVICE_START_REQUESTED", "local", "Foreground service start requested")
+            refreshUi("Foreground service start requested")
+        })
+        grid.addView(actionButton("Stop Agent Service", "Safe shutdown", ButtonTone.SECONDARY) {
+            stopService(Intent(this@MainActivity, AgentForegroundService::class.java))
+            auditLogStore.append("SERVICE_STOP_REQUESTED", "local", "Foreground service stop requested")
+            refreshUi("Foreground service stop requested")
+        })
+        grid.addView(actionButton("Open Accessibility Permission", "Back / Home / Scroll gate", ButtonTone.SECONDARY) {
+            auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Accessibility settings opened by owner")
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        })
+        grid.addView(actionButton("Open Notification Listener Permission", "Notification summary gate", ButtonTone.SECONDARY) {
+            auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Notification listener settings opened by owner")
+            startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+        })
+        grid.addView(actionButton("Open DSG Status API", "Verify backend", ButtonTone.SECONDARY) {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL)))
+        })
+        grid.addView(actionButton("Open Bridge Manifest", "OpenClaw mapping", ButtonTone.SECONDARY) {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL)))
+        })
+        card.addView(grid)
+        addWithMargin(root, card, bottom = 12)
+    }
+
+    private fun addFullFileManagerCard(root: LinearLayout) {
+        val fmCard = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        fmCard.addView(sectionHeader("Full File Manager Mode", "Owner-approved all-files access"))
+
+        fmCard.addView(TextView(this).apply {
+            text = "High-risk mode. Android Settings must grant All files access manually. Every file action still goes through inbox approval, Keystore signing, permission gate, and audit."
+            textSize = 13f
+            setTextColor(COLOR_TEXT_MUTED)
+            setPadding(0, 0, 0, dp(12))
+        })
+
+        val storageCard = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            background = rounded(COLOR_ACCENT_SOFT, 18, COLOR_ACCENT_BORDER, 1)
+            setPadding(dp(14), dp(14), dp(14), dp(14))
+            addView(TextView(this@MainActivity).apply {
+                text = "☁️ Claw File Workspace"
+                textSize = 16f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(COLOR_TEXT)
+            })
+            addView(TextView(this@MainActivity).apply {
+                text = "40 GB cloud target • local selection first • sensitive files blocked by policy"
+                textSize = 12f
+                setTextColor(COLOR_TEXT_MUTED)
+                setPadding(0, dp(4), 0, dp(10))
+            })
+            addView(View(this@MainActivity).apply {
+                background = rounded(COLOR_PRIMARY, 6)
+            }, LinearLayout.LayoutParams(dp(132), dp(8)))
+        }
+        addWithMargin(fmCard, storageCard, bottom = 12)
+
+        fmCard.addView(actionButton("Open Full File Manager Permission", "Android All files access", ButtonTone.WARNING) {
+            auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened All files access settings")
+            val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                data = Uri.parse("package:$packageName")
+            }
+            runCatching { startActivity(intent) }.getOrElse {
+                startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
             }
         })
-
-        root.addView(Button(this).apply {
-            text = "Stop Agent Service"
-            setOnClickListener {
-                stopService(Intent(this@MainActivity, AgentForegroundService::class.java))
-                auditLogStore.append("SERVICE_STOP_REQUESTED", "local", "Foreground service stop requested")
-                refreshUi("Foreground service stop requested")
-            }
+        fmCard.addView(actionButton("Queue file command: list shared storage", "Requires approval + all-files gate", ButtonTone.PRIMARY) {
+            queueDemoCommand(
+                AgentCommandType.FILE_LIST_ROOT,
+                FullFileManager.rootPath().absolutePath,
+                "Owner requested a full-file-manager listing of shared storage root",
+            )
         })
-
-        root.addView(Button(this).apply {
-            text = "Open Accessibility Permission"
-            setOnClickListener {
-                auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Accessibility settings opened by owner")
-                startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
-            }
+        fmCard.addView(actionButton("Queue file command: send selected files to Claw", "Creates approved file workflow", ButtonTone.SECONDARY) {
+            queueDemoCommand(
+                AgentCommandType.FILE_SEND_TO_CLAW,
+                "selected-files://local-demo",
+                "Owner requested selected files to be sent to Claw after review",
+            )
         })
-
-        root.addView(Button(this).apply {
-            text = "Open Notification Listener Permission"
-            setOnClickListener {
-                auditLogStore.append("OPEN_PERMISSION_SCREEN", "local", "Notification listener settings opened by owner")
-                startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
-            }
-        })
-
-        root.addView(Button(this).apply {
-            text = "Open DSG Status API"
-            setOnClickListener { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.STATUS_URL))) }
-        })
-
-        root.addView(Button(this).apply {
-            text = "Open Bridge Manifest"
-            setOnClickListener { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL))) }
-        })
-
-        root.addView(sectionTitle("Full File Manager Mode"))
-        root.addView(TextView(this).apply {
-            text = "High-risk mode. It requests Android All files access so this app can list and manage shared storage. The owner must open the Android settings screen and enable it manually. File operations still go through Command Inbox approval, Keystore signing, permission gate, and audit log."
-            textSize = 14f
-        })
-
-        root.addView(Button(this).apply {
-            text = "Open Full File Manager Permission"
-            setOnClickListener {
-                auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened All files access settings")
-                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
-                    data = Uri.parse("package:$packageName")
-                }
-                runCatching { startActivity(intent) }.getOrElse {
-                    startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
-                }
-            }
-        })
-
-        root.addView(Button(this).apply {
-            text = "Queue file command: list shared storage"
-            setOnClickListener {
-                queueDemoCommand(
-                    AgentCommandType.FILE_LIST_ROOT,
-                    FullFileManager.rootPath().absolutePath,
-                    "Owner requested a full-file-manager listing of shared storage root",
-                )
-            }
-        })
-
-        root.addView(Button(this).apply {
-            text = "Queue file command: send selected files to Claw"
-            setOnClickListener {
-                queueDemoCommand(
-                    AgentCommandType.FILE_SEND_TO_CLAW,
-                    "selected-files://local-demo",
-                    "Owner requested selected files to be sent to Claw after review",
-                )
-            }
-        })
-
-        root.addView(Button(this).apply {
-            text = "Queue file command: delete sensitive test file"
-            setOnClickListener {
-                queueDemoCommand(
-                    AgentCommandType.FILE_DELETE,
-                    "/sdcard/Download/api_keys.env",
-                    "Owner requested delete test for a sensitive file. This must be blocked by policy in MVP.",
-                )
-            }
+        fmCard.addView(actionButton("Queue file command: delete sensitive test file", "Should be blocked in MVP", ButtonTone.DANGER) {
+            queueDemoCommand(
+                AgentCommandType.FILE_DELETE,
+                "/sdcard/Download/api_keys.env",
+                "Owner requested delete test for a sensitive file. This must be blocked by policy in MVP.",
+            )
         })
 
         filePreviewView = TextView(this).apply {
-            text = "No file listing yet."
+            text = "No file listing yet. Queue and approve FILE_LIST_ROOT after enabling permission."
             textSize = 12f
-            setPadding(0, 12, 0, 12)
+            setTextColor(COLOR_TEXT_MUTED)
+            background = rounded(COLOR_BG, 16, COLOR_BORDER, 1)
+            setPadding(dp(14), dp(12), dp(14), dp(12))
         }
-        root.addView(filePreviewView)
+        addWithMargin(fmCard, filePreviewView, top = 8, bottom = 0)
+        addWithMargin(root, fmCard, bottom = 12)
+    }
 
-        root.addView(sectionTitle("Local Command Inbox"))
-        root.addView(TextView(this).apply {
-            text = "Demo commands model Chat / CLI / MCP requests. No command runs until owner approves it here."
-            textSize = 14f
-        })
+    private fun addCommandInbox(root: LinearLayout) {
+        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        card.addView(sectionHeader("Command Inbox", "Approve before execution"))
 
-        root.addView(Button(this).apply {
-            text = "Queue demo: open_url"
-            setOnClickListener {
-                queueDemoCommand(
-                    AgentCommandType.OPEN_URL,
-                    DsgConfig.STATUS_URL,
-                    "Open DSG status page for visible owner verification",
-                )
-            }
+        val demoRow = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        demoRow.addView(actionButton("Queue demo: open_url", "Visible browser action", ButtonTone.SECONDARY) {
+            queueDemoCommand(
+                AgentCommandType.OPEN_URL,
+                DsgConfig.STATUS_URL,
+                "Open DSG status page for visible owner verification",
+            )
         })
-
-        root.addView(Button(this).apply {
-            text = "Queue demo: open_app settings"
-            setOnClickListener {
-                queueDemoCommand(
-                    AgentCommandType.OPEN_APP,
-                    "com.android.settings",
-                    "Open Android Settings package for owner-approved setup",
-                )
-            }
+        demoRow.addView(actionButton("Queue demo: open_app settings", "Open Android Settings", ButtonTone.SECONDARY) {
+            queueDemoCommand(
+                AgentCommandType.OPEN_APP,
+                "com.android.settings",
+                "Open Android Settings package for owner-approved setup",
+            )
         })
-
-        root.addView(Button(this).apply {
-            text = "Queue demo: back"
-            setOnClickListener { queueDemoCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back through Accessibility after owner approval") }
+        demoRow.addView(actionButton("Queue demo: back", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.BACK, "GLOBAL_BACK", "Run Android Back through Accessibility after owner approval")
         })
-
-        root.addView(Button(this).apply {
-            text = "Queue demo: home"
-            setOnClickListener { queueDemoCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home through Accessibility after owner approval") }
+        demoRow.addView(actionButton("Queue demo: home", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.HOME, "GLOBAL_HOME", "Run Android Home through Accessibility after owner approval")
         })
-
-        root.addView(Button(this).apply {
-            text = "Queue demo: scroll down"
-            setOnClickListener { queueDemoCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE", "Run one scroll down through Accessibility after owner approval") }
+        demoRow.addView(actionButton("Queue demo: scroll down", "Accessibility-gated", ButtonTone.SECONDARY) {
+            queueDemoCommand(AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE", "Run one scroll down through Accessibility after owner approval")
         })
-
-        root.addView(Button(this).apply {
-            text = "Kill Switch: Clear Pending Commands"
-            setOnClickListener {
-                val count = commandStore.clearPending()
-                auditLogStore.append("KILL_SWITCH_CLEAR_PENDING", "local", "Owner cleared $count pending command(s)")
-                refreshUi("Kill switch cleared $count pending command(s)")
-            }
+        demoRow.addView(actionButton("Kill Switch: Clear Pending Commands", "Owner emergency stop", ButtonTone.DANGER) {
+            val count = commandStore.clearPending()
+            auditLogStore.append("KILL_SWITCH_CLEAR_PENDING", "local", "Owner cleared $count pending command(s)")
+            refreshUi("Kill switch cleared $count pending command(s)")
         })
+        card.addView(demoRow)
 
         commandListView = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(0, 16, 0, 16)
+            setPadding(0, dp(10), 0, 0)
         }
-        root.addView(commandListView)
-
-        root.addView(sectionTitle("Local Audit Log"))
-        auditView = TextView(this).apply { textSize = 12f }
-        root.addView(auditView)
-
-        setContentView(ScrollView(this).apply { addView(root) })
-        refreshUi()
+        card.addView(commandListView)
+        addWithMargin(root, card, bottom = 12)
     }
 
-    private fun sectionTitle(textValue: String): TextView = TextView(this).apply {
-        text = textValue
-        textSize = 20f
-        setPadding(0, 32, 0, 8)
+    private fun addAuditLog(root: LinearLayout) {
+        val card = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        card.addView(sectionHeader("Local Audit Log", "Hash-chained device evidence"))
+        auditView = TextView(this).apply {
+            textSize = 12f
+            setTextColor(COLOR_TEXT_MUTED)
+            background = rounded(COLOR_BG, 16, COLOR_BORDER, 1)
+            setPadding(dp(14), dp(12), dp(14), dp(12))
+        }
+        card.addView(auditView)
+        addWithMargin(root, card, bottom = 0)
     }
 
     private fun queueDemoCommand(type: AgentCommandType, target: String, reason: String) {
@@ -266,7 +328,7 @@ class MainActivity : Activity() {
 
     private fun refreshUi(extra: String? = null) {
         statusView.text = buildStatusText(extra)
-        if (::filePreviewView.isInitialized && permissionGate.isFullFileManagerEnabled()) {
+        if (::filePreviewView.isInitialized && permissionGate.isFullFileManagerEnabled() && !fileListRendered) {
             filePreviewView.text = "Full file manager permission enabled. Queue and approve list command to render files."
         }
         renderCommands()
@@ -279,39 +341,42 @@ class MainActivity : Activity() {
         if (pending.isEmpty()) {
             commandListView.addView(TextView(this).apply {
                 text = "No pending commands."
-                textSize = 14f
+                textSize = 13f
+                setTextColor(COLOR_TEXT_MUTED)
+                setPadding(0, dp(8), 0, 0)
             })
             return
         }
 
         pending.forEach { command ->
-            val card = LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                setPadding(0, 16, 0, 16)
+            val item = card(COLOR_CARD_ALT, radius = 18, stroke = COLOR_BORDER).apply {
+                setPadding(dp(14), dp(14), dp(14), dp(14))
             }
-            card.addView(TextView(this).apply {
+            item.addView(TextView(this).apply {
+                text = command.type.name
+                textSize = 15f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(COLOR_TEXT)
+            })
+            item.addView(TextView(this).apply {
                 text = command.toHumanText()
-                textSize = 14f
+                textSize = 12f
+                setTextColor(COLOR_TEXT_MUTED)
+                setPadding(0, dp(8), 0, dp(10))
             })
 
             val actionRow = LinearLayout(this).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
             }
-            actionRow.addView(Button(this).apply {
-                text = "Approve"
-                setOnClickListener { approveCommand(command) }
+            actionRow.addView(compactButton("Approve", ButtonTone.PRIMARY) { approveCommand(command) })
+            actionRow.addView(compactButton("Reject", ButtonTone.SECONDARY) {
+                commandStore.markRejected(command.commandId)
+                auditLogStore.append("COMMAND_REJECTED", command.commandId, "Owner rejected ${command.type.name}")
+                refreshUi("Rejected ${command.type.name}")
             })
-            actionRow.addView(Button(this).apply {
-                text = "Reject"
-                setOnClickListener {
-                    commandStore.markRejected(command.commandId)
-                    auditLogStore.append("COMMAND_REJECTED", command.commandId, "Owner rejected ${command.type.name}")
-                    refreshUi("Rejected ${command.type.name}")
-                }
-            })
-            card.addView(actionRow)
-            commandListView.addView(card)
+            item.addView(actionRow)
+            addWithMargin(commandListView, item, bottom = 10)
         }
     }
 
@@ -405,6 +470,7 @@ class MainActivity : Activity() {
             AgentCommandType.NOTIFICATION_SUMMARY -> CommandExecutionResult(false, "Notification summary executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
             AgentCommandType.FILE_LIST_ROOT -> {
                 val summary = FullFileManager.buildListSummary()
+                fileListRendered = true
                 filePreviewView.text = summary
                 auditLogStore.append("FILE_LISTED", command.commandId, "Listed shared storage root")
                 CommandExecutionResult(true, "Listed shared storage root")
@@ -425,13 +491,182 @@ class MainActivity : Activity() {
     private fun buildStatusText(extra: String? = null): String {
         return listOfNotNull(
             "Backend: ${DsgConfig.BASE_URL}",
-            "Mode: owner-device, permission-first, approval-signature-required, audit-required",
-            "Accessibility enabled: ${permissionGate.isAccessibilityEnabled()}",
-            "Notification listener enabled: ${permissionGate.isNotificationListenerEnabled()}",
-            "Full file manager enabled: ${permissionGate.isFullFileManagerEnabled()}",
-            "Enabled actions v1: status, open_url, open_settings, open_app, back, home, scroll_down, file_list_root, file_send_to_claw",
-            "Pending commands: ${commandStore.listPending().size}",
+            "Mode: owner-device • permission-first • signed approval • audit-required",
+            "Accessibility: ${permissionGate.isAccessibilityEnabled()}",
+            "Notifications: ${permissionGate.isNotificationListenerEnabled()}",
+            "Full file manager: ${permissionGate.isFullFileManagerEnabled()}",
+            "Actions: open_url, open_app, back, home, scroll, file_list_root, file_send_to_claw",
+            "Pending: ${commandStore.listPending().size}",
             extra,
         ).joinToString("\n")
+    }
+
+    private fun sectionHeader(title: String, subtitle: String): View {
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, 0, 0, dp(12))
+            addView(TextView(this@MainActivity).apply {
+                text = title
+                textSize = 20f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(COLOR_TEXT)
+            })
+            addView(TextView(this@MainActivity).apply {
+                text = subtitle
+                textSize = 12f
+                setTextColor(COLOR_TEXT_MUTED)
+                setPadding(0, dp(2), 0, 0)
+            })
+        }
+    }
+
+    private fun actionButton(title: String, subtitle: String, tone: ButtonTone, onClick: () -> Unit): View {
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            background = rounded(buttonBg(tone), 16, buttonBorder(tone), 1)
+            setPadding(dp(14), dp(12), dp(14), dp(12))
+            setOnClickListener { onClick() }
+        }
+        row.addView(TextView(this).apply {
+            text = buttonIcon(tone)
+            textSize = 20f
+            gravity = Gravity.CENTER
+        }, LinearLayout.LayoutParams(dp(34), dp(34)))
+        row.addView(LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(10), 0, 0, 0)
+            addView(TextView(this@MainActivity).apply {
+                text = title
+                textSize = 14f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(if (tone == ButtonTone.PRIMARY) Color.WHITE else COLOR_TEXT)
+            })
+            addView(TextView(this@MainActivity).apply {
+                text = subtitle
+                textSize = 11f
+                setTextColor(if (tone == ButtonTone.PRIMARY) COLOR_TEXT_SOFT_DARK else COLOR_TEXT_MUTED)
+            })
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        addBottomMargin(row, 10)
+        return row
+    }
+
+    private fun compactButton(textValue: String, tone: ButtonTone, onClick: () -> Unit): Button {
+        return Button(this).apply {
+            text = textValue
+            textSize = 12f
+            isAllCaps = false
+            setTextColor(if (tone == ButtonTone.PRIMARY) Color.WHITE else COLOR_TEXT)
+            background = rounded(buttonBg(tone), 14, buttonBorder(tone), 1)
+            setOnClickListener { onClick() }
+            val lp = LinearLayout.LayoutParams(0, dp(44), 1f)
+            lp.setMargins(0, 0, dp(8), 0)
+            layoutParams = lp
+        }
+    }
+
+    private fun tab(label: String, active: Boolean): TextView {
+        return TextView(this).apply {
+            text = label
+            textSize = 13f
+            typeface = Typeface.DEFAULT_BOLD
+            gravity = Gravity.CENTER
+            setTextColor(if (active) Color.WHITE else COLOR_TEXT_MUTED)
+            background = rounded(if (active) COLOR_PRIMARY else COLOR_CARD, 22, if (active) COLOR_PRIMARY else COLOR_BORDER, 1)
+            val lp = LinearLayout.LayoutParams(0, dp(42), 1f)
+            lp.setMargins(0, 0, dp(8), 0)
+            layoutParams = lp
+        }
+    }
+
+    private fun statusPill(label: String, ok: Boolean): TextView {
+        return TextView(this).apply {
+            text = label
+            textSize = 11f
+            typeface = Typeface.DEFAULT_BOLD
+            gravity = Gravity.CENTER
+            setTextColor(if (ok) COLOR_GREEN else COLOR_RED)
+            background = rounded(if (ok) COLOR_GREEN_SOFT else COLOR_RED_SOFT, 18, if (ok) COLOR_GREEN_BORDER else COLOR_RED_BORDER, 1)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+        }
+    }
+
+    private fun card(color: Int = COLOR_CARD, radius: Int = 24, stroke: Int = COLOR_BORDER): LinearLayout {
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            background = rounded(color, radius, stroke, 1)
+        }
+    }
+
+    private fun rounded(color: Int, radius: Int, strokeColor: Int? = null, strokeWidth: Int = 0): GradientDrawable {
+        return GradientDrawable().apply {
+            setColor(color)
+            cornerRadius = dp(radius).toFloat()
+            if (strokeColor != null && strokeWidth > 0) setStroke(dp(strokeWidth), strokeColor)
+        }
+    }
+
+    private fun addWithMargin(parent: LinearLayout, child: View, top: Int = 0, bottom: Int = 0) {
+        val lp = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        lp.setMargins(0, dp(top), 0, dp(bottom))
+        parent.addView(child, lp)
+    }
+
+    private fun addBottomMargin(view: View, bottom: Int) {
+        view.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+            setMargins(0, 0, 0, dp(bottom))
+        }
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    private fun buttonBg(tone: ButtonTone): Int = when (tone) {
+        ButtonTone.PRIMARY -> COLOR_PRIMARY
+        ButtonTone.SECONDARY -> COLOR_CARD_ALT
+        ButtonTone.WARNING -> COLOR_WARNING_SOFT
+        ButtonTone.DANGER -> COLOR_RED_SOFT
+    }
+
+    private fun buttonBorder(tone: ButtonTone): Int = when (tone) {
+        ButtonTone.PRIMARY -> COLOR_PRIMARY
+        ButtonTone.SECONDARY -> COLOR_BORDER
+        ButtonTone.WARNING -> COLOR_WARNING_BORDER
+        ButtonTone.DANGER -> COLOR_RED_BORDER
+    }
+
+    private fun buttonIcon(tone: ButtonTone): String = when (tone) {
+        ButtonTone.PRIMARY -> "🚀"
+        ButtonTone.SECONDARY -> "›"
+        ButtonTone.WARNING -> "⚠️"
+        ButtonTone.DANGER -> "⛔"
+    }
+
+    private enum class ButtonTone { PRIMARY, SECONDARY, WARNING, DANGER }
+
+    companion object {
+        private const val COLOR_BG = 0xFFF5F6FA.toInt()
+        private const val COLOR_CARD = 0xFFFFFFFF.toInt()
+        private const val COLOR_CARD_ALT = 0xFFF3F4F8.toInt()
+        private const val COLOR_BORDER = 0xFFE3E5ED.toInt()
+        private const val COLOR_TEXT = 0xFF171821.toInt()
+        private const val COLOR_TEXT_MUTED = 0xFF707486.toInt()
+        private const val COLOR_PRIMARY = 0xFF5B5FEF.toInt()
+        private const val COLOR_PRIMARY_SOFT = 0xFF8387FF.toInt()
+        private const val COLOR_ACCENT_SOFT = 0xFFEFF7FF.toInt()
+        private const val COLOR_ACCENT_BORDER = 0xFFB7DBFF.toInt()
+        private const val COLOR_WARNING_SOFT = 0xFFFFF7E8.toInt()
+        private const val COLOR_WARNING_BORDER = 0xFFFFC66D.toInt()
+        private const val COLOR_RED = 0xFFE23B3B.toInt()
+        private const val COLOR_RED_SOFT = 0xFFFFECEC.toInt()
+        private const val COLOR_RED_BORDER = 0xFFFFB5B5.toInt()
+        private const val COLOR_GREEN = 0xFF0FA66B.toInt()
+        private const val COLOR_GREEN_SOFT = 0xFFEAFBF3.toInt()
+        private const val COLOR_GREEN_BORDER = 0xFFA7EACB.toInt()
+        private const val COLOR_SURFACE_DARK = 0xFF111225.toInt()
+        private const val COLOR_SURFACE_DARK_2 = 0xFF1C1E36.toInt()
+        private const val COLOR_BORDER_DARK = 0xFF2F3358.toInt()
+        private const val COLOR_TEXT_MUTED_DARK = 0xFFAEB2D5.toInt()
+        private const val COLOR_TEXT_SOFT_DARK = 0xFFD6D8F6.toInt()
     }
 }

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -19,6 +19,7 @@ import com.dsg.agent.automation.AgentCommandType
 import com.dsg.agent.automation.AgentErrorCodes
 import com.dsg.agent.automation.AuditLogStore
 import com.dsg.agent.automation.CommandExecutionResult
+import com.dsg.agent.automation.FullFileManager
 import com.dsg.agent.automation.PermissionGate
 import com.dsg.agent.automation.OwnerApprovalSigner
 import com.dsg.agent.service.AgentForegroundService
@@ -27,6 +28,7 @@ class MainActivity : Activity() {
     private lateinit var statusView: TextView
     private lateinit var commandListView: LinearLayout
     private lateinit var auditView: TextView
+    private lateinit var filePreviewView: TextView
 
     private lateinit var commandStore: AgentCommandStore
     private lateinit var auditLogStore: AuditLogStore
@@ -115,6 +117,65 @@ class MainActivity : Activity() {
             setOnClickListener { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(DsgConfig.OPENCLAW_URL))) }
         })
 
+        root.addView(sectionTitle("Full File Manager Mode"))
+        root.addView(TextView(this).apply {
+            text = "High-risk mode. It requests Android All files access so this app can list and manage shared storage. The owner must open the Android settings screen and enable it manually. File operations still go through Command Inbox approval, Keystore signing, permission gate, and audit log."
+            textSize = 14f
+        })
+
+        root.addView(Button(this).apply {
+            text = "Open Full File Manager Permission"
+            setOnClickListener {
+                auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened All files access settings")
+                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                    data = Uri.parse("package:$packageName")
+                }
+                runCatching { startActivity(intent) }.getOrElse {
+                    startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
+                }
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue file command: list shared storage"
+            setOnClickListener {
+                queueDemoCommand(
+                    AgentCommandType.FILE_LIST_ROOT,
+                    FullFileManager.rootPath().absolutePath,
+                    "Owner requested a full-file-manager listing of shared storage root",
+                )
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue file command: send selected files to Claw"
+            setOnClickListener {
+                queueDemoCommand(
+                    AgentCommandType.FILE_SEND_TO_CLAW,
+                    "selected-files://local-demo",
+                    "Owner requested selected files to be sent to Claw after review",
+                )
+            }
+        })
+
+        root.addView(Button(this).apply {
+            text = "Queue file command: delete sensitive test file"
+            setOnClickListener {
+                queueDemoCommand(
+                    AgentCommandType.FILE_DELETE,
+                    "/sdcard/Download/api_keys.env",
+                    "Owner requested delete test for a sensitive file. This must be blocked by policy in MVP.",
+                )
+            }
+        })
+
+        filePreviewView = TextView(this).apply {
+            text = "No file listing yet."
+            textSize = 12f
+            setPadding(0, 12, 0, 12)
+        }
+        root.addView(filePreviewView)
+
         root.addView(sectionTitle("Local Command Inbox"))
         root.addView(TextView(this).apply {
             text = "Demo commands model Chat / CLI / MCP requests. No command runs until owner approves it here."
@@ -190,7 +251,7 @@ class MainActivity : Activity() {
     private fun queueDemoCommand(type: AgentCommandType, target: String, reason: String) {
         commandStore.pruneExpired()
         val command = AgentCommand.create(
-            source = "local-demo",
+            source = if (type.name.startsWith("FILE_")) "local-file-manager" else "local-demo",
             type = type,
             target = target,
             reason = reason,
@@ -198,12 +259,16 @@ class MainActivity : Activity() {
             requiresUserConfirm = true,
         )
         commandStore.add(command)
-        auditLogStore.append("COMMAND_QUEUED", command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
+        val eventType = if (type.name.startsWith("FILE_")) "FILE_ACTION_QUEUED" else "COMMAND_QUEUED"
+        auditLogStore.append(eventType, command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
         refreshUi("Queued ${command.type.name}")
     }
 
     private fun refreshUi(extra: String? = null) {
         statusView.text = buildStatusText(extra)
+        if (::filePreviewView.isInitialized && permissionGate.isFullFileManagerEnabled()) {
+            filePreviewView.text = "Full file manager permission enabled. Queue and approve list command to render files."
+        }
         renderCommands()
         renderAuditLog()
     }
@@ -251,6 +316,14 @@ class MainActivity : Activity() {
     }
 
     private fun approveCommand(command: AgentCommand) {
+        val policyBlock = filePolicyBlock(command)
+        if (policyBlock != null) {
+            commandStore.markBlocked(command.commandId, policyBlock)
+            auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, policyBlock, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
+            refreshUi(policyBlock)
+            return
+        }
+
         val gate = permissionGate.evaluate(command)
         if (!gate.allowed) {
             if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) {
@@ -258,7 +331,8 @@ class MainActivity : Activity() {
             } else {
                 commandStore.markBlocked(command.commandId, gate.message)
             }
-            auditLogStore.append("COMMAND_BLOCKED", command.commandId, gate.message, gate.errorCode)
+            val eventType = if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED"
+            auditLogStore.append(eventType, command.commandId, gate.message, gate.errorCode)
             refreshUi("Blocked: ${gate.message}")
             return
         }
@@ -278,18 +352,29 @@ class MainActivity : Activity() {
             return
         }
 
-        auditLogStore.append("COMMAND_APPROVED", signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
+        val approvedEvent = if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_APPROVED" else "COMMAND_APPROVED"
+        auditLogStore.append(approvedEvent, signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
         commandStore.markApproved(signed.commandId, signed.approvalSignature!!)
 
         val result = executeCommand(signed)
         if (result.success) {
             commandStore.markExecuted(signed.commandId)
-            auditLogStore.append("COMMAND_EXECUTED", signed.commandId, result.message)
+            val eventType = if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_EXECUTED" else "COMMAND_EXECUTED"
+            auditLogStore.append(eventType, signed.commandId, result.message)
         } else {
             commandStore.markFailed(signed.commandId, result.errorCode ?: "EXECUTION_FAILED", result.message)
             auditLogStore.append("COMMAND_FAILED", signed.commandId, result.message, result.errorCode)
         }
         refreshUi(result.message)
+    }
+
+    private fun filePolicyBlock(command: AgentCommand): String? {
+        if (!command.type.name.startsWith("FILE_")) return null
+        val lowered = command.target.lowercase()
+        val isSecret = lowered.endsWith(".env") || lowered.contains("api_key") || lowered.contains("apikey") || lowered.contains("token") || lowered.contains("secret") || lowered.endsWith(".pem") || lowered.endsWith(".key")
+        if (isSecret) return "Blocked sensitive file action for ${command.target}. Secret-like files require a future explicit sensitive-file approval sheet."
+        if (command.type == AgentCommandType.FILE_DELETE) return "Delete is blocked in MVP. It requires a future destructive-action confirmation sheet."
+        return null
     }
 
     private fun executeCommand(command: AgentCommand): CommandExecutionResult {
@@ -318,6 +403,18 @@ class MainActivity : Activity() {
             AgentCommandType.HOME -> AccessibilityActionBridge.performHome()
             AgentCommandType.SCROLL_DOWN -> AccessibilityActionBridge.performScrollDown()
             AgentCommandType.NOTIFICATION_SUMMARY -> CommandExecutionResult(false, "Notification summary executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+            AgentCommandType.FILE_LIST_ROOT -> {
+                val summary = FullFileManager.buildListSummary()
+                filePreviewView.text = summary
+                auditLogStore.append("FILE_LISTED", command.commandId, "Listed shared storage root")
+                CommandExecutionResult(true, "Listed shared storage root")
+            }
+            AgentCommandType.FILE_PREVIEW -> CommandExecutionResult(true, "Preview action approved for ${command.target}")
+            AgentCommandType.FILE_SELECT -> CommandExecutionResult(true, "Selected file ${command.target}")
+            AgentCommandType.FILE_SEND_TO_CLAW -> CommandExecutionResult(true, "Queued selected files for Claw processing after owner approval")
+            AgentCommandType.FILE_RENAME,
+            AgentCommandType.FILE_MOVE -> CommandExecutionResult(false, "Rename/move executor is not enabled in this MVP", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+            AgentCommandType.FILE_DELETE -> CommandExecutionResult(false, "Delete executor is blocked in this MVP", AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
         }
     }
 
@@ -331,7 +428,8 @@ class MainActivity : Activity() {
             "Mode: owner-device, permission-first, approval-signature-required, audit-required",
             "Accessibility enabled: ${permissionGate.isAccessibilityEnabled()}",
             "Notification listener enabled: ${permissionGate.isNotificationListenerEnabled()}",
-            "Enabled actions v1: status, open_url, open_settings, open_app, back, home, scroll_down",
+            "Full file manager enabled: ${permissionGate.isFullFileManagerEnabled()}",
+            "Enabled actions v1: status, open_url, open_settings, open_app, back, home, scroll_down, file_list_root, file_send_to_claw",
             "Pending commands: ${commandStore.listPending().size}",
             extra,
         ).joinToString("\n")

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/AgentBackendClient.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/AgentBackendClient.kt
@@ -1,0 +1,104 @@
+package com.dsg.agent.automation
+
+import com.dsg.agent.DsgConfig
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+class AgentBackendClient {
+    fun poll(deviceId: String = "android.owner.default"): List<AgentCommand> {
+        val url = URL("${DsgConfig.BASE_URL}/api/agent/commands?deviceId=$deviceId&includeDone=false")
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = 5000
+            readTimeout = 5000
+        }
+        return try {
+            val text = connection.inputStream.bufferedReader().use { it.readText() }
+            val json = JSONObject(text)
+            val items = json.optJSONArray("commands") ?: JSONArray()
+            (0 until items.length()).mapNotNull { index ->
+                runCatching { fromEnvelope(items.getJSONObject(index)) }.getOrNull()
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    fun sendEvent(command: AgentCommand, eventType: String, executionState: String, message: String, errorCode: String? = null) {
+        val payload = JSONObject()
+            .put("action", "device_event")
+            .put("commandId", command.commandId)
+            .put("eventType", eventType)
+            .put("executionState", executionState)
+            .put("message", message)
+            .put("signatureDigest", command.approvalSignature?.commandDigest)
+            .put("errorCode", errorCode)
+        val url = URL("${DsgConfig.BASE_URL}/api/agent/commands")
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = 5000
+            readTimeout = 5000
+            doOutput = true
+            setRequestProperty("content-type", "application/json")
+        }
+        try {
+            OutputStreamWriter(connection.outputStream).use { writer -> writer.write(payload.toString()) }
+            val code = connection.responseCode
+            if (code >= 400) {
+                connection.errorStream?.bufferedReader()?.use { it.readText() }
+            } else {
+                connection.inputStream.bufferedReader().use { it.readText() }
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun fromEnvelope(envelope: JSONObject): AgentCommand {
+        val tool = envelope.getJSONObject("tool").getString("name")
+        val normalizedArgs = envelope.optJSONObject("normalizedArgs") ?: JSONObject()
+        val policy = envelope.getJSONObject("policy")
+        val targetValue = when {
+            tool == "device.open_url" -> normalizedArgs.optString("url")
+            tool == "device.open_app" -> normalizedArgs.optString("packageName")
+            tool.startsWith("file.") -> normalizedArgs.optString("path", "/sdcard")
+            else -> tool
+        }
+        val type = when (tool) {
+            "device.status.get" -> AgentCommandType.STATUS
+            "device.open_url" -> AgentCommandType.OPEN_URL
+            "device.open_app" -> AgentCommandType.OPEN_APP
+            "device.open_settings" -> AgentCommandType.OPEN_SETTINGS
+            "ui.back" -> AgentCommandType.BACK
+            "ui.home" -> AgentCommandType.HOME
+            "ui.scroll" -> AgentCommandType.SCROLL_DOWN
+            "device.notifications.summary" -> AgentCommandType.NOTIFICATION_SUMMARY
+            "file.list_root" -> AgentCommandType.FILE_LIST_ROOT
+            "file.preview" -> AgentCommandType.FILE_PREVIEW
+            "file.select" -> AgentCommandType.FILE_SELECT
+            "file.send_to_claw" -> AgentCommandType.FILE_SEND_TO_CLAW
+            "file.rename" -> AgentCommandType.FILE_RENAME
+            "file.move" -> AgentCommandType.FILE_MOVE
+            "file.delete" -> AgentCommandType.FILE_DELETE
+            else -> AgentCommandType.STATUS
+        }
+        val local = AgentCommand.create(
+            source = "backend-queue",
+            type = type,
+            target = targetValue,
+            reason = "Backend queued ${tool} for owner approval",
+            requiresPermission = PermissionGate.requiredPermissionFor(type),
+            requiresUserConfirm = true,
+        )
+        return local.copy(
+            commandId = envelope.getString("commandId"),
+            policyVersion = policy.optString("policyVersion", local.policyVersion),
+            idempotencyKey = envelope.getJSONObject("idempotency").optString("key", local.idempotencyKey),
+            commandDigest = envelope.getJSONObject("idempotency").optString("digest", local.commandDigest).removePrefix("sha256:"),
+            expiresAt = runCatching { java.time.Instant.parse(policy.getString("expiresAt")).toEpochMilli() }.getOrDefault(local.expiresAt),
+        )
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/AgentBackendClient.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/AgentBackendClient.kt
@@ -34,7 +34,7 @@ class AgentBackendClient {
             .put("eventType", eventType)
             .put("executionState", executionState)
             .put("message", message)
-            .put("signatureDigest", command.approvalSignature?.commandDigest)
+            .put("signatureDigest", command.approvalSignature?.commandDigest ?: command.commandDigest)
             .put("errorCode", errorCode)
         val url = URL("${DsgConfig.BASE_URL}/api/agent/commands")
         val connection = (url.openConnection() as HttpURLConnection).apply {
@@ -96,8 +96,6 @@ class AgentBackendClient {
         return local.copy(
             commandId = envelope.getString("commandId"),
             policyVersion = policy.optString("policyVersion", local.policyVersion),
-            idempotencyKey = envelope.getJSONObject("idempotency").optString("key", local.idempotencyKey),
-            commandDigest = envelope.getJSONObject("idempotency").optString("digest", local.commandDigest).removePrefix("sha256:"),
             expiresAt = runCatching { java.time.Instant.parse(policy.getString("expiresAt")).toEpochMilli() }.getOrDefault(local.expiresAt),
         )
     }

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommand.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommand.kt
@@ -13,6 +13,13 @@ enum class AgentCommandType {
     HOME,
     SCROLL_DOWN,
     NOTIFICATION_SUMMARY,
+    FILE_LIST_ROOT,
+    FILE_PREVIEW,
+    FILE_SELECT,
+    FILE_SEND_TO_CLAW,
+    FILE_RENAME,
+    FILE_MOVE,
+    FILE_DELETE,
 }
 
 enum class CommandState {
@@ -123,7 +130,7 @@ data class AgentCommand(
 
     companion object {
         private const val DEFAULT_TTL_MS = 15 * 60 * 1000L
-        private const val DEFAULT_POLICY_VERSION = "2026-05-27-owner-command-mvp"
+        private const val DEFAULT_POLICY_VERSION = "2026-05-28-owner-full-file-manager"
 
         fun create(
             source: String,

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt
@@ -1,0 +1,95 @@
+package com.dsg.agent.automation
+
+import android.os.Environment
+import java.io.File
+import java.text.DecimalFormat
+
+object FullFileManager {
+    data class FileEntry(
+        val path: String,
+        val name: String,
+        val isDirectory: Boolean,
+        val sizeBytes: Long,
+        val risk: FileRisk,
+    ) {
+        fun toDisplayText(): String {
+            val type = if (isDirectory) "DIR" else "FILE"
+            return "$type • $name • ${formatBytes(sizeBytes)} • ${risk.label}\n$path"
+        }
+    }
+
+    enum class FileRisk(val label: String) {
+        NORMAL("normal"),
+        SENSITIVE_REVIEW("sensitive-review"),
+        SECRET_BLOCK("secret-block"),
+        ARCHIVE_REVIEW("archive-review"),
+    }
+
+    fun isEnabled(): Boolean = Environment.isExternalStorageManager()
+
+    fun rootPath(): File = Environment.getExternalStorageDirectory()
+
+    fun listRoot(maxItems: Int = 20): List<FileEntry> {
+        val root = rootPath()
+        return root.listFiles()
+            ?.sortedWith(compareByDescending<File> { it.isDirectory }.thenBy { it.name.lowercase() })
+            ?.take(maxItems)
+            ?.map { file ->
+                FileEntry(
+                    path = file.absolutePath,
+                    name = file.name.ifBlank { file.absolutePath },
+                    isDirectory = file.isDirectory,
+                    sizeBytes = if (file.isFile) file.length() else 0L,
+                    risk = riskFor(file),
+                )
+            }
+            ?: emptyList()
+    }
+
+    fun riskFor(file: File): FileRisk {
+        val name = file.name.lowercase()
+        if (file.isDirectory) return FileRisk.NORMAL
+        if (
+            name.endsWith(".env") ||
+            name.contains("api_key") ||
+            name.contains("apikey") ||
+            name.contains("token") ||
+            name.contains("secret") ||
+            name.endsWith(".pem") ||
+            name.endsWith(".key")
+        ) return FileRisk.SECRET_BLOCK
+        if (
+            name.contains("passport") ||
+            name.contains("idcard") ||
+            name.contains("id_card") ||
+            name.contains("บัตร") ||
+            name.contains("พาสปอร์ต")
+        ) return FileRisk.SENSITIVE_REVIEW
+        if (
+            name.endsWith(".zip") ||
+            name.endsWith(".7z") ||
+            name.endsWith(".rar") ||
+            name.endsWith(".tar") ||
+            name.endsWith(".gz")
+        ) return FileRisk.ARCHIVE_REVIEW
+        return FileRisk.NORMAL
+    }
+
+    fun buildListSummary(): String {
+        val entries = listRoot()
+        if (entries.isEmpty()) return "No shared-storage files visible or permission not available."
+        return entries.joinToString("\n\n") { it.toDisplayText() }
+    }
+
+    fun formatBytes(bytes: Long): String {
+        if (bytes <= 0L) return "0 B"
+        val units = arrayOf("B", "KB", "MB", "GB")
+        var value = bytes.toDouble()
+        var unitIndex = 0
+        while (value >= 1024 && unitIndex < units.lastIndex) {
+            value /= 1024
+            unitIndex += 1
+        }
+        return "${DecimalFormat("#.##").format(value)} ${units[unitIndex]}"
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
@@ -3,8 +3,8 @@ package com.dsg.agent.automation
 import android.accessibilityservice.AccessibilityService
 import android.content.ComponentName
 import android.content.Context
+import android.os.Environment
 import android.provider.Settings
-import android.text.TextUtils
 import com.dsg.agent.service.DsgAccessibilityService
 
 object AgentErrorCodes {
@@ -14,6 +14,7 @@ object AgentErrorCodes {
     const val PERMISSION_REVOKED_MID_FLIGHT = "PERMISSION_REVOKED_MID_FLIGHT"
     const val ACCESSIBILITY_SERVICE_NOT_CONNECTED = "ACCESSIBILITY_SERVICE_NOT_CONNECTED"
     const val EXECUTOR_UNSUPPORTED = "EXECUTOR_UNSUPPORTED"
+    const val FILE_SENSITIVE_REVIEW_REQUIRED = "FILE_SENSITIVE_REVIEW_REQUIRED"
 }
 
 data class GateResult(val allowed: Boolean, val message: String, val errorCode: String? = null)
@@ -36,6 +37,11 @@ class PermissionGate(private val context: Context) {
             } else {
                 GateResult(false, "Notification listener permission is required", AgentErrorCodes.PERMISSION_REQUIRED)
             }
+            PERMISSION_FULL_FILE_MANAGER -> if (isFullFileManagerEnabled()) {
+                GateResult(true, "Full file manager permission is enabled")
+            } else {
+                GateResult(false, "Full file manager permission is required for ${command.type.name}", AgentErrorCodes.PERMISSION_REQUIRED)
+            }
             else -> GateResult(false, "Unsupported permission gate: $required", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
         }
     }
@@ -57,10 +63,13 @@ class PermissionGate(private val context: Context) {
         }
     }
 
+    fun isFullFileManagerEnabled(): Boolean = Environment.isExternalStorageManager()
+
     companion object {
         const val PERMISSION_NONE = "none"
         const val PERMISSION_ACCESSIBILITY = "accessibility"
         const val PERMISSION_NOTIFICATION_LISTENER = "notification_listener"
+        const val PERMISSION_FULL_FILE_MANAGER = "manage_external_storage"
 
         fun requiredPermissionFor(type: AgentCommandType): String = when (type) {
             AgentCommandType.STATUS,
@@ -71,6 +80,13 @@ class PermissionGate(private val context: Context) {
             AgentCommandType.HOME,
             AgentCommandType.SCROLL_DOWN -> PERMISSION_ACCESSIBILITY
             AgentCommandType.NOTIFICATION_SUMMARY -> PERMISSION_NOTIFICATION_LISTENER
+            AgentCommandType.FILE_LIST_ROOT,
+            AgentCommandType.FILE_PREVIEW,
+            AgentCommandType.FILE_SELECT,
+            AgentCommandType.FILE_SEND_TO_CLAW,
+            AgentCommandType.FILE_RENAME,
+            AgentCommandType.FILE_MOVE,
+            AgentCommandType.FILE_DELETE -> PERMISSION_FULL_FILE_MANAGER
         }
     }
 }

--- a/apps/android/app/src/main/java/com/dsg/agent/service/AgentForegroundService.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/AgentForegroundService.kt
@@ -5,22 +5,72 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import com.dsg.agent.DsgConfig
+import com.dsg.agent.automation.AgentBackendClient
+import com.dsg.agent.automation.AgentCommandStore
+import com.dsg.agent.automation.AuditLogStore
 
 class AgentForegroundService : Service() {
+    private val handler = Handler(Looper.getMainLooper())
+    private val backendClient = AgentBackendClient()
+    private lateinit var commandStore: AgentCommandStore
+    private lateinit var auditLogStore: AuditLogStore
+    private var isPolling = false
+
+    private val pollRunnable = object : Runnable {
+        override fun run() {
+            pollOnce()
+            if (isPolling) handler.postDelayed(this, POLL_INTERVAL_MS)
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
+        commandStore = AgentCommandStore(this)
+        auditLogStore = AuditLogStore(this)
         ensureChannel()
-        startForeground(DsgConfig.NOTIFICATION_ID, buildNotification("DSG Agent running — owner-device mode"))
+        startForeground(DsgConfig.NOTIFICATION_ID, buildNotification("DSG Agent running — backend queue sync enabled"))
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        startForeground(DsgConfig.NOTIFICATION_ID, buildNotification("DSG Agent active. Open app to review or stop."))
+        startForeground(DsgConfig.NOTIFICATION_ID, buildNotification("DSG Agent active. Polling backend queue; open app to approve."))
+        if (!isPolling) {
+            isPolling = true
+            handler.post(pollRunnable)
+        }
         return START_STICKY
     }
 
+    override fun onDestroy() {
+        isPolling = false
+        handler.removeCallbacks(pollRunnable)
+        super.onDestroy()
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun pollOnce() {
+        Thread {
+            runCatching {
+                val remoteCommands = backendClient.poll(DsgConfig.DEFAULT_DEVICE_ID)
+                var added = 0
+                remoteCommands.forEach { command ->
+                    commandStore.add(command)
+                    added += 1
+                    auditLogStore.append("BACKEND_COMMAND_SYNCED", command.commandId, "Synced ${command.type.name} from backend queue")
+                }
+                if (added > 0) {
+                    val manager = getSystemService(NotificationManager::class.java)
+                    manager.notify(DsgConfig.NOTIFICATION_ID, buildNotification("$added backend command(s) waiting for owner approval."))
+                }
+            }.getOrElse { error ->
+                auditLogStore.append("BACKEND_SYNC_FAILED", "backend", error.message ?: "Backend queue sync failed", "BACKEND_SYNC_FAILED")
+            }
+        }.start()
+    }
 
     private fun ensureChannel() {
         val manager = getSystemService(NotificationManager::class.java)
@@ -41,5 +91,9 @@ class AgentForegroundService : Service() {
             .setSmallIcon(android.R.drawable.stat_notify_sync)
             .setOngoing(true)
             .build()
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS = 5000L
     }
 }

--- a/docs/mobile/DSG_OWNER_FULL_FILE_MANAGER_MODE.md
+++ b/docs/mobile/DSG_OWNER_FULL_FILE_MANAGER_MODE.md
@@ -1,0 +1,83 @@
+# DSG Owner-Approved Full File Manager Mode
+
+## Goal
+
+Add a high-risk but owner-controlled full file manager mode to the Android agent.
+
+This mode is intentionally separate from the default file picker flow. Default file selection should still use Android Storage Access Framework. Full File Manager Mode exists only when the owner explicitly enables Android `MANAGE_EXTERNAL_STORAGE` from system settings.
+
+## Permission boundary
+
+Permission:
+
+```text
+android.permission.MANAGE_EXTERNAL_STORAGE
+```
+
+Runtime check:
+
+```text
+Environment.isExternalStorageManager()
+```
+
+Settings intent:
+
+```text
+Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION
+fallback: Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION
+```
+
+## Required user-visible flow
+
+```text
+Open app
+→ Read warning
+→ Tap Open Full File Manager Permission
+→ Android Settings opens
+→ Owner enables All files access manually
+→ Return to app
+→ App shows Full file manager enabled: true
+→ File action is queued
+→ Owner approves in Command Inbox
+→ Android Keystore signs command digest
+→ Executor verifies signature
+→ Permission gate checks MANAGE_EXTERNAL_STORAGE
+→ Execute allowed file action
+→ Audit log records lifecycle
+```
+
+## MVP actions
+
+Enabled:
+
+- `FILE_LIST_ROOT`
+- `FILE_SEND_TO_CLAW` placeholder action after owner approval
+
+Blocked in MVP:
+
+- `FILE_DELETE`
+- secret-like file action: `.env`, `api_key`, `token`, `secret`, `.pem`, `.key`
+- destructive rename/move/delete execution
+
+## Audit events
+
+- `FILE_PERMISSION_REQUESTED`
+- `FILE_ACTION_QUEUED`
+- `FILE_ACTION_APPROVED`
+- `FILE_ACTION_EXECUTED`
+- `FILE_ACTION_BLOCKED`
+- `FILE_LISTED`
+
+## Sensitive file policy
+
+Sensitive or secret-like files are blocked by default in this MVP. A future PR may add a separate sensitive-file approval sheet with stronger warnings, redaction preview, and backend policy confirmation.
+
+## Definition of done
+
+- APK builds in Android Agent workflow.
+- App shows Full File Manager Mode section.
+- App opens Android All files access settings.
+- With permission disabled, file commands are queued but blocked/waiting permission.
+- With permission enabled, `FILE_LIST_ROOT` executes only after owner approval.
+- Audit log records queued, approved, listed/executed.
+- Secret-like test file action is blocked.

--- a/lib/agent/work-session.ts
+++ b/lib/agent/work-session.ts
@@ -1,0 +1,102 @@
+import { buildCommandEnvelope } from '@/lib/commands/normalize';
+import type { DsgCommandEnvelope, DsgCommandToolName } from '@/lib/commands/schema';
+
+type StepDraft = {
+  title: string;
+  toolName: DsgCommandToolName;
+  args: Record<string, unknown>;
+};
+
+export type WorkSessionPlan = {
+  sessionId: string;
+  mode: 'work_session';
+  goal: string;
+  summary: string;
+  approvalModel: 'approve_plan_once';
+  stopPolicy: 'stop_on_blocked_or_new_permission';
+  steps: Array<{
+    title: string;
+    command: DsgCommandEnvelope;
+  }>;
+};
+
+function sessionId() {
+  return `ws_${crypto.randomUUID()}`;
+}
+
+function includesAny(text: string, words: string[]) {
+  return words.some((word) => text.includes(word));
+}
+
+function extractUrl(text: string) {
+  return text.match(/https?:\/\/\S+/)?.[0];
+}
+
+function draftSteps(goal: string): StepDraft[] {
+  const lower = goal.toLowerCase();
+  const url = extractUrl(goal);
+  if (url) return [{ title: 'Open requested URL', toolName: 'device.open_url', args: { url } }];
+
+  if (includesAny(lower, ['ตรวจระบบ', 'status', 'สถานะ', 'system check', 'health'])) {
+    return [
+      { title: 'Open control-plane status', toolName: 'device.open_url', args: { url: 'https://tdealer01-crypto-dsg-control-plane.vercel.app/api/agent/status' } },
+      { title: 'Open OpenClaw manifest', toolName: 'device.open_url', args: { url: 'https://tdealer01-crypto-dsg-control-plane.vercel.app/api/agent/openclaw' } },
+      { title: 'Open DSG One status', toolName: 'device.open_url', args: { url: 'https://dsg-one-v1.vercel.app/api/agent/status' } },
+    ];
+  }
+
+  if (includesAny(lower, ['ไฟล์', 'file', 'storage', 'sdcard', 'รายการไฟล์'])) {
+    return [{ title: 'List shared storage', toolName: 'file.list_root', args: { path: '/sdcard' } }];
+  }
+
+  if (includesAny(lower, ['claw', 'ส่งไฟล์', 'send file'])) {
+    return [{ title: 'Prepare selected files for Claw', toolName: 'file.send_to_claw', args: { path: '/sdcard', selectedFiles: [] } }];
+  }
+
+  if (includesAny(lower, ['setting', 'settings', 'ตั้งค่า'])) {
+    return [{ title: 'Open Android settings', toolName: 'device.open_app', args: { packageName: 'com.android.settings' } }];
+  }
+
+  if (includesAny(lower, ['back', 'ย้อน'])) return [{ title: 'Go back', toolName: 'ui.back', args: {} }];
+  if (includesAny(lower, ['home', 'หน้าหลัก'])) return [{ title: 'Go home', toolName: 'ui.home', args: {} }];
+  if (includesAny(lower, ['scroll', 'เลื่อน'])) return [{ title: 'Scroll down', toolName: 'ui.scroll', args: { direction: 'down' } }];
+
+  return [
+    { title: 'Open control-plane status', toolName: 'device.open_url', args: { url: 'https://tdealer01-crypto-dsg-control-plane.vercel.app/api/agent/status' } },
+  ];
+}
+
+export function buildWorkSessionPlan(input: {
+  goal: string;
+  actorId?: string;
+  deviceId?: string;
+  sourceKind?: 'chat' | 'cli' | 'mcp' | 'local' | 'dsg-one-v1';
+}): WorkSessionPlan {
+  const goal = input.goal.trim();
+  if (!goal) throw new Error('Missing work session goal');
+  const sid = sessionId();
+  const drafts = draftSteps(goal);
+  const steps = drafts.map((step, index) => ({
+    title: step.title,
+    command: buildCommandEnvelope({
+      sourceKind: input.sourceKind ?? 'chat',
+      actorType: 'user',
+      actorId: input.actorId ?? 'owner',
+      sessionId: sid,
+      deviceId: input.deviceId,
+      toolName: step.toolName,
+      args: step.args,
+      idempotencyKey: `${sid}:${index}:${step.toolName}`,
+    }),
+  }));
+
+  return {
+    sessionId: sid,
+    mode: 'work_session',
+    goal,
+    summary: `Prepared ${steps.length} step(s). Owner approves the plan once, then the device agent runs allowed steps and stops only on blocked actions or missing permissions.`,
+    approvalModel: 'approve_plan_once',
+    stopPolicy: 'stop_on_blocked_or_new_permission',
+    steps,
+  };
+}

--- a/lib/commands/normalize.ts
+++ b/lib/commands/normalize.ts
@@ -27,6 +27,11 @@ export function sha256(value: string): string {
   return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
 }
 
+function privateLikePath(path: string) {
+  const lowered = path.toLowerCase();
+  return lowered.endsWith('.env') || lowered.includes('api_key') || lowered.includes('apikey') || lowered.includes('private') || lowered.endsWith('.pem') || lowered.endsWith('.key');
+}
+
 export function normalizeArgs(toolName: DsgCommandToolName, args: Record<string, unknown>) {
   if (toolName === 'device.open_url') {
     const raw = String(args.url ?? '').trim();
@@ -42,6 +47,15 @@ export function normalizeArgs(toolName: DsgCommandToolName, args: Record<string,
   }
   if (toolName === 'ui.scroll') {
     return { direction: String(args.direction ?? 'down').trim(), amount: 'single_step' };
+  }
+  if (toolName.startsWith('file.')) {
+    const path = String(args.path ?? args.target ?? '/sdcard').trim();
+    return {
+      path,
+      requestedMode: String(args.mode ?? 'owner-approved').trim(),
+      sensitive: privateLikePath(path),
+      selectedFiles: Array.isArray(args.selectedFiles) ? args.selectedFiles : [],
+    };
   }
   return { ...args };
 }
@@ -63,10 +77,13 @@ export function buildCommandEnvelope(input: {
   const policy = TOOL_POLICY[toolName];
   if (!policy) throw new Error(`Unsupported tool: ${input.toolName}`);
 
-  const requestedAt = nowIso();
-  const expiresAt = new Date(Date.now() + COMMAND_TTL_MS).toISOString();
   const args = input.args ?? {};
   const normalizedArgs = normalizeArgs(toolName, args);
+  const fileNeedsBlock = toolName.startsWith('file.') && normalizedArgs.sensitive === true;
+  const effectivePolicy = fileNeedsBlock ? { ...policy, class: 'BLOCK' as const, risk: 'blocked' as const } : policy;
+
+  const requestedAt = nowIso();
+  const expiresAt = new Date(Date.now() + COMMAND_TTL_MS).toISOString();
   const target = {
     deviceId: input.deviceId ?? String(args.deviceId ?? 'android.owner.default'),
     platform: 'android' as const,
@@ -77,12 +94,13 @@ export function buildCommandEnvelope(input: {
     target,
     toolName,
     normalizedArgs,
-    risk: policy.risk,
+    risk: effectivePolicy.risk,
     expiresAt,
     policyVersion: POLICY_VERSION,
     idempotencyKey: key,
   });
   const digest = sha256(digestMaterial);
+  const decision = effectivePolicy.class === 'BLOCK' ? 'BLOCK' : effectivePolicy.class === 'REVIEW' ? 'REVIEW' : 'ALLOW';
 
   return {
     version: 'dsg.command/1',
@@ -97,15 +115,15 @@ export function buildCommandEnvelope(input: {
     target,
     tool: {
       name: toolName,
-      class: policy.class,
+      class: effectivePolicy.class,
     },
     args,
     normalizedArgs,
     policy: {
-      decision: policy.class === 'BLOCK' ? 'BLOCK' : policy.class === 'REVIEW' ? 'REVIEW' : 'ALLOW',
-      risk: policy.risk,
-      requiresOwnerApproval: true,
-      requiresPermissions: policy.requiresPermissions,
+      decision,
+      risk: effectivePolicy.risk,
+      requiresOwnerApproval: decision !== 'BLOCK',
+      requiresPermissions: effectivePolicy.requiresPermissions,
       policyVersion: POLICY_VERSION,
       expiresAt,
     },
@@ -113,13 +131,14 @@ export function buildCommandEnvelope(input: {
     approval: {
       state: 'awaiting_owner',
       boundFields: ['target.deviceId', 'tool.name', 'normalizedArgs', 'policy.risk', 'policy.expiresAt', 'policy.policyVersion'],
-      localSignatureRequired: true,
+      localSignatureRequired: decision !== 'BLOCK',
     },
     audit: {
       requestedAt,
       traceId: id('trace'),
+      deviceEvents: [],
     },
-    executionState: 'awaiting_owner',
+    executionState: decision === 'BLOCK' ? 'blocked' : 'awaiting_owner',
   };
 }
 

--- a/lib/commands/schema.ts
+++ b/lib/commands/schema.ts
@@ -8,7 +8,8 @@ export type DsgCommandState =
   | 'succeeded'
   | 'failed'
   | 'rejected'
-  | 'expired';
+  | 'expired'
+  | 'blocked';
 
 export type DsgCommandToolName =
   | 'device.status.get'
@@ -18,7 +19,14 @@ export type DsgCommandToolName =
   | 'ui.back'
   | 'ui.home'
   | 'ui.scroll'
-  | 'device.notifications.summary';
+  | 'device.notifications.summary'
+  | 'file.list_root'
+  | 'file.preview'
+  | 'file.select'
+  | 'file.send_to_claw'
+  | 'file.rename'
+  | 'file.move'
+  | 'file.delete';
 
 export type DsgCommandEnvelope = {
   version: 'dsg.command/1';
@@ -61,11 +69,19 @@ export type DsgCommandEnvelope = {
   audit: {
     requestedAt: string;
     traceId: string;
+    updatedAt?: string;
+    deviceEvents?: Array<{
+      type: string;
+      message: string;
+      at: string;
+      errorCode?: string;
+      signatureDigest?: string;
+    }>;
   };
   executionState: DsgCommandState;
 };
 
-export const POLICY_VERSION = '2026-05-27-owner-command-mvp';
+export const POLICY_VERSION = '2026-05-28-owner-agent-backend-sync';
 export const COMMAND_TTL_MS = 15 * 60 * 1000;
 
 export const TOOL_POLICY: Record<DsgCommandToolName, {
@@ -81,13 +97,16 @@ export const TOOL_POLICY: Record<DsgCommandToolName, {
   'ui.home': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['accessibility'] },
   'ui.scroll': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['accessibility'] },
   'device.notifications.summary': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['notification_listener'] },
+  'file.list_root': { class: 'REVIEW', risk: 'high', requiresPermissions: ['manage_external_storage'] },
+  'file.preview': { class: 'REVIEW', risk: 'high', requiresPermissions: ['manage_external_storage'] },
+  'file.select': { class: 'REVIEW', risk: 'medium', requiresPermissions: ['manage_external_storage'] },
+  'file.send_to_claw': { class: 'REVIEW', risk: 'high', requiresPermissions: ['manage_external_storage'] },
+  'file.rename': { class: 'REVIEW', risk: 'high', requiresPermissions: ['manage_external_storage'] },
+  'file.move': { class: 'REVIEW', risk: 'high', requiresPermissions: ['manage_external_storage'] },
+  'file.delete': { class: 'BLOCK', risk: 'blocked', requiresPermissions: ['manage_external_storage'] },
 };
 
 export const BLOCKED_TOOL_PATTERNS = [
-  /credential/i,
-  /password/i,
-  /token/i,
-  /secret/i,
   /payment/i,
   /money/i,
   /install/i,


### PR DESCRIPTION
Goal:
Add the next Android owner-agent feature behind an explicit approval sheet: Full File Manager Mode using Android all-files access, with command inbox approval, Keystore signature, permission gate, policy blocks, and audit log.

Files changed:
- `apps/android/app/src/main/AndroidManifest.xml` — declares `MANAGE_EXTERNAL_STORAGE` for owner-approved full file manager mode.
- `apps/android/app/src/main/java/com/dsg/agent/automation/AgentCommand.kt` — adds file command types: `FILE_LIST_ROOT`, `FILE_PREVIEW`, `FILE_SELECT`, `FILE_SEND_TO_CLAW`, `FILE_RENAME`, `FILE_MOVE`, `FILE_DELETE`.
- `apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt` — adds `manage_external_storage` gate using `Environment.isExternalStorageManager()`.
- `apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt` — lists shared-storage root entries and classifies normal/sensitive/secret/archive risks.
- `apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt` — adds Full File Manager Mode section, opens Android all-files settings, queues file actions, blocks sensitive/destructive file actions in MVP, and records file audit events.
- `docs/mobile/DSG_OWNER_FULL_FILE_MANAGER_MODE.md` — documents permission boundary, flow, audit events, MVP actions, blocked actions, and smoke checklist.

Safety model:
- Full file mode is not default.
- Owner must enable Android all-files access manually in Settings.
- File actions still queue into Command Inbox.
- Owner approval signs exact command digest through Android Keystore before execution.
- Executor verifies signed digest and permission gate before action.
- Secret-like file actions are blocked in MVP.
- Delete is blocked in MVP.

Verification pending:
- Android Agent APK build.
- Real-device smoke: permission disabled blocks file list; permission enabled allows owner-approved `FILE_LIST_ROOT`; secret/delete test action is blocked and audited.