### PR TITLE
feat: Owner Autonomous Mode + DadBot AI Chat (Claude Haiku real-time)

### DIFF
--- a/app/api/agent/chat/route.ts
+++ b/app/api/agent/chat/route.ts
@@ -1,0 +1,181 @@
+// DadBot streaming chat endpoint — proxies to Anthropic Claude with DSG command tools
+import { NextRequest } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const SYSTEM_PROMPT = `คุณคือ DadBot (แดดบอท) ผู้ช่วย AI ของ DSG Agent บน Android ของเจ้าของ
+คุณช่วยเจ้าของควบคุมเครื่อง Android ผ่านคำสั่งภาษาธรรมชาติ ทั้งภาษาไทยและอังกฤษ
+
+คำสั่งที่คุณสั่งบนเครื่องได้:
+- OPEN_URL: เปิด URL (target = URL เต็ม เช่น https://youtube.com)
+- OPEN_APP: เปิดแอป (target = package name เช่น com.android.settings)
+- OPEN_SETTINGS: เปิด Android Settings
+- BACK: กดปุ่ม Back
+- HOME: กดปุ่ม Home
+- SCROLL_DOWN: เลื่อนหน้าจอลง
+- STATUS: ดูสถานะระบบ
+- FILE_LIST_ROOT: แสดงรายการไฟล์ใน storage
+- FILE_PREVIEW: ดูเนื้อหาไฟล์ (target = file path)
+- FILE_RENAME: เปลี่ยนชื่อ (target = "path||newName")
+- FILE_MOVE: ย้ายไฟล์ (target = "path||destDir")
+- FILE_DELETE: ลบไฟล์ (target = file path)
+
+กฎ:
+- ตอบสั้น กระชับ ใช้ภาษาเดียวกับผู้ใช้
+- เมื่อผู้ใช้สั่งให้ทำอะไรบนเครื่อง ให้ใช้ tool queue_command ทันที ไม่ต้องถามซ้ำ
+- แจ้งผู้ใช้สั้น ๆ ว่ากำลังทำอะไร แล้วค่อย call tool`;
+
+const DSG_TOOLS = [
+  {
+    name: 'queue_command',
+    description: "Queue a command for immediate execution on the owner's Android device",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        command_type: {
+          type: 'string',
+          enum: [
+            'OPEN_URL', 'OPEN_APP', 'OPEN_SETTINGS', 'BACK', 'HOME', 'SCROLL_DOWN',
+            'STATUS', 'FILE_LIST_ROOT', 'FILE_PREVIEW', 'FILE_RENAME', 'FILE_MOVE', 'FILE_DELETE',
+          ],
+        },
+        target: { type: 'string', description: 'Target for the command (URL, package, path, etc.)' },
+        reason: { type: 'string', description: 'Short human-readable reason' },
+      },
+      required: ['command_type', 'target', 'reason'],
+    },
+  },
+];
+
+export async function GET() {
+  return Response.json({
+    ok: true,
+    endpoint: 'POST /api/agent/chat',
+    body: '{ messages: [{role: "user"|"assistant", content: string}] }',
+    stream: 'text/event-stream — {"type":"text","delta":"..."} | {"type":"command",...} | {"type":"done"} | {"type":"error",...}',
+    model: 'claude-opus-4-8',
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return sseError('ANTHROPIC_API_KEY not configured on server');
+  }
+
+  let messages: { role: string; content: string }[] = [];
+  try {
+    const body = await request.json();
+    messages = Array.isArray(body.messages) ? body.messages : [];
+  } catch {
+    return sseError('Invalid JSON body');
+  }
+
+  if (messages.length === 0) return sseError('messages array is empty');
+
+  let anthropicRes: Response;
+  try {
+    anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-8',
+        max_tokens: 1024,
+        stream: true,
+        system: SYSTEM_PROMPT,
+        tools: DSG_TOOLS,
+        messages,
+      }),
+    });
+  } catch (e) {
+    return sseError(`Failed to reach Anthropic API: ${e instanceof Error ? e.message : e}`);
+  }
+
+  if (!anthropicRes.ok || !anthropicRes.body) {
+    const errText = await anthropicRes.text().catch(() => '');
+    return sseError(`Anthropic ${anthropicRes.status}: ${errText.slice(0, 200)}`);
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const emit = (obj: unknown) =>
+        controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+
+      const reader = anthropicRes.body!.getReader();
+      const dec = new TextDecoder();
+      let buf = '';
+      let toolBuf: { name: string; input: string } | null = null;
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += dec.decode(value, { stream: true });
+          const lines = buf.split('\n');
+          buf = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const raw = line.slice(6).trim();
+            if (!raw || raw === '[DONE]') continue;
+            let ev: Record<string, unknown>;
+            try { ev = JSON.parse(raw); } catch { continue; }
+
+            const t = ev.type as string;
+            if (t === 'content_block_start') {
+              const block = ev.content_block as Record<string, unknown> | undefined;
+              if (block?.type === 'tool_use') {
+                toolBuf = { name: block.name as string, input: '' };
+              }
+            } else if (t === 'content_block_delta') {
+              const delta = ev.delta as Record<string, unknown> | undefined;
+              if (delta?.type === 'text_delta') {
+                emit({ type: 'text', delta: delta.text });
+              } else if (delta?.type === 'input_json_delta' && toolBuf) {
+                toolBuf.input += delta.partial_json as string;
+              }
+            } else if (t === 'content_block_stop' && toolBuf) {
+              let args: Record<string, unknown> = {};
+              try { args = JSON.parse(toolBuf.input || '{}'); } catch { /* skip */ }
+              emit({
+                type: 'command',
+                commandType: args.command_type ?? 'STATUS',
+                target: args.target ?? '',
+                reason: args.reason ?? toolBuf.name,
+              });
+              toolBuf = null;
+            } else if (t === 'message_stop') {
+              emit({ type: 'done' });
+            }
+          }
+        }
+        emit({ type: 'done' });
+      } catch (e) {
+        emit({ type: 'error', message: e instanceof Error ? e.message : 'Stream read error' });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}
+
+function sseError(message: string): Response {
+  const body = `data: ${JSON.stringify({ type: 'error', message })}\n\ndata: {"type":"done"}\n\n`;
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}

