### PR TITLE
feat(batch4): go-live readiness report (re-port of #114)

### DIFF
--- a/app/api/settings/go-live/export/route.ts
+++ b/app/api/settings/go-live/export/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgPermission } from '../../../../../lib/auth/require-org-permission';
+import { logServerError, serverErrorResponse } from '../../../../../lib/security/error-response';
+import { buildGoLiveReadinessReport } from '../../../../../lib/readiness/go-live';
+
+export const dynamic = 'force-dynamic';
+
+const PRIVATE_HEADERS = {
+  'cache-control': 'private, no-store, max-age=0',
+};
+
+export async function GET(req: NextRequest) {
+  const access = await requireOrgPermission('org.view_reports');
+  if (access.ok === false) {
+    return NextResponse.json({ error: access.error }, { status: access.status, headers: PRIVATE_HEADERS });
+  }
+
+  const format = new URL(req.url).searchParams.get('format') || 'json';
+
+  try {
+    const report = await buildGoLiveReadinessReport(access.orgId);
+
+    if (format === 'md') {
+      const md = [
+        '# Go-live readiness',
+        '',
+        `Status: **${report.status}**`,
+        '',
+        '## Blockers',
+        report.blockers.map((b) => `- ${b}`).join('\n') || '- None',
+        '',
+        '## Warnings',
+        report.warnings.map((w) => `- ${w}`).join('\n') || '- None',
+        '',
+      ].join('\n');
+      return new NextResponse(md, {
+        headers: { ...PRIVATE_HEADERS, 'content-type': 'text/markdown; charset=utf-8' },
+      });
+    }
+
+    return NextResponse.json(report, { headers: PRIVATE_HEADERS });
+  } catch (error) {
+    logServerError(error, 'settings-go-live-export');
+    return serverErrorResponse({ headers: PRIVATE_HEADERS });
+  }
+}

--- a/app/api/settings/go-live/route.ts
+++ b/app/api/settings/go-live/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { requireOrgPermission } from '../../../../lib/auth/require-org-permission';
+import { logServerError, serverErrorResponse } from '../../../../lib/security/error-response';
+import { buildGoLiveReadinessReport } from '../../../../lib/readiness/go-live';
+
+export const dynamic = 'force-dynamic';
+
+const PRIVATE_HEADERS = {
+  'cache-control': 'private, no-store, max-age=0',
+};
+
+export async function GET() {
+  const access = await requireOrgPermission('org.view_reports');
+  if (access.ok === false) {
+    return NextResponse.json({ error: access.error }, { status: access.status, headers: PRIVATE_HEADERS });
+  }
+
+  try {
+    const report = await buildGoLiveReadinessReport(access.orgId);
+    return NextResponse.json(report, { headers: PRIVATE_HEADERS });
+  } catch (error) {
+    logServerError(error, 'settings-go-live');
+    return serverErrorResponse({ headers: PRIVATE_HEADERS });
+  }
+}

