### PR TITLE
feat(ccvs): raise coverage thresholds to Phase-1 targets, add control catalog and evidence schema

### DIFF
--- a/.github/workflows/ccvs-evidence.yml
+++ b/.github/workflows/ccvs-evidence.yml
@@ -1,0 +1,96 @@
+name: ccvs-evidence
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-evidence:
+    name: Emit CCVS unit evidence envelope
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Emit evidence envelope
+        id: emit
+        run: |
+          node - <<'JSEOF'
+          const fs = require('fs');
+          const crypto = require('crypto');
+
+          let coverage = {};
+          try {
+            const summary = JSON.parse(fs.readFileSync('coverage/coverage-summary.json', 'utf8'));
+            const t = summary.total;
+            coverage = {
+              lines: t.lines.pct,
+              branches: t.branches.pct,
+              functions: t.functions.pct,
+              statements: t.statements.pct
+            };
+          } catch (e) {
+            console.warn('coverage-summary.json not found – coverage metrics will be empty:', e.message);
+          }
+
+          const envelope = {
+            schema_version: '1.0.0',
+            evidence_type: 'unit',
+            subject: [{
+              name: 'repo:' + process.env.GITHUB_REPOSITORY,
+              digest: { sha1: process.env.GITHUB_SHA }
+            }],
+            run: {
+              repo: process.env.GITHUB_REPOSITORY,
+              commit: process.env.GITHUB_SHA,
+              ref: process.env.GITHUB_REF,
+              workflow_run_id: process.env.GITHUB_RUN_ID,
+              builder_id: 'https://github.com/actions/runner',
+              invocation_id: process.env.GITHUB_RUN_ID + '-' + (process.env.GITHUB_RUN_ATTEMPT || '1')
+            },
+            oidc: {
+              issuer: 'https://token.actions.githubusercontent.com',
+              audience: 'ccvs-evidence',
+              sub: 'repo:' + process.env.GITHUB_REPOSITORY + ':ref:' + process.env.GITHUB_REF,
+              repository: process.env.GITHUB_REPOSITORY,
+              ref: process.env.GITHUB_REF
+            },
+            metrics: { coverage },
+            integrity: {
+              previous_chain_hash: '',
+              chain_hash: ''
+            },
+            policy_version: 'v1',
+            generated_at: new Date().toISOString()
+          };
+
+          const raw = JSON.stringify(envelope, null, 2);
+          const digest = crypto.createHash('sha256').update(raw).digest('hex');
+          envelope.integrity.chain_hash = 'sha256:' + digest;
+
+          const out = JSON.stringify(envelope, null, 2);
+          fs.writeFileSync('ccvs-unit-evidence.json', out);
+          console.log('Evidence chain_hash: sha256:' + digest);
+          console.log('Coverage:', JSON.stringify(coverage));
+          JSEOF
+
+      - name: Upload evidence artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccvs-unit-evidence-${{ github.run_id }}
+          path: ccvs-unit-evidence.json
+          retention-days: 90
+          if-no-files-found: warn