--- a/app/api/agent/chat/route.ts
+++ b/app/api/agent/chat/route.ts
@@ -53,7 +53,7 @@ export async function GET() {
     endpoint: 'POST /api/agent/chat',
     body: '{ messages: [{role: "user"|"assistant", content: string}] }',
     stream: 'text/event-stream — {"type":"text","delta":"..."} | {"type":"command",...} | {"type":"done"} | {"type":"error",...}',
-    model: 'claude-opus-4-8',
+    model: 'claude-haiku-4-5-20251001',
   });
 }
 
@@ -83,7 +83,7 @@ export async function POST(request: NextRequest) {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'claude-opus-4-8',
+        model: 'claude-haiku-4-5-20251001',
         max_tokens: 1024,
         stream: true,
         system: SYSTEM_PROMPT,

--- a/app/api/agent/commands/route.ts
+++ b/app/api/agent/commands/route.ts
@@ -109,6 +109,13 @@ export async function POST(request: NextRequest) {
       index.delete(command.idempotency.key);
     }
 
+    // X-DSG-Autonomous: true — owner pre-authorised; mark command approved for instant Android execution
+    if (request.headers.get('X-DSG-Autonomous') === 'true') {
+      command.executionState = 'approved';
+      command.approval.state = 'approved';
+      command.audit.updatedAt = new Date().toISOString();
+    }
+
     queue().set(command.commandId, command);
     index.set(command.idempotency.key, command.commandId);
 

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -45,6 +45,9 @@ class MainActivity : Activity() {
 
     private var fileListRendered = false
     private var workSessionEnabled = false
+    private var autonomousModeEnabled: Boolean
+        get() = getSharedPreferences("dsg_prefs", MODE_PRIVATE).getBoolean("autonomous_mode", false)
+        set(value) { getSharedPreferences("dsg_prefs", MODE_PRIVATE).edit().putBoolean("autonomous_mode", value).apply() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -69,6 +72,7 @@ class MainActivity : Activity() {
         }
         addHero(root)
         addTabs(root)
+        addAutonomousModeCard(root)
         addNoCodeChat(root)
         addWorkSessionCard(root)
         addFileManagerCard(root)
@@ -167,6 +171,44 @@ class MainActivity : Activity() {
         row.addView(compactButton("Clear", ButtonTone.SECONDARY) { chatInput.setText("") })
         box.addView(row)
         addWithMargin(root, box, bottom = 12)
+    }
+
+    private fun addAutonomousModeCard(root: LinearLayout) {
+        val card = card(if (autonomousModeEnabled) Color.parseColor("#1a2e1a") else COLOR_CARD_ALT,
+            stroke = if (autonomousModeEnabled) Color.parseColor("#4ade80") else COLOR_BORDER).apply {
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+        }
+        card.addView(TextView(this).apply {
+            text = if (autonomousModeEnabled) "⚡ AUTONOMOUS MODE — ON" else "🔒 Autonomous Mode — Off"
+            textSize = 15f
+            typeface = Typeface.DEFAULT_BOLD
+            setTextColor(if (autonomousModeEnabled) Color.parseColor("#4ade80") else COLOR_TEXT_MUTED)
+        })
+        card.addView(TextView(this).apply {
+            text = if (autonomousModeEnabled)
+                "All commands execute instantly. No approval dialog. No file blocks. Permission gates bypassed."
+            else
+                "Enable to run all commands without approval popups, remove file restrictions, and bypass permission gates."
+            textSize = 12f
+            setTextColor(COLOR_TEXT_MUTED)
+            setPadding(0, dp(4), 0, dp(10))
+        })
+        val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        if (autonomousModeEnabled) {
+            row.addView(compactButton("Disable Autonomous Mode", ButtonTone.SECONDARY) {
+                autonomousModeEnabled = false
+                auditLogStore.append("AUTONOMOUS_MODE_DISABLED", "owner", "Owner disabled autonomous mode")
+                render()
+            })
+        } else {
+            row.addView(compactButton("Enable Autonomous Mode", ButtonTone.PRIMARY) {
+                autonomousModeEnabled = true
+                auditLogStore.append("AUTONOMOUS_MODE_ENABLED", "owner", "Owner enabled autonomous mode — all gates bypassed")
+                render()
+            })
+        }
+        card.addView(row)
+        addWithMargin(root, card, bottom = 12)
     }
 
     private fun addWorkSessionCard(root: LinearLayout) {
@@ -320,7 +362,14 @@ class MainActivity : Activity() {
         val command = AgentCommand.create(source, type, target, reason, PermissionGate.requiredPermissionFor(type), true)
         commandStore.add(command)
         auditLogStore.append(if (type.name.startsWith("FILE_")) "FILE_ACTION_QUEUED" else "COMMAND_QUEUED", command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
-        refreshUi("Queued ${command.type.name}")
+        // Autonomous mode: skip inbox, execute immediately
+        if (autonomousModeEnabled) {
+            auditLogStore.append("AUTONOMOUS_AUTO_EXEC", command.commandId, "Autonomous mode — executing ${command.type.name} without approval dialog")
+            approveCommand(command)
+        } else {
+            refreshUi("Queued ${command.type.name}")
+            runInSessionIfAllowed(command)
+        }
         return command
     }
 
@@ -335,22 +384,26 @@ class MainActivity : Activity() {
         approveCommand(command)
     }
 
-    private fun sessionCanRun(command: AgentCommand): Boolean = when (command.type) {
-        AgentCommandType.STATUS,
-        AgentCommandType.OPEN_URL,
-        AgentCommandType.OPEN_SETTINGS,
-        AgentCommandType.OPEN_APP,
-        AgentCommandType.BACK,
-        AgentCommandType.HOME,
-        AgentCommandType.SCROLL_DOWN,
-        AgentCommandType.FILE_LIST_ROOT,
-        AgentCommandType.FILE_SEND_TO_CLAW -> true
-        AgentCommandType.NOTIFICATION_SUMMARY,
-        AgentCommandType.FILE_PREVIEW,
-        AgentCommandType.FILE_SELECT,
-        AgentCommandType.FILE_RENAME,
-        AgentCommandType.FILE_MOVE,
-        AgentCommandType.FILE_DELETE -> false
+    // In autonomous mode all command types are allowed; otherwise whitelist only low-risk ones
+    private fun sessionCanRun(command: AgentCommand): Boolean {
+        if (autonomousModeEnabled) return true
+        return when (command.type) {
+            AgentCommandType.STATUS,
+            AgentCommandType.OPEN_URL,
+            AgentCommandType.OPEN_SETTINGS,
+            AgentCommandType.OPEN_APP,
+            AgentCommandType.BACK,
+            AgentCommandType.HOME,
+            AgentCommandType.SCROLL_DOWN,
+            AgentCommandType.FILE_LIST_ROOT,
+            AgentCommandType.FILE_SEND_TO_CLAW -> true
+            AgentCommandType.NOTIFICATION_SUMMARY,
+            AgentCommandType.FILE_PREVIEW,
+            AgentCommandType.FILE_SELECT,
+            AgentCommandType.FILE_RENAME,
+            AgentCommandType.FILE_MOVE,
+            AgentCommandType.FILE_DELETE -> false
+        }
     }
 
     private fun refreshUi(extra: String? = null) {
@@ -401,14 +454,16 @@ class MainActivity : Activity() {
     }
 
     private fun approveCommand(command: AgentCommand) {
-        val blockMessage = filePolicyBlock(command)
-        if (blockMessage != null) {
-            commandStore.markBlocked(command.commandId, blockMessage)
-            auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, blockMessage, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
-            refreshUi(blockMessage)
-            return
+        if (!autonomousModeEnabled) {
+            val blockMessage = filePolicyBlock(command)
+            if (blockMessage != null) {
+                commandStore.markBlocked(command.commandId, blockMessage)
+                auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, blockMessage, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
+                refreshUi(blockMessage)
+                return
+            }
         }
-        val gate = permissionGate.evaluate(command)
+        val gate = permissionGate.evaluate(command, autonomousModeEnabled)
         if (!gate.allowed) {
             if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) commandStore.markWaitingPermission(command.commandId, gate.message) else commandStore.markBlocked(command.commandId, gate.message)
             auditLogStore.append(if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED", command.commandId, gate.message, gate.errorCode)
@@ -479,11 +534,48 @@ class MainActivity : Activity() {
                 CommandExecutionResult(true, "Listed shared storage root")
             }
             AgentCommandType.FILE_SEND_TO_CLAW -> CommandExecutionResult(true, "Prepared selected files for Claw workflow")
-            AgentCommandType.FILE_PREVIEW,
-            AgentCommandType.FILE_SELECT,
-            AgentCommandType.FILE_RENAME,
-            AgentCommandType.FILE_MOVE,
-            AgentCommandType.FILE_DELETE -> CommandExecutionResult(false, "File executor not enabled for this action", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+            AgentCommandType.FILE_PREVIEW -> {
+                val content = FullFileManager.readFile(command.target)
+                filePreviewView.text = content
+                auditLogStore.append("FILE_PREVIEWED", command.commandId, "Previewed ${command.target}")
+                CommandExecutionResult(true, "Previewed: ${command.target}")
+            }
+            AgentCommandType.FILE_SELECT -> {
+                filePreviewView.text = "Selected: ${command.target}"
+                auditLogStore.append("FILE_SELECTED", command.commandId, "Selected ${command.target}")
+                CommandExecutionResult(true, "Selected: ${command.target}")
+            }
+            AgentCommandType.FILE_RENAME -> {
+                val parts = command.target.split("||")
+                if (parts.size < 2) return CommandExecutionResult(false, "Rename format: <path>||<newName>", "INVALID_ARGS")
+                val ok = FullFileManager.renameFile(parts[0].trim(), parts[1].trim())
+                if (ok) {
+                    auditLogStore.append("FILE_RENAMED", command.commandId, "Renamed ${parts[0]} → ${parts[1]}")
+                    CommandExecutionResult(true, "Renamed to ${parts[1]}")
+                } else {
+                    CommandExecutionResult(false, "Rename failed for ${parts[0]}", "FILE_OP_FAILED")
+                }
+            }
+            AgentCommandType.FILE_MOVE -> {
+                val parts = command.target.split("||")
+                if (parts.size < 2) return CommandExecutionResult(false, "Move format: <path>||<destDir>", "INVALID_ARGS")
+                val ok = FullFileManager.moveFile(parts[0].trim(), parts[1].trim())
+                if (ok) {
+                    auditLogStore.append("FILE_MOVED", command.commandId, "Moved ${parts[0]} → ${parts[1]}")
+                    CommandExecutionResult(true, "Moved to ${parts[1]}")
+                } else {
+                    CommandExecutionResult(false, "Move failed for ${parts[0]}", "FILE_OP_FAILED")
+                }
+            }
+            AgentCommandType.FILE_DELETE -> {
+                val ok = FullFileManager.deleteFile(command.target)
+                if (ok) {
+                    auditLogStore.append("FILE_DELETED", command.commandId, "Deleted ${command.target}")
+                    CommandExecutionResult(true, "Deleted: ${command.target}")
+                } else {
+                    CommandExecutionResult(false, "Delete failed for ${command.target}", "FILE_OP_FAILED")
+                }
+            }
         }
     }
 
@@ -493,7 +585,7 @@ class MainActivity : Activity() {
 
     private fun buildStatusText(extra: String? = null): String = listOfNotNull(
         "Backend: ${DsgConfig.BASE_URL}",
-        "Mode: no-code • work-session • signed execution • audit",
+        if (autonomousModeEnabled) "⚡ AUTONOMOUS MODE: ON — all gates bypassed" else "Mode: no-code • work-session • signed execution • audit",
         "Work Session: $workSessionEnabled",
         "Accessibility: ${permissionGate.isAccessibilityEnabled()}",
         "Notifications: ${permissionGate.isNotificationListenerEnabled()}",

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -26,6 +26,9 @@ import com.dsg.agent.automation.AgentCommandType
 import com.dsg.agent.automation.AgentErrorCodes
 import com.dsg.agent.automation.AuditLogStore
 import com.dsg.agent.automation.CommandExecutionResult
+import com.dsg.agent.automation.DadBotCallback
+import com.dsg.agent.automation.DadBotClient
+import com.dsg.agent.automation.DadBotMessage
 import com.dsg.agent.automation.FullFileManager
 import com.dsg.agent.automation.OwnerApprovalSigner
 import com.dsg.agent.automation.PermissionGate
@@ -45,6 +48,12 @@ class MainActivity : Activity() {
 
     private var fileListRendered = false
     private var workSessionEnabled = false
+    private val dadBotMessages = mutableListOf<DadBotMessage>()
+    private var dadBotTyping = false
+    private lateinit var dadBotClient: DadBotClient
+    private lateinit var dadBotMessageList: LinearLayout
+    private lateinit var dadBotStreamView: TextView
+    private lateinit var dadBotInput: EditText
     private var autonomousModeEnabled: Boolean
         get() = getSharedPreferences("dsg_prefs", MODE_PRIVATE).getBoolean("autonomous_mode", false)
         set(value) { getSharedPreferences("dsg_prefs", MODE_PRIVATE).edit().putBoolean("autonomous_mode", value).apply() }
@@ -56,6 +65,7 @@ class MainActivity : Activity() {
         auditLogStore = AuditLogStore(this)
         permissionGate = PermissionGate(this)
         approvalSigner = OwnerApprovalSigner()
+        dadBotClient = DadBotClient()
         render()
     }
 
@@ -73,6 +83,7 @@ class MainActivity : Activity() {
         addHero(root)
         addTabs(root)
         addAutonomousModeCard(root)
+        addDadBotSection(root)
         addNoCodeChat(root)
         addWorkSessionCard(root)
         addFileManagerCard(root)

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt
@@ -1,0 +1,88 @@
+package com.dsg.agent.automation
+
+import android.os.Handler
+import android.os.Looper
+import com.dsg.agent.DsgConfig
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+data class DadBotMessage(val role: String, val content: String)
+
+interface DadBotCallback {
+    fun onToken(text: String)
+    fun onCommand(type: AgentCommandType, target: String, reason: String)
+    fun onDone()
+    fun onError(message: String)
+}
+
+class DadBotClient {
+    private val ui = Handler(Looper.getMainLooper())
+
+    fun chat(messages: List<DadBotMessage>, callback: DadBotCallback) {
+        Thread {
+            var conn: HttpURLConnection? = null
+            try {
+                val url = URL("${DsgConfig.BASE_URL}/api/agent/chat")
+                conn = (url.openConnection() as HttpURLConnection).apply {
+                    requestMethod = "POST"
+                    connectTimeout = 15_000
+                    readTimeout = 60_000
+                    doOutput = true
+                    setRequestProperty("Content-Type", "application/json")
+                    setRequestProperty("Accept", "text/event-stream")
+                }
+
+                val arr = JSONArray().also { a -> messages.forEach { m -> a.put(JSONObject().put("role", m.role).put("content", m.content)) } }
+                OutputStreamWriter(conn.outputStream).use { it.write(JSONObject().put("messages", arr).toString()) }
+
+                if (conn.responseCode >= 400) {
+                    val err = conn.errorStream?.bufferedReader()?.readText() ?: "HTTP ${conn.responseCode}"
+                    ui.post { callback.onError(err) }
+                    return@Thread
+                }
+
+                conn.inputStream.bufferedReader().use { reader ->
+                    var line: String?
+                    while (reader.readLine().also { line = it } != null) {
+                        val l = line?.trim() ?: continue
+                        if (!l.startsWith("data: ")) continue
+                        val data = l.removePrefix("data: ").trim()
+                        if (data.isEmpty()) continue
+                        val json = runCatching { JSONObject(data) }.getOrNull() ?: continue
+
+                        when (json.optString("type")) {
+                            "text" -> {
+                                val token = json.optString("delta")
+                                if (token.isNotEmpty()) ui.post { callback.onToken(token) }
+                            }
+                            "command" -> {
+                                val cmdType = runCatching {
+                                    AgentCommandType.valueOf(json.optString("commandType", "STATUS"))
+                                }.getOrDefault(AgentCommandType.STATUS)
+                                val target = json.optString("target", "")
+                                val reason = json.optString("reason", "DadBot")
+                                ui.post { callback.onCommand(cmdType, target, reason) }
+                            }
+                            "error" -> {
+                                val msg = json.optString("message", "Unknown error")
+                                ui.post { callback.onError(msg) }
+                            }
+                            "done" -> {
+                                ui.post { callback.onDone() }
+                                return@use
+                            }
+                        }
+                    }
+                    ui.post { callback.onDone() }
+                }
+            } catch (e: Exception) {
+                ui.post { callback.onError(e.message ?: "Connection error") }
+            } finally {
+                conn?.disconnect()
+            }
+        }.start()
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt
@@ -46,7 +46,9 @@ object FullFileManager {
             ?: emptyList()
     }
 
-    fun riskFor(file: File): FileRisk {
+    fun riskFor(file: File, autonomousMode: Boolean = false): FileRisk {
+        // Autonomous mode: owner accepts all file risks — no blocks
+        if (autonomousMode) return FileRisk.NORMAL
         val name = file.name.lowercase()
         if (file.isDirectory) return FileRisk.NORMAL
         if (
@@ -74,6 +76,30 @@ object FullFileManager {
         ) return FileRisk.ARCHIVE_REVIEW
         return FileRisk.NORMAL
     }
+
+    fun readFile(path: String, maxBytes: Long = 8192L): String {
+        val file = File(path)
+        if (!file.exists() || !file.isFile) return "File not found: $path"
+        return try {
+            file.inputStream().use { it.readBytes().take(maxBytes.toInt()) }.toByteArray().toString(Charsets.UTF_8)
+        } catch (e: Exception) {
+            "Cannot read file: ${e.message}"
+        }
+    }
+
+    fun renameFile(path: String, newName: String): Boolean {
+        val file = File(path)
+        val dest = File(file.parent ?: return false, newName)
+        return file.renameTo(dest)
+    }
+
+    fun moveFile(path: String, destDir: String): Boolean {
+        val file = File(path)
+        val dest = File(destDir, file.name)
+        return file.renameTo(dest)
+    }
+
+    fun deleteFile(path: String): Boolean = File(path).deleteRecursively()
 
     fun buildListSummary(): String {
         val entries = listRoot()

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
@@ -20,9 +20,13 @@ object AgentErrorCodes {
 data class GateResult(val allowed: Boolean, val message: String, val errorCode: String? = null)
 
 class PermissionGate(private val context: Context) {
-    fun evaluate(command: AgentCommand): GateResult {
+    fun evaluate(command: AgentCommand, autonomousMode: Boolean = false): GateResult {
         if (command.isExpired()) {
             return GateResult(false, "Command expired before owner approval", AgentErrorCodes.COMMAND_EXPIRED)
+        }
+        // Autonomous mode: owner has pre-authorised all commands — bypass permission gates
+        if (autonomousMode) {
+            return GateResult(true, "Autonomous mode — permission gate bypassed by owner")
         }
         val required = requiredPermissionFor(command.type)
         return when (required) {


### PR DESCRIPTION
## Goal
Owner Autonomous Mode (bypass all gates) + DadBot real-time AI chat ใน Android app

## Files changed
- `PermissionGate.kt` — bypass permission gates ใน autonomous mode
- `FullFileManager.kt` — bypass file risk + readFile/rename/move/delete ops
- `MainActivity.kt` — Autonomous Mode card, DadBot section, FILE executor, status text
- `app/api/agent/commands/route.ts` — X-DSG-Autonomous header pre-approves commands
- `app/api/agent/chat/route.ts` — SSE streaming → claude-haiku-4-5-20251001 + queue_command tool
- `automation/DadBotClient.kt` — HttpURLConnection SSE reader, UI thread callbacks

## Verification
- [x] `npx tsc --noEmit` → 0 errors
- [x] Cherry-pick clean, no conflicts
- [ ] DadBot: `GET /api/agent/chat` → ok:true
- [ ] Autonomous mode toggle persists across app restart

## Known limits
- DadBot history resets on Activity destroy
- ANTHROPIC_API_KEY ต้องตั้งใน Vercel (owner set แล้ว)

## User-visible benefit
สั่งงาน Android ด้วยภาษาไทย/อังกฤษ real-time ไม่มี popup ไม่มี gate

---
_Generated by [Claude Code](https://claude.ai/code/session_0118FXD4ZxyNcSUuF5gF7Wqj)_