### PR TITLE
ci(android): add -f to DELETE curl for correct HTTP error detection

### DIFF
--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -99,11 +99,11 @@ jobs:
           ASSET_IDS=$(echo "$RELEASE" | jq -r '.assets[] | select(.name | endswith(".apk")) | .id')
           while IFS= read -r ID; do
             [ -z "$ID" ] && continue
-            curl -sS -X DELETE \
+            curl -fsS -X DELETE \
               -H "Authorization: Bearer ${{ github.token }}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ github.repository }}/releases/assets/$ID" \
-              && echo "Deleted asset $ID" || echo "Warning: could not delete $ID"
+              && echo "Deleted asset $ID" || echo "Warning: could not delete $ID (continuing)"
           done <<< "$ASSET_IDS"
 
           # Upload new APK via uploads endpoint


### PR DESCRIPTION
Goal:
Address Codex P2 review on PR #629 — the `curl -sS -X DELETE` for removing old APK assets was missing `-f`, causing it to exit 0 even on HTTP 4xx/5xx errors and print misleading "Deleted asset" logs.

Files changed:
- `.github/workflows/android-agent.yml` — add `-f` to the asset DELETE curl command

Verification:
- [ ] On 4xx HTTP error, curl now exits non-zero and "Warning: could not delete" is printed (not "Deleted asset")
- [ ] On 204 success, behavior unchanged

Known limits:
- A 404 (asset doesn't exist) also triggers the warning message, which is slightly misleading but acceptable

User-visible benefit:
- Accurate CI logs when release asset deletion fails

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP5sfg4vFCYAYcbu33fEpZ)_