### PR TITLE
feat(batch4): security audit API, quota policy, admin anti-lockout (re-port of #114)

### DIFF
--- a/app/api/settings/members/[userId]/route.ts
+++ b/app/api/settings/members/[userId]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../../lib/supabase-server';
+import { preventRemovingLastOwner } from '../../../../../lib/auth/admin-safety';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ userId: string }> };
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: 'Forbidden' }, { status: access.status });
+  const { userId } = await params;
+  const body = await req.json().catch(() => ({}));
+  const role = String(body.role || '').trim();
+  if (!role) return NextResponse.json({ error: 'role is required' }, { status: 400 });
+  if (role === 'guest_auditor_admin') return NextResponse.json({ error: 'Guest auditor cannot receive admin/security permissions.' }, { status: 400 });
+  const admin = getSupabaseAdmin();
+  try {
+    await preventRemovingLastOwner(admin, access.orgId, userId, role);
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : 'Owner safety check failed.' }, { status: 409 });
+  }
+  const { data, error } = await admin.from('users').update({ role, updated_at: new Date().toISOString() }).eq('org_id', access.orgId).eq('id', userId).select('id,role').single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data });
+}

--- a/app/api/settings/quota/route.ts
+++ b/app/api/settings/quota/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { getEffectiveExecutionQuotaForOrg, buildQuotaSummary } from '../../../../lib/billing/quota-policy';
+
+export const dynamic = 'force-dynamic';
+
+const PRIVATE_HEADERS = {
+  'cache-control': 'private, no-store, max-age=0',
+};
+
+// Read-only quota policy surface. Additive route: does NOT enforce or mutate
+// quota. Existing enforcement lives in app/api/usage and app/api/execute on
+// main; this endpoint only reports the effective policy + a best-effort
+// current-usage count so operators can see their plan limits.
+export async function GET() {
+  const access = await requireOrgRole(['org_admin', 'billing_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: access.error || 'Forbidden' }, { status: access.status, headers: PRIVATE_HEADERS });
+
+  const admin = getSupabaseAdmin();
+  const policy = await getEffectiveExecutionQuotaForOrg(access.orgId, admin);
+
+  // Best-effort current execution count for the org over the policy window.
+  // usage_counters tracks executions per billing_period; degrade to 0 on error.
+  let currentExecutions = 0;
+  const { data } = await admin
+    .from('usage_counters')
+    .select('executions')
+    .eq('org_id', access.orgId);
+  if (Array.isArray(data)) {
+    currentExecutions = data.reduce((sum, row) => sum + (Number(row.executions) || 0), 0);
+  }
+
+  const summary = buildQuotaSummary(policy.planKey, currentExecutions);
+  return NextResponse.json(
+    { quota: { ...summary, windowDays: policy.windowDays } },
+    { headers: PRIVATE_HEADERS },
+  );
+}

--- a/app/api/settings/security/audit-events/route.ts
+++ b/app/api/settings/security/audit-events/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { exportAuditEventsAsJson } from '../../../../../lib/security/batch4-audit-events';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: access.error || 'Forbidden' }, { status: access.status });
+  const sp = new URL(req.url).searchParams;
+  const page = Math.max(1, Number(sp.get('page') || '1'));
+  const pageSize = Math.min(100, Math.max(1, Number(sp.get('page_size') || '20')));
+  const items = await exportAuditEventsAsJson(access.orgId, { start_date: sp.get('start_date'), end_date: sp.get('end_date'), event_type: sp.get('event_type'), email: sp.get('email') });
+  const start = (page - 1) * pageSize;
+  return NextResponse.json({ items: items.slice(start, start + pageSize), page, page_size: pageSize, total: items.length });
+}

--- a/app/api/settings/security/audit-export/route.ts
+++ b/app/api/settings/security/audit-export/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../../lib/authz';
+import { exportAuditEventsAsCsv, exportAuditEventsAsJson } from '../../../../../lib/security/batch4-audit-events';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin', 'runtime_auditor']);
+  if (!access.ok) return NextResponse.json({ error: access.error || 'Forbidden' }, { status: access.status });
+  const sp = new URL(req.url).searchParams;
+  const format = sp.get('format') || 'json';
+  const filters = { start_date: sp.get('start_date'), end_date: sp.get('end_date'), event_type: sp.get('event_type'), email: sp.get('email') };
+  if (format === 'csv') {
+    const csv = await exportAuditEventsAsCsv(access.orgId, filters);
+    return new NextResponse(csv, { headers: { 'content-type': 'text/csv; charset=utf-8', 'content-disposition': 'attachment; filename="audit-export.csv"' } });
+  }
+  return NextResponse.json({ items: await exportAuditEventsAsJson(access.orgId, filters) }, { headers: { 'cache-control': 'no-store' } });
+}