--- a/docs/ccvs/control-catalog.json
+++ b/docs/ccvs/control-catalog.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "1.0.0",
+  "catalog_id": "ccvs-control-catalog",
+  "last_updated": "2026-05-28",
+  "description": "CCVS control catalog. Maps governance controls to requirements and evidence types. Every production claim gate must trace back to at least one control in this catalog with current signed evidence.",
+  "controls": [
+    {
+      "id": "CTRL-001",
+      "family": "software-supply-chain",
+      "name": "Build Provenance",
+      "description": "Every production artifact must have SLSA-aligned build provenance signed by the hosted build platform.",
+      "requirements": ["SLSA-BUILD-L2", "SLSA-BUILD-L3"],
+      "evidence_type": "provenance",
+      "owner": "platform-team",
+      "frequency": "per-release",
+      "acceptance_criteria": "provenance.json exists; subject digest matches release artifact; builder_id is an expected hosted runner; cosign verify-blob passes with expected identity and issuer",
+      "corrective_action_status": "pending-implementation"
+    },
+    {
+      "id": "CTRL-002",
+      "family": "testing",
+      "name": "Unit Test Evidence",
+      "description": "All production code must have signed unit test evidence meeting per-repo coverage thresholds.",
+      "requirements": ["ISO42001-A.6.2", "NIST-AI-RMF-MEASURE"],
+      "evidence_type": "unit",
+      "owner": "engineering",
+      "frequency": "per-commit",
+      "acceptance_criteria": "tests_passed > 0; coverage.lines >= threshold; signed Sigstore bundle exists; chain_hash continuous from previous run",
+      "corrective_action_status": "in-progress"
+    },
+    {
+      "id": "CTRL-003",
+      "family": "testing",
+      "name": "Integration Test Evidence",
+      "description": "Critical integration paths must have signed integration test evidence with masked external interactions.",
+      "requirements": ["ISO42001-A.6.2", "NIST-AI-RMF-MEASURE"],
+      "evidence_type": "integration",
+      "owner": "engineering",
+      "frequency": "per-commit",
+      "acceptance_criteria": "decision_trace present; service_graph_ref present; masked_requests logged; chain_hash continuous",
+      "corrective_action_status": "pending-implementation"
+    },
+    {
+      "id": "CTRL-004",
+      "family": "testing",
+      "name": "Adversarial and Replay Test Evidence",
+      "description": "Gate and security-critical paths must pass adversarial and replay tests with detection latency within bounds.",
+      "requirements": ["EU-AI-ACT-ART9", "NIST-AI-RMF-GOVERN"],
+      "evidence_type": "adversarial",
+      "owner": "security-team",
+      "frequency": "per-release",
+      "acceptance_criteria": "all attack vectors pass; replay nonce rejected with detection_latency_ms < 1000; replay_store_hit confirmed",
+      "corrective_action_status": "pending-implementation"
+    },
+    {
+      "id": "CTRL-005",
+      "family": "human-oversight",
+      "name": "Human Oversight Record",
+      "description": "High-severity decisions must have a signed oversight record with segregation-of-duties verification.",
+      "requirements": ["EU-AI-ACT-ART14", "ISO42001-A.4.3"],
+      "evidence_type": "oversight",
+      "owner": "governance-team",
+      "frequency": "per-high-severity-decision",
+      "acceptance_criteria": "approver_identity present; approver_identity != requester_identity (SoD); competence_ref valid; signed bundle exists and verifies",
+      "corrective_action_status": "pending-implementation"
+    },
+    {
+      "id": "CTRL-006",
+      "family": "sbom",
+      "name": "Software Bill of Materials",
+      "description": "Every release must have an SBOM meeting NTIA minimum elements in SPDX or CycloneDX format bound to the release digest.",
+      "requirements": ["NTIA-SBOM-MIN", "EU-AI-ACT-ART12"],
+      "evidence_type": "sbom",
+      "owner": "platform-team",
+      "frequency": "per-release",
+      "acceptance_criteria": "SPDX or CycloneDX schema validates; supplier/name/version/identifier/dependency/author/timestamp all present; SBOM digest bound to release artifact digest",
+      "corrective_action_status": "pending-implementation"
+    },
+    {
+      "id": "CTRL-007",
+      "family": "immutable-retention",
+      "name": "Immutable Evidence Retention",
+      "description": "Production evidence must be uploaded to WORM-compliant object storage with verifiable retention receipts.",
+      "requirements": ["EU-AI-ACT-ART12", "ISO42001-A.9.1"],
+      "evidence_type": "unit",
+      "owner": "platform-team",
+      "frequency": "per-commit",
+      "acceptance_criteria": "Object Lock COMPLIANCE mode enabled; Retain-Until-Date set per retention policy; upload receipt retrievable and matches object version ID",
+      "corrective_action_status": "pending-implementation"
+    },
+    {
+      "id": "CTRL-008",
+      "family": "testing",
+      "name": "Mutation Testing Gate",
+      "description": "Critical governance paths must pass mutation score thresholds before a Claim Passed gate is asserted.",
+      "requirements": ["NIST-AI-RMF-MEASURE", "ISO42001-A.6.2"],
+      "evidence_type": "mutation",
+      "owner": "engineering",
+      "frequency": "per-release",
+      "acceptance_criteria": "mutation_score >= 95 for proof/hash/replay paths; >= 90 for gate/governance/command paths; signed mutation evidence bundle exists",
+      "corrective_action_status": "pending-implementation"
+    }
+  ],
+  "requirement_registry": {
+    "ISO42001-A.6.2": "ISO/IEC 42001:2023 Annex A, Control A.6.2 – AI system testing",
+    "ISO42001-A.4.3": "ISO/IEC 42001:2023 Annex A, Control A.4.3 – Human oversight of AI systems",
+    "ISO42001-A.9.1": "ISO/IEC 42001:2023 Annex A, Control A.9.1 – Record-keeping",
+    "NIST-AI-RMF-MEASURE": "NIST AI RMF 1.0 – MEASURE function",
+    "NIST-AI-RMF-GOVERN": "NIST AI RMF 1.0 – GOVERN function",
+    "EU-AI-ACT-ART9": "EU AI Act Article 9 – Risk management system",
+    "EU-AI-ACT-ART12": "EU AI Act Article 12 – Record-keeping",
+    "EU-AI-ACT-ART14": "EU AI Act Article 14 – Human oversight",
+    "SLSA-BUILD-L2": "SLSA v1.0 Build Track Level 2 – hosted build platform provenance",
+    "SLSA-BUILD-L3": "SLSA v1.0 Build Track Level 3 – hardened builds",
+    "NTIA-SBOM-MIN": "NTIA SBOM Minimum Elements (2021)"
+  }
+}

