### PR TITLE
feat(batch4): domain governance (re-port of #114)

### DIFF
--- a/app/api/settings/domains/[id]/route.ts
+++ b/app/api/settings/domains/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: access.error }, { status: access.status });
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('org_domains')
+    .update({
+      status: body.status,
+      claim_mode: body.claim_mode,
+      auto_join_mode: body.auto_join_mode,
+      notes: body.notes ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('org_id', access.orgId)
+    .select('*')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data });
+}

--- a/app/api/settings/domains/route.ts
+++ b/app/api/settings/domains/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { requireOrgRole } from '../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { normalizeDomain } from '../../../../lib/auth/domain-governance';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: access.error }, { status: access.status });
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('org_domains')
+    .select('*')
+    .eq('org_id', access.orgId)
+    .order('created_at', { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ items: data || [] });
+}
+
+export async function POST(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: access.error }, { status: access.status });
+  const body = await req.json().catch(() => ({}));
+  const domain = normalizeDomain(body.domain);
+  if (!domain) return NextResponse.json({ error: 'Domain is required' }, { status: 400 });
+  const admin = getSupabaseAdmin();
+  const token = `dsg-verify-${randomUUID()}`;
+  const payload = {
+    org_id: access.orgId,
+    domain,
+    status: body.status || 'approved',
+    claim_mode: body.claim_mode || 'manual',
+    auto_join_mode: body.auto_join_mode || 'disabled',
+    verification_method: 'dns_txt',
+    verification_token: token,
+    notes: body.notes || null,
+  };
+  const { data, error } = await admin.from('org_domains').insert(payload).select('*').single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(
+    {
+      item: data,
+      verification_step:
+        'Human verification required. Publish token via DNS and complete ops review.',
+    },
+    { status: 201 },
+  );
+}

