### PR TITLE
Require access for finance approvals, improve DSG quick-action test payload, and add immutable finance audit ledger triggers

### DIFF
--- a/app/api/dsg/v1/gates/evaluate/route.ts
+++ b/app/api/dsg/v1/gates/evaluate/route.ts
@@ -6,6 +6,16 @@ import { readJsonBody } from '../../../../../../lib/security/request-json';
 
 export const dynamic = 'force-dynamic';
 
+function validationErrorCode(details: { field: string; message: string }[]) {
+  if (details.some((detail) => detail.field === 'nonce' && detail.message === 'required')) {
+    return 'missing_nonce';
+  }
+  if (details.some((detail) => detail.field === 'idempotencyKey' && detail.message === 'required')) {
+    return 'missing_idempotency_key';
+  }
+  return 'validation_failed';
+}
+
 export async function POST(request: Request) {
   const rateLimitResult = await applyRateLimit({
     key: getRateLimitKey(request, 'dsg-gate'),
@@ -31,7 +41,7 @@ export async function POST(request: Request) {
   const validated = validateDeterministicProofRequest(body.value);
   if (!validated.ok) {
     return NextResponse.json(
-      { ok: false, error: validated.error, details: validated.details ?? [] },
+      { ok: false, error: validationErrorCode(validated.details ?? []), details: validated.details ?? [] },
       { status: 400, headers: rateLimitHeaders },
     );
   }

--- a/app/api/finance-governance/approvals/route.ts
+++ b/app/api/finance-governance/approvals/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { handleFinanceGovernanceApiError } from '../../../../lib/finance-governance/api-error';
+import { requireFinanceGovernanceAccess } from '../../../../lib/finance-governance/access-gate';
 import { notifyApprovalStatusChange } from '../../../../lib/finance-governance/notify';
 import { FinanceGovernanceRepository } from '../../../../lib/finance-governance/repository';
 import { getOrg } from '../../../../lib/server/getOrg';
@@ -34,6 +35,8 @@ export async function POST(request: Request) {
     if (!ALLOWED_ACTIONS.has(action as AllowedAction)) {
       return NextResponse.json({ error: 'action must be approve, reject, or escalate' }, { status: 400 });
     }
+
+    requireFinanceGovernanceAccess(request, orgId, action as AllowedAction);
 
     const result = await repository.applyAction(orgId, approvalId, action as AllowedAction);
     void notifyApprovalStatusChange({

--- a/components/QuickActions.tsx
+++ b/components/QuickActions.tsx
@@ -28,20 +28,37 @@ export function QuickActions() {
     setRunning('test_action');
     setResult(null);
     try {
+      const requestId = crypto.randomUUID();
       const res = await fetch('/api/dsg/v1/gates/evaluate', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          action: 'test.ping',
-          context: { source: 'quick_actions_widget', test: true },
+          planId: 'quick_actions_test_ping',
+          riskLevel: 'low',
+          nonce: `qa_nonce_${requestId}`,
+          idempotencyKey: `qa_idem_${requestId}`,
+          context: {
+            source: 'quick_actions_widget',
+            test: true,
+            requirement_clear: true,
+            tool_available: true,
+            // Client-side quick checks cannot prove permission or secret binding.
+            // Keep these false so the gate cannot be mistaken for production audit evidence.
+            permission_granted: false,
+            secret_bound: false,
+            dependency_resolved: true,
+            testable: true,
+            deploy_target_ready: false,
+            audit_hook_available: false,
+          },
         }),
       });
       const json = await res.json().catch(() => ({}));
       setResult({
         id: 'test_action',
-        ok: res.ok,
+        ok: res.ok && json.ok === true,
         message: res.ok
-          ? `Gate result: ${json.decision ?? json.status ?? 'OK'}`
+          ? `Gate result: ${json.gateStatus ?? json.proofStatus ?? 'UNKNOWN'} (client-only check, not audit evidence)`
           : json.error ?? `Error ${res.status}`,
       });
     } catch (err) {
@@ -60,7 +77,7 @@ export function QuickActions() {
       id: 'test_action',
       icon: Zap,
       label: 'Run a test action',
-      description: 'POST a test payload to the gates evaluate endpoint.',
+      description: 'Check the gate contract without claiming production audit evidence.',
       onClick: runTestAction,
     },
     {

--- a/supabase/migrations/20260601143000_finance_audit_ledger_immutable.sql
+++ b/supabase/migrations/20260601143000_finance_audit_ledger_immutable.sql
@@ -1,0 +1,9 @@
+create or replace trigger prevent_update_finance_governance_audit_ledger
+  before update on public.finance_governance_audit_ledger
+  for each row
+  execute function public.raise_immutable_record('Cannot update finance_governance_audit_ledger');
+
+create or replace trigger prevent_delete_finance_governance_audit_ledger
+  before delete on public.finance_governance_audit_ledger
+  for each row
+  execute function public.raise_immutable_record('Cannot delete finance_governance_audit_ledger');

--- a/tests/integration/api/finance-governance-actions.test.ts
+++ b/tests/integration/api/finance-governance-actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const submit = vi.fn();
 const applyAction = vi.fn();
+const getOrg = vi.fn();
 
 vi.mock('../../../lib/finance-governance/repository', () => ({
   FinanceGovernanceRepository: vi.fn().mockImplementation(() => ({
@@ -10,11 +11,21 @@ vi.mock('../../../lib/finance-governance/repository', () => ({
   })),
 }));
 
+vi.mock('../../../lib/server/getOrg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/server/getOrg')>();
+  return {
+    ...actual,
+    getOrg,
+  };
+});
+
 describe('finance governance action routes', () => {
   beforeEach(() => {
     vi.resetModules();
     submit.mockReset();
     applyAction.mockReset();
+    getOrg.mockReset();
+    getOrg.mockResolvedValue('org-test');
     submit.mockImplementation(async (_orgId: string, caseId: string) => ({ ok: true, action: 'submit', caseId, nextStatus: 'pending' }));
     applyAction.mockImplementation(async (_orgId: string, approvalId: string, action: string) => ({ ok: true, action, approvalId, nextStatus: action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'escalated' }));
   });
@@ -35,6 +46,40 @@ describe('finance governance action routes', () => {
     expect(body.action).toBe('submit');
     expect(body.caseId).toBe('case-001');
     expect(body.nextStatus).toBe('pending');
+  });
+
+  it('denies generic approval actions when actor role is not allowed', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/approvals/route');
+
+    const request = new Request('http://localhost/api/finance-governance/approvals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-actor-role': 'viewer', 'x-org-plan': 'enterprise' },
+      body: JSON.stringify({ approvalId: 'APR-1004', action: 'approve' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe('role_not_allowed');
+    expect(applyAction).not.toHaveBeenCalled();
+  });
+
+  it('applies generic approval actions only after finance governance access passes', async () => {
+    const { POST } = await import('../../../app/api/finance-governance/approvals/route');
+
+    const request = new Request('http://localhost/api/finance-governance/approvals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-actor-role': 'finance_approver', 'x-org-plan': 'enterprise' },
+      body: JSON.stringify({ approvalId: 'APR-1005', action: 'reject' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.action).toBe('reject');
+    expect(applyAction).toHaveBeenCalledWith('org-test', 'APR-1005', 'reject');
   });
 
   it('approves an approval item', async () => {

--- a/tests/migrations/finance-governance-audit-ledger-immutability.test.ts
+++ b/tests/migrations/finance-governance-audit-ledger-immutability.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+
+describe('finance governance audit ledger immutability migration', () => {
+  it('keeps the ledger constrained to submit/approve/reject/escalate actions', () => {
+    const sql = readFileSync('supabase/migrations/20260429060000_finance_governance_audit_ledger.sql', 'utf8');
+
+    expect(sql).toContain("action in ('submit', 'approve', 'reject', 'escalate')");
+    expect(sql).toContain("result in ('ok', 'error', 'denied')");
+    expect(sql).toContain('record_hash text not null unique');
+  });
+
+  it('adds DB-level update and delete blockers to the finance audit ledger', () => {
+    const sql = readFileSync('supabase/migrations/20260601143000_finance_audit_ledger_immutable.sql', 'utf8');
+
+    expect(sql).toContain('create or replace trigger prevent_update_finance_governance_audit_ledger');
+    expect(sql).toContain('before update on public.finance_governance_audit_ledger');
+    expect(sql).toContain("execute function public.raise_immutable_record('Cannot update finance_governance_audit_ledger')");
+    expect(sql).toContain('create or replace trigger prevent_delete_finance_governance_audit_ledger');
+    expect(sql).toContain('before delete on public.finance_governance_audit_ledger');
+    expect(sql).toContain("execute function public.raise_immutable_record('Cannot delete finance_governance_audit_ledger')");
+  });
+});


### PR DESCRIPTION
### Motivation

- Surface clearer validation error codes for DSG deterministic gate requests so clients can distinguish missing required fields like `nonce` and `idempotencyKey`.
- Enforce server-side access checks for generic finance governance approval actions to prevent unauthorized role use.
- Make the finance governance audit ledger immutable at the DB level so audit records cannot be updated or deleted after insertion.

### Description

- Added `validationErrorCode` helper in `app/api/dsg/v1/gates/evaluate/route.ts` to map validation details to specific error codes like `missing_nonce` and `missing_idempotency_key`.
- Introduced an access gate by importing and calling `requireFinanceGovernanceAccess` in `app/api/finance-governance/approvals/route.ts` before applying generic actions.
- Updated the client quick-action `runTestAction` in `components/QuickActions.tsx` to generate a `crypto.randomUUID()` request id and include `nonce`, `idempotencyKey`, richer `context` fields, and clarified messaging that the check is client-only and not production audit evidence.
- Added a new DB migration `supabase/migrations/20260601143000_finance_audit_ledger_immutable.sql` which creates triggers to block `UPDATE` and `DELETE` on `public.finance_governance_audit_ledger`.

### Testing

- Updated and ran integration tests in `tests/integration/api/finance-governance-actions.test.ts` which now mock `getOrg` and assert role-denial and successful action flows; these tests passed.
- Added migration unit tests in `tests/migrations/finance-governance-audit-ledger-immutability.test.ts` that verify the ledger constraints and presence of immutability triggers; these tests passed.
- Ran the test suite with `vitest` for the modified areas and all affected tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d97ee1fb0832890b512ff229a8ed3)