--- a/docs/ccvs/evidence-schema.json
+++ b/docs/ccvs/evidence-schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dsg.one/schemas/ccvs/evidence-envelope/v1",
+  "title": "CCVS Evidence Envelope v1.0.0",
+  "description": "Canonical evidence envelope for CCVS governance records. Aligned with in-toto Statement/v1 subject+predicate model. Use predicateType to distinguish artifact classes. All fields under 'integrity' must reference verifiable external bundles before a Claim Passed gate can be asserted.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "evidence_type",
+    "subject",
+    "run",
+    "oidc",
+    "metrics",
+    "integrity",
+    "generated_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "evidence_type": {
+      "type": "string",
+      "enum": ["unit", "integration", "adversarial", "replay", "oversight", "sbom", "provenance", "mutation"],
+      "description": "Classifies the artifact type. Determines which predicate namespace to use when wrapping in an in-toto Statement."
+    },
+    "subject": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "digest"],
+        "properties": {
+          "name": { "type": "string" },
+          "digest": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "run": {
+      "type": "object",
+      "required": ["repo", "commit", "workflow_run_id", "builder_id", "invocation_id"],
+      "properties": {
+        "repo": { "type": "string" },
+        "commit": { "type": "string", "minLength": 7 },
+        "ref": { "type": "string" },
+        "workflow_run_id": { "type": "string" },
+        "builder_id": { "type": "string" },
+        "invocation_id": { "type": "string" },
+        "runner_os": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "oidc": {
+      "type": "object",
+      "required": ["issuer", "audience", "sub"],
+      "properties": {
+        "issuer": { "type": "string", "format": "uri" },
+        "audience": { "type": "string" },
+        "sub": { "type": "string" },
+        "repository": { "type": "string" },
+        "ref": { "type": "string" },
+        "environment": { "type": "string" },
+        "jti": { "type": "string", "description": "JWT ID – used for nonce/replay-cache lookup." }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "tests_total": { "type": "integer", "minimum": 0 },
+        "tests_passed": { "type": "integer", "minimum": 0 },
+        "tests_failed": { "type": "integer", "minimum": 0 },
+        "coverage": {
+          "type": "object",
+          "properties": {
+            "lines": { "type": "number", "minimum": 0, "maximum": 100 },
+            "branches": { "type": "number", "minimum": 0, "maximum": 100 },
+            "functions": { "type": "number", "minimum": 0, "maximum": 100 },
+            "statements": { "type": "number", "minimum": 0, "maximum": 100 }
+          },
+          "additionalProperties": false
+        },
+        "mutation_score": { "type": "number", "minimum": 0, "maximum": 100 },
+        "duration_ms": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "integrity": {
+      "type": "object",
+      "required": ["chain_hash"],
+      "properties": {
+        "previous_chain_hash": {
+          "type": "string",
+          "description": "Chain hash of the immediately preceding evidence envelope. Empty string for the first record."
+        },
+        "chain_hash": {
+          "type": "string",
+          "description": "SHA-256 of the canonicalized envelope (excluding this field). Signed by Cosign/Sigstore."
+        },
+        "sbom_ref": { "type": "string", "description": "Path or URI to the accompanying SBOM file." },
+        "bundle_ref": { "type": "string", "description": "Path or URI to the Sigstore bundle (.sigstore.json)." },
+        "verification_policy_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "policy_version": { "type": "string" },
+    "nonce": { "type": "string", "description": "Single-use nonce for replay-attack prevention." },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "generated_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,13 +35,15 @@ export default defineConfig({
         '**/*.d.ts',
       ],
       thresholds: {
-        lines: 20,
-        functions: 45,
-        branches: 20,
-        statements: 20,
-        // Revenue-critical paths have higher per-file floors (enforced via CI comments)
-        // lib/billing/*:    ~88% lines (entitlements 100%, fulfillment 93%, overage 71%)
-        // lib/usage/*:      100% lines (quota.ts fully covered)
+        // Phase-1 targets (raised from 20/45/20/20 per CCVS compliance gap remediation).
+        // Phase-2: 75/80/70/75. Phase-3: 85/90/80/85.
+        // Critical governance paths target ≥90/90/85/90 as per-file floors in Phase-2:
+        //   lib/gate/**, lib/governance/**, lib/commands/**, lib/executors/**,
+        //   lib/model-provider/**, lib/deployment/**, lib/billing/**, lib/usage/**
+        lines: 60,
+        functions: 65,
+        branches: 55,
+        statements: 60,
       },
     },
   },


### PR DESCRIPTION
Addresses CCVS spec compliance gaps for the governance control plane:
- vitest.config.ts: raise global thresholds from 20/45/20/20 to Phase-1
  60/65/55/60 (lines/functions/branches/statements). Comment documents
  Phase-2/3 milestones and identifies critical governance paths
  (lib/gate, lib/governance, lib/commands, lib/executors, lib/model-provider,
  lib/deployment, lib/billing, lib/usage) as per-file floor candidates
  in Phase-2. The prior 20% floor was insufficient for a governance layer.
- docs/ccvs/evidence-schema.json: same canonical evidence envelope schema
  shared across all three repos (in-toto-aligned, Sigstore-ready)
- docs/ccvs/control-catalog.json: 8-control catalog (CTRL-001..008)
  mapping to ISO 42001, NIST AI RMF, EU AI Act, SLSA, NTIA requirements
- .github/workflows/ccvs-evidence.yml: workflow emitting evidence envelopes
  with per-run retention as foundation for the immutable custody pipeline