--- a/app/dashboard/settings/domains/page.tsx
+++ b/app/dashboard/settings/domains/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Domain = {
+  id: string;
+  domain: string;
+  status: string;
+  claim_mode: string;
+  auto_join_mode: string;
+  verification_token: string | null;
+  notes: string | null;
+};
+
+export default function DomainsSettingsPage() {
+  const [items, setItems] = useState<Domain[]>([]);
+  const [domain, setDomain] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    const res = await fetch('/api/settings/domains', { cache: 'no-store' });
+    const j = await res.json();
+    setItems(j.items || []);
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function add() {
+    setLoading(true);
+    await fetch('/api/settings/domains', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain }),
+    });
+    setDomain('');
+    setLoading(false);
+    await load();
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-white p-8">
+      <h1 className="text-3xl font-semibold">Domain Governance</h1>
+      <p className="text-slate-300 mt-2">
+        Verified domains assert ownership. Approved domains enable policy evaluation.
+      </p>
+      <div className="mt-6 flex gap-2">
+        <input
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="example.com"
+          className="bg-slate-900 border border-slate-700 rounded px-3 py-2"
+        />
+        <button
+          onClick={() => void add()}
+          disabled={loading}
+          className="bg-emerald-400 text-slate-950 px-4 py-2 rounded"
+        >
+          Add domain
+        </button>
+      </div>
+      <div className="mt-8 space-y-3">
+        {items.map((d) => (
+          <div key={d.id} className="border border-slate-800 bg-slate-900 rounded p-4">
+            <p className="font-semibold">
+              {d.domain} <span className="text-xs text-slate-400">({d.status})</span>
+            </p>
+            <p className="text-sm text-slate-300">
+              Claim mode: {d.claim_mode} · Auto-join mode: {d.auto_join_mode}
+            </p>
+            <p className="text-xs text-slate-400 mt-1">
+              Verification token: {d.verification_token || 'pending generation'}
+            </p>
+          </div>
+        ))}
+      </div>
+      <div className="mt-8 text-sm text-slate-400">
+        <p>
+          Verification is an ops/human step in Batch 4. No automated DNS verification is performed.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/lib/auth/domain-governance.ts
+++ b/lib/auth/domain-governance.ts
@@ -1,0 +1,145 @@
+import { getSupabaseAdmin } from '../supabase-server';
+
+export type OrgDomainStatus = 'approved' | 'verified' | 'disabled';
+export type ClaimMode = 'manual' | 'automatic';
+export type AutoJoinMode = 'disabled' | 'auto_join' | 'require_approval';
+
+export type OrgDomainRow = {
+  id: string;
+  org_id: string;
+  domain: string;
+  status: OrgDomainStatus;
+  verification_method: string | null;
+  verification_token: string | null;
+  verified_at: string | null;
+  claim_mode: ClaimMode;
+  auto_join_mode: AutoJoinMode;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DomainGovernanceResolution = {
+  source: 'db' | 'env' | 'default';
+  domain: string;
+  status: OrgDomainStatus;
+  claim_mode: ClaimMode;
+  auto_join_mode: AutoJoinMode;
+  org_id: string | null;
+  is_managed_identity: boolean;
+  verification_token?: string | null;
+};
+
+export function normalizeDomain(value: string | null | undefined): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^@+/, '');
+}
+
+export async function getOrgDomains(orgId: string): Promise<OrgDomainRow[]> {
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('org_domains')
+    .select('*')
+    .eq('org_id', orgId)
+    .order('domain', { ascending: true });
+  if (error) throw error;
+  return (data || []) as OrgDomainRow[];
+}
+
+export async function findMatchingOrgDomain(emailDomain: string): Promise<OrgDomainRow | null> {
+  const domain = normalizeDomain(emailDomain);
+  if (!domain) return null;
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('org_domains')
+    .select('*')
+    .eq('domain', domain)
+    .in('status', ['approved', 'verified']);
+  if (error) throw error;
+  const rows = (data || []) as OrgDomainRow[];
+  return rows.find((r) => r.status === 'verified') || rows[0] || null;
+}
+
+function envList(name: string): string[] {
+  return String(process.env[name] || '')
+    .split(',')
+    .map(normalizeDomain)
+    .filter(Boolean);
+}
+
+export async function resolveDomainGovernance(
+  emailDomain: string,
+  orgId?: string | null,
+): Promise<DomainGovernanceResolution> {
+  const domain = normalizeDomain(emailDomain);
+  if (!domain) {
+    return {
+      source: 'default',
+      domain,
+      status: 'disabled',
+      claim_mode: 'manual',
+      auto_join_mode: 'disabled',
+      org_id: orgId || null,
+      is_managed_identity: false,
+    };
+  }
+
+  let dbRule: OrgDomainRow | null = null;
+  if (orgId) {
+    const rows = await getOrgDomains(orgId);
+    dbRule = rows.find((r) => r.domain === domain && r.status !== 'disabled') || null;
+  }
+  if (!dbRule) dbRule = await findMatchingOrgDomain(domain);
+
+  if (dbRule) {
+    return {
+      source: 'db',
+      domain,
+      status: dbRule.status,
+      claim_mode: dbRule.claim_mode,
+      auto_join_mode: dbRule.auto_join_mode,
+      org_id: dbRule.org_id,
+      is_managed_identity: dbRule.claim_mode === 'automatic' || dbRule.status === 'verified',
+      verification_token: dbRule.verification_token,
+    };
+  }
+
+  if (
+    envList('APPROVED_AUTO_JOIN_DOMAINS').includes(domain) ||
+    envList('APPROVED_DOMAINS').includes(domain)
+  ) {
+    return {
+      source: 'env',
+      domain,
+      status: 'approved',
+      claim_mode: 'manual',
+      auto_join_mode: 'auto_join',
+      org_id: orgId || null,
+      is_managed_identity: false,
+    };
+  }
+
+  if (envList('APPROVAL_REQUIRED_DOMAINS').includes(domain)) {
+    return {
+      source: 'env',
+      domain,
+      status: 'approved',
+      claim_mode: 'manual',
+      auto_join_mode: 'require_approval',
+      org_id: orgId || null,
+      is_managed_identity: false,
+    };
+  }
+
+  return {
+    source: 'default',
+    domain,
+    status: 'disabled',
+    claim_mode: 'manual',
+    auto_join_mode: 'disabled',
+    org_id: orgId || null,
+    is_managed_identity: false,
+  };
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3689,6 +3689,51 @@ export type Database = {
           },
         ]
       }
