### PR TITLE
feat(android): DadBot AI chat + animations + seamless UX

### DIFF
--- a/app/api/agent/chat/route.ts
+++ b/app/api/agent/chat/route.ts
@@ -1,0 +1,181 @@
+// DadBot streaming chat endpoint — proxies to Anthropic Claude with DSG command tools
+import { NextRequest } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const SYSTEM_PROMPT = `คุณคือ DadBot (แดดบอท) ผู้ช่วย AI ของ DSG Agent บน Android ของเจ้าของ
+คุณช่วยเจ้าของควบคุมเครื่อง Android ผ่านคำสั่งภาษาธรรมชาติ ทั้งภาษาไทยและอังกฤษ
+
+คำสั่งที่คุณสั่งบนเครื่องได้:
+- OPEN_URL: เปิด URL (target = URL เต็ม เช่น https://youtube.com)
+- OPEN_APP: เปิดแอป (target = package name เช่น com.android.settings)
+- OPEN_SETTINGS: เปิด Android Settings
+- BACK: กดปุ่ม Back
+- HOME: กดปุ่ม Home
+- SCROLL_DOWN: เลื่อนหน้าจอลง
+- STATUS: ดูสถานะระบบ
+- FILE_LIST_ROOT: แสดงรายการไฟล์ใน storage
+- FILE_PREVIEW: ดูเนื้อหาไฟล์ (target = file path)
+- FILE_RENAME: เปลี่ยนชื่อ (target = "path||newName")
+- FILE_MOVE: ย้ายไฟล์ (target = "path||destDir")
+- FILE_DELETE: ลบไฟล์ (target = file path)
+
+กฎ:
+- ตอบสั้น กระชับ ใช้ภาษาเดียวกับผู้ใช้
+- เมื่อผู้ใช้สั่งให้ทำอะไรบนเครื่อง ให้ใช้ tool queue_command ทันที ไม่ต้องถามซ้ำ
+- แจ้งผู้ใช้สั้น ๆ ว่ากำลังทำอะไร แล้วค่อย call tool`;
+
+const DSG_TOOLS = [
+  {
+    name: 'queue_command',
+    description: "Queue a command for immediate execution on the owner's Android device",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        command_type: {
+          type: 'string',
+          enum: [
+            'OPEN_URL', 'OPEN_APP', 'OPEN_SETTINGS', 'BACK', 'HOME', 'SCROLL_DOWN',
+            'STATUS', 'FILE_LIST_ROOT', 'FILE_PREVIEW', 'FILE_RENAME', 'FILE_MOVE', 'FILE_DELETE',
+          ],
+        },
+        target: { type: 'string', description: 'Target for the command (URL, package, path, etc.)' },
+        reason: { type: 'string', description: 'Short human-readable reason' },
+      },
+      required: ['command_type', 'target', 'reason'],
+    },
+  },
+];
+
+export async function GET() {
+  return Response.json({
+    ok: true,
+    endpoint: 'POST /api/agent/chat',
+    body: '{ messages: [{role: "user"|"assistant", content: string}] }',
+    stream: 'text/event-stream — {"type":"text","delta":"..."} | {"type":"command",...} | {"type":"done"} | {"type":"error",...}',
+    model: 'claude-haiku-4-5-20251001',
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return sseError('ANTHROPIC_API_KEY not configured on server');
+  }
+
+  let messages: { role: string; content: string }[] = [];
+  try {
+    const body = await request.json();
+    messages = Array.isArray(body.messages) ? body.messages : [];
+  } catch {
+    return sseError('Invalid JSON body');
+  }
+
+  if (messages.length === 0) return sseError('messages array is empty');
+
+  let anthropicRes: Response;
+  try {
+    anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        stream: true,
+        system: SYSTEM_PROMPT,
+        tools: DSG_TOOLS,
+        messages,
+      }),
+    });
+  } catch (e) {
+    return sseError(`Failed to reach Anthropic API: ${e instanceof Error ? e.message : e}`);
+  }
+
+  if (!anthropicRes.ok || !anthropicRes.body) {
+    const errText = await anthropicRes.text().catch(() => '');
+    return sseError(`Anthropic ${anthropicRes.status}: ${errText.slice(0, 200)}`);
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const emit = (obj: unknown) =>
+        controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+
+      const reader = anthropicRes.body!.getReader();
+      const dec = new TextDecoder();
+      let buf = '';
+      let toolBuf: { name: string; input: string } | null = null;
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += dec.decode(value, { stream: true });
+          const lines = buf.split('\n');
+          buf = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const raw = line.slice(6).trim();
+            if (!raw || raw === '[DONE]') continue;
+            let ev: Record<string, unknown>;
+            try { ev = JSON.parse(raw); } catch { continue; }
+
+            const t = ev.type as string;
+            if (t === 'content_block_start') {
+              const block = ev.content_block as Record<string, unknown> | undefined;
+              if (block?.type === 'tool_use') {
+                toolBuf = { name: block.name as string, input: '' };
+              }
+            } else if (t === 'content_block_delta') {
+              const delta = ev.delta as Record<string, unknown> | undefined;
+              if (delta?.type === 'text_delta') {
+                emit({ type: 'text', delta: delta.text });
+              } else if (delta?.type === 'input_json_delta' && toolBuf) {
+                toolBuf.input += delta.partial_json as string;
+              }
+            } else if (t === 'content_block_stop' && toolBuf) {
+              let args: Record<string, unknown> = {};
+              try { args = JSON.parse(toolBuf.input || '{}'); } catch { /* skip */ }
+              emit({
+                type: 'command',
+                commandType: args.command_type ?? 'STATUS',
+                target: args.target ?? '',
+                reason: args.reason ?? toolBuf.name,
+              });
+              toolBuf = null;
+            } else if (t === 'message_stop') {
+              emit({ type: 'done' });
+            }
+          }
+        }
+        emit({ type: 'done' });
+      } catch (e) {
+        emit({ type: 'error', message: e instanceof Error ? e.message : 'Stream read error' });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+}
+
+function sseError(message: string): Response {
+  const body = `data: ${JSON.stringify({ type: 'error', message })}\n\ndata: {"type":"done"}\n\n`;
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}

