### PR TITLE
feat(dsg): add breach signal sandbox policy tests

### DIFF
--- a/docs/dsg-breach-signal-sandbox-test-plan.md
+++ b/docs/dsg-breach-signal-sandbox-test-plan.md
@@ -1,0 +1,97 @@
+# DSG Breach Signal Sandbox Test Plan
+
+Status: design + unit-test scaffold only. This document does not authorize autonomous dark-web browsing, Tor crawling, dump downloading, credential use, wallet use, payment, login, or production claims.
+
+## Goal
+
+Add a deterministic policy gate for breach-signal intake so DSG can help owners understand what may have leaked without storing stolen raw data.
+
+The gate is intentionally scoped to redacted evidence, metadata, hashes, and owner-side confirmation. It is not a dark-web crawler and must not become a data-dump collector.
+
+## Safety Boundary
+
+Allowed inputs:
+
+- owner scope such as domain, repo, brand, or system name
+- legal purpose such as owner notification or breach prevention
+- source category, not full illegal source content
+- masked samples such as `som***@example.com`
+- hash proofs such as `sha256:...`
+- claimed data types such as `email`, `hashed_password`, or `api_key`
+- owner/provider/internal confirmation flags
+
+Blocked inputs/actions:
+
+- raw stolen data
+- full database dumps
+- full password, token, private key, API key, session token, payment data, or private records
+- login/payment/download requirements
+- autonomous Tor/dark-web browsing
+- unknown network route without review
+
+## Decision Model
+
+| Condition | Decision |
+| --- | --- |
+| Missing owner scope | BLOCK |
+| Missing legal purpose | BLOCK |
+| Raw data included | BLOCK |
+| Full dump included | BLOCK |
+| Source requires login/payment/download | BLOCK |
+| Autonomous agent access | BLOCK |
+| Autonomous access over Tor | BLOCK |
+| Masked evidence only, no owner confirmation | REVIEW |
+| Owner confirmation present | INCIDENT_REPORT_ALLOWED |
+| Provider/internal log confirmation present | INCIDENT_REPORT_ALLOWED |
+
+## Evidence Levels
+
+| Level | Meaning |
+| --- | --- |
+| L0 | No credible evidence yet |
+| L1 | Owner/source category mentioned |
+| L2 | Masked sample or hash exists |
+| L3 | Owner confirmed sample/hash matches their system |
+| L4 | Provider or internal logs confirm incident |
+
+## Severity Model
+
+| Severity | Claimed data type examples |
+| --- | --- |
+| LOW | brand/domain mention only |
+| MEDIUM | email, username, employee name |
+| HIGH | hashed password, phone, internal endpoint, customer table/record |
+| CRITICAL | API key, private key, session token, admin credential, payment data, production secret |
+
+## Unit Test Coverage Added
+
+File: `tests/unit/dsg/breach-signal-policy.test.ts`
+
+Covers:
+
+1. blocks raw stolen data and full dumps
+2. blocks autonomous Tor access even with a legitimate-looking purpose
+3. returns REVIEW for masked evidence without owner confirmation
+4. allows incident report only after owner confirmation or stronger evidence
+5. blocks when owner scope or legal purpose is missing
+
+## Local/Sandbox Commands
+
+Recommended local verification commands after checkout:
+
+```bash
+npm run typecheck
+npx vitest run tests/unit/dsg/breach-signal-policy.test.ts
+```
+
+Broader repo checks before merge:
+
+```bash
+npm run test:unit
+npm run test
+npm run build
+```
+
+## Truth Boundary
+
+This PR does not prove production readiness and does not add a production breach-monitoring service. It only adds a deterministic policy gate and unit tests for safe breach-signal intake behavior.

