### PR TITLE
Enforce org RBAC across API routes, add permissions, mask secrets, server-side org plan, and readiness/CI tweaks

### DIFF
--- a/app/api/agent-execute/route.ts
+++ b/app/api/agent-execute/route.ts
@@ -5,19 +5,29 @@ import {
 } from '../../../lib/agent-governance/service';
 import type { AgentExecuteBody } from '../../../lib/agent-governance/types';
 import { readJsonBody } from '../../../lib/security/request-json';
+import { requireOrgPermission } from '../../../lib/auth/require-org-permission';
 
 export async function POST(req: NextRequest) {
+  const access = await requireOrgPermission('org.execute');
+  if (access.ok !== true) {
+    return NextResponse.json({ ok: false, error: access.error }, { status: access.status });
+  }
+
   const parsed = await readJsonBody<AgentExecuteBody>(req, { maxBytes: 65_536 });
   if (!parsed.ok) {
     return NextResponse.json({ ok: false, error: parsed.error }, { status: parsed.status });
   }
   const body = parsed.value;
-  if (!body?.workspace_id || !body?.org_id || !body?.provider || !body?.agent_id) {
+  if (!body?.workspace_id || !body?.provider || !body?.agent_id) {
     return NextResponse.json({ ok: false, error: 'invalid_payload' }, { status: 400 });
   }
 
+  if (body.org_id && body.org_id !== access.orgId) {
+    return NextResponse.json({ ok: false, error: 'org_mismatch' }, { status: 403 });
+  }
+
   const steps = body.plan?.length ? body.plan : await planExecution(body.message ?? '');
-  const created = await createExecutionRequest({ ...body, plan: steps });
+  const created = await createExecutionRequest({ ...body, org_id: access.orgId, plan: steps });
 
   return NextResponse.json({ ok: true, execution_id: created.id, steps: created.steps }, { status: 201 });
 }

--- a/app/api/api-keys/[id]/route.ts
+++ b/app/api/api-keys/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,12 +28,11 @@ export async function DELETE(
     return NextResponse.json(err, { status: 400 });
   }
 
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_api_keys');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   // Find the key scoped to this org
   const { data: existing, error: fetchError } = await supabase

--- a/app/api/api-keys/route.ts
+++ b/app/api/api-keys/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
 import { createHash, randomBytes } from 'crypto';
 
 export const dynamic = 'force-dynamic';
@@ -42,12 +43,11 @@ async function getOrgId(supabase: Awaited<ReturnType<typeof createClient>>, auth
 }
 
 export async function GET(): Promise<NextResponse> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_api_keys');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   const { data: keys, error } = await supabase
     .from('api_keys')
@@ -73,12 +73,11 @@ export async function GET(): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_api_keys');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   let body: unknown;
   try {

--- a/app/api/gateway/tools/execute/route.ts
+++ b/app/api/gateway/tools/execute/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { executeGatewayTool, normalizeGatewayToolRequest } from '../../../../../lib/gateway/executor';
 import { readJsonBody } from '../../../../../lib/security/request-json';
 
@@ -32,14 +34,55 @@ function statusForDecision(result: Awaited<ReturnType<typeof executeGatewayTool>
   return 502;
 }
 
+async function resolveServerSideOrgPlan(orgId: string) {
+  const admin = getSupabaseAdmin() as any;
+
+  const { data: subscription } = await admin
+    .from('billing_subscriptions')
+    .select('plan_key,status,updated_at')
+    .eq('org_id', orgId)
+    .in('status', ['active', 'trialing'])
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (subscription?.plan_key) {
+    return String(subscription.plan_key);
+  }
+
+  const { data: organization } = await admin
+    .from('organizations')
+    .select('plan')
+    .eq('id', orgId)
+    .maybeSingle();
+
+  return organization?.plan ? String(organization.plan) : 'free';
+}
+
 export async function POST(request: Request) {
   try {
+    const access = await requireOrgPermission('org.execute');
+    if (access.ok !== true) {
+      return NextResponse.json({ ok: false, decision: 'block', reason: access.error }, { status: access.status });
+    }
+
     const parsed = await readJsonBody<Record<string, unknown>>(request, { maxBytes: 32_768 });
     if (!parsed.ok) {
       return NextResponse.json({ ok: false, decision: 'block', reason: parsed.error }, { status: parsed.status });
     }
+
+    const serverPlan = await resolveServerSideOrgPlan(access.orgId);
     const body = parsed.value ?? {};
-    const gatewayRequest = normalizeGatewayToolRequest(body, request.headers);
+    const gatewayRequest = normalizeGatewayToolRequest(
+      {
+        ...body,
+        orgId: access.orgId,
+        actorId: access.userId,
+        actorRole: access.role,
+        orgPlan: serverPlan,
+      },
+      new Headers(),
+    );
     const result = await executeGatewayTool(gatewayRequest);
 
     return NextResponse.json(result, { status: statusForDecision(result) });

--- a/app/api/notification-settings/route.ts
+++ b/app/api/notification-settings/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
 
 export const dynamic = 'force-dynamic';
+
+function maskConfiguredSecret(value: string | null | undefined) {
+  if (!value) return null;
+  const suffix = value.slice(-4);
+  return suffix ? `configured:••••${suffix}` : 'configured';
+}
 
 async function getUserAndOrg(supabase: Awaited<ReturnType<typeof createClient>>, authUserId: string) {
   const { data } = await supabase
@@ -39,11 +46,15 @@ export async function GET(): Promise<NextResponse> {
       connected: settings?.slack ?? false,
       channelId: null as string | null,
       events: ['approval.required', 'agent.failed', 'gate.evaluated'],
-      webhookUrl: settings?.slack_webhook_url ?? null,
+      webhookUrl: null as string | null,
+      secretConfigured: Boolean(settings?.slack_webhook_url),
+      secretPreview: maskConfiguredSecret(settings?.slack_webhook_url),
     },
     pagerduty: {
       connected: settings?.pagerduty ?? false,
-      integrationKey: settings?.pagerduty_key ?? null,
+      integrationKey: null as string | null,
+      secretConfigured: Boolean(settings?.pagerduty_key),
+      secretPreview: maskConfiguredSecret(settings?.pagerduty_key),
       triggerOn: ['agent.failed'],
     },
   };
@@ -52,6 +63,9 @@ export async function GET(): Promise<NextResponse> {
 }
 
 export async function PUT(req: NextRequest): Promise<NextResponse> {
+  const access = await requireOrgPermission('org.manage_notifications');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
+
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -123,11 +137,15 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
       connected: slackEnabled,
       channelId: null as string | null,
       events: ['approval.required', 'agent.failed', 'gate.evaluated'],
-      webhookUrl: slackWebhookUrl,
+      webhookUrl: null as string | null,
+      secretConfigured: Boolean(slackWebhookUrl),
+      secretPreview: maskConfiguredSecret(slackWebhookUrl),
     },
     pagerduty: {
       connected: pagerdutyEnabled,
-      integrationKey: pagerdutyKey,
+      integrationKey: null as string | null,
+      secretConfigured: Boolean(pagerdutyKey),
+      secretPreview: maskConfiguredSecret(pagerdutyKey),
       triggerOn: ['agent.failed'],
     },
   };

--- a/app/api/team/route.ts
+++ b/app/api/team/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
 
 export const dynamic = 'force-dynamic';
 
@@ -61,12 +62,11 @@ export async function GET(): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.invite_members');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   let body: unknown;
   try {

--- a/app/api/webhooks-config/[id]/route.ts
+++ b/app/api/webhooks-config/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,12 +17,11 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_webhooks');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   const { id } = await params;
   const { error } = await supabase
@@ -38,12 +38,11 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_webhooks');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   const { id } = await params;
 

--- a/app/api/webhooks-config/route.ts
+++ b/app/api/webhooks-config/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
 import { createHash, randomBytes } from 'crypto';
 
 export const dynamic = 'force-dynamic';
@@ -14,12 +15,11 @@ async function getOrgId(supabase: Awaited<ReturnType<typeof createClient>>, auth
 }
 
 export async function GET(): Promise<NextResponse> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_webhooks');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   // Fetch webhook configs
   const { data: configs, error } = await supabase
@@ -64,12 +64,11 @@ export async function GET(): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireOrgPermission('org.manage_webhooks');
+  if (access.ok !== true) return NextResponse.json({ error: access.error }, { status: access.status });
 
-  const orgId = await getOrgId(supabase, user.id);
-  if (!orgId) return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+  const supabase = await createClient();
+  const orgId = access.orgId;
 
   let body: Record<string, unknown>;
   try {

--- a/lib/auth/rbac.ts
+++ b/lib/auth/rbac.ts
@@ -10,7 +10,10 @@ export type OrgPermission =
   | 'org.view_reports'
   | 'org.view_evidence'
   | 'org.invite_members'
-  | 'org.invite_guests';
+  | 'org.invite_guests'
+  | 'org.manage_api_keys'
+  | 'org.manage_webhooks'
+  | 'org.manage_notifications';
 
 const ALL_PERMISSIONS: OrgPermission[] = [
   'org.manage_access',
@@ -23,6 +26,9 @@ const ALL_PERMISSIONS: OrgPermission[] = [
   'org.view_evidence',
   'org.invite_members',
   'org.invite_guests',
+  'org.manage_api_keys',
+  'org.manage_webhooks',
+  'org.manage_notifications',
 ];
 
 const ROLE_PERMISSIONS: Record<OrgRole, Set<OrgPermission>> = {
@@ -37,6 +43,9 @@ const ROLE_PERMISSIONS: Record<OrgRole, Set<OrgPermission>> = {
     'org.view_evidence',
     'org.invite_members',
     'org.invite_guests',
+    'org.manage_api_keys',
+    'org.manage_webhooks',
+    'org.manage_notifications',
   ]),
   operator: new Set<OrgPermission>(['org.manage_agents', 'org.execute', 'org.view_reports', 'org.view_evidence']),
   viewer: new Set<OrgPermission>(['org.view_reports', 'org.view_evidence']),

--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -141,9 +141,14 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
     financeGovernanceBackend,
   };
 
-  // ok reflects config/env checks only — live network probes (supabaseServiceRole,
-  // dsgCoreHealth, financeGovernanceBackend) are informational and may timeout under load.
-  const criticalChecks = { env: envCheck, nextAuthSecret, dsgCoreConfig, financeGovernanceSurface };
+  // Production readiness is fail-closed: a green release gate requires the
+  // environment, service-role DB probe, DSG core, and finance backend to pass.
+  // Local developers can opt out only with READINESS_STRICT=false; production
+  // and preview deploys default to strict checks.
+  const strictReadiness = parseBooleanFlag(process.env.READINESS_STRICT, process.env.NODE_ENV === 'production' || Boolean(process.env.VERCEL));
+  const criticalChecks = strictReadiness
+    ? checks
+    : { env: envCheck, nextAuthSecret, dsgCoreConfig, financeGovernanceSurface };
 
   return {
     ok: Object.values(criticalChecks).every((check) => check.ok),

--- a/scripts/go-no-go-gate.sh
+++ b/scripts/go-no-go-gate.sh
@@ -51,6 +51,38 @@ check_endpoint() {
   fi
 }
 
+check_json_ok_endpoint() {
+  local path="$1"
+  local output_file="$2"
+  local url="${BASE_URL%/}${path}"
+  local code
+  code=$(http_code "$url" "$output_file")
+  if ! [[ "$code" =~ ^(2|3)[0-9][0-9]$ ]]; then
+    echo "❌ ${path} -> HTTP ${code}"
+    if grep -qi "CONNECT tunnel failed" "$output_file" 2>/dev/null; then
+      echo "   Proxy tunnel failure detected. Re-run from GitHub Actions or a direct-network shell."
+    fi
+    failures=$((failures + 1))
+    return
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "❌ ${path} -> cannot verify JSON .ok because jq is not installed"
+    failures=$((failures + 1))
+    return
+  fi
+
+  local ok
+  ok=$(jq -r '.ok // false' "$output_file" 2>/dev/null || echo false)
+  if [[ "$ok" == "true" ]]; then
+    echo "✅ ${path} -> HTTP ${code} ok=true"
+  else
+    echo "❌ ${path} -> HTTP ${code} ok=${ok}"
+    jq -r '.error // .checks // .readiness // empty' "$output_file" 2>/dev/null || true
+    failures=$((failures + 1))
+  fi
+}
+
 echo "== Trust surface checks for ${BASE_URL} =="
 check_endpoint "/terms"
 check_endpoint "/privacy"
@@ -58,23 +90,8 @@ check_endpoint "/security"
 check_endpoint "/support"
 
 echo "== Runtime baseline checks =="
-check_endpoint "/api/health"
-
-readiness_code=$(http_code "${BASE_URL%/}/api/readiness" "$readiness_file")
-if [[ "$readiness_code" =~ ^(2|3)[0-9][0-9]$ ]]; then
-  readiness_status=$(jq -r '.status // .readiness.status // .readiness_status // "ready"' "$readiness_file" 2>/dev/null || echo "ready")
-  echo "✅ /api/readiness -> HTTP ${readiness_code} status=${readiness_status}"
-elif [[ "$readiness_code" == "500" ]]; then
-  echo "❌ /api/readiness -> HTTP 500"
-  echo "   Deployment readiness endpoint returned an internal server error. Inspect Vercel deployment logs before any agent execution."
-  failures=$((failures + 1))
-else
-  echo "❌ /api/readiness -> HTTP ${readiness_code}"
-  if grep -qi "CONNECT tunnel failed" "$readiness_file" 2>/dev/null; then
-    echo "   Proxy tunnel failure detected. Re-run from GitHub Actions or a direct-network shell."
-  fi
-  failures=$((failures + 1))
-fi
+check_json_ok_endpoint "/api/health" "$response_file"
+check_json_ok_endpoint "/api/readiness" "$readiness_file"
 
 # /api/core/monitor is intentionally no longer a release dependency. /api/readiness is the source of truth.
 

--- a/tests/unit/api/api-keys-route.test.ts
+++ b/tests/unit/api/api-keys-route.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../lib/supabase/server', () => ({ createClient: vi.fn() }));
+vi.mock('../../../lib/auth/require-org-permission', () => ({ requireOrgPermission: vi.fn() }));
 
 import { GET, POST } from '../../../app/api/api-keys/route';
 import { createClient } from '../../../lib/supabase/server';
+import { requireOrgPermission } from '../../../lib/auth/require-org-permission';
 import { NextRequest } from 'next/server';
 
 const mockCreateClient = vi.mocked(createClient);
+const mockRequireOrgPermission = vi.mocked(requireOrgPermission);
 
 const ORG_ID = 'org-test-123';
 const AUTH_USER = { id: 'auth-user-1' };
@@ -61,10 +64,19 @@ function makeClient(user: unknown, orgId: string | null, extraFromBehavior?: (ta
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockRequireOrgPermission.mockResolvedValue({
+    ok: true,
+    orgId: ORG_ID,
+    userId: 'user-1',
+    authUserId: AUTH_USER.id,
+    email: 'owner@example.com',
+    role: 'owner',
+  });
 });
 
 describe('GET /api/api-keys', () => {
   it('returns 401 when not authenticated', async () => {
+    mockRequireOrgPermission.mockResolvedValueOnce({ ok: false, status: 401, error: 'Unauthorized' });
     mockCreateClient.mockResolvedValue(makeClient(null, null) as any);
     const res = await GET();
     expect(res.status).toBe(401);
@@ -72,10 +84,11 @@ describe('GET /api/api-keys', () => {
     expect(body.error).toMatch(/Unauthorized/);
   });
 
-  it('returns 404 when user has no org', async () => {
+  it('returns 403 when user lacks API key permission', async () => {
+    mockRequireOrgPermission.mockResolvedValueOnce({ ok: false, status: 403, error: 'Insufficient permission' });
     mockCreateClient.mockResolvedValue(makeClient(AUTH_USER, null) as any);
     const res = await GET();
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(403);
   });
 
   it('returns only keys for the authenticated user org (org isolation)', async () => {
@@ -109,6 +122,7 @@ describe('POST /api/api-keys', () => {
   }
 
   it('returns 401 when not authenticated', async () => {
+    mockRequireOrgPermission.mockResolvedValueOnce({ ok: false, status: 401, error: 'Unauthorized' });
     mockCreateClient.mockResolvedValue(makeClient(null, null) as any);
     const res = await POST(makePostRequest({ name: 'Test', scopes: ['read'] }));
     expect(res.status).toBe(401);

--- a/tests/unit/auth/rbac.test.ts
+++ b/tests/unit/auth/rbac.test.ts
@@ -12,6 +12,9 @@ const ALL: OrgPermission[] = [
   'org.view_evidence',
   'org.invite_members',
   'org.invite_guests',
+  'org.manage_api_keys',
+  'org.manage_webhooks',
+  'org.manage_notifications',
 ];
 
 describe('org rbac matrix', () => {
@@ -34,6 +37,9 @@ describe('org rbac matrix', () => {
         'org.view_evidence',
         'org.invite_members',
         'org.invite_guests',
+        'org.manage_api_keys',
+        'org.manage_webhooks',
+        'org.manage_notifications',
       ],
       operator: ['org.manage_agents', 'org.execute', 'org.view_reports', 'org.view_evidence'],
       viewer: ['org.view_reports', 'org.view_evidence'],

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "npm install",
+  "installCommand": "npm ci",
   "crons": [
     {
       "path": "/api/cron/flush-meter-outbox",


### PR DESCRIPTION
### Motivation

- Harden server-side endpoints by verifying organization-level permissions before performing org-scoped operations. 
- Expand RBAC to cover API key, webhook, and notification management and avoid leaking secrets in API responses. 
- Ensure gateway tool execution uses server-side org plan and actor context to make correct entitlement decisions. 
- Make deployment readiness gating configurable and improve the release gate script and CI install command.

### Description

- Add `requireOrgPermission` checks to multiple API routes (`agent-execute`, `api-keys`, gateway tool execute, `notification-settings`, `team`, `webhooks-config`) and use the returned `orgId`/actor info rather than client-derived values. 
- Extend RBAC with new permissions: `org.manage_api_keys`, `org.manage_webhooks`, and `org.manage_notifications` and grant them to `owner` and `admin` roles in `lib/auth/rbac.ts`. 
- In `agent-execute`, remove `org_id` from required payload fields, verify any provided `org_id` matches the access context, and ensure `createExecutionRequest` is called with `org_id` from the permission check. 
- For the gateway tool execute path, add `resolveServerSideOrgPlan` to read the org plan from the database and pass `orgPlan`, `actorId`, and `actorRole` into `normalizeGatewayToolRequest`. 
- Mask and hide raw webhook/pagerduty secrets in `notification-settings` responses by returning `secretConfigured` and `secretPreview` with `configured:••••xxxx` instead of returning the raw secrets. 
- Improve readiness behavior in `lib/deployment/readiness.ts` by making the critical checks strict by default in production/preview and configurable via `READINESS_STRICT`. 
- Improve the release gate script `scripts/go-no-go-gate.sh` to validate JSON `ok` fields using `jq` and add `check_json_ok_endpoint`. 
- Change Vercel install command to `npm ci` in `vercel.json`.

### Testing

- Updated unit tests for API keys (`tests/unit/api/api-keys-route.test.ts`) to mock `requireOrgPermission` and reflect new auth flows, and then ran the unit test suite with Vitest which passed. 
- Updated RBAC unit tests (`tests/unit/auth/rbac.test.ts`) to include the new permissions and ran those tests with Vitest which passed. 
- No automated end-to-end changes were included beyond unit tests; CI install command updated to `npm ci` to match reproducible installs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8a6ad75483288007a6d867e6f5c2)