### PR TITLE
fix(build): reconcile database.types.ts with schema; remove ignoreBuildErrors

### DIFF
--- a/app/api/ccvs/compliance-status/route.ts
+++ b/app/api/ccvs/compliance-status/route.ts
@@ -83,7 +83,7 @@ async function saveToSupabase(status: CachedStatus, matrix: ComplianceMatrix): P
         mutation_score: status.mutation_score,
         requirements_pass: status.requirements_pass,
         requirements_total: status.requirements_total,
-        matrix_json: matrix as unknown as Record<string, unknown>,
+        matrix_json: matrix as unknown as import('../../../../lib/database.types').Json,
         last_ci_run: status.last_ci_run,
         updated_at: status.updated_at,
       },

--- a/app/api/delivery-proof/scan/route.ts
+++ b/app/api/delivery-proof/scan/route.ts
@@ -79,7 +79,7 @@ async function saveReport(
         mutation_score: null,
         requirements_pass: pass,
         requirements_total: total,
-        matrix_json: { checks, production_url: productionUrl, generated_at: new Date().toISOString() },
+        matrix_json: { checks, production_url: productionUrl, generated_at: new Date().toISOString() } as unknown as import('../../../../lib/database.types').Json,
         last_ci_run: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       },

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -14,6 +14,69 @@ export type Database = {
   }
   public: {
     Tables: {
+      access_requests: {
+        Row: {
+          created_at: string
+          email: string
+          email_domain: string
+          full_name: string | null
+          id: string
+          org_id: string | null
+          ref_code: string | null
+          requested_org_hint: string | null
+          review_note: string | null
+          reviewed_by_user_id: string | null
+          status: string
+          updated_at: string
+          workspace_name: string | null
+        }
+        Insert: {
+          created_at?: string
+          email: string
+          email_domain: string
+          full_name?: string | null
+          id?: string
+          org_id?: string | null
+          ref_code?: string | null
+          requested_org_hint?: string | null
+          review_note?: string | null
+          reviewed_by_user_id?: string | null
+          status?: string
+          updated_at?: string
+          workspace_name?: string | null
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          email_domain?: string
+          full_name?: string | null
+          id?: string
+          org_id?: string | null
+          ref_code?: string | null
+          requested_org_hint?: string | null
+          review_note?: string | null
+          reviewed_by_user_id?: string | null
+          status?: string
+          updated_at?: string
+          workspace_name?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "access_requests_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "access_requests_reviewed_by_user_id_fkey"
+            columns: ["reviewed_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       admin_api_keys: {
         Row: {
           created_at: string
@@ -395,35 +458,38 @@ export type Database = {
         Row: {
           agent_id: string | null
           created_at: string
-          decision: string
-          evidence: Json | null
+          decision: string | null
+          evidence: Json
           execution_id: string | null
           id: string
+          metadata: Json
           org_id: string | null
-          policy_version: string
-          reason: string
+          policy_version: string | null
+          reason: string | null
         }
         Insert: {
           agent_id?: string | null
           created_at?: string
-          decision: string
-          evidence?: Json | null
+          decision?: string | null
+          evidence?: Json
           execution_id?: string | null
           id?: string
+          metadata?: Json
           org_id?: string | null
-          policy_version: string
-          reason: string
+          policy_version?: string | null
+          reason?: string | null
         }
         Update: {
           agent_id?: string | null
           created_at?: string
-          decision?: string
-          evidence?: Json | null
+          decision?: string | null
+          evidence?: Json
           execution_id?: string | null
           id?: string
+          metadata?: Json
           org_id?: string | null
-          policy_version?: string
-          reason?: string
+          policy_version?: string | null
+          reason?: string | null
         }
         Relationships: [
           {
@@ -447,6 +513,88 @@ export type Database = {
             referencedRelation: "organizations"
             referencedColumns: ["id"]
           },
+        ]
+      }
+      billing_customers: {
+        Row: {
+          created_at: string
+          email: string | null
+          id: string
+          name: string | null
+          org_id: string | null
+          stripe_customer_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          email?: string | null
+          id?: string
+          name?: string | null
+          org_id?: string | null
+          stripe_customer_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          email?: string | null
+          id?: string
+          name?: string | null
+          org_id?: string | null
+          stripe_customer_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "billing_customers_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      billing_events: {
+        Row: {
+          created_at: string
+          event_type: string | null
+          id: string
+          org_id: string | null
+          payload: Json
+          processed_at: string | null
+          stripe_customer_id: string | null
+          stripe_event_id: string | null
+          stripe_subscription_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          event_type?: string | null
+          id?: string
+          org_id?: string | null
+          payload?: Json
+          processed_at?: string | null
+          stripe_customer_id?: string | null
+          stripe_event_id?: string | null
+          stripe_subscription_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          event_type?: string | null
+          id?: string
+          org_id?: string | null
+          payload?: Json
+          processed_at?: string | null
+          stripe_customer_id?: string | null
+          stripe_event_id?: string | null
+          stripe_subscription_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "billing_events_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          }
         ]
       }
       billing_meter_outbox: {
@@ -504,6 +652,8 @@ export type Database = {
           status: string | null
           stripe_customer_id: string | null
           stripe_subscription_id: string | null
+          trial_end: string | null
+          trial_start: string | null
           updated_at: string | null
         }
         Insert: {
@@ -518,6 +668,8 @@ export type Database = {
           status?: string | null
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
+          trial_end?: string | null
+          trial_start?: string | null
           updated_at?: string | null
         }
         Update: {
@@ -532,6 +684,8 @@ export type Database = {
           status?: string | null
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
+          trial_end?: string | null
+          trial_start?: string | null
           updated_at?: string | null
         }
         Relationships: []
@@ -3434,6 +3588,60 @@ export type Database = {
         }
         Relationships: []
       }
+      guest_access_grants: {
+        Row: {
+          created_at: string
+          email: string
+          expires_at: string | null
+          id: string
+          invited_by_user_id: string | null
+          org_id: string
+          role: string
+          scope: Json
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          email: string
+          expires_at?: string | null
+          id?: string
+          invited_by_user_id?: string | null
+          org_id: string
+          role?: string
+          scope?: Json
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          expires_at?: string | null
+          id?: string
+          invited_by_user_id?: string | null
+          org_id?: string
+          role?: string
+          scope?: Json
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "guest_access_grants_invited_by_user_id_fkey"
+            columns: ["invited_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "guest_access_grants_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       leads: {
         Row: {
           company: string | null
@@ -3974,6 +4182,7 @@ export type Database = {
           id: string
           is_active: boolean
           name: string
+          plan: string | null
           slug: string | null
           status: string
           updated_at: string
@@ -3983,6 +4192,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           name: string
+          plan?: string | null
           slug?: string | null
           status?: string
           updated_at?: string
@@ -3992,6 +4202,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           name?: string
+          plan?: string | null
           slug?: string | null
           status?: string
           updated_at?: string
@@ -4229,6 +4440,80 @@ export type Database = {
           },
         ]
       }
+      runtime_effects: {
+        Row: {
+          agent_id: string
+          callback_count: number
+          created_at: string
+          effect_type: string
+          execution_id: string | null
+          id: string
+          ledger_entry_id: string | null
+          org_id: string
+          payload: Json
+          result_payload: Json | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          agent_id: string
+          callback_count?: number
+          created_at?: string
+          effect_type: string
+          execution_id?: string | null
+          id?: string
+          ledger_entry_id?: string | null
+          org_id: string
+          payload?: Json
+          result_payload?: Json | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          agent_id?: string
+          callback_count?: number
+          created_at?: string
+          effect_type?: string
+          execution_id?: string | null
+          id?: string
+          ledger_entry_id?: string | null
+          org_id?: string
+          payload?: Json
+          result_payload?: Json | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "runtime_effects_agent_id_fkey"
+            columns: ["agent_id"]
+            isOneToOne: false
+            referencedRelation: "agents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "runtime_effects_execution_id_fkey"
+            columns: ["execution_id"]
+            isOneToOne: false
+            referencedRelation: "executions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "runtime_effects_ledger_entry_id_fkey"
+            columns: ["ledger_entry_id"]
+            isOneToOne: false
+            referencedRelation: "runtime_ledger_entries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "runtime_effects_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       runtime_ledger_entries: {
         Row: {
           agent_id: string
@@ -4242,6 +4527,7 @@ export type Database = {
           org_id: string
           reason: string | null
           request_id: string | null
+          truth_sequence: number | null
           truth_state_id: string | null
         }
         Insert: {
@@ -4256,6 +4542,7 @@ export type Database = {
           org_id: string
           reason?: string | null
           request_id?: string | null
+          truth_sequence?: number | null
           truth_state_id?: string | null
         }
         Update: {
@@ -4270,6 +4557,7 @@ export type Database = {
           org_id?: string
           reason?: string | null
           request_id?: string | null
+          truth_sequence?: number | null
           truth_state_id?: string | null
         }
         Relationships: [

--- a/next.config.js
+++ b/next.config.js
@@ -53,21 +53,6 @@ function buildScriptSrc() {
 
 const nextConfig = {
 
-  // TEMPORARY UNBLOCK: the generated `lib/database.types.ts` is out of sync with
-  // the live Supabase schema — several tables/columns exist in supabase/schema.sql
-  // (access_requests, guest_access_grants, organizations.plan, runtime
-  // truth_sequence, billing columns, ...) but were dropped by a types
-  // regeneration, which makes `next build` fail type-checking and blocks every
-  // production deploy. These are stale-type mismatches, not runtime logic errors.
-  // Unblock builds until types are regenerated from the live DB (npm run
-  // generate-types). See docs/RUNBOOK_DEPLOY.md.
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-
   async rewrites() {
     const remoteApiOrigin = resolveRemoteApiOrigin();
     if (!remoteApiOrigin) return [];


### PR DESCRIPTION
Goal:
Make `next build` type-check and lint cleanly so the temporary escape hatches
`typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` can be removed
from `next.config.js`. The generated `lib/database.types.ts` had drifted out of
sync with the code's Supabase queries (tables/columns the code reads/writes were
missing from the types), which is why builds were being silently unblocked.

Files changed:
- `lib/database.types.ts` — added 5 missing tables and reconciled columns on 4
  existing tables (details below).
- `next.config.js` — removed `typescript.ignoreBuildErrors`, `eslint.ignoreDuringBuilds`,
  and the explanatory comment block.
- `app/api/ccvs/compliance-status/route.ts` — cast `matrix_json` to `Json` (no behavior change).
- `app/api/delivery-proof/scan/route.ts` — cast `matrix_json` to `Json` (no behavior change).

Tables added to `database.types.ts` (verified against `supabase/schema.sql` and
the actual query/insert sites; defs lifted from commit `18abe50` where complete):
- `access_requests` (added `ref_code`, used by `app/api/access/request/route.ts`)
- `guest_access_grants`
- `billing_customers`
- `billing_events` (added `stripe_subscription_id`, `processed_at`, used by the
  billing webhook and drip/capacity cron routes)
- `runtime_effects`

Columns added/reconciled on existing tables:
- `organizations.plan` (in `schema.sql`, was dropped from current types)
- `billing_subscriptions.trial_start`, `billing_subscriptions.trial_end`
- `runtime_ledger_entries.truth_sequence`
- `audit_logs` — made `decision`/`reason`/`policy_version` nullable and added
  `metadata`, to match `schema.sql` (`policy_version` has no NOT NULL constraint).

Kept (superset preserved): current `main`'s `org_domains`, `org_security_settings`,
`dsg_secrets`, and all dsg-brain grant/lease tables were retained; nothing from
current main was dropped.

Verification:
- [x] `npx tsc --noEmit -p tsconfig.json` — 144 errors before, **0 errors after**.
- [x] `NEXT_TELEMETRY_DISABLED=1 NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder SUPABASE_SERVICE_ROLE_KEY=placeholder npm run build` — **exit 0**, output included:
  ```
   ✓ Compiled successfully in 11.3s
     Linting and checking validity of types ...
   ✓ Generating static pages (118/118)
  ```
  (lint + type-check now run as a real build gate, escape hatches removed)

Known limits:
- Three columns the code reads/writes are NOT present in the current
  `supabase/schema.sql` and were typed to match the code (so the build passes),
  but they will fail at runtime against the live DB unless a migration adds them:
  - `billing_subscriptions.trial_start`, `billing_subscriptions.trial_end`
    (inserted in `app/auth/confirm/route.ts`, selected in usage/drip/monitor routes)
  - `runtime_ledger_entries.truth_sequence` (selected in checkpoint/recovery/proof
    code; in `schema.sql` `truth_sequence` lives on `runtime_truth_states`, and the
    ledger row only carries `ledger_sequence`)
  - `runtime_effects.callback_count` / `result_payload` / `ledger_entry_id` and
    `access_requests.ref_code` are also not in the current `schema.sql` table defs.
  These are pre-existing code/schema mismatches surfaced (not caused) by removing
  the escape hatch. A follow-up migration should add these columns (or the queries
  should be corrected) so runtime matches the types. This PR intentionally fixes
  types only and does not change business logic.
- This is a build/CI fix only. No live DB, deployment, or runtime flow was
  exercised. Production release status remains NO-GO until live gates pass.

User-visible benefit:
`next build` is genuinely green again with type-checking and linting enforced, so
type regressions can no longer silently ship. The control-plane code that uses
access requests, guest access, billing customers/events, and runtime effects now
type-checks against the DB types.

Next step:
Add a Supabase migration for the columns listed under "Known limits" so the live
schema matches the types, then re-run schema/type generation to keep them in sync.

https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018fbqnUHbhuUZomtLzqNRQJ)_