+      org_domains: {
+        Row: {
+          auto_join_mode: string
+          claim_mode: string
+          created_at: string
+          domain: string
+          id: string
+          notes: string | null
+          org_id: string
+          status: string
+          updated_at: string
+          verification_method: string | null
+          verification_token: string | null
+          verified_at: string | null
+        }
+        Insert: {
+          auto_join_mode?: string
+          claim_mode?: string
+          created_at?: string
+          domain: string
+          id?: string
+          notes?: string | null
+          org_id: string
+          status?: string
+          updated_at?: string
+          verification_method?: string | null
+          verification_token?: string | null
+          verified_at?: string | null
+        }
+        Update: {
+          auto_join_mode?: string
+          claim_mode?: string
+          created_at?: string
+          domain?: string
+          id?: string
+          notes?: string | null
+          org_id?: string
+          status?: string
+          updated_at?: string
+          verification_method?: string | null
+          verification_token?: string | null
+          verified_at?: string | null
+        }
+        Relationships: []
+      }
       org_billing_policies: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260531_batch4_org_domains.sql
+++ b/supabase/migrations/20260531_batch4_org_domains.sql
@@ -1,0 +1,31 @@
+-- Batch 4 — Domain governance (re-port of PR #114)
+-- Creates ONLY the org_domains table required by the domain governance feature.
+-- Source DDL: 20260401_batch4_enterprise_hardening.sql (commit 626ac41).
+-- Idempotent: safe to re-run.
+
+create extension if not exists pgcrypto;
+
+create table if not exists org_domains (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  domain text not null,
+  status text not null default 'approved' check (status in ('approved','verified','disabled')),
+  verification_method text null,
+  verification_token text null,
+  verified_at timestamptz null,
+  claim_mode text not null default 'manual' check (claim_mode in ('manual','automatic')),
+  auto_join_mode text not null default 'disabled' check (auto_join_mode in ('disabled','auto_join','require_approval')),
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, domain)
+);
+
+create index if not exists idx_org_domains_domain_status on org_domains(domain, status);
+create index if not exists idx_org_domains_org_id on org_domains(org_id);
+
+-- RLS: API routes use the Supabase service-role admin client and enforce
+-- org scoping in application code (requireOrgRole). Enable RLS so that the
+-- table is locked down by default; the service role bypasses RLS, and no
+-- anon/authenticated policy is granted (deny-by-default).
+alter table org_domains enable row level security;