--- a/app/dashboard/settings/go-live/page.tsx
+++ b/app/dashboard/settings/go-live/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type ReadinessItem = { key: string; ok: boolean; detail?: string };
+type ReadinessCategory = { name: string; items: ReadinessItem[] };
+type GoLiveReadinessReport = {
+  org_id: string;
+  status: 'ready' | 'needs-attention' | 'not-ready';
+  blockers: string[];
+  warnings: string[];
+  categories: ReadinessCategory[];
+  recommended_next_steps: string[];
+};
+
+export default function GoLivePage() {
+  const [report, setReport] = useState<GoLiveReadinessReport | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/settings/go-live', { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then(setReport)
+      .catch(() => setError(true));
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-white p-8">
+      <h1 className="text-3xl font-semibold">Go-live readiness</h1>
+      <p className="text-slate-300 mt-2">Structured checklist for enterprise rollout.</p>
+
+      {error && <p className="mt-4 text-red-300">Unable to load the readiness report.</p>}
+      {!error && !report && <p className="mt-4">Loading...</p>}
+
+      {report && (
+        <div className="mt-6">
+          <div className="rounded border border-slate-700 bg-slate-900 p-4">
+            <p className="text-sm text-slate-300">Overall status</p>
+            <p className="text-2xl font-semibold">{report.status}</p>
+          </div>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            {report.categories.map((c) => (
+              <div key={c.name} className="rounded border border-slate-800 bg-slate-900 p-4">
+                <p className="font-semibold">{c.name}</p>
+                {c.items.map((i) => (
+                  <p key={i.key} className="text-sm text-slate-300">
+                    {i.ok ? '✅' : '⚠️'} {i.key}
+                    {i.detail ? <span className="text-slate-500"> — {i.detail}</span> : null}
+                  </p>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6">
+            <p className="font-semibold">Blockers</p>
+            {report.blockers.length > 0 ? (
+              report.blockers.map((b) => (
+                <p key={b} className="text-sm text-red-300">
+                  • {b}
+                </p>
+              ))
+            ) : (
+              <p className="text-sm text-slate-400">None</p>
+            )}
+
+            <p className="font-semibold mt-4">Warnings</p>
+            {report.warnings.length > 0 ? (
+              report.warnings.map((w) => (
+                <p key={w} className="text-sm text-amber-300">
+                  • {w}
+                </p>
+              ))
+            ) : (
+              <p className="text-sm text-slate-400">None</p>
+            )}
+          </div>
+
+          <div className="mt-4 flex gap-3">
+            <a className="border border-slate-700 rounded px-3 py-2" href="/api/settings/go-live/export?format=json">
+              Export JSON
+            </a>
+            <a className="border border-slate-700 rounded px-3 py-2" href="/api/settings/go-live/export?format=md">
+              Export Markdown
+            </a>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/lib/readiness/go-live.ts
+++ b/lib/readiness/go-live.ts
@@ -1,0 +1,142 @@
+import { getSupabaseAdmin } from '../supabase-server';
+import { getQuotaForPlan } from '../billing/entitlements';
+
+/**
+ * Go-live readiness report (re-port of PR #114, adapted to current `main` schema).
+ *
+ * Schema adaptation notes (see PR "Known limits"):
+ * - PR #114 read `org_security_settings` with columns `sso_enabled`, `sso_enforced`,
+ *   `sso_metadata`, `break_glass_email_enabled`. None of those exist on current `main`.
+ *   Current `main` exposes `org_sso_configs` with only `provider`, `display_name`,
+ *   `is_enabled`. SSO *enforcement* and *break-glass* have no backing column, so those
+ *   signals are reported as "unknown / not-configured" instead of referencing missing
+ *   columns. We do NOT invent columns.
+ * - PR #114 read an `org_domains` table for domain governance. No such table exists on
+ *   current `main`, so the whole "Domain governance" category is reported as unknown.
+ * - PR #114 read `access_requests` and `guest_access_grants` directly. Those tables exist
+ *   in `supabase/schema.sql` but are NOT present in the generated `lib/database.types.ts`
+ *   on current `main` (the typed client rejects them, which is a pre-existing baseline gap
+ *   shared with sibling settings routes). To avoid adding new typecheck errors we use
+ *   `audit_logs` as the real, typed evidence source for security/audit signals instead.
+ * - PR #114 used `getPlanQuotaPolicy(...).executionsPer30Days`. That module does not exist
+ *   on current `main`; the equivalent is `getQuotaForPlan(plan)` in `lib/billing/entitlements`.
+ */
+
+export type ReadinessStatus = 'ready' | 'needs-attention' | 'not-ready';
+
+export type ReadinessItem = { key: string; ok: boolean; detail?: string };
+export type ReadinessCategory = { name: string; items: ReadinessItem[] };
+
+export type GoLiveReadinessReport = {
+  org_id: string;
+  status: ReadinessStatus;
+  blockers: string[];
+  warnings: string[];
+  categories: ReadinessCategory[];
+  recommended_next_steps: string[];
+};
+
+export async function buildGoLiveReadinessReport(orgId: string): Promise<GoLiveReadinessReport> {
+  const admin = getSupabaseAdmin();
+
+  const [owners, sso, sub, signIns, audit, onboarding] = await Promise.all([
+    admin.from('users').select('id').eq('org_id', orgId).eq('role', 'owner').eq('is_active', true),
+    admin.from('org_sso_configs').select('provider,is_enabled').eq('org_id', orgId).maybeSingle(),
+    admin
+      .from('billing_subscriptions')
+      .select('plan_key,status')
+      .eq('org_id', orgId)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    admin.from('sign_in_events').select('id').eq('org_id', orgId).limit(1),
+    admin.from('audit_logs').select('id').eq('org_id', orgId).limit(1),
+    admin.from('org_onboarding_states').select('id,bootstrap_status').eq('org_id', orgId).maybeSingle(),
+  ]);
+
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+
+  const ownerCount = (owners.data || []).length;
+  if (ownerCount < 1) blockers.push('At least one active owner is required.');
+
+  // Current main only knows whether an SSO provider config exists and is enabled.
+  // Enforcement and break-glass have no backing column -> reported as unknown.
+  const ssoConfigured = Boolean(sso.data?.is_enabled && sso.data?.provider);
+  if (!ssoConfigured) warnings.push('SSO is not configured (optional but recommended for enterprise rollout).');
+
+  const planKey = sub.data?.plan_key ?? null;
+  const quota = getQuotaForPlan(planKey);
+  if (!planKey) warnings.push('No billing subscription found; org is on the default plan.');
+
+  const signInLoggingActive = (signIns.data || []).length > 0;
+  const auditLoggingActive = (audit.data || []).length > 0;
+  if (!auditLoggingActive) warnings.push('No audit log entries yet; confirm governance logging is wired.');
+
+  const onboardingExists = Boolean(onboarding.data?.id);
+  const onboardingComplete = onboarding.data?.bootstrap_status === 'completed';
+
+  const categories: ReadinessCategory[] = [
+    {
+      name: 'Identity & access',
+      items: [
+        { key: 'login_entry_unified', ok: true },
+        { key: 'access_mode_resolved', ok: true },
+        { key: 'sso_configured', ok: ssoConfigured },
+        // No backing column on current main -> unknown, surfaced as not-ok with a detail.
+        { key: 'sso_enforced', ok: false, detail: 'unknown: no backing column on current schema' },
+        { key: 'break_glass_configured', ok: false, detail: 'unknown: no backing column on current schema' },
+        { key: 'owner_count_valid', ok: ownerCount > 0 },
+      ],
+    },
+    {
+      name: 'Domain governance',
+      items: [
+        // PR #114 read org_domains; no such table on current main.
+        { key: 'verified_domains_present', ok: false, detail: 'unknown: org_domains table not present on current schema' },
+        { key: 'approved_domains_present', ok: false, detail: 'unknown: org_domains table not present on current schema' },
+        { key: 'claim_mode_defined', ok: false, detail: 'unknown: org_domains table not present on current schema' },
+      ],
+    },
+    {
+      name: 'Billing & quota',
+      items: [
+        { key: 'billing_policy_exists', ok: Boolean(planKey) },
+        { key: 'quota_policy_resolvable', ok: quota > 0, detail: `monthly execution quota: ${quota}` },
+        { key: 'seat_activation_model_active', ok: true },
+      ],
+    },
+    {
+      name: 'Security & audit',
+      items: [
+        { key: 'sign_in_events_logging_active', ok: signInLoggingActive },
+        { key: 'audit_log_active', ok: auditLoggingActive },
+        { key: 'audit_export_available', ok: true },
+      ],
+    },
+    {
+      name: 'Onboarding',
+      items: [
+        { key: 'onboarding_state_exists', ok: onboardingExists },
+        { key: 'onboarding_bootstrap_complete', ok: onboardingComplete },
+        { key: 'quickstart_checklist_available', ok: true },
+      ],
+    },
+  ];
+
+  const status: ReadinessStatus =
+    blockers.length > 0 ? 'not-ready' : warnings.length > 0 ? 'needs-attention' : 'ready';
+
+  return {
+    org_id: orgId,
+    status,
+    blockers,
+    warnings,
+    categories,
+    recommended_next_steps: [
+      'Configure and enable SSO for the organization',
+      'Complete the onboarding bootstrap checklist',
+      'Export and archive weekly audit logs',
+    ],
+  };
+}

--- a/tests/unit/readiness/go-live.test.ts
+++ b/tests/unit/readiness/go-live.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Adapted from PR #114. The original mock targeted the old `org_security_settings` /
+ * `org_domains` schema. This version mocks the tables the re-ported `buildGoLiveReadinessReport`
+ * actually reads on current `main`: users, org_sso_configs, billing_subscriptions,
+ * sign_in_events, audit_logs, org_onboarding_states.
+ */
+
+type TableData = unknown[] | Record<string, unknown> | null;
+
+/**
+ * Builds a chainable PostgREST-like query stub. Every filter/modifier returns the same
+ * builder; awaiting it (thenable) or calling `.maybeSingle()` resolves to `{ data, error }`.
+ * `listData` is returned for list-style queries; `singleData` for `.maybeSingle()`.
+ */
+function makeBuilder(listData: TableData, singleData: TableData) {
+  const result = { data: listData, error: null as null };
+  const builder: Record<string, unknown> = {};
+  const chain = () => builder;
+
+  builder.select = chain;
+  builder.eq = chain;
+  builder.order = chain;
+  builder.limit = chain;
+  builder.maybeSingle = async () => ({ data: singleData, error: null });
+  // Make the builder awaitable for list-style queries (no terminal .maybeSingle()).
+  builder.then = (resolve: (value: typeof result) => unknown) => resolve(result);
+
+  return builder;
+}
+
+function mockSupabase(overrides: Record<string, { list?: TableData; single?: TableData }> = {}) {
+  return {
+    getSupabaseAdmin: () => ({
+      from: (table: string) => {
+        const o = overrides[table] || {};
+        return makeBuilder(o.list ?? [], o.single ?? null);
+      },
+    }),
+  };
+}
+
+describe('go-live readiness', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('flags a blocker when there is no active owner', async () => {
+    vi.doMock('../../../lib/supabase-server', () => mockSupabase({ users: { list: [] } }));
+
+    const { buildGoLiveReadinessReport } = await import('../../../lib/readiness/go-live');
+    const report = await buildGoLiveReadinessReport('org1');
+
+    expect(report.status).toBe('not-ready');
+    expect(report.blockers.length).toBeGreaterThan(0);
+    expect(report.blockers.some((b) => b.toLowerCase().includes('owner'))).toBe(true);
+  });
+
+  it('returns needs-attention when owner exists but optional signals are missing', async () => {
+    vi.doMock('../../../lib/supabase-server', () => mockSupabase({ users: { list: [{ id: 'u1' }] } }));
+
+    const { buildGoLiveReadinessReport } = await import('../../../lib/readiness/go-live');
+    const report = await buildGoLiveReadinessReport('org1');
+
+    expect(report.blockers).toHaveLength(0);
+    expect(report.status).toBe('needs-attention');
+    expect(report.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('returns ready when owner, SSO, billing, audit and onboarding are all satisfied', async () => {
+    vi.doMock('../../../lib/supabase-server', () =>
+      mockSupabase({
+        users: { list: [{ id: 'u1' }] },
+        org_sso_configs: { single: { provider: 'okta', is_enabled: true } },
+        billing_subscriptions: { single: { plan_key: 'pro', status: 'active' } },
+        sign_in_events: { list: [{ id: 's1' }] },
+        audit_logs: { list: [{ id: 'a1' }] },
+        org_onboarding_states: { single: { id: 'ob1', bootstrap_status: 'completed' } },
+      }),
+    );
+
+    const { buildGoLiveReadinessReport } = await import('../../../lib/readiness/go-live');
+    const report = await buildGoLiveReadinessReport('org1');
+
+    expect(report.blockers).toHaveLength(0);
+    expect(report.warnings).toHaveLength(0);
+    expect(report.status).toBe('ready');
+
+    const ids = report.categories.find((c) => c.name === 'Identity & access');
+    expect(ids?.items.find((i) => i.key === 'sso_configured')?.ok).toBe(true);
+
+    // Degraded signals with no backing column on current schema stay not-ok with a detail.
+    const enforced = ids?.items.find((i) => i.key === 'sso_enforced');
+    expect(enforced?.ok).toBe(false);
+    expect(enforced?.detail).toMatch(/unknown/i);
+  });
+});


### PR DESCRIPTION
Goal:
Re-port the single "Go-live readiness report" feature from the stale, closed PR #114 onto current `main`. PR #114 assumed a 3-month-old batch-3 schema and cannot merge directly; this PR adapts the feature to the schema `main` actually ships.

Files changed:
- `lib/readiness/go-live.ts` — core report builder, adapted to current `main` tables/columns.
- `app/api/settings/go-live/route.ts` — GET readiness report (JSON).
- `app/api/settings/go-live/export/route.ts` — GET export (`?format=json|md`).
- `app/dashboard/settings/go-live/page.tsx` — dashboard view.
- `tests/unit/readiness/go-live.test.ts` — ported and adapted from #114.

Schema adaptation (why the re-port was non-trivial):
- #114 read `org_security_settings` with columns `sso_enabled`, `sso_enforced`, `sso_metadata`, `break_glass_email_enabled`. None of those exist on current `main`. `main` exposes `org_sso_configs` (`provider`, `display_name`, `is_enabled`) only.
- #114 read an `org_domains` table that does not exist on current `main`.
- #114 read `access_requests` and `guest_access_grants`. Those tables exist in `supabase/schema.sql` but are NOT in the generated `lib/database.types.ts` on current `main` (a pre-existing baseline gap also affecting sibling settings routes), so the typed admin client rejects them.
- #114 used `getPlanQuotaPolicy(...).executionsPer30Days`, a module that does not exist on current `main`; replaced with `getQuotaForPlan(plan)` from `lib/billing/entitlements`.
No new columns or tables were invented, and `lib/database.types.ts` was not modified.

Auth pattern: routes use `requireOrgPermission('org.view_reports')` with `private, no-store` headers and the shared `logServerError`/`serverErrorResponse` helpers, matching sibling `app/api/settings/...` routes (the #114 `requireOrgRole` shape differs from current `main`).

Verification:
- [x] `npm ci` — completed (6 moderate npm-audit advisories, pre-existing, unrelated).
- [x] `npm run typecheck 2>&1 | grep -E "go-live|readiness"` — EMPTY (prints `NO_NEW_GO_LIVE_ERRORS`). Total typecheck errors unchanged at 144 before and after (all pre-existing in ~unrelated files; this feature adds zero new errors).
- [x] `npx vitest run tests/unit/readiness/go-live.test.ts` — PASS (3/3 tests, no-owner blocker / needs-attention / fully-ready cases).

Known limits:
The following #114 readiness signals were DOWNGRADED because current `main`'s schema lacks the backing columns/tables, and are reported as "unknown / not-configured" rather than referencing non-existent columns:
- `sso_enforced` — no enforcement column on `org_sso_configs` (only `is_enabled`).
- `break_glass_configured` — no break-glass column anywhere on current `main`.
- Entire "Domain governance" category (`verified_domains_present`, `approved_domains_present`, `claim_mode_defined`) — no `org_domains` table on current `main`.
- `request_access_logging_active` and `guest_access_visible` (from #114) were dropped from the live query because `access_requests`/`guest_access_grants` are absent from `lib/database.types.ts`; security/audit evidence now derives from the typed `audit_logs` and `sign_in_events` tables instead.
No live HTTP/Supabase smoke evidence was captured, so the route behavior in production is `not verified`. Production release status remains NO-GO.

User-visible benefit:
Org admins/owners (and any role with `org.view_reports`) get a structured, DB-backed go-live readiness checklist at `/dashboard/settings/go-live`, with JSON and Markdown export, built from the organization's real owners, SSO config, billing plan/quota, audit + sign-in logging, and onboarding state.

Next step:
If domain governance and SSO-enforcement/break-glass signals are required for go-live, add the backing schema (e.g. `org_domains`, enforcement columns) plus a migration and regenerate `lib/database.types.ts`, then restore those signals. Add a live smoke check against the deployed route once on a preview deployment.

https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ)_