--- a/app/api/settings/security/route.ts
+++ b/app/api/settings/security/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '../../../../lib/authz';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { preventDisablingAllRecoveryPaths } from '../../../../lib/auth/admin-safety';
+
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(req: NextRequest) {
+  const access = await requireOrgRole(['org_admin']);
+  if (!access.ok) return NextResponse.json({ error: access.error || 'Forbidden' }, { status: access.status });
+  const body = await req.json().catch(() => ({}));
+  const admin = getSupabaseAdmin();
+
+  if (body.sso_enforced === true) {
+    try { await preventDisablingAllRecoveryPaths(admin, access.orgId); }
+    catch (e) { return NextResponse.json({ error: e instanceof Error ? e.message : 'Cannot enforce SSO.' }, { status: 409 }); }
+  }
+
+  const { data, error } = await admin
+    .from('org_security_settings')
+    .upsert({ org_id: access.orgId, sso_enabled: Boolean(body.sso_enabled), sso_enforced: Boolean(body.sso_enforced), break_glass_email_enabled: body.break_glass_email_enabled !== false, sso_metadata: body.sso_metadata || {}, updated_at: new Date().toISOString() }, { onConflict: 'org_id' })
+    .select('*')
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ item: data });
+}

--- a/lib/auth/admin-safety.ts
+++ b/lib/auth/admin-safety.ts
@@ -1,0 +1,27 @@
+export async function ensureOrgHasOwner(admin: any, orgId: string) {
+  const { data, error } = await admin.from('users').select('id').eq('org_id', orgId).eq('role', 'owner').eq('is_active', true);
+  if (error) throw error;
+  if (!data || data.length === 0) throw new Error('Organization must always have at least one owner.');
+  return true;
+}
+
+export async function preventRemovingLastOwner(admin: any, orgId: string, userId: string, targetRole: string) {
+  if (targetRole === 'owner') return true;
+  const { data, error } = await admin.from('users').select('id').eq('org_id', orgId).eq('role', 'owner').eq('is_active', true);
+  if (error) throw error;
+  if ((data || []).length <= 1 && (data || [])[0]?.id === userId) throw new Error('Cannot remove or demote the last owner. Add another owner first.');
+  return true;
+}
+
+export async function canEnforceSsoSafely(admin: any, orgId: string) {
+  const { data: config } = await admin.from('org_security_settings').select('sso_enabled,sso_metadata,break_glass_email_enabled').eq('org_id', orgId).maybeSingle();
+  const hasSsoConfig = Boolean(config?.sso_enabled && config?.sso_metadata && Object.keys(config.sso_metadata || {}).length > 0);
+  const hasBreakGlass = Boolean(config?.break_glass_email_enabled);
+  return { ok: hasSsoConfig || hasBreakGlass, hasSsoConfig, hasBreakGlass };
+}
+
+export async function preventDisablingAllRecoveryPaths(admin: any, orgId: string) {
+  const { ok } = await canEnforceSsoSafely(admin, orgId);
+  if (!ok) throw new Error('Cannot enforce SSO yet. Configure SSO or keep break-glass email sign-in enabled for owners.');
+  return true;
+}

