### PR TITLE
chore: add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: tdealer01-crypto


### PR DESCRIPTION
Adds `.github/FUNDING.yml` to show a "Sponsor" button on the repository page once GitHub Sponsors is approved for the account.

```yaml
github: tdealer01-crypto
```

**Next step:** Apply for GitHub Sponsors at https://github.com/sponsors — button will appear automatically after approval.

https://claude.ai/code/session_0118FXD4ZxyNcSUuF5gF7Wqj

---
_Generated by [Claude Code](https://claude.ai/code/session_0118FXD4ZxyNcSUuF5gF7Wqj)_