--- a/lib/dsg/breach-signal/policy.ts
+++ b/lib/dsg/breach-signal/policy.ts
@@ -1,0 +1,139 @@
+export type BreachSignalDecision = "BLOCK" | "REVIEW" | "INCIDENT_REPORT_ALLOWED";
+export type BreachEvidenceLevel = "L0" | "L1" | "L2" | "L3" | "L4";
+export type BreachSeverity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type BreachSignalInput = {
+  owner?: string;
+  sourceCategory?: string;
+  legalPurpose?: string;
+  rawDataIncluded?: boolean;
+  fullDumpIncluded?: boolean;
+  requiresLogin?: boolean;
+  requiresPayment?: boolean;
+  requiresDownload?: boolean;
+  autonomousAgentAccess?: boolean;
+  networkRoute?: "standard" | "tor" | "unknown";
+  claimedDataTypes?: string[];
+  maskedSamples?: string[];
+  hashes?: string[];
+  ownerConfirmed?: boolean;
+  providerConfirmed?: boolean;
+  internalLogConfirmed?: boolean;
+};
+
+export type BreachSignalEvaluation = {
+  decision: BreachSignalDecision;
+  evidenceLevel: BreachEvidenceLevel;
+  severity: BreachSeverity;
+  reasons: string[];
+  allowedActions: string[];
+  blockedActions: string[];
+  rawDataStored: false;
+};
+
+const CRITICAL_DATA_TYPES = new Set([
+  "api_key",
+  "private_key",
+  "session_token",
+  "admin_credential",
+  "payment_data",
+  "production_secret",
+]);
+
+const HIGH_DATA_TYPES = new Set([
+  "hashed_password",
+  "phone",
+  "internal_endpoint",
+  "customer_table",
+  "customer_record",
+]);
+
+const MEDIUM_DATA_TYPES = new Set(["email", "username", "employee_name"]);
+
+function normalizeList(values?: string[]): string[] {
+  return (values ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean);
+}
+
+function hasMaskedEvidence(input: BreachSignalInput): boolean {
+  return Boolean((input.maskedSamples?.length ?? 0) > 0 || (input.hashes?.length ?? 0) > 0);
+}
+
+function getEvidenceLevel(input: BreachSignalInput): BreachEvidenceLevel {
+  if (input.providerConfirmed || input.internalLogConfirmed) return "L4";
+  if (input.ownerConfirmed) return "L3";
+  if (hasMaskedEvidence(input)) return "L2";
+  if (input.owner || input.sourceCategory) return "L1";
+  return "L0";
+}
+
+function getSeverity(input: BreachSignalInput): BreachSeverity {
+  const dataTypes = normalizeList(input.claimedDataTypes);
+
+  if (dataTypes.some((type) => CRITICAL_DATA_TYPES.has(type))) return "CRITICAL";
+  if (dataTypes.some((type) => HIGH_DATA_TYPES.has(type))) return "HIGH";
+  if (dataTypes.some((type) => MEDIUM_DATA_TYPES.has(type))) return "MEDIUM";
+  return "LOW";
+}
+
+export function evaluateBreachSignal(input: BreachSignalInput): BreachSignalEvaluation {
+  const reasons: string[] = [];
+  const blockedActions = [
+    "do_not_download_full_dump",
+    "do_not_store_raw_stolen_data",
+    "do_not_pay_or_login_to_source",
+    "do_not_allow_autonomous_dark_web_browsing",
+  ];
+
+  const owner = input.owner?.trim();
+  const legalPurpose = input.legalPurpose?.trim();
+
+  if (!owner) reasons.push("OWNER_SCOPE_REQUIRED");
+  if (!legalPurpose) reasons.push("LEGAL_PURPOSE_REQUIRED");
+  if (input.rawDataIncluded) reasons.push("RAW_DATA_INCLUDED");
+  if (input.fullDumpIncluded) reasons.push("FULL_DUMP_INCLUDED");
+  if (input.requiresLogin) reasons.push("SOURCE_REQUIRES_LOGIN");
+  if (input.requiresPayment) reasons.push("SOURCE_REQUIRES_PAYMENT");
+  if (input.requiresDownload) reasons.push("SOURCE_REQUIRES_DOWNLOAD");
+  if (input.autonomousAgentAccess) reasons.push("AUTONOMOUS_AGENT_ACCESS_BLOCKED");
+  if (input.networkRoute === "tor" && input.autonomousAgentAccess) reasons.push("TOR_AUTONOMOUS_ACCESS_BLOCKED");
+  if (input.networkRoute === "unknown") reasons.push("UNKNOWN_NETWORK_ROUTE");
+
+  const evidenceLevel = getEvidenceLevel(input);
+  const severity = getSeverity(input);
+
+  const hardBlock = reasons.length > 0;
+
+  if (hardBlock) {
+    return {
+      decision: "BLOCK",
+      evidenceLevel,
+      severity,
+      reasons,
+      allowedActions: ["redact_or_discard_raw_material", "capture_minimal_metadata_only", "request_owner_scope"],
+      blockedActions,
+      rawDataStored: false,
+    };
+  }
+
+  if (evidenceLevel === "L3" || evidenceLevel === "L4") {
+    return {
+      decision: "INCIDENT_REPORT_ALLOWED",
+      evidenceLevel,
+      severity,
+      reasons: ["OWNER_OR_PROVIDER_CONFIRMATION_PRESENT", "RAW_DATA_NOT_STORED"],
+      allowedActions: ["create_owner_notification_report", "create_remediation_checklist", "record_audit_evidence_manifest"],
+      blockedActions,
+      rawDataStored: false,
+    };
+  }
+
+  return {
+    decision: "REVIEW",
+    evidenceLevel,
+    severity,
+    reasons: ["OWNER_VERIFICATION_REQUIRED", "RAW_DATA_NOT_STORED"],
+    allowedActions: ["request_owner_verification", "create_redacted_preliminary_report", "record_audit_evidence_manifest"],
+    blockedActions,
+    rawDataStored: false,
+  };
+}

