### PR TITLE
ci(android): skip APK publish on PRs, publish only on push to main

### DIFF
--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -99,11 +99,11 @@ jobs:
           ASSET_IDS=$(echo "$RELEASE" | jq -r '.assets[] | select(.name | endswith(".apk")) | .id')
           while IFS= read -r ID; do
             [ -z "$ID" ] && continue
-            curl -sS -X DELETE \
+            curl -fsS -X DELETE \
               -H "Authorization: Bearer ${{ github.token }}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ github.repository }}/releases/assets/$ID" \
-              && echo "Deleted asset $ID" || echo "Warning: could not delete $ID"
+              && echo "Deleted asset $ID" || echo "Warning: could not delete $ID (continuing)"
           done <<< "$ASSET_IDS"
 
           # Upload new APK via uploads endpoint

--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "apps/android/**"
       - ".github/workflows/android-agent.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/android/**"
+      - ".github/workflows/android-agent.yml"
   workflow_dispatch:
 
 permissions:
@@ -83,6 +89,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish APK to android-apk-latest release
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           set -e
           APK=$(ls apps/android/app/build/outputs/apk/debug/*.apk | head -1)


### PR DESCRIPTION
Goal:
Fix persistent "Publish APK to android-apk-latest release" failure. Root cause: `pull_request` `GITHUB_TOKEN` cannot upload release assets (org-level restriction overrides `contents: write`). Fix by: (1) skipping the publish step on PRs, (2) adding a `push` trigger on main so APK is published after merge with a token that has actual write access.

Files changed:
- `.github/workflows/android-agent.yml` — add `push` trigger on main, add `if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'` to publish step

Verification:
- [ ] PR CI passes (publish step skipped, build+artifact still run)
- [ ] After merge to main, push trigger fires and APK is published to `android-apk-latest` release

Known limits:
- APK is published on push to main, not on PR. PRs still validate the build.

User-visible benefit:
- CI green on PRs; APK auto-published to Releases after every merge to main

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP5sfg4vFCYAYcbu33fEpZ)_