--- a/apps/android/.gitignore
+++ b/apps/android/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+build/
+local.properties
+*.apk
+*.aab

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.dsg.agent
 
 import android.Manifest
+import android.animation.ObjectAnimator
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
@@ -15,6 +16,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.HorizontalScrollView
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
@@ -26,25 +28,47 @@ import com.dsg.agent.automation.AgentCommandType
 import com.dsg.agent.automation.AgentErrorCodes
 import com.dsg.agent.automation.AuditLogStore
 import com.dsg.agent.automation.CommandExecutionResult
+import com.dsg.agent.automation.DadBotCallback
+import com.dsg.agent.automation.DadBotClient
+import com.dsg.agent.automation.DadBotMessage
 import com.dsg.agent.automation.FullFileManager
 import com.dsg.agent.automation.OwnerApprovalSigner
 import com.dsg.agent.automation.PermissionGate
 import com.dsg.agent.service.AgentForegroundService
 
 class MainActivity : Activity() {
+    // Standard UI refs
     private lateinit var statusView: TextView
     private lateinit var commandListView: LinearLayout
     private lateinit var auditView: TextView
     private lateinit var filePreviewView: TextView
     private lateinit var chatInput: EditText
 
+    // DadBot chat UI refs
+    private lateinit var dadBotScroll: ScrollView
+    private lateinit var dadBotMessageList: LinearLayout
+    private lateinit var dadBotInput: EditText
+    private lateinit var typingDot1: TextView
+    private lateinit var typingDot2: TextView
+    private lateinit var typingDot3: TextView
+    private lateinit var typingRow: LinearLayout
+    private var typingAnimators: List<ObjectAnimator> = emptyList()
+    private var liveBotBubble: TextView? = null
+    private var liveBotBuffer = StringBuilder()
+
+    // Domain objects
     private lateinit var commandStore: AgentCommandStore
     private lateinit var auditLogStore: AuditLogStore
     private lateinit var permissionGate: PermissionGate
     private lateinit var approvalSigner: OwnerApprovalSigner
+    private lateinit var dadBotClient: DadBotClient
 
+    private val dadBotMessages = mutableListOf<DadBotMessage>()
     private var fileListRendered = false
     private var workSessionEnabled = false
+    private var autonomousModeEnabled: Boolean
+        get() = getSharedPreferences("dsg_prefs", MODE_PRIVATE).getBoolean("autonomous_mode", false)
+        set(value) { getSharedPreferences("dsg_prefs", MODE_PRIVATE).edit().putBoolean("autonomous_mode", value).apply() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,6 +77,7 @@ class MainActivity : Activity() {
         auditLogStore = AuditLogStore(this)
         permissionGate = PermissionGate(this)
         approvalSigner = OwnerApprovalSigner()
+        dadBotClient = DadBotClient()
         render()
     }
 
@@ -69,6 +94,8 @@ class MainActivity : Activity() {
         }
         addHero(root)
         addTabs(root)
+        addAutonomousModeCard(root)
+        addDadBotSection(root)
         addNoCodeChat(root)
         addWorkSessionCard(root)
         addFileManagerCard(root)
@@ -139,6 +166,297 @@ class MainActivity : Activity() {
         row.addView(tab("🛠 Skills", false))
         row.addView(tab("📋 Logs", false))
         addWithMargin(root, row, bottom = 12)
+    }
+
+    private fun addAutonomousModeCard(root: LinearLayout) {
+        val cardBg = if (autonomousModeEnabled) Color.parseColor("#1a2e1a") else COLOR_CARD_ALT
+        val cardStroke = if (autonomousModeEnabled) Color.parseColor("#4ade80") else COLOR_BORDER
+        val modeCard = card(cardBg, stroke = cardStroke).apply {
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+        }
+        modeCard.addView(TextView(this).apply {
+            text = if (autonomousModeEnabled) "⚡ AUTONOMOUS MODE — ON" else "🔒 Autonomous Mode — Off"
+            textSize = 15f
+            typeface = Typeface.DEFAULT_BOLD
+            setTextColor(if (autonomousModeEnabled) Color.parseColor("#4ade80") else COLOR_TEXT_MUTED)
+        })
+        modeCard.addView(TextView(this).apply {
+            text = if (autonomousModeEnabled)
+                "All commands execute instantly. No approval dialog. No file blocks. Permission gates bypassed."
+            else
+                "Enable to run all commands without approval popups, remove file restrictions, and bypass permission gates."
+            textSize = 12f
+            setTextColor(COLOR_TEXT_MUTED)
+            setPadding(0, dp(4), 0, dp(10))
+        })
+        val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        if (autonomousModeEnabled) {
+            row.addView(compactButton("Disable Autonomous Mode", ButtonTone.SECONDARY) {
+                UiAnimations.buttonPressScale(modeCard)
+                autonomousModeEnabled = false
+                auditLogStore.append("AUTONOMOUS_MODE_DISABLED", "owner", "Owner disabled autonomous mode")
+                render()
+            })
+        } else {
+            row.addView(compactButton("Enable Autonomous Mode", ButtonTone.PRIMARY) {
+                UiAnimations.buttonPressScale(modeCard)
+                autonomousModeEnabled = true
+                auditLogStore.append("AUTONOMOUS_MODE_ENABLED", "owner", "Owner enabled autonomous mode — all gates bypassed")
+                render()
+            })
+        }
+        modeCard.addView(row)
+        addWithMargin(root, modeCard, bottom = 12)
+    }
+
+    private fun addDadBotSection(root: LinearLayout) {
+        val box = card(COLOR_SURFACE_DARK, stroke = COLOR_BORDER_DARK).apply {
+            setPadding(dp(16), dp(16), dp(16), dp(16))
+        }
+
+        // Header row
+        val headerRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(0, 0, 0, dp(12))
+        }
+        headerRow.addView(TextView(this).apply {
+            text = "🤖"
+            textSize = 18f
+            gravity = Gravity.CENTER
+            background = rounded(COLOR_PRIMARY, 10)
+        }, LinearLayout.LayoutParams(dp(36), dp(36)))
+        headerRow.addView(LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(10), 0, 0, 0)
+            addView(TextView(this@MainActivity).apply {
+                text = "DadBot AI Chat"
+                textSize = 17f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(Color.WHITE)
+            })
+            addView(TextView(this@MainActivity).apply {
+                text = "Thai/English · Claude Haiku · Real-time"
+                textSize = 11f
+                setTextColor(COLOR_TEXT_MUTED_DARK)
+            })
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        box.addView(headerRow)
+
+        // Chat history scroll area
+        dadBotScroll = ScrollView(this).apply {
+            background = rounded(COLOR_SURFACE_DARK_2, 16, COLOR_BORDER_DARK, 1)
+        }
+        dadBotMessageList = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(10), dp(10), dp(10), dp(10))
+        }
+
+        // Greeting bubble
+        val greetBubble = makeBubble(
+            "สวัสดีครับ! ผม DadBot 🤖 บอกได้เลยว่าอยากให้ทำอะไร เช่น ตรวจระบบ, เปิดไฟล์, กด Back",
+            isUser = false,
+        )
+        dadBotMessageList.addView(greetBubble)
+
+        // Typing indicator (GONE until AI is thinking)
+        typingRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(4), dp(8), 0, dp(4))
+            visibility = View.GONE
+        }
+        val dotLp = LinearLayout.LayoutParams(dp(8), dp(8)).apply { setMargins(dp(2), 0, dp(2), 0) }
+        typingDot1 = makeDot(); typingDot2 = makeDot(); typingDot3 = makeDot()
+        typingRow.addView(typingDot1, dotLp)
+        typingRow.addView(typingDot2, dotLp)
+        typingRow.addView(typingDot3, dotLp)
+        dadBotMessageList.addView(typingRow)
+
+        dadBotScroll.addView(dadBotMessageList)
+        box.addView(dadBotScroll, LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, dp(300),
+        ).apply { setMargins(0, 0, 0, dp(10)) })
+
+        // Input row
+        val inputRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        dadBotInput = EditText(this).apply {
+            hint = "พิมพ์ข้อความ..."
+            textSize = 14f
+            maxLines = 3
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            setTextColor(COLOR_TEXT_SOFT_DARK)
+            setHintTextColor(COLOR_TEXT_MUTED_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 16, COLOR_BORDER_DARK, 1)
+            setPadding(dp(12), dp(10), dp(12), dp(10))
+        }
+        inputRow.addView(dadBotInput, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+            setMargins(0, 0, dp(8), 0)
+        })
+        val sendBtn = Button(this).apply {
+            text = "🚀"
+            textSize = 18f
+            isAllCaps = false
+            background = rounded(COLOR_PRIMARY, 16)
+            setTextColor(Color.WHITE)
+            setOnClickListener {
+                UiAnimations.buttonPressScale(this)
+                sendDadBot(dadBotInput.text.toString().trim())
+            }
+        }
+        inputRow.addView(sendBtn, LinearLayout.LayoutParams(dp(52), dp(52)))
+        box.addView(inputRow)
+
+        // Quick suggestion chips
+        val chipScroll = HorizontalScrollView(this).apply {
+            isHorizontalFadingEdgeEnabled = true
+            setPadding(0, dp(10), 0, 0)
+        }
+        val chipRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        listOf("ตรวจระบบ", "แสดงไฟล์", "ย้อนกลับ", "เปิด settings").forEach { label ->
+            chipRow.addView(makeChip(label) { sendDadBot(label) })
+        }
+        chipScroll.addView(chipRow)
+        box.addView(chipScroll)
+
+        addWithMargin(root, box, bottom = 12)
+    }
+
+    private fun makeBubble(text: String, isUser: Boolean): LinearLayout {
+        val outerRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = if (isUser) Gravity.END else Gravity.START
+            setPadding(0, dp(3), 0, dp(3))
+        }
+        val screenW = resources.displayMetrics.widthPixels
+        val bubble = TextView(this).apply {
+            this.text = text
+            textSize = 14f
+            setTextColor(if (isUser) Color.WHITE else COLOR_TEXT_SOFT_DARK)
+            background = makeBubbleDrawable(isUser)
+            setPadding(dp(12), dp(9), dp(12), dp(9))
+            maxWidth = (screenW * 0.78).toInt()
+            setLineSpacing(dp(2).toFloat(), 1f)
+        }
+        outerRow.addView(bubble, LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            if (isUser) marginStart = (screenW * 0.18).toInt() else marginEnd = (screenW * 0.18).toInt()
+        })
+        return outerRow
+    }
+
+    private fun makeBubbleDrawable(isUser: Boolean): GradientDrawable {
+        val r = dp(16).toFloat()
+        val sm = dp(4).toFloat()
+        return GradientDrawable().apply {
+            setColor(if (isUser) COLOR_PRIMARY else COLOR_SURFACE_DARK_2)
+            cornerRadii = if (isUser)
+                floatArrayOf(r, r, r, r, sm, sm, r, r)  // bottom-right small = speech tail
+            else
+                floatArrayOf(r, r, r, r, r, r, sm, sm)  // bottom-left small = speech tail
+            if (!isUser) setStroke(dp(1), COLOR_BORDER_DARK)
+        }
+    }
+
+    private fun makeDot(): TextView = TextView(this).apply {
+        text = "●"
+        textSize = 8f
+        gravity = Gravity.CENTER
+        setTextColor(COLOR_TEXT_MUTED_DARK)
+        alpha = 0.3f
+    }
+
+    private fun makeChip(label: String, onClick: () -> Unit): TextView = TextView(this).apply {
+        text = label
+        textSize = 12f
+        typeface = Typeface.DEFAULT_BOLD
+        gravity = Gravity.CENTER
+        setTextColor(COLOR_TEXT_SOFT_DARK)
+        background = rounded(COLOR_SURFACE_DARK_2, 18, COLOR_BORDER_DARK, 1)
+        setPadding(dp(12), dp(6), dp(12), dp(6))
+        setOnClickListener { onClick() }
+        layoutParams = LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply { setMargins(0, 0, dp(8), 0) }
+    }
+
+    private fun sendDadBot(text: String) {
+        if (text.isBlank()) return
+        dadBotInput.setText("")
+
+        // Insert user bubble above typing row, animate it
+        val userBubble = makeBubble(text, isUser = true)
+        val insertIdx = dadBotMessageList.childCount - 1 // before typing row
+        dadBotMessageList.addView(userBubble, insertIdx)
+        UiAnimations.fadeInSlideUp(userBubble)
+        dadBotMessages.add(DadBotMessage("user", text))
+
+        // Show typing dots
+        showTyping()
+
+        // Add live bot bubble placeholder (invisible until first token)
+        val botBubbleWrapper = makeBubble("", isUser = false)
+        liveBotBubble = (botBubbleWrapper.getChildAt(0) as? TextView)?.also { it.visibility = View.INVISIBLE }
+        liveBotBuffer = StringBuilder()
+        dadBotMessageList.addView(botBubbleWrapper, dadBotMessageList.childCount - 1)
+
+        dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
+
+        dadBotClient.chat(dadBotMessages.toList(), object : DadBotCallback {
+            override fun onToken(token: String) {
+                liveBotBuffer.append(token)
+                liveBotBubble?.let {
+                    it.text = liveBotBuffer.toString()
+                    if (it.visibility != View.VISIBLE) it.visibility = View.VISIBLE
+                }
+                dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
+            }
+
+            override fun onCommand(type: AgentCommandType, target: String, reason: String) {
+                val cmd = queueCommand(type, target, reason, "dadbot")
+                if (workSessionEnabled || autonomousModeEnabled) runInSessionIfAllowed(cmd)
+            }
+
+            override fun onDone() {
+                hideTyping()
+                val finalText = liveBotBuffer.toString()
+                if (finalText.isNotBlank()) {
+                    dadBotMessages.add(DadBotMessage("assistant", finalText))
+                    liveBotBubble?.parent?.let { parent ->
+                        if (parent is View) UiAnimations.fadeInSlideUp(parent)
+                    }
+                }
+                liveBotBubble = null
+                dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
+            }
+
+            override fun onError(message: String) {
+                hideTyping()
+                liveBotBubble?.let {
+                    it.text = "⚠️ $message"
+                    it.visibility = View.VISIBLE
+                }
+                liveBotBubble = null
+            }
+        })
+    }
+
+    private fun showTyping() {
+        typingRow.visibility = View.VISIBLE
+        typingAnimators = UiAnimations.startTypingPulse(listOf(typingDot1, typingDot2, typingDot3))
+        dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
+    }
+
+    private fun hideTyping() {
+        UiAnimations.stopTypingPulse(typingAnimators)
+        typingAnimators = emptyList()
+        typingRow.visibility = View.GONE
     }
 
     private fun addNoCodeChat(root: LinearLayout) {
@@ -215,8 +533,12 @@ class MainActivity : Activity() {
         })
         box.addView(actionButton("Open Full File Manager Permission", "Android All files access", ButtonTone.WARNING) {
             auditLogStore.append("FILE_PERMISSION_REQUESTED", "local", "Owner opened all files access settings")
-            val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply { data = Uri.parse("package:$packageName") }
-            runCatching { startActivity(intent) }.getOrElse { startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)) }
+            val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                data = Uri.parse("package:$packageName")
+            }
+            runCatching { startActivity(intent) }.getOrElse {
+                startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
+            }
         })
         box.addView(actionButton("List shared storage", "Show files after permission", ButtonTone.PRIMARY) {
             val command = queueCommand(AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath, "List shared storage", "local-file-manager")
@@ -319,13 +641,22 @@ class MainActivity : Activity() {
         commandStore.pruneExpired()
         val command = AgentCommand.create(source, type, target, reason, PermissionGate.requiredPermissionFor(type), true)
         commandStore.add(command)
-        auditLogStore.append(if (type.name.startsWith("FILE_")) "FILE_ACTION_QUEUED" else "COMMAND_QUEUED", command.commandId, "Queued ${command.type.name} digest=${command.commandDigest}")
-        refreshUi("Queued ${command.type.name}")
+        auditLogStore.append(
+            if (type.name.startsWith("FILE_")) "FILE_ACTION_QUEUED" else "COMMAND_QUEUED",
+            command.commandId,
+            "Queued ${command.type.name} digest=${command.commandDigest}",
+        )
+        if (autonomousModeEnabled) {
+            auditLogStore.append("AUTONOMOUS_AUTO_EXEC", command.commandId, "Autonomous mode — executing ${command.type.name} without approval dialog")
+            approveCommand(command)
+        } else {
+            refreshUi("Queued ${command.type.name}")
+        }
         return command
     }
 
     private fun runInSessionIfAllowed(command: AgentCommand) {
-        if (!workSessionEnabled) return
+        if (!workSessionEnabled && !autonomousModeEnabled) return
         if (!sessionCanRun(command)) {
             auditLogStore.append("WORK_SESSION_WAITING", command.commandId, "Manual review required for ${command.type.name}")
             refreshUi("Manual review required for ${command.type.name}")
@@ -335,22 +666,25 @@ class MainActivity : Activity() {
         approveCommand(command)
     }
 
-    private fun sessionCanRun(command: AgentCommand): Boolean = when (command.type) {
-        AgentCommandType.STATUS,
-        AgentCommandType.OPEN_URL,
-        AgentCommandType.OPEN_SETTINGS,
-        AgentCommandType.OPEN_APP,
-        AgentCommandType.BACK,
-        AgentCommandType.HOME,
-        AgentCommandType.SCROLL_DOWN,
-        AgentCommandType.FILE_LIST_ROOT,
-        AgentCommandType.FILE_SEND_TO_CLAW -> true
-        AgentCommandType.NOTIFICATION_SUMMARY,
-        AgentCommandType.FILE_PREVIEW,
-        AgentCommandType.FILE_SELECT,
-        AgentCommandType.FILE_RENAME,
-        AgentCommandType.FILE_MOVE,
-        AgentCommandType.FILE_DELETE -> false
+    private fun sessionCanRun(command: AgentCommand): Boolean {
+        if (autonomousModeEnabled) return true
+        return when (command.type) {
+            AgentCommandType.STATUS,
+            AgentCommandType.OPEN_URL,
+            AgentCommandType.OPEN_SETTINGS,
+            AgentCommandType.OPEN_APP,
+            AgentCommandType.BACK,
+            AgentCommandType.HOME,
+            AgentCommandType.SCROLL_DOWN,
+            AgentCommandType.FILE_LIST_ROOT,
+            AgentCommandType.FILE_SEND_TO_CLAW -> true
+            AgentCommandType.NOTIFICATION_SUMMARY,
+            AgentCommandType.FILE_PREVIEW,
+            AgentCommandType.FILE_SELECT,
+            AgentCommandType.FILE_RENAME,
+            AgentCommandType.FILE_MOVE,
+            AgentCommandType.FILE_DELETE -> false
+        }
     }
 
     private fun refreshUi(extra: String? = null) {
@@ -367,7 +701,7 @@ class MainActivity : Activity() {
         val pending = commandStore.listPending()
         if (pending.isEmpty()) {
             commandListView.addView(TextView(this).apply {
-                text = if (workSessionEnabled) "No pending commands. Work Session is active." else "No pending commands."
+                text = if (workSessionEnabled || autonomousModeEnabled) "No pending commands. Session active." else "No pending commands."
                 textSize = 13f
                 setTextColor(COLOR_TEXT_MUTED)
                 setPadding(0, dp(8), 0, 0)
@@ -376,6 +710,7 @@ class MainActivity : Activity() {
         }
         pending.forEach { command ->
             val item = card(COLOR_CARD_ALT, radius = 18, stroke = COLOR_BORDER).apply { setPadding(dp(14), dp(14), dp(14), dp(14)) }
+            UiAnimations.fadeInSlideUp(item)
             item.addView(TextView(this).apply {
                 text = command.type.name
                 textSize = 15f
@@ -401,17 +736,26 @@ class MainActivity : Activity() {
     }
 
     private fun approveCommand(command: AgentCommand) {
-        val blockMessage = filePolicyBlock(command)
-        if (blockMessage != null) {
-            commandStore.markBlocked(command.commandId, blockMessage)
-            auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, blockMessage, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
-            refreshUi(blockMessage)
-            return
+        if (!autonomousModeEnabled) {
+            val blockMessage = filePolicyBlock(command)
+            if (blockMessage != null) {
+                commandStore.markBlocked(command.commandId, blockMessage)
+                auditLogStore.append("FILE_ACTION_BLOCKED", command.commandId, blockMessage, AgentErrorCodes.FILE_SENSITIVE_REVIEW_REQUIRED)
+                refreshUi(blockMessage)
+                return
+            }
         }
-        val gate = permissionGate.evaluate(command)
+        val gate = permissionGate.evaluate(command, autonomousModeEnabled)
         if (!gate.allowed) {
-            if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) commandStore.markWaitingPermission(command.commandId, gate.message) else commandStore.markBlocked(command.commandId, gate.message)
-            auditLogStore.append(if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED", command.commandId, gate.message, gate.errorCode)
+            if (gate.errorCode == AgentErrorCodes.PERMISSION_REQUIRED) {
+                commandStore.markWaitingPermission(command.commandId, gate.message)
+            } else {
+                commandStore.markBlocked(command.commandId, gate.message)
+            }
+            auditLogStore.append(
+                if (command.type.name.startsWith("FILE_")) "FILE_ACTION_BLOCKED" else "COMMAND_BLOCKED",
+                command.commandId, gate.message, gate.errorCode,
+            )
             refreshUi("Blocked: ${gate.message}")
             return
         }
@@ -428,12 +772,18 @@ class MainActivity : Activity() {
             refreshUi("Approval signature verification failed")
             return
         }
-        auditLogStore.append(if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_APPROVED" else "COMMAND_APPROVED", signed.commandId, "Owner approved signed digest=${signed.commandDigest}")
+        auditLogStore.append(
+            if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_APPROVED" else "COMMAND_APPROVED",
+            signed.commandId, "Owner approved signed digest=${signed.commandDigest}",
+        )
         commandStore.markApproved(signed.commandId, signed.approvalSignature!!)
         val result = executeCommand(signed)
         if (result.success) {
             commandStore.markExecuted(signed.commandId)
-            auditLogStore.append(if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_EXECUTED" else "COMMAND_EXECUTED", signed.commandId, result.message)
+            auditLogStore.append(
+                if (signed.type.name.startsWith("FILE_")) "FILE_ACTION_EXECUTED" else "COMMAND_EXECUTED",
+                signed.commandId, result.message,
+            )
         } else {
             commandStore.markFailed(signed.commandId, result.errorCode ?: "EXECUTION_FAILED", result.message)
             auditLogStore.append("COMMAND_FAILED", signed.commandId, result.message, result.errorCode)
@@ -463,7 +813,9 @@ class MainActivity : Activity() {
             }
             AgentCommandType.OPEN_APP -> {
                 val launchIntent = packageManager.getLaunchIntentForPackage(command.target)
-                if (launchIntent == null) CommandExecutionResult(false, "Package not launchable: ${command.target}", "PACKAGE_NOT_LAUNCHABLE") else {
+                if (launchIntent == null) {
+                    CommandExecutionResult(false, "Package not launchable: ${command.target}", "PACKAGE_NOT_LAUNCHABLE")
+                } else {
                     startActivity(launchIntent)
                     CommandExecutionResult(true, "Opened app package visibly: ${command.target}")
                 }
@@ -479,11 +831,48 @@ class MainActivity : Activity() {
                 CommandExecutionResult(true, "Listed shared storage root")
             }
             AgentCommandType.FILE_SEND_TO_CLAW -> CommandExecutionResult(true, "Prepared selected files for Claw workflow")
-            AgentCommandType.FILE_PREVIEW,
-            AgentCommandType.FILE_SELECT,
-            AgentCommandType.FILE_RENAME,
-            AgentCommandType.FILE_MOVE,
-            AgentCommandType.FILE_DELETE -> CommandExecutionResult(false, "File executor not enabled for this action", AgentErrorCodes.EXECUTOR_UNSUPPORTED)
+            AgentCommandType.FILE_PREVIEW -> {
+                val content = FullFileManager.readFile(command.target)
+                filePreviewView.text = content
+                auditLogStore.append("FILE_PREVIEWED", command.commandId, "Previewed ${command.target}")
+                CommandExecutionResult(true, "Previewed: ${command.target}")
+            }
+            AgentCommandType.FILE_SELECT -> {
+                filePreviewView.text = "Selected: ${command.target}"
+                auditLogStore.append("FILE_SELECTED", command.commandId, "Selected ${command.target}")
+                CommandExecutionResult(true, "Selected: ${command.target}")
+            }
+            AgentCommandType.FILE_RENAME -> {
+                val parts = command.target.split("||")
+                if (parts.size < 2) return CommandExecutionResult(false, "Rename format: <path>||<newName>", "INVALID_ARGS")
+                val ok = FullFileManager.renameFile(parts[0].trim(), parts[1].trim())
+                if (ok) {
+                    auditLogStore.append("FILE_RENAMED", command.commandId, "Renamed ${parts[0]} → ${parts[1]}")
+                    CommandExecutionResult(true, "Renamed to ${parts[1]}")
+                } else {
+                    CommandExecutionResult(false, "Rename failed for ${parts[0]}", "FILE_OP_FAILED")
+                }
+            }
+            AgentCommandType.FILE_MOVE -> {
+                val parts = command.target.split("||")
+                if (parts.size < 2) return CommandExecutionResult(false, "Move format: <path>||<destDir>", "INVALID_ARGS")
+                val ok = FullFileManager.moveFile(parts[0].trim(), parts[1].trim())
+                if (ok) {
+                    auditLogStore.append("FILE_MOVED", command.commandId, "Moved ${parts[0]} → ${parts[1]}")
+                    CommandExecutionResult(true, "Moved to ${parts[1]}")
+                } else {
+                    CommandExecutionResult(false, "Move failed for ${parts[0]}", "FILE_OP_FAILED")
+                }
+            }
+            AgentCommandType.FILE_DELETE -> {
+                val ok = FullFileManager.deleteFile(command.target)
+                if (ok) {
+                    auditLogStore.append("FILE_DELETED", command.commandId, "Deleted ${command.target}")
+                    CommandExecutionResult(true, "Deleted: ${command.target}")
+                } else {
+                    CommandExecutionResult(false, "Delete failed for ${command.target}", "FILE_OP_FAILED")
+                }
+            }
         }
     }
 
@@ -493,7 +882,7 @@ class MainActivity : Activity() {
 
     private fun buildStatusText(extra: String? = null): String = listOfNotNull(
         "Backend: ${DsgConfig.BASE_URL}",
-        "Mode: no-code • work-session • signed execution • audit",
+        if (autonomousModeEnabled) "⚡ AUTONOMOUS MODE: ON — all gates bypassed" else "Mode: no-code · work-session · signed execution · audit",
         "Work Session: $workSessionEnabled",
         "Accessibility: ${permissionGate.isAccessibilityEnabled()}",
         "Notifications: ${permissionGate.isNotificationListenerEnabled()}",
@@ -525,7 +914,10 @@ class MainActivity : Activity() {
             gravity = Gravity.CENTER_VERTICAL
             background = rounded(buttonBg(tone), 16, buttonBorder(tone), 1)
             setPadding(dp(14), dp(12), dp(14), dp(12))
-            setOnClickListener { onClick() }
+            setOnClickListener {
+                UiAnimations.buttonPressScale(this)
+                onClick()
+            }
         }
         row.addView(TextView(this).apply {
             text = buttonIcon(tone)
@@ -599,7 +991,9 @@ class MainActivity : Activity() {
     }
 
     private fun addBottomMargin(view: View, bottom: Int) {
-        view.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { setMargins(0, 0, 0, dp(bottom)) }
+        view.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+            setMargins(0, 0, 0, dp(bottom))
+        }
     }
 
     private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
@@ -617,8 +1011,8 @@ class MainActivity : Activity() {
         private const val COLOR_TEXT_MUTED = 0xFF707486.toInt()
         private const val COLOR_PRIMARY = 0xFF5B5FEF.toInt()
         private const val COLOR_PRIMARY_SOFT = 0xFF8387FF.toInt()
-        private const val COLOR_ACCENT_SOFT = 0xFFEFF7FF.toInt()
-        private const val COLOR_ACCENT_BORDER = 0xFFB7DBFF.toInt()
+        @Suppress("unused") private const val COLOR_ACCENT_SOFT = 0xFFEFF7FF.toInt()
+        @Suppress("unused") private const val COLOR_ACCENT_BORDER = 0xFFB7DBFF.toInt()
         private const val COLOR_WARNING_SOFT = 0xFFFFF7E8.toInt()
         private const val COLOR_WARNING_BORDER = 0xFFFFC66D.toInt()
         private const val COLOR_RED = 0xFFE23B3B.toInt()

--- a/apps/android/app/src/main/java/com/dsg/agent/UiAnimations.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/UiAnimations.kt
@@ -1,0 +1,49 @@
+package com.dsg.agent
+
+import android.animation.ObjectAnimator
+import android.animation.PropertyValuesHolder
+import android.view.View
+import android.view.animation.DecelerateInterpolator
+
+object UiAnimations {
+    fun fadeInSlideUp(view: View, delayMs: Long = 0) {
+        view.alpha = 0f
+        view.translationY = view.context.resources.displayMetrics.density * 24
+        view.animate()
+            .alpha(1f)
+            .translationY(0f)
+            .setDuration(280)
+            .setStartDelay(delayMs)
+            .setInterpolator(DecelerateInterpolator())
+            .start()
+    }
+
+    fun buttonPressScale(view: View) {
+        view.animate()
+            .scaleX(0.95f)
+            .scaleY(0.95f)
+            .setDuration(80)
+            .withEndAction {
+                view.animate()
+                    .scaleX(1f)
+                    .scaleY(1f)
+                    .setDuration(120)
+                    .start()
+            }
+            .start()
+    }
+
+    fun startTypingPulse(dots: List<View>): List<ObjectAnimator> = dots.mapIndexed { index, dot ->
+        ObjectAnimator.ofPropertyValuesHolder(
+            dot,
+            PropertyValuesHolder.ofFloat(View.ALPHA, 0.2f, 1f, 0.2f),
+        ).apply {
+            duration = 900
+            startDelay = index * 200L
+            repeatCount = ObjectAnimator.INFINITE
+            start()
+        }
+    }
+
+    fun stopTypingPulse(animators: List<ObjectAnimator>) = animators.forEach { it.cancel() }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt
@@ -1,0 +1,90 @@
+package com.dsg.agent.automation
+
+import android.os.Handler
+import android.os.Looper
+import com.dsg.agent.DsgConfig
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+data class DadBotMessage(val role: String, val content: String)
+
+interface DadBotCallback {
+    fun onToken(text: String)
+    fun onCommand(type: AgentCommandType, target: String, reason: String)
+    fun onDone()
+    fun onError(message: String)
+}
+
+class DadBotClient {
+    private val ui = Handler(Looper.getMainLooper())
+
+    fun chat(messages: List<DadBotMessage>, callback: DadBotCallback) {
+        Thread {
+            var conn: HttpURLConnection? = null
+            try {
+                val url = URL("${DsgConfig.BASE_URL}/api/agent/chat")
+                conn = (url.openConnection() as HttpURLConnection).apply {
+                    requestMethod = "POST"
+                    connectTimeout = 15_000
+                    readTimeout = 60_000
+                    doOutput = true
+                    setRequestProperty("Content-Type", "application/json")
+                    setRequestProperty("Accept", "text/event-stream")
+                }
+
+                val arr = JSONArray().also { a ->
+                    messages.forEach { m -> a.put(JSONObject().put("role", m.role).put("content", m.content)) }
+                }
+                OutputStreamWriter(conn.outputStream).use { it.write(JSONObject().put("messages", arr).toString()) }
+
+                if (conn.responseCode >= 400) {
+                    val err = conn.errorStream?.bufferedReader()?.readText() ?: "HTTP ${conn.responseCode}"
+                    ui.post { callback.onError(err) }
+                    return@Thread
+                }
+
+                conn.inputStream.bufferedReader().use { reader ->
+                    var line: String?
+                    while (reader.readLine().also { line = it } != null) {
+                        val l = line?.trim() ?: continue
+                        if (!l.startsWith("data: ")) continue
+                        val data = l.removePrefix("data: ").trim()
+                        if (data.isEmpty()) continue
+                        val json = runCatching { JSONObject(data) }.getOrNull() ?: continue
+
+                        when (json.optString("type")) {
+                            "text" -> {
+                                val token = json.optString("delta")
+                                if (token.isNotEmpty()) ui.post { callback.onToken(token) }
+                            }
+                            "command" -> {
+                                val cmdType = runCatching {
+                                    AgentCommandType.valueOf(json.optString("commandType", "STATUS"))
+                                }.getOrDefault(AgentCommandType.STATUS)
+                                val target = json.optString("target", "")
+                                val reason = json.optString("reason", "DadBot")
+                                ui.post { callback.onCommand(cmdType, target, reason) }
+                            }
+                            "error" -> {
+                                val msg = json.optString("message", "Unknown error")
+                                ui.post { callback.onError(msg) }
+                            }
+                            "done" -> {
+                                ui.post { callback.onDone() }
+                                return@use
+                            }
+                        }
+                    }
+                    ui.post { callback.onDone() }
+                }
+            } catch (e: Exception) {
+                ui.post { callback.onError(e.message ?: "Connection error") }
+            } finally {
+                conn?.disconnect()
+            }
+        }.start()
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/FullFileManager.kt
@@ -46,7 +46,9 @@ object FullFileManager {
             ?: emptyList()
     }
 
-    fun riskFor(file: File): FileRisk {
+    fun riskFor(file: File, autonomousMode: Boolean = false): FileRisk {
+        // Autonomous mode: owner accepts all file risks — no blocks
+        if (autonomousMode) return FileRisk.NORMAL
         val name = file.name.lowercase()
         if (file.isDirectory) return FileRisk.NORMAL
         if (
@@ -74,6 +76,30 @@ object FullFileManager {
         ) return FileRisk.ARCHIVE_REVIEW
         return FileRisk.NORMAL
     }
+
+    fun readFile(path: String, maxBytes: Long = 8192L): String {
+        val file = File(path)
+        if (!file.exists() || !file.isFile) return "File not found: $path"
+        return try {
+            file.inputStream().use { it.readBytes().take(maxBytes.toInt()) }.toByteArray().toString(Charsets.UTF_8)
+        } catch (e: Exception) {
+            "Cannot read file: ${e.message}"
+        }
+    }
+
+    fun renameFile(path: String, newName: String): Boolean {
+        val file = File(path)
+        val dest = File(file.parent ?: return false, newName)
+        return file.renameTo(dest)
+    }
+
+    fun moveFile(path: String, destDir: String): Boolean {
+        val file = File(path)
+        val dest = File(destDir, file.name)
+        return file.renameTo(dest)
+    }
+
+    fun deleteFile(path: String): Boolean = File(path).deleteRecursively()
 
     fun buildListSummary(): String {
         val entries = listRoot()

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/PermissionGate.kt
@@ -20,9 +20,13 @@ object AgentErrorCodes {
 data class GateResult(val allowed: Boolean, val message: String, val errorCode: String? = null)
 
 class PermissionGate(private val context: Context) {
-    fun evaluate(command: AgentCommand): GateResult {
+    fun evaluate(command: AgentCommand, autonomousMode: Boolean = false): GateResult {
         if (command.isExpired()) {
             return GateResult(false, "Command expired before owner approval", AgentErrorCodes.COMMAND_EXPIRED)
+        }
+        // Autonomous mode: owner has pre-authorised all commands — bypass permission gates
+        if (autonomousMode) {
+            return GateResult(true, "Autonomous mode — permission gate bypassed by owner")
         }
         val required = requiredPermissionFor(command.type)
         return when (required) {


### PR DESCRIPTION
- Add DadBotClient.kt — SSE token-streaming reader (Claude Haiku via /api/agent/chat)
- Add app/api/agent/chat/route.ts — SSE backend endpoint with Thai/English system prompt and queue_command tool
- Add UiAnimations.kt — fadeInSlideUp, buttonPressScale, startTypingPulse / stopTypingPulse using android.animation.*
- Add PermissionGate.kt — autonomousMode flag bypasses all permission gates
- Add FullFileManager.kt — readFile / renameFile / moveFile / deleteFile + riskFor autonomousMode bypass
- Rewrite MainActivity.kt — implement addDadBotSection (was called but missing in PR #621):
  • Chat bubble layout: user bubbles right-aligned (purple), bot bubbles left-aligned (dark)
  • 3-dot animated typing indicator (pulsing ObjectAnimator, GONE by default)
  • Live streaming text updates into bot bubble as tokens arrive
  • Quick suggestion chips: ตรวจระบบ / แสดงไฟล์ / ย้อนกลับ / เปิด settings
  • Autonomous Mode card with buttonPressScale animation on toggle
  • All action buttons get buttonPressScale touch feedback
  • Command inbox items fade in with slideUp animation
  • Autonomous + Work Session auto-execute from DadBot onCommand callback

https://claude.ai/code/session_01DP5sfg4vFCYAYcbu33fEpZ