--- a/tests/unit/dsg/breach-signal-policy.test.ts
+++ b/tests/unit/dsg/breach-signal-policy.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateBreachSignal } from "../../../lib/dsg/breach-signal/policy";
+
+describe("breach signal policy gate", () => {
+  it("blocks when raw stolen data or full dumps are included", () => {
+    const result = evaluateBreachSignal({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      sourceCategory: "breach-signal",
+      rawDataIncluded: true,
+      fullDumpIncluded: true,
+      claimedDataTypes: ["email"],
+    });
+
+    expect(result.decision).toBe("BLOCK");
+    expect(result.rawDataStored).toBe(false);
+    expect(result.reasons).toContain("RAW_DATA_INCLUDED");
+    expect(result.reasons).toContain("FULL_DUMP_INCLUDED");
+    expect(result.blockedActions).toContain("do_not_download_full_dump");
+  });
+
+  it("blocks autonomous Tor access even when the purpose looks legitimate", () => {
+    const result = evaluateBreachSignal({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      sourceCategory: "breach-signal",
+      networkRoute: "tor",
+      autonomousAgentAccess: true,
+      maskedSamples: ["som***@example.com"],
+      claimedDataTypes: ["email"],
+    });
+
+    expect(result.decision).toBe("BLOCK");
+    expect(result.evidenceLevel).toBe("L2");
+    expect(result.reasons).toContain("AUTONOMOUS_AGENT_ACCESS_BLOCKED");
+    expect(result.reasons).toContain("TOR_AUTONOMOUS_ACCESS_BLOCKED");
+  });
+
+  it("allows only review for masked evidence without owner confirmation", () => {
+    const result = evaluateBreachSignal({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      sourceCategory: "breach-signal",
+      networkRoute: "standard",
+      maskedSamples: ["som***@example.com", "sk_live_****a91f"],
+      claimedDataTypes: ["email", "api_key"],
+    });
+
+    expect(result.decision).toBe("REVIEW");
+    expect(result.evidenceLevel).toBe("L2");
+    expect(result.severity).toBe("CRITICAL");
+    expect(result.reasons).toContain("OWNER_VERIFICATION_REQUIRED");
+    expect(result.allowedActions).toContain("request_owner_verification");
+    expect(result.rawDataStored).toBe(false);
+  });
+
+  it("allows incident report only after owner confirmation or stronger evidence", () => {
+    const result = evaluateBreachSignal({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      sourceCategory: "breach-signal",
+      networkRoute: "standard",
+      maskedSamples: ["som***@example.com"],
+      hashes: ["sha256:owner-confirmed-sample"],
+      claimedDataTypes: ["hashed_password"],
+      ownerConfirmed: true,
+    });
+
+    expect(result.decision).toBe("INCIDENT_REPORT_ALLOWED");
+    expect(result.evidenceLevel).toBe("L3");
+    expect(result.severity).toBe("HIGH");
+    expect(result.allowedActions).toContain("create_owner_notification_report");
+    expect(result.rawDataStored).toBe(false);
+  });
+
+  it("blocks cases without owner scope or legal purpose", () => {
+    const result = evaluateBreachSignal({
+      sourceCategory: "breach-signal",
+      maskedSamples: ["som***@example.com"],
+      claimedDataTypes: ["email"],
+    });
+
+    expect(result.decision).toBe("BLOCK");
+    expect(result.reasons).toContain("OWNER_SCOPE_REQUIRED");
+    expect(result.reasons).toContain("LEGAL_PURPOSE_REQUIRED");
+    expect(result.rawDataStored).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a sandboxed breach-signal policy gate and unit-test coverage for DSG responsible disclosure intake.

This PR intentionally does **not** add dark-web crawling, Tor automation, raw dump ingestion, payment/login flows, or production breach-monitoring claims.

## Changes

- `lib/dsg/breach-signal/policy.ts`
  - deterministic policy evaluation for breach-signal intake
  - blocks raw stolen data, full dumps, login/payment/download requirements, autonomous agent access, autonomous Tor access, missing owner scope, and missing legal purpose
  - returns `REVIEW` for masked evidence without owner confirmation
  - returns `INCIDENT_REPORT_ALLOWED` only when owner/provider/internal confirmation exists
  - forces `rawDataStored: false`

- `tests/unit/dsg/breach-signal-policy.test.ts`
  - covers hard-block behavior
  - covers autonomous Tor block behavior
  - covers masked-evidence review state
  - covers owner-confirmed incident-report allowance
  - covers missing owner/legal purpose block

- `docs/dsg-breach-signal-sandbox-test-plan.md`
  - documents sandbox boundary, evidence levels, severity model, and verification commands

## Sandbox verification intended

```bash
npm run typecheck
npx vitest run tests/unit/dsg/breach-signal-policy.test.ts
```

Broader checks before merge:

```bash
npm run test:unit
npm run test
npm run build
```

## Truth boundary

I opened this as a design/test PR only. I did not run repo-local commands in this chat environment, and this PR does not prove production readiness, deployability, or any dark-web safety capability. CI / reviewer verification is required before merge.