### PR TITLE
feat(android): Hermes Agent stack — memory, skills, scheduler, Telegram, subagents, Local API :8642

### DIFF
--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -99,11 +99,11 @@ jobs:
           ASSET_IDS=$(echo "$RELEASE" | jq -r '.assets[] | select(.name | endswith(".apk")) | .id')
           while IFS= read -r ID; do
             [ -z "$ID" ] && continue
-            curl -sS -X DELETE \
+            curl -fsS -X DELETE \
               -H "Authorization: Bearer ${{ github.token }}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ github.repository }}/releases/assets/$ID" \
-              && echo "Deleted asset $ID" || echo "Warning: could not delete $ID"
+              && echo "Deleted asset $ID" || echo "Warning: could not delete $ID (continuing)"
           done <<< "$ASSET_IDS"
 
           # Upload new APK via uploads endpoint

--- a/.github/workflows/android-agent.yml
+++ b/.github/workflows/android-agent.yml
@@ -5,6 +5,12 @@ on:
     paths:
       - "apps/android/**"
       - ".github/workflows/android-agent.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/android/**"
+      - ".github/workflows/android-agent.yml"
   workflow_dispatch:
 
 permissions:
@@ -83,6 +89,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish APK to android-apk-latest release
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           set -e
           APK=$(ls apps/android/app/build/outputs/apk/debug/*.apk | head -1)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,52 @@ DSG ONE is a runtime governance layer for AI agents. Connect it in one line, gat
 | EU AI Act Annex IV | `GET /api/compliance-evidence-pack/annex4` | 9-item checklist, 7 covered, 2 partial |
 | MCP server marketing | `/pricing`, `/compliance-evidence-pack` | Positioned as differentiator vs Vanta/Sonar |
 | Zenodo DOI trust | `/pricing`, `/compliance-evidence-pack` | doi.org/10.5281/zenodo.18225586 prominently surfaced |
+| Android APK | `apps/android` | Hermes Agent stack — memory, skills, scheduler, Telegram gateway, subagents, Local API :8642 |
+
+---
+
+## 📱 Android Agent APK — Hermes Stack (2026-05-30)
+
+**Download:** [android-apk-latest release](https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/releases/tag/android-apk-latest)
+
+DSG Agent Android app — no-code AI work-session agent with a Hermes-inspired self-improvement stack built entirely on Android SDK (no extra Gradle dependencies).
+
+| Feature | Description |
+|---|---|
+| 🧠 Memory | Persistent entries (SharedPreferences JSON) auto-injected as `[ความจำ]` context block into every DadBot message; auto-captured from bot responses |
+| 🛠 Skills | Custom skill sequences; DadBot self-creates them via `[SKILL:name\|DESC:desc\|STEPS:CMD:target]` syntax in responses |
+| ⏰ Scheduler | `AlarmManager` cron tasks that fire DadBot automatically at configured intervals; results logged to audit trail |
+| 🌐 Telegram Gateway | Long-poll Telegram Bot → DadBot → reply; token + allowed chat ID stored in SharedPreferences |
+| 🤖 Subagents | `@sub1: prompt @sub2: prompt` — parallel DadBot instances, each with amber-bordered bubble |
+| 🔧 Tool call cards | Amber-bordered command card inserted into chat on every `onCommand()` event |
+| 🌐 Local API `:8642` | Pure-`ServerSocket` HTTP server — OpenAI `POST /v1/chat/completions` (stream + non-stream) and Anthropic `POST /v1/messages`; CORS enabled |
+| 8-tab nav | Chat · Sessions · Memory · Skills · Cron · Gateway · Files · Logs — horizontally scrollable |
+
+**Connect any OpenAI-compatible client to the on-device agent:**
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<device-ip>:8642/v1", api_key="x")
+resp = client.chat.completions.create(
+    model="dsg-agent",
+    messages=[{"role": "user", "content": "ตรวจระบบ"}],
+    stream=True,
+)
+for chunk in resp:
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+**Or Anthropic SDK:**
+
+```python
+import anthropic
+client = anthropic.Anthropic(base_url="http://<device-ip>:8642", api_key="x")
+msg = client.messages.create(model="dsg-agent", max_tokens=1024,
+    messages=[{"role": "user", "content": "แสดงไฟล์"}])
+print(msg.content[0].text)
+```
+
+---
 
 ## 🟢 GO / NO-GO — 2026-05-28 (CCVS v1.2 + Security Hardening)
 

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:allowBackup="false"
@@ -19,6 +21,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".automation.SchedulerReceiver"
+            android:exported="false" />
 
         <service
             android:name=".service.AgentForegroundService"

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -25,8 +25,10 @@ import android.text.style.TypefaceSpan
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.net.ConnectivityManager
 import android.widget.Button
 import android.widget.EditText
+import android.widget.HorizontalScrollView
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
@@ -38,13 +40,20 @@ import com.dsg.agent.automation.AgentCommandType
 import com.dsg.agent.automation.AgentErrorCodes
 import com.dsg.agent.automation.AuditLogStore
 import com.dsg.agent.automation.CommandExecutionResult
+import com.dsg.agent.automation.CustomSkill
 import com.dsg.agent.automation.DadBotCallback
 import com.dsg.agent.automation.DadBotClient
 import com.dsg.agent.automation.DadBotMessage
 import com.dsg.agent.automation.FullFileManager
+import com.dsg.agent.automation.MemoryStore
 import com.dsg.agent.automation.OwnerApprovalSigner
 import com.dsg.agent.automation.PermissionGate
+import com.dsg.agent.automation.ScheduledTaskStore
+import com.dsg.agent.automation.SkillStore
 import com.dsg.agent.service.AgentForegroundService
+import com.dsg.agent.service.TelegramGateway
+import java.net.HttpURLConnection
+import java.net.URL
 
 class MainActivity : Activity() {
     // Standard UI refs
@@ -57,8 +66,12 @@ class MainActivity : Activity() {
     // Navigation
     private lateinit var outerScroll: ScrollView
     private var dadBotSectionView: View? = null
+    private var sessionsSectionView: View? = null
+    private var memorySectionView: View? = null
     private var fileSectionView: View? = null
     private var skillsSectionView: View? = null
+    private var cronSectionView: View? = null
+    private var gatewaySectionView: View? = null
     private var logsSectionView: View? = null
 
     // DadBot chat UI refs
@@ -73,6 +86,16 @@ class MainActivity : Activity() {
     private var liveBotBubble: TextView? = null
     private var liveBotWrapper: LinearLayout? = null
     private var liveBotBuffer = StringBuilder()
+    private var subagentCount = 0
+    private var subagentChip: TextView? = null
+
+    // Dynamic section list views (refreshed without full render)
+    private var sessionsListView: LinearLayout? = null
+    private var memoryListView: LinearLayout? = null
+    private var logsListView: LinearLayout? = null
+    private var cronListView: LinearLayout? = null
+    private var statusDot: TextView? = null
+    private var gatewayStatusDot: TextView? = null
 
     // Domain objects
     private lateinit var commandStore: AgentCommandStore
@@ -80,6 +103,10 @@ class MainActivity : Activity() {
     private lateinit var permissionGate: PermissionGate
     private lateinit var approvalSigner: OwnerApprovalSigner
     private lateinit var dadBotClient: DadBotClient
+    private lateinit var memoryStore: MemoryStore
+    private lateinit var skillStore: SkillStore
+    private lateinit var scheduledTaskStore: ScheduledTaskStore
+    private lateinit var telegramGateway: TelegramGateway
 
     private val dadBotMessages = mutableListOf<DadBotMessage>()
     private var fileListRendered = false
@@ -96,7 +123,13 @@ class MainActivity : Activity() {
         permissionGate = PermissionGate(this)
         approvalSigner = OwnerApprovalSigner()
         dadBotClient = DadBotClient()
+        memoryStore = MemoryStore(this)
+        skillStore = SkillStore(this)
+        scheduledTaskStore = ScheduledTaskStore(this)
+        telegramGateway = TelegramGateway(this)
         render()
+        checkBackendStatus()
+        scheduledTaskStore.scheduleAll()
     }
 
     override fun onResume() {
@@ -114,11 +147,14 @@ class MainActivity : Activity() {
         addTabs(root)
         addAutonomousModeCard(root)
         addDadBotSection(root)
-        addNoCodeChat(root)
+        addSessionsSection(root)
+        addMemorySection(root)
+        addSkillsSection(root)
+        addCronSection(root)
+        addGatewaySection(root)
         addWorkSessionCard(root)
         addFileManagerCard(root)
-        addCommandInbox(root)
-        addAuditLog(root)
+        addLogsSection(root)
         outerScroll = ScrollView(this).apply {
             setBackgroundColor(COLOR_BG)
             addView(root)
@@ -172,19 +208,30 @@ class MainActivity : Activity() {
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
         hero.addView(statusView)
+        // Hermes-style backend status strip
+        statusDot = TextView(this).apply {
+            text = "● Checking..."
+            textSize = 11f
+            setTextColor(COLOR_TEXT_MUTED_DARK)
+            setPadding(0, dp(8), 0, 0)
+        }
+        hero.addView(statusDot)
         addWithMargin(root, hero, bottom = 12)
     }
 
     private fun addTabs(root: LinearLayout) {
-        val row = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-        }
-        row.addView(tab("💬 Chat", true) { scrollToView(dadBotSectionView) })
-        row.addView(tab("📁 Files", false) { scrollToView(fileSectionView) })
-        row.addView(tab("🛠 Skills", false) { scrollToView(skillsSectionView) })
-        row.addView(tab("📋 Logs", false) { scrollToView(logsSectionView) })
-        addWithMargin(root, row, bottom = 12)
+        val scroll = HorizontalScrollView(this).apply { isHorizontalScrollBarEnabled = false }
+        val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        row.addView(tab("💬 Chat", true)     { scrollToView(dadBotSectionView) })
+        row.addView(tab("🗂 Sessions", false) { scrollToView(sessionsSectionView) })
+        row.addView(tab("🧠 Memory", false)  { scrollToView(memorySectionView) })
+        row.addView(tab("🛠 Skills", false)  { scrollToView(skillsSectionView) })
+        row.addView(tab("⏰ Cron", false)    { scrollToView(cronSectionView) })
+        row.addView(tab("🌐 Gateway", false) { scrollToView(gatewaySectionView) })
+        row.addView(tab("📁 Files", false)   { scrollToView(fileSectionView) })
+        row.addView(tab("📋 Logs", false)    { scrollToView(logsSectionView) })
+        scroll.addView(row)
+        addWithMargin(root, scroll, bottom = 12)
     }
 
     private fun scrollToView(v: View?) {
@@ -431,6 +478,50 @@ class MainActivity : Activity() {
         setOnClickListener { onClick(it) }
     }
 
+    private fun makeToolCallCard(type: AgentCommandType, target: String, reason: String): View {
+        val card = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            background = GradientDrawable().apply {
+                setColor(COLOR_SURFACE_DARK_2)
+                cornerRadius = dp(10).toFloat()
+                setStroke(dp(2), COLOR_HERMES_AMBER)
+            }
+            setPadding(dp(12), dp(8), dp(12), dp(8))
+        }
+        card.addView(TextView(this).apply {
+            text = "🔧 ${type.name.lowercase()}"; textSize = 12f; typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_HERMES_AMBER)
+        })
+        val short = if (target.length > 60) target.take(57) + "..." else target
+        card.addView(TextView(this).apply { text = "  TYPE: ${type.name}"; textSize = 11f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+        card.addView(TextView(this).apply { text = "  TARGET: $short"; textSize = 11f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+        card.addView(TextView(this).apply { text = "  \"$reason\""; textSize = 11f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+        val outerRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.START
+            setPadding(0, dp(3), 0, dp(3))
+        }
+        outerRow.addView(card, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+            marginEnd = (resources.displayMetrics.widthPixels * 0.18).toInt()
+        })
+        return outerRow
+    }
+
+    private fun checkBackendStatus() {
+        Thread {
+            val ok = runCatching {
+                val conn = (URL(DsgConfig.STATUS_URL).openConnection() as HttpURLConnection).apply {
+                    connectTimeout = 5_000; readTimeout = 5_000; requestMethod = "GET"
+                }
+                val code = conn.responseCode; conn.disconnect(); code < 400
+            }.getOrDefault(false)
+            runOnUiThread {
+                statusDot?.text = if (ok) "● ${DsgConfig.BASE_URL}" else "● Offline — ${DsgConfig.BASE_URL}"
+                statusDot?.setTextColor(if (ok) COLOR_GREEN else COLOR_RED)
+            }
+        }.start()
+    }
+
     private fun makeWelcomeCard(icon: String, title: String, subtitle: String, onClick: () -> Unit): LinearLayout {
         val cardView = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
@@ -542,17 +633,21 @@ class MainActivity : Activity() {
         if (text.isBlank()) return
         dadBotInput.setText("")
 
-        // Insert user bubble above typing row, animate it
+        // Subagent detection: @sub1: … @sub2: …
+        val subParts = text.split(Regex("@sub\\d+:")).map { it.trim() }.filter { it.isNotBlank() }
+        if (subParts.size > 1) {
+            subParts.forEachIndexed { i, part -> launchSubagent(i + 1, part) }
+            return
+        }
+
         val userBubble = makeBubble(text, isUser = true)
-        val insertIdx = dadBotMessageList.childCount - 1 // before typing row
+        val insertIdx = dadBotMessageList.childCount - 1
         dadBotMessageList.addView(userBubble, insertIdx)
         UiAnimations.fadeInSlideUp(userBubble)
         dadBotMessages.add(DadBotMessage("user", text))
 
-        // Show typing dots
         showTyping()
 
-        // Live bot bubble — contentWrap is child 0 of outerRow, bubble TextView is child 0 of contentWrap
         val botBubbleWrapper = makeBubble("กำลังคิด...", isUser = false)
         liveBotWrapper = botBubbleWrapper
         val contentWrap = botBubbleWrapper.getChildAt(0) as? LinearLayout
@@ -563,17 +658,20 @@ class MainActivity : Activity() {
         dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
         scrollToView(dadBotSectionView)
 
+        val memCtx = memoryStore.toContextBlock()
+
         dadBotClient.chat(dadBotMessages.toList(), object : DadBotCallback {
             override fun onToken(token: String) {
                 liveBotBuffer.append(token)
-                liveBotBubble?.let {
-                    it.alpha = 1f
-                    it.text = liveBotBuffer.toString() + "▋"  // streaming cursor
-                }
+                liveBotBubble?.let { it.alpha = 1f; it.text = liveBotBuffer.toString() + "▋" }
                 dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
             }
 
             override fun onCommand(type: AgentCommandType, target: String, reason: String) {
+                // Insert Hermes-style tool call card into chat
+                val toolCard = makeToolCallCard(type, target, reason)
+                dadBotMessageList.addView(toolCard, dadBotMessageList.childCount - 1)
+                UiAnimations.fadeInSlideUp(toolCard)
                 val cmd = queueCommand(type, target, reason, "dadbot")
                 if (workSessionEnabled && !autonomousModeEnabled) this@MainActivity.runInSessionIfAllowed(cmd)
             }
@@ -585,6 +683,18 @@ class MainActivity : Activity() {
                     dadBotMessages.add(DadBotMessage("assistant", finalText))
                     liveBotBubble?.setText(renderMarkdown(finalText), TextView.BufferType.SPANNABLE)
                     liveBotWrapper?.let { UiAnimations.fadeInSlideUp(it) }
+                    // Auto-capture memory from bot response
+                    Regex("(?:จำ|จำไว้ว่า|remember):\\s*(.+)", RegexOption.IGNORE_CASE).find(finalText)?.groupValues?.get(1)?.trim()?.let { captured ->
+                        if (captured.length in 3..200) memoryStore.add(captured)
+                    }
+                    // Auto-capture skill definitions
+                    skillStore.parseFromBotResponse(finalText)?.let { newSkill ->
+                        skillStore.add(newSkill)
+                        val confirmBubble = makeBubble("✅ บันทึก skill: ${newSkill.name}", isUser = false)
+                        dadBotMessageList.addView(confirmBubble, dadBotMessageList.childCount - 1)
+                        UiAnimations.fadeInSlideUp(confirmBubble)
+                    }
+                    renderSessionsList()
                 } else {
                     liveBotWrapper?.visibility = View.GONE
                 }
@@ -607,7 +717,58 @@ class MainActivity : Activity() {
                 }
                 liveBotBubble = null; liveBotWrapper = null
             }
+        }, memCtx)
+    }
+
+    private fun launchSubagent(index: Int, prompt: String) {
+        subagentCount++
+        subagentChip?.let { it.text = "🤖 Subagents ($subagentCount running)"; it.visibility = View.VISIBLE }
+
+        val wrapperRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.START
+            setPadding(0, dp(3), 0, dp(3))
+        }
+        val bubble = TextView(this).apply {
+            text = "🤖 Sub $index: กำลังคิด..."
+            textSize = 13f
+            setTextColor(COLOR_HERMES_CREAM)
+            background = GradientDrawable().apply {
+                setColor(COLOR_HERMES_TEAL)
+                cornerRadius = dp(14).toFloat()
+                setStroke(dp(1), COLOR_HERMES_AMBER)
+            }
+            setPadding(dp(12), dp(9), dp(12), dp(9))
+            maxWidth = (resources.displayMetrics.widthPixels * 0.78).toInt()
+        }
+        wrapperRow.addView(bubble, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+            marginEnd = (resources.displayMetrics.widthPixels * 0.08).toInt()
         })
+        dadBotMessageList.addView(wrapperRow, dadBotMessageList.childCount - 1)
+        UiAnimations.fadeInSlideUp(wrapperRow)
+
+        val buf = StringBuilder()
+        val memCtx = memoryStore.toContextBlock()
+        dadBotClient.chat(listOf(DadBotMessage("user", prompt)), object : DadBotCallback {
+            override fun onToken(token: String) {
+                buf.append(token)
+                bubble.text = "🤖 Sub $index: ${buf}▋"
+                dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
+            }
+            override fun onCommand(type: AgentCommandType, target: String, reason: String) {
+                queueCommand(type, target, reason, "subagent-$index")
+            }
+            override fun onDone() {
+                bubble.text = "🤖 Sub $index: $buf"
+                subagentCount = maxOf(0, subagentCount - 1)
+                if (subagentCount == 0) subagentChip?.visibility = View.GONE
+            }
+            override fun onError(message: String) {
+                bubble.text = "🤖 Sub $index ⚠️ $message"
+                subagentCount = maxOf(0, subagentCount - 1)
+                if (subagentCount == 0) subagentChip?.visibility = View.GONE
+            }
+        }, memCtx)
     }
 
     private fun showTyping() {
@@ -626,31 +787,352 @@ class MainActivity : Activity() {
         typingDot3.alpha = 0f
     }
 
-    private fun addNoCodeChat(root: LinearLayout) {
-        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        box.addView(sectionHeader("No-code Chat", "พิมพ์งานเดียว แล้วให้ Agent สร้างงานให้"))
-        box.addView(TextView(this).apply {
-            text = "ตัวอย่าง: ตรวจระบบให้ครบ, เปิด status, แสดงไฟล์, ส่งไฟล์ให้ Claw, เปิด settings, back, home, scroll"
-            textSize = 12f
-            setTextColor(COLOR_TEXT_MUTED)
-            setPadding(0, 0, 0, dp(10))
+    private fun addSessionsSection(root: LinearLayout) {
+        val box = card(COLOR_HERMES_TEAL, stroke = COLOR_HERMES_AMBER).apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        val headerRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, 0, 0, dp(10)) }
+        headerRow.addView(TextView(this).apply {
+            text = "🗂 Sessions"; textSize = 17f; typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_HERMES_CREAM)
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        headerRow.addView(compactButton("New Chat", ButtonTone.SECONDARY) {
+            dadBotMessages.clear()
+            // Keep only greeting + typingRow; clear everything else
+            while (dadBotMessageList.childCount > 2) dadBotMessageList.removeViewAt(dadBotMessageList.childCount - 2)
+            renderSessionsList()
+            dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
         })
-        chatInput = EditText(this).apply {
-            hint = "พิมพ์เป้าหมายงาน เช่น ตรวจระบบให้ครบ"
-            textSize = 14f
-            minLines = 3
-            maxLines = 5
-            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-            setTextColor(COLOR_TEXT)
-            setHintTextColor(COLOR_TEXT_MUTED)
-            background = rounded(COLOR_BG, 18, COLOR_BORDER, 1)
-            setPadding(dp(14), dp(12), dp(14), dp(12))
+        box.addView(headerRow)
+        sessionsListView = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        box.addView(sessionsListView)
+        sessionsSectionView = box
+        addWithMargin(root, box, bottom = 12)
+        renderSessionsList()
+    }
+
+    private fun renderSessionsList() {
+        val list = sessionsListView ?: return
+        list.removeAllViews()
+        if (dadBotMessages.isEmpty()) {
+            list.addView(TextView(this).apply {
+                text = "No sessions yet — start chatting above"; textSize = 12f
+                setTextColor(COLOR_TEXT_MUTED_DARK); setPadding(0, dp(4), 0, 0)
+            })
+            return
         }
-        addWithMargin(box, chatInput, bottom = 10)
-        val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
-        row.addView(compactButton("Run", ButtonTone.PRIMARY) { runNoCodePrompt() })
-        row.addView(compactButton("Clear", ButtonTone.SECONDARY) { chatInput.setText("") })
-        box.addView(row)
+        dadBotMessages.forEach { msg ->
+            val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, dp(4), 0, dp(4)) }
+            val badge = if (msg.role == "user") "👤" else "🤖"
+            row.addView(TextView(this).apply { text = badge; textSize = 13f; setPadding(0, 0, dp(8), 0) })
+            val preview = msg.content.take(60).replace("\n", " ") + if (msg.content.length > 60) "…" else ""
+            row.addView(TextView(this).apply {
+                text = preview; textSize = 12f; setTextColor(COLOR_TEXT_SOFT_DARK)
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            list.addView(row)
+        }
+    }
+
+    private fun addMemorySection(root: LinearLayout) {
+        val box = card(COLOR_HERMES_TEAL, stroke = COLOR_HERMES_AMBER).apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        val headerRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, 0, 0, dp(10)) }
+        headerRow.addView(TextView(this).apply {
+            text = "🧠 Memory"; textSize = 17f; typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_HERMES_CREAM)
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        headerRow.addView(compactButton("Clear All", ButtonTone.DANGER) {
+            memoryStore.clear(); renderMemoryList()
+        })
+        box.addView(headerRow)
+
+        // Inline add row
+        val addRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, 0, 0, dp(8)) }
+        val addInput = EditText(this).apply {
+            hint = "เพิ่มความจำ..."; textSize = 13f; maxLines = 2
+            setTextColor(COLOR_TEXT_SOFT_DARK); setHintTextColor(COLOR_TEXT_MUTED_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 12, COLOR_BORDER_DARK, 1)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+        }
+        addRow.addView(addInput, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply { marginEnd = dp(8) })
+        addRow.addView(Button(this).apply {
+            text = "+ Add"; textSize = 12f; isAllCaps = false
+            setTextColor(Color.WHITE); background = rounded(COLOR_PRIMARY, 12)
+            setOnClickListener {
+                val txt = addInput.text.toString().trim()
+                if (txt.isNotBlank()) { memoryStore.add(txt); addInput.setText(""); renderMemoryList() }
+            }
+        }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, dp(40)))
+        box.addView(addRow)
+
+        memoryListView = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        box.addView(memoryListView)
+        memorySectionView = box
+        addWithMargin(root, box, bottom = 12)
+        renderMemoryList()
+    }
+
+    private fun renderMemoryList() {
+        val list = memoryListView ?: return
+        list.removeAllViews()
+        val entries = memoryStore.list()
+        if (entries.isEmpty()) {
+            list.addView(TextView(this).apply { text = "No memories yet"; textSize = 12f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+            return
+        }
+        entries.forEach { entry ->
+            val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, dp(3), 0, dp(3)) }
+            row.addView(TextView(this).apply { text = "●"; textSize = 12f; setTextColor(COLOR_HERMES_AMBER); setPadding(0, 0, dp(8), 0) })
+            row.addView(TextView(this).apply {
+                text = entry.content; textSize = 12f; setTextColor(COLOR_TEXT_SOFT_DARK)
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            row.addView(TextView(this).apply {
+                text = "×"; textSize = 16f; setTextColor(COLOR_RED)
+                setPadding(dp(8), 0, 0, 0)
+                setOnClickListener { memoryStore.delete(entry.id); renderMemoryList() }
+            })
+            list.addView(row)
+        }
+    }
+
+    private fun addSkillsSection(root: LinearLayout) {
+        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(sectionHeader("🛠 Skills", "Built-in commands + custom learned skills"))
+
+        // Built-in commands grid by category
+        data class SkillEntry(val icon: String, val label: String, val type: AgentCommandType, val target: String)
+        val categories = mapOf(
+            "Navigation" to listOf(
+                SkillEntry("↩️", "Back", AgentCommandType.BACK, "GLOBAL_BACK"),
+                SkillEntry("🏠", "Home", AgentCommandType.HOME, "GLOBAL_HOME"),
+                SkillEntry("⬇️", "Scroll", AgentCommandType.SCROLL_DOWN, "FOCUSED_OR_ROOT_NODE"),
+                SkillEntry("🔗", "URL...", AgentCommandType.OPEN_URL, DsgConfig.STATUS_URL),
+                SkillEntry("📱", "Settings", AgentCommandType.OPEN_SETTINGS, ""),
+            ),
+            "Files" to listOf(
+                SkillEntry("📁", "List Files", AgentCommandType.FILE_LIST_ROOT, FullFileManager.rootPath().absolutePath),
+                SkillEntry("👁", "Preview", AgentCommandType.FILE_PREVIEW, ""),
+                SkillEntry("📤", "Send→Claw", AgentCommandType.FILE_SEND_TO_CLAW, "selected-files://local"),
+            ),
+            "System" to listOf(
+                SkillEntry("📊", "Status", AgentCommandType.STATUS, ""),
+                SkillEntry("🔔", "Notifs", AgentCommandType.NOTIFICATION_SUMMARY, ""),
+            ),
+        )
+        categories.forEach { (catName, entries) ->
+            box.addView(TextView(this).apply {
+                text = catName; textSize = 12f; typeface = Typeface.DEFAULT_BOLD
+                setTextColor(COLOR_HERMES_AMBER); setPadding(0, dp(8), 0, dp(4))
+            })
+            val row1 = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+            val row2 = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+            entries.forEachIndexed { i, e ->
+                val targetRow = if (i < 3) row1 else row2
+                val card2 = LinearLayout(this).apply {
+                    orientation = LinearLayout.VERTICAL
+                    background = GradientDrawable().apply {
+                        setColor(COLOR_SURFACE_DARK_2); cornerRadius = dp(10).toFloat()
+                        setStroke(dp(2), COLOR_HERMES_AMBER)
+                    }
+                    setPadding(dp(8), dp(8), dp(8), dp(8))
+                }
+                card2.addView(TextView(this).apply { text = "${e.icon} ${e.label}"; textSize = 11f; typeface = Typeface.DEFAULT_BOLD; setTextColor(Color.WHITE) })
+                card2.addView(Button(this).apply {
+                    text = "▶ Queue"; textSize = 10f; isAllCaps = false
+                    setTextColor(COLOR_HERMES_AMBER); background = rounded(COLOR_CARD_ALT, 8)
+                    setPadding(0, dp(2), 0, dp(2))
+                    setOnClickListener {
+                        UiAnimations.buttonPressScale(this)
+                        val cmd = queueCommand(e.type, e.target, "Skill: ${e.label}", "skills-panel")
+                        runInSessionIfAllowed(cmd)
+                    }
+                }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(30)).apply { topMargin = dp(4) })
+                targetRow.addView(card2, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply { setMargins(0, 0, dp(6), dp(6)) })
+            }
+            box.addView(row1)
+            if (row2.childCount > 0) box.addView(row2)
+        }
+
+        // Custom skills
+        val customHeader = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, dp(8), 0, dp(4)) }
+        customHeader.addView(TextView(this).apply {
+            text = "Custom Skills (${skillStore.list().size})"; textSize = 12f; typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_HERMES_CREAM)
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        box.addView(customHeader)
+
+        val customList = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        skillStore.list().forEach { skill ->
+            val cRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, dp(4), 0, dp(4)) }
+            cRow.addView(TextView(this).apply {
+                text = "📋 ${skill.name}  (${skill.steps.joinToString("+") { it.name }})"; textSize = 12f; setTextColor(COLOR_TEXT_SOFT_DARK)
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            cRow.addView(Button(this).apply {
+                text = "▶"; textSize = 11f; isAllCaps = false
+                setTextColor(COLOR_HERMES_AMBER); background = rounded(COLOR_CARD_ALT, 8)
+                setOnClickListener {
+                    skill.steps.forEachIndexed { i, type ->
+                        val cmd = queueCommand(type, skill.targets.getOrElse(i) { "" }, "Skill: ${skill.name} step ${i + 1}", "custom-skill")
+                        runInSessionIfAllowed(cmd)
+                    }
+                }
+            }, LinearLayout.LayoutParams(dp(36), dp(36)).apply { marginStart = dp(6) })
+            cRow.addView(Button(this).apply {
+                text = "×"; textSize = 14f; isAllCaps = false
+                setTextColor(COLOR_RED); background = rounded(COLOR_CARD_ALT, 8)
+                setOnClickListener { skillStore.delete(skill.id); render() }
+            }, LinearLayout.LayoutParams(dp(36), dp(36)).apply { marginStart = dp(4) })
+            customList.addView(cRow)
+        }
+        if (skillStore.list().isEmpty()) {
+            customList.addView(TextView(this).apply { text = "No custom skills yet. DadBot can create them automatically."; textSize = 12f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+        }
+        box.addView(customList)
+
+        // Kill switch
+        addWithMargin(box, actionButton("Kill Switch: Clear All Pending", "Owner emergency stop", ButtonTone.DANGER) {
+            val count = commandStore.clearPending()
+            auditLogStore.append("KILL_SWITCH_CLEAR_PENDING", "local", "Owner cleared $count pending command(s)")
+            refreshUi("Kill switch cleared $count pending command(s)")
+        }, top = 8)
+
+        commandListView = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL; setPadding(0, dp(6), 0, 0) }
+        box.addView(commandListView)
+        skillsSectionView = box
+        addWithMargin(root, box, bottom = 12)
+    }
+
+    private fun addCronSection(root: LinearLayout) {
+        val box = card(COLOR_HERMES_TEAL, stroke = COLOR_HERMES_AMBER).apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(TextView(this).apply {
+            text = "⏰ Cron / Scheduler"; textSize = 17f; typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_HERMES_CREAM); setPadding(0, 0, 0, dp(10))
+        })
+
+        // Add form
+        val promptInput = EditText(this).apply {
+            hint = "Prompt ที่จะส่งให้ DadBot..."; textSize = 13f; maxLines = 2
+            setTextColor(COLOR_TEXT_SOFT_DARK); setHintTextColor(COLOR_TEXT_MUTED_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 10, COLOR_BORDER_DARK, 1)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+        }
+        val intervalInput = EditText(this).apply {
+            hint = "นาที"; textSize = 13f; maxLines = 1
+            inputType = android.text.InputType.TYPE_CLASS_NUMBER
+            setTextColor(COLOR_TEXT_SOFT_DARK); setHintTextColor(COLOR_TEXT_MUTED_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 10, COLOR_BORDER_DARK, 1)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+        }
+        addWithMargin(box, promptInput, bottom = 6)
+        val addFormRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL }
+        addFormRow.addView(intervalInput, LinearLayout.LayoutParams(0, dp(40), 1f).apply { marginEnd = dp(8) })
+        addFormRow.addView(Button(this).apply {
+            text = "+ Add"; textSize = 12f; isAllCaps = false
+            setTextColor(Color.WHITE); background = rounded(COLOR_PRIMARY, 12)
+            setOnClickListener {
+                val prompt = promptInput.text.toString().trim()
+                val mins = intervalInput.text.toString().toIntOrNull() ?: 60
+                if (prompt.isNotBlank()) {
+                    val task = com.dsg.agent.automation.ScheduledTask(
+                        id = ScheduledTaskStore.newId(), prompt = prompt,
+                        intervalMinutes = mins, enabled = true,
+                        nextRunAt = System.currentTimeMillis() + mins * 60_000L, lastRunAt = 0L,
+                    )
+                    scheduledTaskStore.add(task)
+                    scheduledTaskStore.scheduleTask(task)
+                    promptInput.setText(""); intervalInput.setText("")
+                    renderCronList()
+                }
+            }
+        }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, dp(40)))
+        addWithMargin(box, addFormRow, bottom = 10)
+
+        cronListView = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        box.addView(cronListView)
+        cronSectionView = box
+        addWithMargin(root, box, bottom = 12)
+        renderCronList()
+    }
+
+    private fun renderCronList() {
+        val list = cronListView ?: return
+        list.removeAllViews()
+        val tasks = scheduledTaskStore.list()
+        if (tasks.isEmpty()) {
+            list.addView(TextView(this).apply { text = "No scheduled tasks yet"; textSize = 12f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+            return
+        }
+        tasks.forEach { task ->
+            val row = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, dp(4), 0, dp(4)) }
+            val dot = if (task.enabled) "●" else "○"
+            row.addView(TextView(this).apply {
+                text = "$dot "${task.prompt.take(30)}${if (task.prompt.length > 30) "…" else ""}" every ${task.intervalMinutes}m"
+                textSize = 11f; setTextColor(if (task.enabled) COLOR_HERMES_CREAM else COLOR_TEXT_MUTED_DARK)
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            row.addView(Button(this).apply {
+                text = if (task.enabled) "⏸" else "▶"; textSize = 13f; isAllCaps = false
+                setTextColor(COLOR_HERMES_AMBER); background = rounded(COLOR_CARD_ALT, 8)
+                setOnClickListener {
+                    scheduledTaskStore.update(task.id) { it.copy(enabled = !it.enabled) }
+                    renderCronList()
+                }
+            }, LinearLayout.LayoutParams(dp(36), dp(36)).apply { marginStart = dp(6) })
+            row.addView(Button(this).apply {
+                text = "×"; textSize = 14f; isAllCaps = false
+                setTextColor(COLOR_RED); background = rounded(COLOR_CARD_ALT, 8)
+                setOnClickListener { scheduledTaskStore.delete(task.id); renderCronList() }
+            }, LinearLayout.LayoutParams(dp(36), dp(36)).apply { marginStart = dp(4) })
+            list.addView(row)
+        }
+    }
+
+    private fun addGatewaySection(root: LinearLayout) {
+        val box = card(COLOR_HERMES_TEAL, stroke = COLOR_HERMES_AMBER).apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        val headerRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL; setPadding(0, 0, 0, dp(10)) }
+        gatewayStatusDot = TextView(this).apply { text = "● Offline"; textSize = 12f; setTextColor(COLOR_RED) }
+        headerRow.addView(TextView(this).apply {
+            text = "🌐 Gateway"; textSize = 17f; typeface = Typeface.DEFAULT_BOLD; setTextColor(COLOR_HERMES_CREAM)
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        headerRow.addView(gatewayStatusDot)
+        box.addView(headerRow)
+
+        val telegramPrefs = getSharedPreferences("dsg_telegram_prefs", MODE_PRIVATE)
+        val tokenInput = EditText(this).apply {
+            hint = "Telegram Bot Token"; textSize = 13f; maxLines = 1
+            setText(telegramPrefs.getString("token", ""))
+            setTextColor(COLOR_TEXT_SOFT_DARK); setHintTextColor(COLOR_TEXT_MUTED_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 10, COLOR_BORDER_DARK, 1)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+        }
+        val chatIdInput = EditText(this).apply {
+            hint = "Allowed Chat ID"; textSize = 13f; maxLines = 1
+            inputType = android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_SIGNED
+            setText(telegramPrefs.getString("chatId", ""))
+            setTextColor(COLOR_TEXT_SOFT_DARK); setHintTextColor(COLOR_TEXT_MUTED_DARK)
+            background = rounded(COLOR_SURFACE_DARK_2, 10, COLOR_BORDER_DARK, 1)
+            setPadding(dp(10), dp(6), dp(10), dp(6))
+        }
+        addWithMargin(box, tokenInput, bottom = 6)
+        addWithMargin(box, chatIdInput, bottom = 10)
+
+        val btnRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        btnRow.addView(compactButton("Start Telegram", ButtonTone.PRIMARY) {
+            val token = tokenInput.text.toString().trim()
+            val chatId = chatIdInput.text.toString().trim()
+            if (token.isNotBlank()) {
+                telegramPrefs.edit().putString("token", token).putString("chatId", chatId).apply()
+                telegramGateway.start(token, chatId)
+                gatewayStatusDot?.text = "● Live"; gatewayStatusDot?.setTextColor(COLOR_GREEN)
+                auditLogStore.append("TELEGRAM_GATEWAY_START", "owner", "Telegram gateway started")
+            }
+        })
+        btnRow.addView(compactButton("Stop", ButtonTone.SECONDARY) {
+            telegramGateway.stop()
+            gatewayStatusDot?.text = "● Offline"; gatewayStatusDot?.setTextColor(COLOR_RED)
+        })
+        box.addView(btnRow)
+        box.addView(TextView(this).apply {
+            text = "Discord / Slack / WhatsApp — coming soon"; textSize = 11f
+            setTextColor(COLOR_TEXT_MUTED_DARK); setPadding(0, dp(8), 0, 0)
+        })
+        gatewaySectionView = box
         addWithMargin(root, box, bottom = 12)
     }
 
@@ -756,18 +1238,53 @@ class MainActivity : Activity() {
         addWithMargin(root, box, bottom = 12)
     }
 
-    private fun addAuditLog(root: LinearLayout) {
-        val box = card().apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
-        box.addView(sectionHeader("Local Audit Log", "Device evidence"))
-        auditView = TextView(this).apply {
-            textSize = 12f
-            setTextColor(COLOR_TEXT_MUTED)
-            background = rounded(COLOR_BG, 16, COLOR_BORDER, 1)
-            setPadding(dp(14), dp(12), dp(14), dp(12))
+    private fun addLogsSection(root: LinearLayout) {
+        val box = card(COLOR_HERMES_TEAL, stroke = COLOR_HERMES_AMBER).apply { setPadding(dp(16), dp(16), dp(16), dp(16)) }
+        box.addView(TextView(this).apply {
+            text = "📋 Logs"; textSize = 17f; typeface = Typeface.DEFAULT_BOLD
+            setTextColor(COLOR_HERMES_CREAM); setPadding(0, 0, 0, dp(10))
+        })
+        val logScroll = ScrollView(this).apply {
+            background = rounded(COLOR_SURFACE_DARK_2, 10, COLOR_BORDER_DARK, 1)
         }
+        logsListView = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(10), dp(8), dp(10), dp(8))
+        }
+        logScroll.addView(logsListView)
+        box.addView(logScroll, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(200)))
+        // Keep auditView for backward-compat (used in renderAuditLog)
+        auditView = TextView(this).apply { visibility = View.GONE }
         box.addView(auditView)
         logsSectionView = box
         addWithMargin(root, box)
+    }
+
+    private fun renderLogsList() {
+        val list = logsListView ?: return
+        list.removeAllViews()
+        val raw = auditLogStore.tail(50)
+        if (raw.isBlank()) {
+            list.addView(TextView(this).apply { text = "No audit events yet"; textSize = 11f; setTextColor(COLOR_TEXT_MUTED_DARK) })
+            return
+        }
+        raw.split("\n\n").reversed().forEach { entry ->
+            if (entry.isBlank()) return@forEach
+            val firstLine = entry.lines().firstOrNull() ?: return@forEach
+            val color = when {
+                firstLine.contains("KILL_SWITCH") || firstLine.contains("FAILED") || firstLine.contains("ERROR") -> COLOR_RED
+                firstLine.contains("APPROVED") || firstLine.contains("ENABLED") || firstLine.contains("EXECUTED") || firstLine.contains("STARTED") || firstLine.contains("DONE") -> COLOR_GREEN
+                firstLine.contains("BLOCKED") || firstLine.contains("REJECTED") || firstLine.contains("WAITING") -> COLOR_HERMES_AMBER
+                else -> COLOR_TEXT_MUTED_DARK
+            }
+            val tv = TextView(this).apply {
+                text = "● $firstLine"
+                textSize = 10f
+                setTextColor(color)
+                setPadding(0, dp(2), 0, dp(2))
+            }
+            list.addView(tv)
+        }
     }
 
     private fun runNoCodePrompt() {
@@ -863,7 +1380,8 @@ class MainActivity : Activity() {
             filePreviewView.text = "Full file manager permission enabled. Start Work Session, then ask: แสดงไฟล์"
         }
         renderCommands()
-        renderAuditLog()
+        renderLogsList()
+        renderSessionsList()
     }
 
     private fun renderCommands() {
@@ -1047,7 +1565,7 @@ class MainActivity : Activity() {
     }
 
     private fun renderAuditLog() {
-        auditView.text = auditLogStore.tail(20).ifEmpty { "No audit events yet." }
+        renderLogsList()
     }
 
     private fun buildStatusText(extra: String? = null): String = listOfNotNull(
@@ -1130,7 +1648,8 @@ class MainActivity : Activity() {
         gravity = Gravity.CENTER
         setTextColor(if (active) Color.WHITE else COLOR_TEXT_MUTED)
         background = rounded(if (active) COLOR_PRIMARY else COLOR_CARD, 22, if (active) COLOR_PRIMARY else COLOR_BORDER, 1)
-        layoutParams = LinearLayout.LayoutParams(0, dp(42), 1f).apply { setMargins(0, 0, dp(8), 0) }
+        setPadding(dp(16), 0, dp(16), 0)
+        layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, dp(42)).apply { setMargins(0, 0, dp(8), 0) }
         setOnClickListener { onClick() }
     }
 
@@ -1174,7 +1693,7 @@ class MainActivity : Activity() {
     private enum class ButtonTone { PRIMARY, SECONDARY, WARNING, DANGER }
 
     companion object {
-        // Kimi-style dark palette
+        // Kimi dark palette
         private val COLOR_BG = 0xFF0D0D0D.toInt()
         private val COLOR_CARD = 0xFF111111.toInt()
         private val COLOR_CARD_ALT = 0xFF1A1A1A.toInt()
@@ -1198,5 +1717,9 @@ class MainActivity : Activity() {
         private val COLOR_BORDER_DARK = 0xFF2A2A2A.toInt()
         private val COLOR_TEXT_MUTED_DARK = 0xFF888888.toInt()
         private val COLOR_TEXT_SOFT_DARK = 0xFFD0D0D0.toInt()
+        // Hermes Agent palette
+        private val COLOR_HERMES_TEAL  = 0xFF041C1C.toInt()
+        private val COLOR_HERMES_CREAM = 0xFFFFE6CB.toInt()
+        private val COLOR_HERMES_AMBER = 0xFFFFBD38.toInt()
     }
 }

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -51,6 +51,7 @@ import com.dsg.agent.automation.PermissionGate
 import com.dsg.agent.automation.ScheduledTaskStore
 import com.dsg.agent.automation.SkillStore
 import com.dsg.agent.service.AgentForegroundService
+import com.dsg.agent.service.LocalApiServer
 import com.dsg.agent.service.TelegramGateway
 import java.net.HttpURLConnection
 import java.net.URL
@@ -96,6 +97,7 @@ class MainActivity : Activity() {
     private var cronListView: LinearLayout? = null
     private var statusDot: TextView? = null
     private var gatewayStatusDot: TextView? = null
+    private var localApiStatusDot: TextView? = null
 
     // Domain objects
     private lateinit var commandStore: AgentCommandStore
@@ -107,6 +109,7 @@ class MainActivity : Activity() {
     private lateinit var skillStore: SkillStore
     private lateinit var scheduledTaskStore: ScheduledTaskStore
     private lateinit var telegramGateway: TelegramGateway
+    private lateinit var localApiServer: LocalApiServer
 
     private val dadBotMessages = mutableListOf<DadBotMessage>()
     private var fileListRendered = false
@@ -127,6 +130,7 @@ class MainActivity : Activity() {
         skillStore = SkillStore(this)
         scheduledTaskStore = ScheduledTaskStore(this)
         telegramGateway = TelegramGateway(this)
+        localApiServer = LocalApiServer(this)
         render()
         checkBackendStatus()
         scheduledTaskStore.scheduleAll()
@@ -1128,6 +1132,38 @@ class MainActivity : Activity() {
             gatewayStatusDot?.text = "● Offline"; gatewayStatusDot?.setTextColor(COLOR_RED)
         })
         box.addView(btnRow)
+
+        // Local API subsection — OpenAI + Anthropic compatible HTTP server on port 8642
+        box.addView(TextView(this).apply {
+            text = "──── Local API ────"; textSize = 11f
+            setTextColor(COLOR_HERMES_AMBER); setPadding(0, dp(10), 0, dp(4))
+        })
+        val apiStatusRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            setPadding(0, 0, 0, dp(6))
+        }
+        localApiStatusDot = TextView(this).apply { text = "● Offline"; textSize = 12f; setTextColor(COLOR_RED) }
+        apiStatusRow.addView(localApiStatusDot!!, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        box.addView(apiStatusRow)
+        val apiBtnRow = LinearLayout(this).apply { orientation = LinearLayout.HORIZONTAL }
+        apiBtnRow.addView(compactButton("Start Local API", ButtonTone.PRIMARY) {
+            localApiServer.start()
+            val ip = localApiServer.getLocalIp()
+            localApiStatusDot?.text = "● http://$ip:${LocalApiServer.DEFAULT_PORT}"
+            localApiStatusDot?.setTextColor(COLOR_GREEN)
+            auditLogStore.append("LOCAL_API_START", "owner", "Local API started on $ip:${LocalApiServer.DEFAULT_PORT}")
+        })
+        apiBtnRow.addView(compactButton("Stop", ButtonTone.SECONDARY) {
+            localApiServer.stop()
+            localApiStatusDot?.text = "● Offline"
+            localApiStatusDot?.setTextColor(COLOR_RED)
+        })
+        box.addView(apiBtnRow)
+        box.addView(TextView(this).apply {
+            text = "  POST /v1/chat/completions (OpenAI)  ·  POST /v1/messages (Anthropic)"
+            textSize = 10f; setTextColor(COLOR_TEXT_MUTED_DARK); setPadding(0, dp(4), 0, 0)
+        })
+
         box.addView(TextView(this).apply {
             text = "Discord / Slack / WhatsApp — coming soon"; textSize = 11f
             setTextColor(COLOR_TEXT_MUTED_DARK); setPadding(0, dp(8), 0, 0)

--- a/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt
@@ -54,6 +54,13 @@ class MainActivity : Activity() {
     private lateinit var filePreviewView: TextView
     private lateinit var chatInput: EditText
 
+    // Navigation
+    private lateinit var outerScroll: ScrollView
+    private var dadBotSectionView: View? = null
+    private var fileSectionView: View? = null
+    private var skillsSectionView: View? = null
+    private var logsSectionView: View? = null
+
     // DadBot chat UI refs
     private lateinit var dadBotScroll: ScrollView
     private lateinit var dadBotMessageList: LinearLayout
@@ -112,10 +119,11 @@ class MainActivity : Activity() {
         addFileManagerCard(root)
         addCommandInbox(root)
         addAuditLog(root)
-        setContentView(ScrollView(this).apply {
+        outerScroll = ScrollView(this).apply {
             setBackgroundColor(COLOR_BG)
             addView(root)
-        })
+        }
+        setContentView(outerScroll)
         refreshUi()
     }
 
@@ -172,11 +180,16 @@ class MainActivity : Activity() {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
         }
-        row.addView(tab("💬 Chat", true))
-        row.addView(tab("📁 Files", false))
-        row.addView(tab("🛠 Skills", false))
-        row.addView(tab("📋 Logs", false))
+        row.addView(tab("💬 Chat", true) { scrollToView(dadBotSectionView) })
+        row.addView(tab("📁 Files", false) { scrollToView(fileSectionView) })
+        row.addView(tab("🛠 Skills", false) { scrollToView(skillsSectionView) })
+        row.addView(tab("📋 Logs", false) { scrollToView(logsSectionView) })
         addWithMargin(root, row, bottom = 12)
+    }
+
+    private fun scrollToView(v: View?) {
+        v ?: return
+        outerScroll.post { outerScroll.smoothScrollTo(0, v.top) }
     }
 
     private fun addAutonomousModeCard(root: LinearLayout) {
@@ -351,6 +364,7 @@ class MainActivity : Activity() {
         box.addView(promptRow1)
         box.addView(promptRow2)
 
+        dadBotSectionView = box
         addWithMargin(root, box, bottom = 12)
     }
 
@@ -547,6 +561,7 @@ class MainActivity : Activity() {
         dadBotMessageList.addView(botBubbleWrapper, dadBotMessageList.childCount - 1)
 
         dadBotScroll.post { dadBotScroll.fullScroll(View.FOCUS_DOWN) }
+        scrollToView(dadBotSectionView)
 
         dadBotClient.chat(dadBotMessages.toList(), object : DadBotCallback {
             override fun onToken(token: String) {
@@ -708,6 +723,7 @@ class MainActivity : Activity() {
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
         addWithMargin(box, filePreviewView, top = 8)
+        fileSectionView = box
         addWithMargin(root, box, bottom = 12)
     }
 
@@ -736,6 +752,7 @@ class MainActivity : Activity() {
             setPadding(0, dp(10), 0, 0)
         }
         box.addView(commandListView)
+        skillsSectionView = box
         addWithMargin(root, box, bottom = 12)
     }
 
@@ -749,6 +766,7 @@ class MainActivity : Activity() {
             setPadding(dp(14), dp(12), dp(14), dp(12))
         }
         box.addView(auditView)
+        logsSectionView = box
         addWithMargin(root, box)
     }
 
@@ -1105,7 +1123,7 @@ class MainActivity : Activity() {
         layoutParams = LinearLayout.LayoutParams(0, dp(44), 1f).apply { setMargins(0, 0, dp(8), 0) }
     }
 
-    private fun tab(label: String, active: Boolean): TextView = TextView(this).apply {
+    private fun tab(label: String, active: Boolean, onClick: () -> Unit = {}): TextView = TextView(this).apply {
         text = label
         textSize = 13f
         typeface = Typeface.DEFAULT_BOLD
@@ -1113,6 +1131,7 @@ class MainActivity : Activity() {
         setTextColor(if (active) Color.WHITE else COLOR_TEXT_MUTED)
         background = rounded(if (active) COLOR_PRIMARY else COLOR_CARD, 22, if (active) COLOR_PRIMARY else COLOR_BORDER, 1)
         layoutParams = LinearLayout.LayoutParams(0, dp(42), 1f).apply { setMargins(0, 0, dp(8), 0) }
+        setOnClickListener { onClick() }
     }
 
     private fun statusPill(label: String, ok: Boolean): TextView = TextView(this).apply {

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt
@@ -21,7 +21,7 @@ interface DadBotCallback {
 class DadBotClient {
     private val ui = Handler(Looper.getMainLooper())
 
-    fun chat(messages: List<DadBotMessage>, callback: DadBotCallback) {
+    fun chat(messages: List<DadBotMessage>, callback: DadBotCallback, memoryContext: String? = null) {
         Thread {
             var conn: HttpURLConnection? = null
             try {
@@ -35,8 +35,13 @@ class DadBotClient {
                     setRequestProperty("Accept", "text/event-stream")
                 }
 
+                val effectiveMessages = if (!memoryContext.isNullOrBlank() && messages.isNotEmpty()) {
+                    val first = messages[0]
+                    listOf(first.copy(content = "$memoryContext\n\n${first.content}")) + messages.drop(1)
+                } else messages
+
                 val arr = JSONArray().also { a ->
-                    messages.forEach { m -> a.put(JSONObject().put("role", m.role).put("content", m.content)) }
+                    effectiveMessages.forEach { m -> a.put(JSONObject().put("role", m.role).put("content", m.content)) }
                 }
                 OutputStreamWriter(conn.outputStream).use { it.write(JSONObject().put("messages", arr).toString()) }
 

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/MemoryStore.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/MemoryStore.kt
@@ -1,0 +1,52 @@
+package com.dsg.agent.automation
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+data class MemoryEntry(val id: String, val content: String, val ts: Long)
+
+class MemoryStore(ctx: Context) {
+    private val prefs = ctx.getSharedPreferences("dsg_memory", Context.MODE_PRIVATE)
+
+    fun add(content: String): MemoryEntry {
+        val entry = MemoryEntry(UUID.randomUUID().toString(), content.trim(), System.currentTimeMillis())
+        val array = readArray()
+        array.put(JSONObject().put("id", entry.id).put("content", entry.content).put("ts", entry.ts))
+        prefs.edit().putString(KEY, array.toString()).apply()
+        return entry
+    }
+
+    fun list(): List<MemoryEntry> = (0 until readArray().length()).mapNotNull { i ->
+        runCatching {
+            val obj = readArray().getJSONObject(i)
+            MemoryEntry(obj.getString("id"), obj.getString("content"), obj.getLong("ts"))
+        }.getOrNull()
+    }
+
+    fun delete(id: String) {
+        val remaining = list().filter { it.id != id }
+        val array = JSONArray()
+        remaining.forEach { e -> array.put(JSONObject().put("id", e.id).put("content", e.content).put("ts", e.ts)) }
+        prefs.edit().putString(KEY, array.toString()).apply()
+    }
+
+    fun clear() = prefs.edit().putString(KEY, "[]").apply()
+
+    fun toContextBlock(): String {
+        val entries = list()
+        if (entries.isEmpty()) return ""
+        val lines = entries.joinToString("\n") { "- ${it.content}" }
+        return "[ความจำ]\n$lines\n[/ความจำ]"
+    }
+
+    private fun readArray(): JSONArray {
+        val raw = prefs.getString(KEY, "[]") ?: "[]"
+        return runCatching { JSONArray(raw) }.getOrDefault(JSONArray())
+    }
+
+    companion object {
+        private const val KEY = "memories"
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/ScheduledTaskStore.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/ScheduledTaskStore.kt
@@ -1,0 +1,101 @@
+package com.dsg.agent.automation
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+data class ScheduledTask(
+    val id: String,
+    val prompt: String,
+    val intervalMinutes: Int,
+    val enabled: Boolean,
+    val nextRunAt: Long,
+    val lastRunAt: Long,
+)
+
+class ScheduledTaskStore(private val ctx: Context) {
+    private val prefs = ctx.getSharedPreferences("dsg_scheduler", Context.MODE_PRIVATE)
+
+    fun add(task: ScheduledTask) {
+        val all = list().toMutableList()
+        all.add(task)
+        save(all)
+    }
+
+    fun list(): List<ScheduledTask> {
+        val raw = prefs.getString(KEY, "[]") ?: "[]"
+        val array = runCatching { JSONArray(raw) }.getOrDefault(JSONArray())
+        return (0 until array.length()).mapNotNull { i ->
+            runCatching {
+                val obj = array.getJSONObject(i)
+                ScheduledTask(
+                    id = obj.getString("id"),
+                    prompt = obj.getString("prompt"),
+                    intervalMinutes = obj.getInt("intervalMinutes"),
+                    enabled = obj.getBoolean("enabled"),
+                    nextRunAt = obj.getLong("nextRunAt"),
+                    lastRunAt = obj.getLong("lastRunAt"),
+                )
+            }.getOrNull()
+        }
+    }
+
+    fun update(id: String, transform: (ScheduledTask) -> ScheduledTask) {
+        save(list().map { if (it.id == id) transform(it) else it })
+    }
+
+    fun delete(id: String) {
+        cancelAlarm(id)
+        save(list().filter { it.id != id })
+    }
+
+    fun scheduleAll() = list().filter { it.enabled }.forEach { scheduleTask(it) }
+
+    fun scheduleTask(task: ScheduledTask) {
+        val alarmManager = ctx.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val pending = pendingFor(task.id, task.prompt)
+        val intervalMs = task.intervalMinutes * 60_000L
+        if (intervalMs > 0) {
+            alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, task.nextRunAt, intervalMs, pending)
+        } else {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, task.nextRunAt, pending)
+        }
+    }
+
+    private fun cancelAlarm(id: String) {
+        val alarmManager = ctx.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(ctx, SchedulerReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(ctx, id.hashCode(), intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE)
+        if (pending != null) alarmManager.cancel(pending)
+    }
+
+    private fun pendingFor(id: String, prompt: String): PendingIntent {
+        val intent = Intent(ctx, SchedulerReceiver::class.java).apply {
+            putExtra("taskId", id)
+            putExtra("prompt", prompt)
+        }
+        return PendingIntent.getBroadcast(ctx, id.hashCode(), intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    private fun save(tasks: List<ScheduledTask>) {
+        val array = JSONArray()
+        tasks.forEach { t ->
+            array.put(JSONObject()
+                .put("id", t.id).put("prompt", t.prompt)
+                .put("intervalMinutes", t.intervalMinutes).put("enabled", t.enabled)
+                .put("nextRunAt", t.nextRunAt).put("lastRunAt", t.lastRunAt))
+        }
+        prefs.edit().putString(KEY, array.toString()).apply()
+    }
+
+    companion object {
+        private const val KEY = "tasks"
+        fun newId(): String = UUID.randomUUID().toString()
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/SchedulerReceiver.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/SchedulerReceiver.kt
@@ -1,0 +1,35 @@
+package com.dsg.agent.automation
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class SchedulerReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val taskId = intent.getStringExtra("taskId") ?: return
+        val prompt = intent.getStringExtra("prompt") ?: return
+
+        val memoryStore = MemoryStore(context)
+        val auditLogStore = AuditLogStore(context)
+        val scheduledTaskStore = ScheduledTaskStore(context)
+
+        scheduledTaskStore.update(taskId) { it.copy(lastRunAt = System.currentTimeMillis()) }
+        auditLogStore.append("SCHEDULER_TASK_FIRED", taskId, "Scheduled: $prompt")
+
+        val memCtx = memoryStore.toContextBlock()
+        val messages = listOf(DadBotMessage("user", prompt))
+
+        DadBotClient().chat(messages, object : DadBotCallback {
+            override fun onToken(text: String) {}
+            override fun onCommand(type: AgentCommandType, target: String, reason: String) {
+                auditLogStore.append("SCHEDULER_COMMAND", taskId, "${type.name}: $target — $reason")
+            }
+            override fun onDone() {
+                auditLogStore.append("SCHEDULER_TASK_DONE", taskId, "Completed: $prompt")
+            }
+            override fun onError(message: String) {
+                auditLogStore.append("SCHEDULER_TASK_ERROR", taskId, "Error: $message")
+            }
+        }, memCtx)
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/automation/SkillStore.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/automation/SkillStore.kt
@@ -1,0 +1,88 @@
+package com.dsg.agent.automation
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+data class CustomSkill(
+    val id: String,
+    val name: String,
+    val description: String,
+    val steps: List<AgentCommandType>,
+    val targets: List<String>,
+    val ts: Long,
+)
+
+class SkillStore(ctx: Context) {
+    private val prefs = ctx.getSharedPreferences("dsg_skills", Context.MODE_PRIVATE)
+
+    fun add(skill: CustomSkill) {
+        val all = list().toMutableList()
+        all.removeIf { it.id == skill.id }
+        all.add(skill)
+        save(all)
+    }
+
+    fun list(): List<CustomSkill> {
+        val raw = prefs.getString(KEY, "[]") ?: "[]"
+        val array = runCatching { JSONArray(raw) }.getOrDefault(JSONArray())
+        return (0 until array.length()).mapNotNull { i ->
+            runCatching {
+                val obj = array.getJSONObject(i)
+                val stepsArr = obj.getJSONArray("steps")
+                val targetsArr = obj.getJSONArray("targets")
+                CustomSkill(
+                    id = obj.getString("id"),
+                    name = obj.getString("name"),
+                    description = obj.optString("description"),
+                    steps = (0 until stepsArr.length()).mapNotNull { j ->
+                        runCatching { AgentCommandType.valueOf(stepsArr.getString(j)) }.getOrNull()
+                    },
+                    targets = (0 until targetsArr.length()).map { j -> targetsArr.getString(j) },
+                    ts = obj.getLong("ts"),
+                )
+            }.getOrNull()
+        }
+    }
+
+    fun delete(id: String) = save(list().filter { it.id != id })
+
+    // Parses [SKILL:name|DESC:desc|STEPS:CMD1:target1,CMD2:target2] from bot response
+    fun parseFromBotResponse(response: String): CustomSkill? {
+        val match = Regex("\\[SKILL:([^|]+)\\|DESC:([^|]+)\\|STEPS:([^]]+)]").find(response) ?: return null
+        val name = match.groupValues[1].trim()
+        val desc = match.groupValues[2].trim()
+        val stepPairs = match.groupValues[3].trim().split(",").mapNotNull { pair ->
+            val parts = pair.trim().split(":", limit = 2)
+            if (parts.size < 2) return@mapNotNull null
+            val type = runCatching { AgentCommandType.valueOf(parts[0].trim()) }.getOrNull() ?: return@mapNotNull null
+            Pair(type, parts[1].trim())
+        }
+        if (stepPairs.isEmpty()) return null
+        return CustomSkill(
+            id = UUID.randomUUID().toString(),
+            name = name, description = desc,
+            steps = stepPairs.map { it.first },
+            targets = stepPairs.map { it.second },
+            ts = System.currentTimeMillis(),
+        )
+    }
+
+    private fun save(skills: List<CustomSkill>) {
+        val array = JSONArray()
+        skills.forEach { skill ->
+            val stepsArr = JSONArray().also { arr -> skill.steps.forEach { arr.put(it.name) } }
+            val targetsArr = JSONArray().also { arr -> skill.targets.forEach { arr.put(it) } }
+            array.put(JSONObject()
+                .put("id", skill.id).put("name", skill.name).put("description", skill.description)
+                .put("steps", stepsArr).put("targets", targetsArr).put("ts", skill.ts))
+        }
+        prefs.edit().putString(KEY, array.toString()).apply()
+    }
+
+    companion object {
+        private const val KEY = "skills"
+        fun newId(): String = UUID.randomUUID().toString()
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/service/LocalApiServer.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/LocalApiServer.kt
@@ -1,0 +1,290 @@
+package com.dsg.agent.service
+
+import android.content.Context
+import com.dsg.agent.automation.AgentCommandType
+import com.dsg.agent.automation.AuditLogStore
+import com.dsg.agent.automation.DadBotCallback
+import com.dsg.agent.automation.DadBotClient
+import com.dsg.agent.automation.DadBotMessage
+import com.dsg.agent.automation.MemoryStore
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStream
+import java.net.ServerSocket
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * Minimal HTTP server that exposes the DSG agent on port 8642 via OpenAI-compatible
+ * and Anthropic-compatible REST APIs, enabling any LLM client to call the on-device agent.
+ *
+ * Endpoints:
+ *   GET  /v1/models                  — list models
+ *   GET  /api/agent/status           — health check
+ *   POST /v1/chat/completions        — OpenAI Chat Completions (stream or non-stream)
+ *   POST /v1/messages                — Anthropic Messages API (non-stream)
+ */
+class LocalApiServer(private val context: Context) {
+
+    @Volatile var isRunning = false
+        private set
+
+    private var serverSocket: ServerSocket? = null
+    private var serverThread: Thread? = null
+
+    companion object {
+        const val DEFAULT_PORT = 8642
+    }
+
+    fun start(port: Int = DEFAULT_PORT) {
+        if (isRunning) return
+        isRunning = true
+        serverThread = Thread { acceptLoop(port) }.also {
+            it.isDaemon = true
+            it.name = "dsg-local-api"
+            it.start()
+        }
+        AuditLogStore(context).append("LOCAL_API_STARTED", "server", "Listening on :$port")
+    }
+
+    fun stop() {
+        isRunning = false
+        runCatching { serverSocket?.close() }
+        serverThread?.interrupt()
+        serverThread = null
+        AuditLogStore(context).append("LOCAL_API_STOPPED", "server", "Server stopped")
+    }
+
+    fun getLocalIp(): String = runCatching {
+        java.net.NetworkInterface.getNetworkInterfaces()?.toList()
+            ?.flatMap { it.inetAddresses.toList() }
+            ?.filterIsInstance<java.net.Inet4Address>()
+            ?.firstOrNull { !it.isLoopbackAddress }
+            ?.hostAddress ?: "localhost"
+    }.getOrDefault("localhost")
+
+    // ── accept loop ────────────────────────────────────────────────────────────
+
+    private fun acceptLoop(port: Int) {
+        runCatching {
+            ServerSocket(port).use { ss ->
+                serverSocket = ss
+                while (isRunning) {
+                    val client = runCatching { ss.accept() }.getOrNull() ?: break
+                    Thread { handleClient(client) }.also { it.isDaemon = true; it.start() }
+                }
+            }
+        }
+        isRunning = false
+    }
+
+    private fun handleClient(socket: java.net.Socket) {
+        runCatching {
+            socket.use { s ->
+                val reader = s.inputStream.bufferedReader(Charsets.UTF_8)
+                val requestLine = reader.readLine()?.trim() ?: return
+                val headers = mutableMapOf<String, String>()
+                var h: String?
+                while (reader.readLine().also { h = it } != null && h!!.isNotBlank()) {
+                    val c = h!!.indexOf(':')
+                    if (c > 0) headers[h!!.substring(0, c).trim().lowercase()] = h!!.substring(c + 1).trim()
+                }
+                val len = headers["content-length"]?.toIntOrNull() ?: 0
+                val body = if (len > 0) {
+                    val buf = CharArray(len)
+                    var read = 0
+                    while (read < len) {
+                        val n = reader.read(buf, read, len - read)
+                        if (n < 0) break
+                        read += n
+                    }
+                    String(buf, 0, read)
+                } else ""
+                val parts = requestLine.split(" ")
+                if (parts.size < 2) return
+                route(parts[0], parts[1].substringBefore("?"), body, s.outputStream)
+            }
+        }
+    }
+
+    // ── routing ────────────────────────────────────────────────────────────────
+
+    private fun route(method: String, path: String, body: String, out: OutputStream) {
+        val wantsStream = runCatching { JSONObject(body).optBoolean("stream", false) }.getOrDefault(false)
+        when {
+            method == "OPTIONS"                                          -> sendCors(out)
+            method == "GET" && path == "/v1/models"                     -> handleModels(out)
+            method == "GET" && (path == "/api/agent/status" || path == "/health") -> handleStatus(out)
+            method == "POST" && path == "/v1/chat/completions"          -> handleChatCompletions(body, out, wantsStream)
+            method == "POST" && path == "/v1/messages"                  -> handleMessages(body, out)
+            else -> sendJson(out, 404, """{"error":{"message":"Not found","type":"not_found_error"}}""")
+        }
+    }
+
+    // ── GET /v1/models ─────────────────────────────────────────────────────────
+
+    private fun handleModels(out: OutputStream) {
+        val data = JSONArray().apply {
+            put(modelObj("dsg-agent")); put(modelObj("dsg-agent-haiku"))
+        }
+        sendJson(out, 200, JSONObject().put("object", "list").put("data", data).toString())
+    }
+
+    private fun modelObj(id: String) = JSONObject().apply {
+        put("id", id); put("object", "model"); put("created", 1_700_000_000L); put("owned_by", "dsg")
+    }
+
+    // ── GET /api/agent/status ──────────────────────────────────────────────────
+
+    private fun handleStatus(out: OutputStream) {
+        sendJson(out, 200, JSONObject().put("status", "ok").put("model", "dsg-agent").put("port", DEFAULT_PORT).toString())
+    }
+
+    // ── POST /v1/chat/completions ──────────────────────────────────────────────
+
+    private fun handleChatCompletions(body: String, out: OutputStream, stream: Boolean) {
+        val json = runCatching { JSONObject(body) }.getOrNull() ?: run {
+            sendJson(out, 400, """{"error":{"message":"Invalid JSON","type":"invalid_request_error"}}"""); return
+        }
+        val messages = parseOpenAiMessages(json.optJSONArray("messages"))
+        if (messages.isEmpty()) {
+            sendJson(out, 400, """{"error":{"message":"messages required","type":"invalid_request_error"}}"""); return
+        }
+        val memCtx = MemoryStore(context).toContextBlock()
+        val id = "chatcmpl-${UUID.randomUUID().toString().replace("-", "").take(16)}"
+
+        if (stream) {
+            val latch = CountDownLatch(1)
+            val hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nConnection: keep-alive\r\n\r\n"
+            runCatching { out.write(hdr.toByteArray(Charsets.UTF_8)); out.flush() }
+            DadBotClient().chat(messages, object : DadBotCallback {
+                override fun onToken(token: String) {
+                    runCatching { out.write(sseChunk(id, token).toByteArray(Charsets.UTF_8)); out.flush() }
+                }
+                override fun onCommand(type: AgentCommandType, target: String, reason: String) {}
+                override fun onDone() {
+                    runCatching {
+                        out.write(sseChunk(id, "", "stop").toByteArray(Charsets.UTF_8))
+                        out.write("data: [DONE]\n\n".toByteArray(Charsets.UTF_8))
+                        out.flush()
+                    }
+                    latch.countDown()
+                }
+                override fun onError(message: String) {
+                    runCatching { out.write("data: {\"error\":{\"message\":\"$message\"}}\n\n".toByteArray(Charsets.UTF_8)); out.flush() }
+                    latch.countDown()
+                }
+            }, memCtx)
+            latch.await(90, TimeUnit.SECONDS)
+        } else {
+            val buf = StringBuilder()
+            val q = LinkedBlockingQueue<Result<String>>(1)
+            DadBotClient().chat(messages, object : DadBotCallback {
+                override fun onToken(t: String) { buf.append(t) }
+                override fun onCommand(type: AgentCommandType, target: String, reason: String) {}
+                override fun onDone() { q.offer(Result.success(buf.toString())) }
+                override fun onError(m: String) { q.offer(Result.failure(Exception(m))) }
+            }, memCtx)
+            val result = q.poll(90, TimeUnit.SECONDS)
+                ?: run { sendJson(out, 500, """{"error":{"message":"Timeout","type":"api_error"}}"""); return }
+            if (result.isFailure) {
+                sendJson(out, 500, """{"error":{"message":"${result.exceptionOrNull()?.message}","type":"api_error"}}"""); return
+            }
+            val content = result.getOrDefault("")
+            sendJson(out, 200, JSONObject().apply {
+                put("id", id); put("object", "chat.completion"); put("model", "dsg-agent")
+                put("choices", JSONArray().put(JSONObject().apply {
+                    put("index", 0)
+                    put("message", JSONObject().put("role", "assistant").put("content", content))
+                    put("finish_reason", "stop")
+                }))
+                put("usage", JSONObject().put("prompt_tokens", 0).put("completion_tokens", content.length / 4).put("total_tokens", content.length / 4))
+            }.toString())
+        }
+    }
+
+    // ── POST /v1/messages (Anthropic) ─────────────────────────────────────────
+
+    private fun handleMessages(body: String, out: OutputStream) {
+        val json = runCatching { JSONObject(body) }.getOrNull() ?: run {
+            sendJson(out, 400, """{"error":{"type":"invalid_request_error","message":"Invalid JSON"}}"""); return
+        }
+        val messages = parseAnthropicMessages(json.optJSONArray("messages"))
+        if (messages.isEmpty()) {
+            sendJson(out, 400, """{"error":{"type":"invalid_request_error","message":"messages required"}}"""); return
+        }
+        val memCtx = MemoryStore(context).toContextBlock()
+        val id = "msg_${UUID.randomUUID().toString().replace("-", "").take(24)}"
+        val buf = StringBuilder()
+        val q = LinkedBlockingQueue<Result<String>>(1)
+        DadBotClient().chat(messages, object : DadBotCallback {
+            override fun onToken(t: String) { buf.append(t) }
+            override fun onCommand(type: AgentCommandType, target: String, reason: String) {}
+            override fun onDone() { q.offer(Result.success(buf.toString())) }
+            override fun onError(m: String) { q.offer(Result.failure(Exception(m))) }
+        }, memCtx)
+        val result = q.poll(90, TimeUnit.SECONDS)
+            ?: run { sendJson(out, 500, """{"error":{"type":"api_error","message":"Timeout"}}"""); return }
+        if (result.isFailure) {
+            sendJson(out, 500, """{"error":{"type":"api_error","message":"${result.exceptionOrNull()?.message}"}}"""); return
+        }
+        val content = result.getOrDefault("")
+        sendJson(out, 200, JSONObject().apply {
+            put("id", id); put("type", "message"); put("role", "assistant"); put("model", "dsg-agent")
+            put("content", JSONArray().put(JSONObject().put("type", "text").put("text", content)))
+            put("stop_reason", "end_turn")
+            put("usage", JSONObject().put("input_tokens", 0).put("output_tokens", content.length / 4))
+        }.toString())
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private fun sseChunk(id: String, delta: String, finishReason: String? = null): String {
+        val choice = JSONObject().apply {
+            put("index", 0)
+            put("delta", if (delta.isNotEmpty()) JSONObject().put("content", delta) else JSONObject())
+            put("finish_reason", finishReason ?: JSONObject.NULL)
+        }
+        return "data: ${JSONObject().put("id", id).put("object", "chat.completion.chunk").put("model", "dsg-agent").put("choices", JSONArray().put(choice))}\n\n"
+    }
+
+    private fun parseOpenAiMessages(arr: JSONArray?): List<DadBotMessage> {
+        arr ?: return emptyList()
+        return (0 until arr.length()).map { i ->
+            val o = arr.getJSONObject(i)
+            DadBotMessage(o.optString("role", "user"), o.optString("content", ""))
+        }
+    }
+
+    private fun parseAnthropicMessages(arr: JSONArray?): List<DadBotMessage> {
+        arr ?: return emptyList()
+        return (0 until arr.length()).map { i ->
+            val o = arr.getJSONObject(i)
+            // Anthropic content can be a plain string or an array of content blocks
+            val raw = o.opt("content")
+            val text = when (raw) {
+                is String -> raw
+                is JSONArray -> (0 until raw.length()).joinToString("") { j ->
+                    val b = raw.getJSONObject(j)
+                    if (b.optString("type") == "text") b.optString("text", "") else ""
+                }
+                else -> ""
+            }
+            DadBotMessage(o.optString("role", "user"), text)
+        }
+    }
+
+    private fun sendJson(out: OutputStream, status: Int, body: String) {
+        val phrase = when (status) { 200 -> "OK"; 400 -> "Bad Request"; 404 -> "Not Found"; else -> "Internal Server Error" }
+        val bytes = body.toByteArray(Charsets.UTF_8)
+        val header = "HTTP/1.1 $status $phrase\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: ${bytes.size}\r\nConnection: close\r\n\r\n"
+        runCatching { out.write(header.toByteArray(Charsets.UTF_8)); out.write(bytes); out.flush() }
+    }
+
+    private fun sendCors(out: OutputStream) {
+        val r = "HTTP/1.1 204 No Content\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization, x-api-key, anthropic-version\r\nConnection: close\r\n\r\n"
+        runCatching { out.write(r.toByteArray(Charsets.UTF_8)); out.flush() }
+    }
+}

--- a/apps/android/app/src/main/java/com/dsg/agent/service/TelegramGateway.kt
+++ b/apps/android/app/src/main/java/com/dsg/agent/service/TelegramGateway.kt
@@ -1,0 +1,105 @@
+package com.dsg.agent.service
+
+import android.content.Context
+import com.dsg.agent.automation.AgentCommandType
+import com.dsg.agent.automation.AuditLogStore
+import com.dsg.agent.automation.DadBotCallback
+import com.dsg.agent.automation.DadBotClient
+import com.dsg.agent.automation.DadBotMessage
+import com.dsg.agent.automation.MemoryStore
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+class TelegramGateway(private val context: Context) {
+    private var pollingThread: Thread? = null
+
+    @Volatile
+    var isRunning: Boolean = false
+        private set
+
+    fun start(token: String, allowedChatId: String) {
+        if (isRunning) return
+        isRunning = true
+        pollingThread = Thread { pollLoop(token, allowedChatId) }.also {
+            it.isDaemon = true
+            it.start()
+        }
+        AuditLogStore(context).append("TELEGRAM_STARTED", "gateway", "Polling started chatId=$allowedChatId")
+    }
+
+    fun stop() {
+        isRunning = false
+        pollingThread?.interrupt()
+        pollingThread = null
+        AuditLogStore(context).append("TELEGRAM_STOPPED", "gateway", "Polling stopped")
+    }
+
+    private fun pollLoop(token: String, allowedChatId: String) {
+        var offset = 0
+        val base = "https://api.telegram.org/bot$token"
+        while (isRunning) {
+            try {
+                val url = URL("$base/getUpdates?timeout=25&offset=$offset")
+                val conn = (url.openConnection() as HttpURLConnection).apply {
+                    connectTimeout = 5_000; readTimeout = 30_000; requestMethod = "GET"
+                }
+                if (conn.responseCode == 200) {
+                    val body = conn.inputStream.bufferedReader().readText()
+                    conn.disconnect()
+                    val updates = JSONObject(body).getJSONArray("result")
+                    for (i in 0 until updates.length()) {
+                        val update = updates.getJSONObject(i)
+                        offset = update.getInt("update_id") + 1
+                        val message = update.optJSONObject("message") ?: continue
+                        val chatId = message.getJSONObject("chat").getLong("id").toString()
+                        if (allowedChatId.isNotBlank() && chatId != allowedChatId) continue
+                        val text = message.optString("text").trim()
+                        if (text.isBlank()) continue
+                        handleMessage(base, chatId, text)
+                    }
+                } else {
+                    conn.disconnect()
+                    Thread.sleep(5_000)
+                }
+            } catch (_: InterruptedException) {
+                break
+            } catch (_: Exception) {
+                if (isRunning) runCatching { Thread.sleep(5_000) }
+            }
+        }
+    }
+
+    private fun handleMessage(base: String, chatId: String, text: String) {
+        val memCtx = MemoryStore(context).toContextBlock()
+        val messages = listOf(DadBotMessage("user", text))
+        val replyBuf = StringBuilder()
+
+        DadBotClient().chat(messages, object : DadBotCallback {
+            override fun onToken(t: String) { replyBuf.append(t) }
+            override fun onCommand(type: AgentCommandType, target: String, reason: String) {
+                AuditLogStore(context).append("TELEGRAM_COMMAND", "gateway", "${type.name}: $target")
+            }
+            override fun onDone() {
+                val reply = replyBuf.toString().ifBlank { "✅ Done" }
+                sendMessage(base, chatId, reply)
+            }
+            override fun onError(message: String) = sendMessage(base, chatId, "⚠️ $message")
+        }, memCtx)
+    }
+
+    private fun sendMessage(base: String, chatId: String, text: String) {
+        runCatching {
+            val conn = (URL("$base/sendMessage").openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"; doOutput = true
+                setRequestProperty("Content-Type", "application/json")
+                connectTimeout = 5_000; readTimeout = 10_000
+            }
+            val body = JSONObject().put("chat_id", chatId).put("text", text).toString()
+            OutputStreamWriter(conn.outputStream).use { it.write(body) }
+            conn.responseCode
+            conn.disconnect()
+        }
+    }
+}


### PR DESCRIPTION
Goal:
Integrate the full Hermes Agent feature set into the DSG Agent Android APK — memory, self-improving skills, cron scheduler, Telegram gateway, subagents, tool call cards — plus a new Local API server on port 8642 that exposes the on-device agent via OpenAI-compatible and Anthropic-compatible REST specs.

Files changed:
- `apps/android/app/src/main/java/com/dsg/agent/automation/MemoryStore.kt` (NEW) — persistent memory entries, context injection
- `apps/android/app/src/main/java/com/dsg/agent/automation/SkillStore.kt` (NEW) — custom skill sequences, self-created by DadBot
- `apps/android/app/src/main/java/com/dsg/agent/automation/ScheduledTaskStore.kt` (NEW) — cron task persistence + AlarmManager
- `apps/android/app/src/main/java/com/dsg/agent/automation/SchedulerReceiver.kt` (NEW) — BroadcastReceiver fires DadBot on alarm
- `apps/android/app/src/main/java/com/dsg/agent/service/TelegramGateway.kt` (NEW) — Telegram Bot long-polling gateway
- `apps/android/app/src/main/java/com/dsg/agent/service/LocalApiServer.kt` (NEW) — OpenAI + Anthropic HTTP server on :8642
- `apps/android/app/src/main/java/com/dsg/agent/automation/DadBotClient.kt` — `memoryContext` param, prepended to first user message
- `apps/android/app/src/main/AndroidManifest.xml` — RECEIVE_BOOT_COMPLETED, SCHEDULE_EXACT_ALARM, SchedulerReceiver registered
- `apps/android/app/src/main/java/com/dsg/agent/MainActivity.kt` — 8-tab nav, Sessions/Memory/Cron/Gateway/Logs sections, subagents, tool call cards, Hermes palette, backend status strip, Local API UI
- `README.md` — Android APK section with feature table + SDK usage examples

Verification:
- [ ] CI: `android-agent.yml` — `gradle assembleDebug` passes on PR
- [ ] APK artifact uploaded to `dsg-agent-debug-apk` workflow artifact
- [ ] On merge to main: APK published to `android-apk-latest` release

Known limits:
- Local API server streams SSE tokens on the Android main thread (Handler callbacks); network write errors are swallowed via `runCatching`
- Telegram gateway is not authenticated beyond `allowedChatId` check
- `SCHEDULE_EXACT_ALARM` requires user grant on Android 12+ (shown in Cron section UI)

User-visible benefit:
- On-device AI agent with persistent memory, self-improving skills, scheduled tasks, Telegram control, and a local API that any LLM client (LangChain, openai-python, claude-python SDK) can call directly over Wi-Fi

Next step:
Merge → CI builds APK → `android-apk-latest` release updated automatically

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP5sfg4vFCYAYcbu33fEpZ)_