--- a/lib/billing/quota-policy.ts
+++ b/lib/billing/quota-policy.ts
@@ -1,0 +1,27 @@
+const DEFAULTS = { trial: 1000, pro: 10000, business: 100000, enterprise: 1000000 };
+
+function envInt(name: string, fallback: number) { const n = Number(process.env[name] || ''); return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback; }
+
+export function getPlanQuotaPolicy(planKey: string | null | undefined) {
+  const key = String(planKey || 'trial').toLowerCase();
+  return {
+    planKey: key,
+    executionsPer30Days: key === 'trial' ? envInt('QUOTA_TRIAL_EXECUTIONS', DEFAULTS.trial) : key === 'pro' ? envInt('QUOTA_PRO_EXECUTIONS', DEFAULTS.pro) : key === 'business' ? envInt('QUOTA_BUSINESS_EXECUTIONS', DEFAULTS.business) : envInt('QUOTA_ENTERPRISE_EXECUTIONS', DEFAULTS.enterprise),
+    windowDays: 30,
+  };
+}
+
+export async function getEffectiveExecutionQuotaForOrg(orgId: string, adminClient: any) {
+  const { data } = await adminClient.from('billing_subscriptions').select('plan_key').eq('org_id', orgId).order('updated_at', { ascending: false }).limit(1).maybeSingle();
+  return getPlanQuotaPolicy(data?.plan_key || 'trial');
+}
+
+export function isQuotaExceeded(currentExecutions: number, quota: { executionsPer30Days: number }) {
+  return currentExecutions >= quota.executionsPer30Days;
+}
+
+export function buildQuotaSummary(planKey: string | null | undefined, currentExecutions: number) {
+  const policy = getPlanQuotaPolicy(planKey);
+  const remaining = Math.max(0, policy.executionsPer30Days - currentExecutions);
+  return { planKey: policy.planKey, executionsPer30Days: policy.executionsPer30Days, currentExecutions, remaining, nearLimit: currentExecutions >= Math.floor(policy.executionsPer30Days * 0.8), exceeded: isQuotaExceeded(currentExecutions, policy) };
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3765,6 +3765,39 @@ export type Database = {
           },
         ]
       }
