### PR TITLE
fix(harmonic-engine): signal spread entropy — UNITY for coherent high signals

### DIFF
--- a/lib/harmonic-engine.ts
+++ b/lib/harmonic-engine.ts
@@ -56,17 +56,20 @@ function weightedHarmonicMean(signals: Signal[]): number {
   return totalWeight / denom;
 }
 
-function shannonEntropy(signals: Signal[]): number {
-  const weightedSum = signals.reduce((s, sig) => s + sig.weight * sig.value, 0);
-  if (weightedSum === 0) return 1;
-  let h = 0;
-  for (const sig of signals) {
-    const p = (sig.weight * sig.value) / weightedSum;
-    if (p > 0) h -= p * Math.log2(p);
-  }
-  // Normalize to 0–1 using max entropy = log2(n)
-  const maxH = Math.log2(Math.max(signals.length, 2));
-  return Math.min(h / maxH, 1);
+/**
+ * Signal spread entropy — measures how scattered values are, not their distribution.
+ * Low spread (all signals similar & high) → low entropy → UNITY.
+ * High spread (signals diverge across 0–1 range) → high entropy → CHAOS.
+ *
+ * Formula: weighted std-dev of values, normalised by max possible std-dev (0.5).
+ */
+function signalSpreadEntropy(signals: Signal[]): number {
+  const totalWeight = signals.reduce((s, sig) => s + sig.weight, 0);
+  if (totalWeight === 0) return 1;
+  const mean = signals.reduce((s, sig) => s + sig.weight * sig.value, 0) / totalWeight;
+  const variance = signals.reduce((s, sig) => s + sig.weight * (sig.value - mean) ** 2, 0) / totalWeight;
+  // Max std-dev for values in [0,1] is 0.5 — normalise to [0,1]
+  return Math.min(Math.sqrt(variance) / 0.5, 1);
 }
 
 function detectPhase(confidence: number, entropy: number, config: ProfileConfig): Phase {
@@ -98,7 +101,7 @@ export class HarmonicEngine {
     }
 
     const confidence = weightedHarmonicMean(signals);
-    const entropy = shannonEntropy(signals);
+    const entropy = signalSpreadEntropy(signals);
 
     // Apply memory penalty: if recent evaluations were unstable, raise entropy
     const adjustedEntropy = this._memoryAdjustedEntropy(entropy);


### PR DESCRIPTION
Goal:
Fix entropy calculation so coherent high-value signals (0.85/0.78/0.92) correctly produce UNITY phase instead of CHAOS.

Root cause:
Old `shannonEntropy()` treated signals as a probability distribution — when all values were high and similar, the distribution was near-uniform → entropy≈1 → CHAOS. This is the wrong model: high uniform signals should mean *low* uncertainty.

Fix:
`signalSpreadEntropy()` — weighted std-dev of values, normalised by 0.5 (max possible std-dev in [0,1]).

Verification:
- [x] Good signals (0.85/0.78/0.92) → entropy **0.117** → UNITY → `allow_execute: true`
- [x] Bad signals (0.1/0.9/0.5) → entropy **0.653** → CHAOS → `allow_execute: false`
- [x] `npx tsc --noEmit` — 0 errors
- [ ] Production smoke: pending merge

https://claude.ai/code/session_0118FXD4ZxyNcSUuF5gF7Wqj

---
_Generated by [Claude Code](https://claude.ai/code/session_0118FXD4ZxyNcSUuF5gF7Wqj)_