--- a/tests/unit/auth/domain-governance.test.ts
+++ b/tests/unit/auth/domain-governance.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import {
+  normalizeDomain,
+  findMatchingOrgDomain,
+  resolveDomainGovernance,
+  type OrgDomainRow,
+} from '../../../lib/auth/domain-governance';
+import { getSupabaseAdmin } from '../../../lib/supabase-server';
+
+const mockGetAdmin = vi.mocked(getSupabaseAdmin);
+
+function row(partial: Partial<OrgDomainRow>): OrgDomainRow {
+  return {
+    id: partial.id ?? 'id-1',
+    org_id: partial.org_id ?? 'org-1',
+    domain: partial.domain ?? 'example.com',
+    status: partial.status ?? 'approved',
+    verification_method: partial.verification_method ?? null,
+    verification_token: partial.verification_token ?? null,
+    verified_at: partial.verified_at ?? null,
+    claim_mode: partial.claim_mode ?? 'manual',
+    auto_join_mode: partial.auto_join_mode ?? 'disabled',
+    notes: partial.notes ?? null,
+    created_at: partial.created_at ?? '2026-01-01T00:00:00.000Z',
+    updated_at: partial.updated_at ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+/**
+ * Builds a chainable Supabase query stub that resolves to `result` once the
+ * chain is awaited. Supports the .select().eq().order()/.in() shapes used by
+ * domain-governance.ts.
+ */
+function makeQuery(result: { data: OrgDomainRow[] | null; error: unknown }) {
+  const q: Record<string, unknown> = {};
+  for (const method of ['select', 'eq', 'order', 'in']) {
+    q[method] = vi.fn(() => q);
+  }
+  (q as any).then = (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve);
+  return q;
+}
+
+function makeAdmin(result: { data: OrgDomainRow[] | null; error: unknown }) {
+  return { from: vi.fn(() => makeQuery(result)) } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.APPROVED_DOMAINS;
+  delete process.env.APPROVED_AUTO_JOIN_DOMAINS;
+  delete process.env.APPROVAL_REQUIRED_DOMAINS;
+});
+
+describe('normalizeDomain', () => {
+  it('trims, lowercases and strips leading @', () => {
+    expect(normalizeDomain('  @Example.COM ')).toBe('example.com');
+  });
+  it('returns empty string for null/undefined', () => {
+    expect(normalizeDomain(null)).toBe('');
+    expect(normalizeDomain(undefined)).toBe('');
+  });
+});
+
+describe('findMatchingOrgDomain', () => {
+  it('returns null for empty domain without touching the db', async () => {
+    expect(await findMatchingOrgDomain('')).toBeNull();
+    expect(mockGetAdmin).not.toHaveBeenCalled();
+  });
+
+  it('prefers a verified row over an approved row', async () => {
+    mockGetAdmin.mockReturnValue(
+      makeAdmin({
+        data: [
+          row({ id: 'approved', status: 'approved' }),
+          row({ id: 'verified', status: 'verified' }),
+        ],
+        error: null,
+      }),
+    );
+    const result = await findMatchingOrgDomain('example.com');
+    expect(result?.id).toBe('verified');
+  });
+
+  it('throws when the db returns an error', async () => {
+    mockGetAdmin.mockReturnValue(makeAdmin({ data: null, error: new Error('boom') }));
+    await expect(findMatchingOrgDomain('example.com')).rejects.toThrow('boom');
+  });
+});
+
+describe('resolveDomainGovernance', () => {
+  it('returns disabled default for empty domain', async () => {
+    const r = await resolveDomainGovernance('');
+    expect(r.source).toBe('default');
+    expect(r.status).toBe('disabled');
+    expect(r.is_managed_identity).toBe(false);
+  });
+
+  it('resolves from db and marks verified domain as managed identity', async () => {
+    mockGetAdmin.mockReturnValue(
+      makeAdmin({ data: [row({ status: 'verified' })], error: null }),
+    );
+    const r = await resolveDomainGovernance('example.com');
+    expect(r.source).toBe('db');
+    expect(r.status).toBe('verified');
+    expect(r.is_managed_identity).toBe(true);
+  });
+
+  it('falls back to env auto_join when no db rule matches', async () => {
+    mockGetAdmin.mockReturnValue(makeAdmin({ data: [], error: null }));
+    process.env.APPROVED_AUTO_JOIN_DOMAINS = 'example.com';
+    const r = await resolveDomainGovernance('Example.com');
+    expect(r.source).toBe('env');
+    expect(r.auto_join_mode).toBe('auto_join');
+  });
+
+  it('falls back to env require_approval list', async () => {
+    mockGetAdmin.mockReturnValue(makeAdmin({ data: [], error: null }));
+    process.env.APPROVAL_REQUIRED_DOMAINS = 'example.com';
+    const r = await resolveDomainGovernance('example.com');
+    expect(r.source).toBe('env');
+    expect(r.auto_join_mode).toBe('require_approval');
+  });
+
+  it('returns disabled default when nothing matches', async () => {
+    mockGetAdmin.mockReturnValue(makeAdmin({ data: [], error: null }));
+    const r = await resolveDomainGovernance('nomatch.com');
+    expect(r.source).toBe('default');
+    expect(r.status).toBe('disabled');
+  });
+});


### PR DESCRIPTION
Goal:
Re-port the single "Domain governance" feature from the stale, closed PR #114 (based on a 3-month-old schema, 797 commits diverged) onto the current `main` so it compiles and works against the current APIs and schema. Open as a focused DRAFT PR. No merge.

Files changed:
- `lib/auth/domain-governance.ts` — `normalizeDomain`, `getOrgDomains`, `findMatchingOrgDomain`, `resolveDomainGovernance` (db + env resolution). Ported from #114; added explicit types, uses `getSupabaseAdmin` from `lib/supabase-server`.
- `app/api/settings/domains/route.ts` — GET (list) / POST (create) for the calling org. Adapted to current main: `requireOrgRole(['org_admin'])` from `lib/authz`, returns `access.error` on failure, `export const dynamic = 'force-dynamic'`.
- `app/api/settings/domains/[id]/route.ts` — PATCH (update status/claim_mode/auto_join_mode/notes), org-scoped. Adapted to Next.js 15 `params: Promise<{ id: string }>` (awaited).
- `app/dashboard/settings/domains/page.tsx` — org_admin domain management UI (add/list, shows verification token).
- `supabase/migrations/20260531_batch4_org_domains.sql` — creates ONLY the `org_domains` table (`create table if not exists`), copied from #114's `20260401_batch4_enterprise_hardening.sql` DDL, plus its `idx_org_domains_domain_status` index, an `org_id` index, and RLS enabled (deny-by-default; routes use the service-role admin client and enforce org scope in app code).
- `lib/database.types.ts` — added the `org_domains` `Tables` entry (Row/Insert/Update/Relationships) matching the migration columns so typecheck does not regress.
- `tests/unit/auth/domain-governance.test.ts` — 10 unit tests for `normalizeDomain`, `findMatchingOrgDomain`, `resolveDomainGovernance`.

Verification:
- [x] `npm ci` → completed (deps installed).
- [x] `npx vitest run tests/unit/auth/domain-governance.test.ts` → `Test Files 1 passed (1)`, `Tests 10 passed (10)`.
- [x] `npm run typecheck 2>&1 | grep -E "domains|domain-governance"` → empty (printed `no new domain errors`). My feature files are confirmed included by `tsc --listFilesOnly`.
- [x] Typecheck delta: baseline on clean `main` = 144 `error TS` lines (pre-existing DB type drift, e.g. `lib/runtime/recovery.ts`, `lib/usage/quota.ts`); with this branch = 144. Net new errors introduced by this feature = 0.

Known limits:
- The `org_domains` table does NOT yet exist in production. The migration `supabase/migrations/20260531_batch4_org_domains.sql` MUST be applied to Supabase before this feature functions. Until applied, the API routes will fail with a missing-relation error. Production status: NO-GO until the migration is applied and verified by a real schema/query result.
- The `org_domains` entry added to `lib/database.types.ts` is hand-written to match the migration; it is not yet regenerated from the live DB. Regenerate generated types after the migration is applied.
- Domain "verification" is an ops/human step only (a `dsg-verify-*` token is issued and stored). No automated DNS TXT verification is performed in this PR.
- The ~144 pre-existing typecheck errors on `main` are out of scope and not addressed here.

User-visible benefit:
Org admins get a Domain Governance settings page (`/dashboard/settings/domains`) and backing API to register, list, and update org email domains, with approval/verification status, claim mode, and auto-join mode — the foundation for domain-based access policy.

Next step:
Apply `20260531_batch4_org_domains.sql` to Supabase, verify `org_domains` exists with a query, regenerate `lib/database.types.ts` from the live DB, then smoke-test the routes against a deployed environment and flip status from NO-GO once verified.

https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ)_