+      org_security_settings: {
+        Row: {
+          break_glass_email_enabled: boolean
+          created_at: string
+          id: string
+          org_id: string
+          sso_enabled: boolean
+          sso_enforced: boolean
+          sso_metadata: Json
+          updated_at: string
+        }
+        Insert: {
+          break_glass_email_enabled?: boolean
+          created_at?: string
+          id?: string
+          org_id: string
+          sso_enabled?: boolean
+          sso_enforced?: boolean
+          sso_metadata?: Json
+          updated_at?: string
+        }
+        Update: {
+          break_glass_email_enabled?: boolean
+          created_at?: string
+          id?: string
+          org_id?: string
+          sso_enabled?: boolean
+          sso_enforced?: boolean
+          sso_metadata?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
       org_sso_configs: {
         Row: {
           break_glass_email_login_enabled: boolean

--- a/lib/security/batch4-audit-events.ts
+++ b/lib/security/batch4-audit-events.ts
@@ -1,0 +1,102 @@
+import { getSupabaseAdmin } from '../supabase-server';
+
+// Batch4 security-settings audit feed.
+//
+// The original PR #114 imported exportAuditEventsAsJson / exportAuditEventsAsCsv
+// / buildAuditExportQuery from lib/security/audit-export.ts. Current main
+// reimplemented that shared lib and only exports fetchAuditLogsForExport, so
+// this thin local helper restores the original event-feed shape WITHOUT editing
+// the shared, superseded lib.
+//
+// It only reads tables that exist in main's generated types (sign_in_events,
+// audit_logs). The original also folded in access_requests + guest_access_grants,
+// but those are not present in main's database types, so they are intentionally
+// omitted to avoid inventing schema / adding typecheck regressions. The feed
+// degrades gracefully (empty list) when a relation is missing.
+
+export type AuditEventFilters = {
+  start_date?: string | null;
+  end_date?: string | null;
+  event_type?: string | null;
+  email?: string | null;
+};
+
+export type AuditEvent = {
+  event_type: string;
+  created_at: string | null;
+  email: string | null;
+  payload: Record<string, unknown>;
+};
+
+export function buildAuditExportQuery(orgId: string, filters: AuditEventFilters) {
+  return { orgId, ...filters };
+}
+
+async function collectEvents(orgId: string, filters: AuditEventFilters): Promise<AuditEvent[]> {
+  const admin = getSupabaseAdmin();
+  const events: AuditEvent[] = [];
+
+  const signInQuery = (() => {
+    let q = admin
+      .from('sign_in_events')
+      .select('id, email, event_type, source, success, created_at')
+      .eq('org_id', orgId);
+    if (filters.start_date) q = q.gte('created_at', filters.start_date);
+    if (filters.end_date) q = q.lte('created_at', filters.end_date);
+    return q.order('created_at', { ascending: false }).limit(2000);
+  })();
+
+  const auditLogQuery = (() => {
+    let q = admin
+      .from('audit_logs')
+      .select('id, org_id, created_at, decision, reason')
+      .eq('org_id', orgId);
+    if (filters.start_date) q = q.gte('created_at', filters.start_date);
+    if (filters.end_date) q = q.lte('created_at', filters.end_date);
+    return q.order('created_at', { ascending: false }).limit(2000);
+  })();
+
+  const [signIn, auditLogs] = await Promise.all([signInQuery, auditLogQuery]);
+
+  for (const row of signIn.data || []) {
+    events.push({
+      event_type: 'sign_in_event',
+      created_at: row.created_at,
+      email: row.email ?? null,
+      payload: row as Record<string, unknown>,
+    });
+  }
+  for (const row of auditLogs.data || []) {
+    events.push({
+      event_type: 'audit_log',
+      created_at: row.created_at,
+      email: null,
+      payload: row as Record<string, unknown>,
+    });
+  }
+
+  return events
+    .filter(
+      (e) =>
+        (!filters.event_type || e.event_type === filters.event_type) &&
+        (!filters.email || String(e.email || '').toLowerCase() === String(filters.email).toLowerCase()),
+    )
+    .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+}
+
+export async function exportAuditEventsAsJson(orgId: string, filters: AuditEventFilters): Promise<AuditEvent[]> {
+  return collectEvents(orgId, filters);
+}
+
+export async function exportAuditEventsAsCsv(orgId: string, filters: AuditEventFilters): Promise<string> {
+  const events = await collectEvents(orgId, filters);
+  const rows = ['event_type,created_at,email,payload'];
+  for (const e of events) {
+    rows.push(
+      [e.event_type, e.created_at || '', e.email || '', JSON.stringify(e.payload).replaceAll('"', '""')]
+        .map((v) => `"${String(v)}"`)
+        .join(','),
+    );
+  }
+  return rows.join('\n');
+}

--- a/supabase/migrations/20260531_batch4_security_settings.sql
+++ b/supabase/migrations/20260531_batch4_security_settings.sql
@@ -1,0 +1,25 @@
+-- Batch4 enterprise controls: org security settings table.
+--
+-- Re-port of the relevant slice of the original 20260401_batch4_enterprise_hardening.sql
+-- from PR #114 (commit 626ac41). Only org_security_settings is created here
+-- because that is the single table the re-ported routes on current main require
+-- and that is not already present in main's schema/types. sign_in_events and
+-- audit_logs already exist on main and are reused as-is.
+--
+-- NO-GO until this migration is applied: PATCH /api/settings/security and the
+-- SSO anti-lockout safety check read/write this table.
+
+create extension if not exists pgcrypto;
+
+create table if not exists org_security_settings (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null unique,
+  sso_enabled boolean not null default false,
+  sso_enforced boolean not null default false,
+  break_glass_email_enabled boolean not null default true,
+  sso_metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_org_security_settings_org_id on org_security_settings(org_id);

--- a/tests/unit/auth/admin-safety.test.ts
+++ b/tests/unit/auth/admin-safety.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { preventRemovingLastOwner, preventDisablingAllRecoveryPaths } from '../../../lib/auth/admin-safety';
+
+function adminMock(ownerCount = 1, security: any = { sso_enabled: false, sso_metadata: {}, break_glass_email_enabled: false }) {
+  return { from: (table: string) => ({ select: () => ({ eq: () => ({ eq: () => ({ eq: async () => ({ data: table === 'users' ? Array.from({ length: ownerCount }).map((_, i) => ({ id: i === 0 ? 'u1' : `u${i + 1}` })) : [], error: null }), maybeSingle: async () => ({ data: security, error: null }) }), maybeSingle: async () => ({ data: security, error: null }) }) }) }) } as any;
+}
+
+describe('admin safety', () => {
+  it('blocks removing last owner', async () => { await expect(preventRemovingLastOwner(adminMock(1), 'org1', 'u1', 'member')).rejects.toThrow(/last owner/i); });
+  it('blocks unsafe sso enforcement', async () => { await expect(preventDisablingAllRecoveryPaths(adminMock(2, { sso_enabled: false, sso_metadata: {}, break_glass_email_enabled: false }), 'org1')).rejects.toThrow(/Cannot enforce SSO yet/i); });
+});

--- a/tests/unit/billing/quota-policy.test.ts
+++ b/tests/unit/billing/quota-policy.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuotaSummary } from '../../../lib/billing/quota-policy';
+
+describe('quota policy defaults', () => {
+  it('resolves trial defaults and near-limit', () => {
+    const summary = buildQuotaSummary('trial', 900);
+    expect(summary.executionsPer30Days).toBe(1000);
+    expect(summary.nearLimit).toBe(true);
+    expect(summary.exceeded).toBe(false);
+  });
+});

--- a/tests/unit/security/batch4-audit-events.test.ts
+++ b/tests/unit/security/batch4-audit-events.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+import { exportAuditEventsAsJson, exportAuditEventsAsCsv, buildAuditExportQuery } from '../../../lib/security/batch4-audit-events';
+
+// Chain that resolves to `result` when awaited (thenable) and is also chainable.
+function makeChain(result: { data: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.gte = vi.fn().mockReturnValue(chain);
+  chain.lte = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockReturnValue(chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(result);
+  return chain;
+}
+
+function wireTables(signInRows: unknown[], auditRows: unknown[]) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'sign_in_events') return makeChain({ data: signInRows });
+    if (table === 'audit_logs') return makeChain({ data: auditRows });
+    return makeChain({ data: [] });
+  });
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+});
+
+describe('batch4 audit events helper', () => {
+  it('buildAuditExportQuery merges org + filters', () => {
+    expect(buildAuditExportQuery('org-1', { event_type: 'sign_in_event' })).toEqual({ orgId: 'org-1', event_type: 'sign_in_event' });
+  });
+
+  it('merges sign_in_events and audit_logs sorted by created_at desc', async () => {
+    wireTables(
+      [{ id: 's1', email: 'a@x.com', created_at: '2026-01-01T00:00:00Z' }],
+      [{ id: 'l1', created_at: '2026-02-01T00:00:00Z', decision: 'allow', reason: 'ok' }],
+    );
+    const events = await exportAuditEventsAsJson('org-1', {});
+    expect(events.map((e) => e.event_type)).toEqual(['audit_log', 'sign_in_event']);
+    expect(events[1].email).toBe('a@x.com');
+  });
+
+  it('filters by event_type', async () => {
+    wireTables(
+      [{ id: 's1', email: 'a@x.com', created_at: '2026-01-01T00:00:00Z' }],
+      [{ id: 'l1', created_at: '2026-02-01T00:00:00Z', decision: 'allow', reason: 'ok' }],
+    );
+    const events = await exportAuditEventsAsJson('org-1', { event_type: 'sign_in_event' });
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('sign_in_event');
+  });
+
+  it('degrades gracefully when relations return no data', async () => {
+    wireTables([], []);
+    const events = await exportAuditEventsAsJson('org-1', {});
+    expect(events).toEqual([]);
+  });
+
+  it('produces CSV with header and escaped payload', async () => {
+    wireTables([{ id: 's1', email: 'a@x.com', created_at: '2026-01-01T00:00:00Z' }], []);
+    const csv = await exportAuditEventsAsCsv('org-1', {});
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('event_type,created_at,email,payload');
+    expect(lines[1]).toContain('sign_in_event');
+    expect(lines[1]).toContain('a@x.com');
+  });
+});


### PR DESCRIPTION
Goal:
Re-port three small enterprise-control features from stale closed PR #114 (commit `626ac41`) onto current `main`: (A) admin anti-lockout safety, (B) quota policy, (C) security audit settings API. PR #114 was built on a ~3-month-old schema/API surface and cannot merge directly, so each piece was adapted to current `main`'s auth/supabase/schema patterns.

Files changed:
- (A) Admin anti-lockout
  - `lib/auth/admin-safety.ts` (ported as-is)
  - `app/api/settings/members/[userId]/route.ts` (ported; adapted to Next.js 15 `params: Promise<...>` + `await params`)
  - `tests/unit/auth/admin-safety.test.ts` (ported as-is)
- (B) Quota policy
  - `lib/billing/quota-policy.ts` (ported as-is; `billing_subscriptions.plan_key` confirmed present on main)
  - `tests/unit/billing/quota-policy.test.ts` (ported as-is)
  - `app/api/settings/quota/route.ts` (NEW, additive, read-only) — surfaces effective policy + best-effort current usage from `usage_counters`. Did NOT touch main's `app/api/usage` or `app/api/execute` (those reimplemented quota; editing them risks regression).
- (C) Security audit settings API
  - `app/api/settings/security/route.ts` (PATCH org security settings; SSO anti-lockout via `preventDisablingAllRecoveryPaths`)
  - `app/api/settings/security/audit-events/route.ts` (GET, paginated)
  - `app/api/settings/security/audit-export/route.ts` (GET, json/csv)
  - `lib/security/batch4-audit-events.ts` (NEW thin helper — see audit-export adaptation note below)
  - `tests/unit/security/batch4-audit-events.test.ts` (NEW)
- Schema/types
  - `supabase/migrations/20260531_batch4_security_settings.sql` (NEW; only `org_security_settings`)
  - `lib/database.types.ts` (added `org_security_settings` table def so typecheck does not regress)

Audit-export API mismatch (how it was adapted):
PR #114's routes imported `exportAuditEventsAsJson` / `exportAuditEventsAsCsv` / `buildAuditExportQuery` from `lib/security/audit-export.ts`. Current `main` reimplemented that shared lib and now only exports `fetchAuditLogsForExport` + `AuditExportResult` — the three original names no longer exist. Rather than edit the shared/superseded `lib/security/audit-export.ts`, I added a NEW thin local helper `lib/security/batch4-audit-events.ts` that restores the original event-feed shape. It reads only `sign_in_events` + `audit_logs` (both present in main's generated types). The original also folded in `access_requests` + `guest_access_grants`; those tables are NOT in main's `database.types.ts`, so they were intentionally omitted to avoid inventing schema or adding typecheck regressions. The feed degrades gracefully (empty list) when a relation is missing.

Verification:
- [x] `npm ci` → added 740 packages, audited 741, 0 errors (6 moderate audit advisories pre-existing).
- [x] `npm run typecheck 2>&1 | grep -E "settings/security|settings/members|admin-safety|quota-policy|settings/quota"` → only match is the PRE-EXISTING `app/dashboard/settings/security/page.tsx` (unchanged from `origin/main`; its error comes from `guest_access_grants` which this PR does not touch). No errors in any file added/changed by this PR.
- [x] Baseline delta measured: total `error TS` count is 144 on this branch; reverting only my `database.types.ts` addition (new files still present) yields 146 — i.e. my files add 0 errors and my type addition removes 2. No new typecheck errors introduced.
- [x] `npx vitest run tests/unit/auth/admin-safety.test.ts tests/unit/billing/quota-policy.test.ts tests/unit/security/batch4-audit-events.test.ts` → 3 files, 8 tests, all passed.

Known limits:
- NO-GO until migration applied: `app/api/settings/security` (PATCH), the SSO anti-lockout check (`canEnforceSsoSafely`/`preventDisablingAllRecoveryPaths`), and the audit feed's `org_security_settings` read all require `supabase/migrations/20260531_batch4_security_settings.sql` to be applied. Not yet applied to any database — table existence is `not verified` against live Supabase.
- Audit feed scope is narrower than #114: only `sign_in_events` + `audit_logs`. `access_requests` / `guest_access_grants` are omitted because they are absent from main's types (adding them would regress typecheck and invent schema). This is a graceful degradation, not full parity with the original.
- Routes were typechecked and unit-tested in isolation; they are NOT verified end-to-end against a live deployment or live auth/RBAC session.
- Auth: ported routes keep the original `requireOrgRole([...])` (still present on main). The new read-only quota route also uses `requireOrgRole`. Not re-pointed to `requireOrgPermission`, which some newer sibling routes use.

User-visible benefit:
- Org admins get an anti-lockout guard that blocks demoting/removing the last owner and blocks enforcing SSO when no recovery path (SSO config or break-glass email) is configured.
- Operators/billing admins/auditors get a read-only quota view (`GET /api/settings/quota`) showing plan limit, current usage, remaining, near-limit, and exceeded flags — without changing enforcement.
- Admins/auditors get a security audit feed and json/csv export over sign-in and decision audit events.

Next step:
- Apply `supabase/migrations/20260531_batch4_security_settings.sql` via authorized Supabase tooling, then verify `org_security_settings` exists with a query result before flipping these features to GO.
- Optionally extend the audit feed to `access_requests` / `guest_access_grants` once those tables (and their types) land on main.

https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ)_