### PR TITLE
feat(dsg): wire evaluateBreachSignal to API route, integration tests, and operator panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,8 @@ OPENROUTER_API_KEY=
 # ============ Auth ============
 NEXTAUTH_SECRET=
 DSG_FINANCE_GOVERNANCE_ENABLED=true
+
+# ============ Breach Signal / HIBP ============
+# Have I Been Pwned API key — required for HIBP domain breach checks in /api/dsg/breach-signal/evaluate
+# Get a key at https://haveibeenpwned.com/API/Key
+HIBP_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,4 @@ NEXTAUTH_SECRET=
 DSG_FINANCE_GOVERNANCE_ENABLED=true
 
 # ============ Breach Signal / HIBP ============
-# Have I Been Pwned API key — required for HIBP domain breach checks in /api/dsg/breach-signal/evaluate
-# Get a key at https://haveibeenpwned.com/API/Key
-HIBP_API_KEY=
+# No API key required — uses the free public HIBP breach list with 24-hour in-memory cache.

--- a/app/api/dsg/breach-signal/evaluate/route.ts
+++ b/app/api/dsg/breach-signal/evaluate/route.ts
@@ -3,6 +3,8 @@ import {
   evaluateBreachSignal,
   type BreachSignalInput,
 } from "../../../../../lib/dsg/breach-signal/policy";
+import { detectFlagsFromUrl } from "../../../../../lib/dsg/breach-signal/url-detect";
+import { checkHibpDomain } from "../../../../../lib/dsg/breach-signal/hibp";
 import { readJsonBody } from "../../../../../lib/security/request-json";
 import {
   applyRateLimit,
@@ -11,6 +13,47 @@ import {
 } from "../../../../../lib/security/rate-limit";
 
 export const dynamic = "force-dynamic";
+
+type RequestBody = BreachSignalInput & { sourceUrl?: string };
+
+async function persistEvaluation(params: {
+  sourceUrl?: string;
+  owner?: string;
+  legalPurpose?: string;
+  decision: string;
+  evidenceLevel: string;
+  severity: string;
+  reasons: string[];
+  allowedActions: string[];
+  blockedActions: string[];
+  hibpChecked: boolean;
+  hibpBreachCount?: number;
+  hibpBreaches?: unknown[];
+  hibpElevatedEvidence: boolean;
+}) {
+  try {
+    const { getSupabaseAdmin } = await import("../../../../../lib/supabase-server");
+    const admin = getSupabaseAdmin();
+    await admin.from("breach_signal_evaluations").insert({
+      source_url: params.sourceUrl ?? null,
+      owner: params.owner ?? null,
+      legal_purpose: params.legalPurpose ?? null,
+      decision: params.decision,
+      evidence_level: params.evidenceLevel,
+      severity: params.severity,
+      reasons: params.reasons,
+      allowed_actions: params.allowedActions,
+      blocked_actions: params.blockedActions,
+      hibp_checked: params.hibpChecked,
+      hibp_breach_count: params.hibpBreachCount ?? null,
+      hibp_breaches: params.hibpBreaches ?? null,
+      hibp_elevated_evidence: params.hibpElevatedEvidence,
+      raw_data_stored: false,
+    });
+  } catch {
+    // DB write is best-effort — evaluation response is not blocked by a DB failure.
+  }
+}
 
 export async function POST(request: Request) {
   const rateLimitResult = await applyRateLimit({
@@ -26,7 +69,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const body = await readJsonBody<BreachSignalInput>(request, { maxBytes: 8_000 });
+  const body = await readJsonBody<RequestBody>(request, { maxBytes: 8_000 });
   if (!body.ok) {
     return NextResponse.json(
       { ok: false, error: body.error },
@@ -34,15 +77,59 @@ export async function POST(request: Request) {
     );
   }
 
-  const input = body.value;
-  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+  const raw = body.value;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     return NextResponse.json(
       { ok: false, error: "body_must_be_object" },
       { status: 400, headers: rlHeaders },
     );
   }
 
-  const evaluation = evaluateBreachSignal(input);
+  const { sourceUrl, ...signalInput } = raw;
+
+  // Auto-detect flags from URL when provided.
+  const urlFlags = sourceUrl ? detectFlagsFromUrl(sourceUrl) : null;
+  const detectedDomain = urlFlags?.detectedDomain ?? null;
+
+  const mergedInput: BreachSignalInput = {
+    ...signalInput,
+    networkRoute: signalInput.networkRoute ?? urlFlags?.networkRoute ?? "unknown",
+    requiresLogin: signalInput.requiresLogin ?? urlFlags?.requiresLogin ?? false,
+    requiresDownload: signalInput.requiresDownload ?? urlFlags?.requiresDownload ?? false,
+  };
+
+  // Resolve domain for HIBP from URL detection or owner field.
+  const hibpDomain = detectedDomain ?? mergedInput.owner?.trim() ?? null;
+
+  // Run HIBP check in parallel with evaluation when domain is available.
+  const [hibpResult] = await Promise.all([
+    hibpDomain ? checkHibpDomain(hibpDomain) : Promise.resolve(null),
+  ]);
+
+  // If HIBP confirms the domain has verified breaches, treat as provider-confirmed.
+  const finalInput: BreachSignalInput =
+    hibpResult?.elevatesEvidence && !mergedInput.providerConfirmed
+      ? { ...mergedInput, providerConfirmed: true }
+      : mergedInput;
+
+  const evaluation = evaluateBreachSignal(finalInput);
+
+  // Persist audit record — fire and forget, does not block response.
+  void persistEvaluation({
+    sourceUrl,
+    owner: mergedInput.owner,
+    legalPurpose: mergedInput.legalPurpose,
+    decision: evaluation.decision,
+    evidenceLevel: evaluation.evidenceLevel,
+    severity: evaluation.severity,
+    reasons: evaluation.reasons,
+    allowedActions: evaluation.allowedActions,
+    blockedActions: evaluation.blockedActions,
+    hibpChecked: hibpResult?.checked ?? false,
+    hibpBreachCount: hibpResult?.breachCount,
+    hibpBreaches: hibpResult?.breaches,
+    hibpElevatedEvidence: hibpResult?.elevatesEvidence ?? false,
+  });
 
   return NextResponse.json(
     {
@@ -55,6 +142,31 @@ export async function POST(request: Request) {
       allowedActions: evaluation.allowedActions,
       blockedActions: evaluation.blockedActions,
       rawDataStored: evaluation.rawDataStored,
+      sourceUrl: sourceUrl ?? null,
+      urlFlags: urlFlags
+        ? {
+            detectedDomain,
+            networkRoute: urlFlags.networkRoute,
+            requiresLogin: urlFlags.requiresLogin,
+            requiresDownload: urlFlags.requiresDownload,
+          }
+        : null,
+      hibp: hibpResult
+        ? {
+            checked: hibpResult.checked,
+            breachCount: hibpResult.breachCount,
+            elevatedEvidence: hibpResult.elevatesEvidence,
+            skipReason: hibpResult.skipReason ?? null,
+            breaches: hibpResult.breaches.map((b) => ({
+              name: b.Name,
+              title: b.Title,
+              domain: b.Domain,
+              breachDate: b.BreachDate,
+              dataClasses: b.DataClasses,
+              isVerified: b.IsVerified,
+            })),
+          }
+        : null,
       boundary: {
         statement:
           "DSG breach-signal policy gate. No raw stolen data is stored. BLOCK is enforced for missing owner scope, missing legal purpose, raw data, full dumps, autonomous agent access, and Tor autonomous access.",

--- a/app/api/dsg/breach-signal/evaluate/route.ts
+++ b/app/api/dsg/breach-signal/evaluate/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import {
+  evaluateBreachSignal,
+  type BreachSignalInput,
+} from "../../../../../lib/dsg/breach-signal/policy";
+import { readJsonBody } from "../../../../../lib/security/request-json";
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from "../../../../../lib/security/rate-limit";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const rateLimitResult = await applyRateLimit({
+    key: getRateLimitKey(request, "dsg-breach-signal"),
+    limit: 30,
+    windowMs: 60_000,
+  });
+  const rlHeaders = buildRateLimitHeaders(rateLimitResult, 30);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { ok: false, error: "rate_limit_exceeded" },
+      { status: 429, headers: rlHeaders },
+    );
+  }
+
+  const body = await readJsonBody<BreachSignalInput>(request, { maxBytes: 8_000 });
+  if (!body.ok) {
+    return NextResponse.json(
+      { ok: false, error: body.error },
+      { status: body.status, headers: rlHeaders },
+    );
+  }
+
+  const input = body.value;
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return NextResponse.json(
+      { ok: false, error: "body_must_be_object" },
+      { status: 400, headers: rlHeaders },
+    );
+  }
+
+  const evaluation = evaluateBreachSignal(input);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      type: "dsg-breach-signal-evaluation",
+      decision: evaluation.decision,
+      evidenceLevel: evaluation.evidenceLevel,
+      severity: evaluation.severity,
+      reasons: evaluation.reasons,
+      allowedActions: evaluation.allowedActions,
+      blockedActions: evaluation.blockedActions,
+      rawDataStored: evaluation.rawDataStored,
+      boundary: {
+        statement:
+          "DSG breach-signal policy gate. No raw stolen data is stored. BLOCK is enforced for missing owner scope, missing legal purpose, raw data, full dumps, autonomous agent access, and Tor autonomous access.",
+        darkWebCrawlingEnabled: false,
+        torAutomationEnabled: false,
+        rawDataStorageEnabled: false,
+      },
+    },
+    { status: 200, headers: rlHeaders },
+  );
+}

--- a/app/api/dsg/breach-signal/history/route.ts
+++ b/app/api/dsg/breach-signal/history/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { requireRuntimeAccess } from "../../../../../lib/authz-runtime";
+import { getSupabaseAdmin } from "../../../../../lib/supabase-server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const access = await requireRuntimeAccess(request, "monitor");
+  if (!access.ok) {
+    return NextResponse.json({ ok: false, error: access.error }, { status: access.status });
+  }
+
+  const url = new URL(request.url);
+  const limit = Math.min(Number(url.searchParams.get("limit") ?? "50"), 100);
+
+  try {
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from("breach_signal_evaluations")
+      .select(
+        "id, source_url, owner, legal_purpose, decision, evidence_level, severity, reasons, hibp_checked, hibp_breach_count, hibp_elevated_evidence, raw_data_stored, created_at",
+      )
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, items: data ?? [], total: data?.length ?? 0 });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "internal_error";
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/app/dashboard/breach-signal/page.tsx
+++ b/app/dashboard/breach-signal/page.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import { useState } from 'react';
+
+type Decision = 'BLOCK' | 'REVIEW' | 'INCIDENT_REPORT_ALLOWED';
+type EvidenceLevel = 'L0' | 'L1' | 'L2' | 'L3' | 'L4';
+type Severity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+type EvaluationResult = {
+  ok: boolean;
+  type: string;
+  decision: Decision;
+  evidenceLevel: EvidenceLevel;
+  severity: Severity;
+  reasons: string[];
+  allowedActions: string[];
+  blockedActions: string[];
+  rawDataStored: false;
+  boundary: {
+    statement: string;
+    darkWebCrawlingEnabled: boolean;
+    torAutomationEnabled: boolean;
+    rawDataStorageEnabled: boolean;
+  };
+  error?: string;
+};
+
+const DECISION_STYLES: Record<Decision, string> = {
+  BLOCK: 'bg-red-500/20 text-red-300 border-red-500/40',
+  REVIEW: 'bg-amber-500/20 text-amber-300 border-amber-500/40',
+  INCIDENT_REPORT_ALLOWED: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40',
+};
+
+const SEVERITY_STYLES: Record<Severity, string> = {
+  LOW: 'text-slate-400',
+  MEDIUM: 'text-amber-400',
+  HIGH: 'text-orange-400',
+  CRITICAL: 'text-red-400',
+};
+
+const EVIDENCE_LABELS: Record<EvidenceLevel, string> = {
+  L0: 'L0 — No evidence',
+  L1: 'L1 — Source category / owner name only',
+  L2: 'L2 — Masked samples or hashes present',
+  L3: 'L3 — Owner confirmed',
+  L4: 'L4 — Provider or internal log confirmed',
+};
+
+export default function BreachSignalPage() {
+  const [owner, setOwner] = useState('');
+  const [legalPurpose, setLegalPurpose] = useState('');
+  const [sourceCategory, setSourceCategory] = useState('breach-signal');
+  const [claimedDataTypes, setClaimedDataTypes] = useState('');
+  const [maskedSamples, setMaskedSamples] = useState('');
+  const [hashes, setHashes] = useState('');
+  const [networkRoute, setNetworkRoute] = useState<'standard' | 'tor' | 'unknown'>('standard');
+  const [rawDataIncluded, setRawDataIncluded] = useState(false);
+  const [fullDumpIncluded, setFullDumpIncluded] = useState(false);
+  const [requiresLogin, setRequiresLogin] = useState(false);
+  const [requiresPayment, setRequiresPayment] = useState(false);
+  const [requiresDownload, setRequiresDownload] = useState(false);
+  const [autonomousAgentAccess, setAutonomousAgentAccess] = useState(false);
+  const [ownerConfirmed, setOwnerConfirmed] = useState(false);
+  const [providerConfirmed, setProviderConfirmed] = useState(false);
+  const [internalLogConfirmed, setInternalLogConfirmed] = useState(false);
+
+  const [result, setResult] = useState<EvaluationResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [apiError, setApiError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setApiError('');
+    setResult(null);
+
+    const body = {
+      owner: owner || undefined,
+      legalPurpose: legalPurpose || undefined,
+      sourceCategory: sourceCategory || undefined,
+      claimedDataTypes: claimedDataTypes
+        ? claimedDataTypes.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined,
+      maskedSamples: maskedSamples
+        ? maskedSamples.split('\n').map((s) => s.trim()).filter(Boolean)
+        : undefined,
+      hashes: hashes
+        ? hashes.split('\n').map((s) => s.trim()).filter(Boolean)
+        : undefined,
+      networkRoute,
+      rawDataIncluded: rawDataIncluded || undefined,
+      fullDumpIncluded: fullDumpIncluded || undefined,
+      requiresLogin: requiresLogin || undefined,
+      requiresPayment: requiresPayment || undefined,
+      requiresDownload: requiresDownload || undefined,
+      autonomousAgentAccess: autonomousAgentAccess || undefined,
+      ownerConfirmed: ownerConfirmed || undefined,
+      providerConfirmed: providerConfirmed || undefined,
+      internalLogConfirmed: internalLogConfirmed || undefined,
+    };
+
+    try {
+      const res = await fetch('/api/dsg/breach-signal/evaluate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+      const data: EvaluationResult = await res.json();
+      if (!res.ok || !data.ok) {
+        setApiError(data.error ?? `HTTP ${res.status}`);
+      } else {
+        setResult(data);
+      }
+    } catch (err) {
+      setApiError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-10">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-white">Breach Signal Evaluation</h1>
+        <p className="mt-1 text-sm text-slate-400">
+          DSG responsible-disclosure intake gate. No raw data is stored. Evaluation is deterministic and sandboxed.
+        </p>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">Signal Metadata</h2>
+
+            <label className="block">
+              <span className="mb-1 block text-xs text-slate-400">Owner domain / identifier</span>
+              <input
+                type="text"
+                value={owner}
+                onChange={(e) => setOwner(e.target.value)}
+                placeholder="example.com"
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+              />
+            </label>
+
+            <label className="mt-3 block">
+              <span className="mb-1 block text-xs text-slate-400">Legal purpose</span>
+              <input
+                type="text"
+                value={legalPurpose}
+                onChange={(e) => setLegalPurpose(e.target.value)}
+                placeholder="owner_notification"
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+              />
+            </label>
+
+            <label className="mt-3 block">
+              <span className="mb-1 block text-xs text-slate-400">Source category</span>
+              <input
+                type="text"
+                value={sourceCategory}
+                onChange={(e) => setSourceCategory(e.target.value)}
+                placeholder="breach-signal"
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+              />
+            </label>
+
+            <label className="mt-3 block">
+              <span className="mb-1 block text-xs text-slate-400">Claimed data types (comma-separated)</span>
+              <input
+                type="text"
+                value={claimedDataTypes}
+                onChange={(e) => setClaimedDataTypes(e.target.value)}
+                placeholder="email, hashed_password, api_key"
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+              />
+            </label>
+
+            <label className="mt-3 block">
+              <span className="mb-1 block text-xs text-slate-400">Masked samples (one per line)</span>
+              <textarea
+                value={maskedSamples}
+                onChange={(e) => setMaskedSamples(e.target.value)}
+                placeholder={'som***@example.com\nsk_live_****a91f'}
+                rows={3}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+              />
+            </label>
+
+            <label className="mt-3 block">
+              <span className="mb-1 block text-xs text-slate-400">Hashes (one per line)</span>
+              <textarea
+                value={hashes}
+                onChange={(e) => setHashes(e.target.value)}
+                placeholder="sha256:abc123..."
+                rows={2}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+              />
+            </label>
+
+            <div className="mt-3">
+              <span className="mb-1 block text-xs text-slate-400">Network route</span>
+              <div className="flex gap-3">
+                {(['standard', 'tor', 'unknown'] as const).map((route) => (
+                  <label key={route} className="flex cursor-pointer items-center gap-1.5">
+                    <input
+                      type="radio"
+                      name="networkRoute"
+                      value={route}
+                      checked={networkRoute === route}
+                      onChange={() => setNetworkRoute(route)}
+                      className="accent-emerald-400"
+                    />
+                    <span className="text-xs text-slate-300">{route}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">Risk Flags</h2>
+            <div className="grid grid-cols-2 gap-2">
+              {[
+                { label: 'Raw data included', value: rawDataIncluded, set: setRawDataIncluded },
+                { label: 'Full dump included', value: fullDumpIncluded, set: setFullDumpIncluded },
+                { label: 'Requires login', value: requiresLogin, set: setRequiresLogin },
+                { label: 'Requires payment', value: requiresPayment, set: setRequiresPayment },
+                { label: 'Requires download', value: requiresDownload, set: setRequiresDownload },
+                { label: 'Autonomous agent access', value: autonomousAgentAccess, set: setAutonomousAgentAccess },
+              ].map(({ label, value, set }) => (
+                <label key={label} className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={value}
+                    onChange={(e) => set(e.target.checked)}
+                    className="accent-red-400"
+                  />
+                  <span className="text-xs text-slate-300">{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">Confirmation</h2>
+            <div className="space-y-2">
+              {[
+                { label: 'Owner confirmed', value: ownerConfirmed, set: setOwnerConfirmed },
+                { label: 'Provider confirmed', value: providerConfirmed, set: setProviderConfirmed },
+                { label: 'Internal log confirmed', value: internalLogConfirmed, set: setInternalLogConfirmed },
+              ].map(({ label, value, set }) => (
+                <label key={label} className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={value}
+                    onChange={(e) => set(e.target.checked)}
+                    className="accent-emerald-400"
+                  />
+                  <span className="text-xs text-slate-300">{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            {loading ? 'Evaluating…' : 'Evaluate Signal'}
+          </button>
+        </form>
+
+        <div className="space-y-4">
+          {apiError && (
+            <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300">
+              <strong>Error:</strong> {apiError}
+            </div>
+          )}
+
+          {!result && !apiError && !loading && (
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 text-center text-sm text-slate-500">
+              Submit a signal to see the evaluation result.
+            </div>
+          )}
+
+          {result && (
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Decision</p>
+                    <span
+                      className={`inline-block rounded-xl border px-3 py-1 text-base font-bold ${DECISION_STYLES[result.decision]}`}
+                    >
+                      {result.decision}
+                    </span>
+                  </div>
+                  <div className="text-right">
+                    <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Severity</p>
+                    <p className={`font-bold ${SEVERITY_STYLES[result.severity]}`}>{result.severity}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Evidence</p>
+                    <p className="text-sm text-slate-300">{result.evidenceLevel}</p>
+                  </div>
+                </div>
+                <p className="mt-3 text-xs text-slate-500">{EVIDENCE_LABELS[result.evidenceLevel]}</p>
+              </div>
+
+              <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Reasons</h3>
+                {result.reasons.length === 0 ? (
+                  <p className="text-xs text-slate-500">—</p>
+                ) : (
+                  <ul className="space-y-1">
+                    {result.reasons.map((r) => (
+                      <li key={r} className="text-xs text-slate-300">
+                        • {r}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-emerald-900/40 bg-emerald-900/10 p-5">
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-emerald-400">Allowed Actions</h3>
+                <ul className="space-y-1">
+                  {result.allowedActions.map((a) => (
+                    <li key={a} className="text-xs text-emerald-300">
+                      ✓ {a}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="rounded-2xl border border-red-900/40 bg-red-900/10 p-5">
+                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-red-400">Blocked Actions</h3>
+                <ul className="space-y-1">
+                  {result.blockedActions.map((a) => (
+                    <li key={a} className="text-xs text-red-300">
+                      ✗ {a}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Safety Boundary</p>
+                <p className="mt-1 text-xs text-slate-400">{result.boundary.statement}</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                  <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">
+                    rawDataStored: {String(result.rawDataStored)}
+                  </span>
+                  <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">
+                    darkWebCrawling: {String(result.boundary.darkWebCrawlingEnabled)}
+                  </span>
+                  <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">
+                    torAutomation: {String(result.boundary.torAutomationEnabled)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/breach-signal/page.tsx
+++ b/app/dashboard/breach-signal/page.tsx
@@ -1,14 +1,37 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 type Decision = 'BLOCK' | 'REVIEW' | 'INCIDENT_REPORT_ALLOWED';
 type EvidenceLevel = 'L0' | 'L1' | 'L2' | 'L3' | 'L4';
 type Severity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
 
+type HibpBreach = {
+  name: string;
+  title: string;
+  domain: string;
+  breachDate: string;
+  dataClasses: string[];
+  isVerified: boolean;
+};
+
+type UrlFlags = {
+  detectedDomain: string | null;
+  networkRoute: 'standard' | 'tor' | 'unknown';
+  requiresLogin: boolean;
+  requiresDownload: boolean;
+};
+
+type HibpInfo = {
+  checked: boolean;
+  breachCount: number;
+  elevatedEvidence: boolean;
+  skipReason: string | null;
+  breaches: HibpBreach[];
+};
+
 type EvaluationResult = {
   ok: boolean;
-  type: string;
   decision: Decision;
   evidenceLevel: EvidenceLevel;
   severity: Severity;
@@ -16,6 +39,9 @@ type EvaluationResult = {
   allowedActions: string[];
   blockedActions: string[];
   rawDataStored: false;
+  sourceUrl: string | null;
+  urlFlags: UrlFlags | null;
+  hibp: HibpInfo | null;
   boundary: {
     statement: string;
     darkWebCrawlingEnabled: boolean;
@@ -23,6 +49,22 @@ type EvaluationResult = {
     rawDataStorageEnabled: boolean;
   };
   error?: string;
+};
+
+type HistoryItem = {
+  id: string;
+  source_url: string | null;
+  owner: string | null;
+  legal_purpose: string | null;
+  decision: string;
+  evidence_level: string;
+  severity: string;
+  reasons: string[];
+  hibp_checked: boolean;
+  hibp_breach_count: number | null;
+  hibp_elevated_evidence: boolean;
+  raw_data_stored: boolean;
+  created_at: string;
 };
 
 const DECISION_STYLES: Record<Decision, string> = {
@@ -40,13 +82,29 @@ const SEVERITY_STYLES: Record<Severity, string> = {
 
 const EVIDENCE_LABELS: Record<EvidenceLevel, string> = {
   L0: 'L0 — No evidence',
-  L1: 'L1 — Source category / owner name only',
-  L2: 'L2 — Masked samples or hashes present',
+  L1: 'L1 — Source / owner name',
+  L2: 'L2 — Masked samples or hashes',
   L3: 'L3 — Owner confirmed',
-  L4: 'L4 — Provider or internal log confirmed',
+  L4: 'L4 — Provider / internal log confirmed',
 };
 
+function formatDate(v: string) {
+  try { return new Date(v).toLocaleString(); } catch { return v; }
+}
+
+function decisionBadge(decision: string) {
+  const s =
+    decision === 'BLOCK' ? 'bg-red-500/20 text-red-300 border border-red-500/40' :
+    decision === 'REVIEW' ? 'bg-amber-500/20 text-amber-300 border border-amber-500/40' :
+    'bg-emerald-500/20 text-emerald-300 border border-emerald-500/40';
+  return <span className={`rounded-lg px-2 py-0.5 text-xs font-bold ${s}`}>{decision}</span>;
+}
+
 export default function BreachSignalPage() {
+  const [tab, setTab] = useState<'evaluate' | 'history'>('evaluate');
+
+  // Form state
+  const [sourceUrl, setSourceUrl] = useState('');
   const [owner, setOwner] = useState('');
   const [legalPurpose, setLegalPurpose] = useState('');
   const [sourceCategory, setSourceCategory] = useState('breach-signal');
@@ -64,9 +122,50 @@ export default function BreachSignalPage() {
   const [providerConfirmed, setProviderConfirmed] = useState(false);
   const [internalLogConfirmed, setInternalLogConfirmed] = useState(false);
 
+  // Auto-detect from URL
+  function handleUrlChange(val: string) {
+    setSourceUrl(val);
+    if (!val.trim()) return;
+    try {
+      const u = new URL(val.trim().startsWith('http') ? val.trim() : `http://${val.trim()}`);
+      if (u.hostname.endsWith('.onion')) setNetworkRoute('tor');
+      const full = u.href;
+      if (/login|signin|auth\b|account|members/i.test(full)) setRequiresLogin(true);
+      if (/download|\.zip$|\.tar$|\.rar$|\.sql$/i.test(full)) setRequiresDownload(true);
+      if (!owner && u.hostname) setOwner(u.hostname.replace(/^www\./, ''));
+    } catch { /* invalid URL — skip */ }
+  }
+
   const [result, setResult] = useState<EvaluationResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [apiError, setApiError] = useState('');
+
+  // History state
+  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState('');
+
+  const loadHistory = useCallback(async () => {
+    setHistoryLoading(true);
+    setHistoryError('');
+    try {
+      const res = await fetch('/api/dsg/breach-signal/history?limit=50', { cache: 'no-store' });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        setHistoryError(data.error ?? `HTTP ${res.status}`);
+      } else {
+        setHistory(data.items ?? []);
+      }
+    } catch (err) {
+      setHistoryError(String(err));
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab === 'history') loadHistory();
+  }, [tab, loadHistory]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -75,6 +174,7 @@ export default function BreachSignalPage() {
     setResult(null);
 
     const body = {
+      sourceUrl: sourceUrl || undefined,
       owner: owner || undefined,
       legalPurpose: legalPurpose || undefined,
       sourceCategory: sourceCategory || undefined,
@@ -111,6 +211,12 @@ export default function BreachSignalPage() {
         setApiError(data.error ?? `HTTP ${res.status}`);
       } else {
         setResult(data);
+        // Sync auto-detected flags back to form
+        if (data.urlFlags) {
+          setNetworkRoute(data.urlFlags.networkRoute);
+          if (data.urlFlags.requiresLogin) setRequiresLogin(true);
+          if (data.urlFlags.requiresDownload) setRequiresDownload(true);
+        }
       }
     } catch (err) {
       setApiError(String(err));
@@ -120,252 +226,370 @@ export default function BreachSignalPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-10">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-white">Breach Signal Evaluation</h1>
-        <p className="mt-1 text-sm text-slate-400">
-          DSG responsible-disclosure intake gate. No raw data is stored. Evaluation is deterministic and sandboxed.
-        </p>
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Breach Signal Evaluation</h1>
+          <p className="mt-1 text-sm text-slate-400">
+            DSG responsible-disclosure intake gate — deterministic, sandboxed, no raw data stored.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {(['evaluate', 'history'] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={[
+                'rounded-xl border px-4 py-2 text-sm font-semibold transition-colors capitalize',
+                tab === t
+                  ? 'border-emerald-400/50 bg-emerald-400/10 text-emerald-200'
+                  : 'border-slate-800 bg-slate-900 text-slate-300 hover:text-slate-100',
+              ].join(' ')}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
       </div>
 
-      <div className="grid gap-8 lg:grid-cols-2">
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">Signal Metadata</h2>
+      {tab === 'evaluate' && (
+        <div className="grid gap-8 lg:grid-cols-2">
+          <form onSubmit={handleSubmit} className="space-y-4">
 
-            <label className="block">
-              <span className="mb-1 block text-xs text-slate-400">Owner domain / identifier</span>
+            {/* URL with auto-detect */}
+            <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                Source URL <span className="text-slate-600 normal-case">(auto-detects Tor / login / download)</span>
+              </h2>
               <input
                 type="text"
-                value={owner}
-                onChange={(e) => setOwner(e.target.value)}
-                placeholder="example.com"
+                value={sourceUrl}
+                onChange={(e) => handleUrlChange(e.target.value)}
+                placeholder="https://example.com/breach or http://xyz.onion/dump"
                 className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
               />
-            </label>
-
-            <label className="mt-3 block">
-              <span className="mb-1 block text-xs text-slate-400">Legal purpose</span>
-              <input
-                type="text"
-                value={legalPurpose}
-                onChange={(e) => setLegalPurpose(e.target.value)}
-                placeholder="owner_notification"
-                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
-              />
-            </label>
-
-            <label className="mt-3 block">
-              <span className="mb-1 block text-xs text-slate-400">Source category</span>
-              <input
-                type="text"
-                value={sourceCategory}
-                onChange={(e) => setSourceCategory(e.target.value)}
-                placeholder="breach-signal"
-                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
-              />
-            </label>
-
-            <label className="mt-3 block">
-              <span className="mb-1 block text-xs text-slate-400">Claimed data types (comma-separated)</span>
-              <input
-                type="text"
-                value={claimedDataTypes}
-                onChange={(e) => setClaimedDataTypes(e.target.value)}
-                placeholder="email, hashed_password, api_key"
-                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
-              />
-            </label>
-
-            <label className="mt-3 block">
-              <span className="mb-1 block text-xs text-slate-400">Masked samples (one per line)</span>
-              <textarea
-                value={maskedSamples}
-                onChange={(e) => setMaskedSamples(e.target.value)}
-                placeholder={'som***@example.com\nsk_live_****a91f'}
-                rows={3}
-                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
-              />
-            </label>
-
-            <label className="mt-3 block">
-              <span className="mb-1 block text-xs text-slate-400">Hashes (one per line)</span>
-              <textarea
-                value={hashes}
-                onChange={(e) => setHashes(e.target.value)}
-                placeholder="sha256:abc123..."
-                rows={2}
-                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
-              />
-            </label>
-
-            <div className="mt-3">
-              <span className="mb-1 block text-xs text-slate-400">Network route</span>
-              <div className="flex gap-3">
-                {(['standard', 'tor', 'unknown'] as const).map((route) => (
-                  <label key={route} className="flex cursor-pointer items-center gap-1.5">
-                    <input
-                      type="radio"
-                      name="networkRoute"
-                      value={route}
-                      checked={networkRoute === route}
-                      onChange={() => setNetworkRoute(route)}
-                      className="accent-emerald-400"
-                    />
-                    <span className="text-xs text-slate-300">{route}</span>
-                  </label>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">Risk Flags</h2>
-            <div className="grid grid-cols-2 gap-2">
-              {[
-                { label: 'Raw data included', value: rawDataIncluded, set: setRawDataIncluded },
-                { label: 'Full dump included', value: fullDumpIncluded, set: setFullDumpIncluded },
-                { label: 'Requires login', value: requiresLogin, set: setRequiresLogin },
-                { label: 'Requires payment', value: requiresPayment, set: setRequiresPayment },
-                { label: 'Requires download', value: requiresDownload, set: setRequiresDownload },
-                { label: 'Autonomous agent access', value: autonomousAgentAccess, set: setAutonomousAgentAccess },
-              ].map(({ label, value, set }) => (
-                <label key={label} className="flex cursor-pointer items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={value}
-                    onChange={(e) => set(e.target.checked)}
-                    className="accent-red-400"
-                  />
-                  <span className="text-xs text-slate-300">{label}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-            <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">Confirmation</h2>
-            <div className="space-y-2">
-              {[
-                { label: 'Owner confirmed', value: ownerConfirmed, set: setOwnerConfirmed },
-                { label: 'Provider confirmed', value: providerConfirmed, set: setProviderConfirmed },
-                { label: 'Internal log confirmed', value: internalLogConfirmed, set: setInternalLogConfirmed },
-              ].map(({ label, value, set }) => (
-                <label key={label} className="flex cursor-pointer items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={value}
-                    onChange={(e) => set(e.target.checked)}
-                    className="accent-emerald-400"
-                  />
-                  <span className="text-xs text-slate-300">{label}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-emerald-400 disabled:opacity-50"
-          >
-            {loading ? 'Evaluating…' : 'Evaluate Signal'}
-          </button>
-        </form>
-
-        <div className="space-y-4">
-          {apiError && (
-            <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300">
-              <strong>Error:</strong> {apiError}
-            </div>
-          )}
-
-          {!result && !apiError && !loading && (
-            <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 text-center text-sm text-slate-500">
-              Submit a signal to see the evaluation result.
-            </div>
-          )}
-
-          {result && (
-            <div className="space-y-4">
-              <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Decision</p>
-                    <span
-                      className={`inline-block rounded-xl border px-3 py-1 text-base font-bold ${DECISION_STYLES[result.decision]}`}
-                    >
-                      {result.decision}
-                    </span>
-                  </div>
-                  <div className="text-right">
-                    <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Severity</p>
-                    <p className={`font-bold ${SEVERITY_STYLES[result.severity]}`}>{result.severity}</p>
-                  </div>
-                  <div className="text-right">
-                    <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Evidence</p>
-                    <p className="text-sm text-slate-300">{result.evidenceLevel}</p>
-                  </div>
+              {sourceUrl && (
+                <div className="mt-2 flex flex-wrap gap-1.5 text-xs">
+                  <span className={`rounded-lg px-2 py-0.5 ${networkRoute === 'tor' ? 'bg-red-500/20 text-red-300' : 'bg-slate-800 text-slate-400'}`}>
+                    route: {networkRoute}
+                  </span>
+                  {requiresLogin && <span className="rounded-lg bg-amber-500/20 px-2 py-0.5 text-amber-300">login detected</span>}
+                  {requiresDownload && <span className="rounded-lg bg-amber-500/20 px-2 py-0.5 text-amber-300">download detected</span>}
                 </div>
-                <p className="mt-3 text-xs text-slate-500">{EVIDENCE_LABELS[result.evidenceLevel]}</p>
-              </div>
+              )}
+            </div>
 
-              <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
-                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Reasons</h3>
-                {result.reasons.length === 0 ? (
-                  <p className="text-xs text-slate-500">—</p>
-                ) : (
-                  <ul className="space-y-1">
-                    {result.reasons.map((r) => (
-                      <li key={r} className="text-xs text-slate-300">
-                        • {r}
-                      </li>
+            {/* Signal Metadata */}
+            <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Signal Metadata</h2>
+              <div className="space-y-3">
+                <label className="block">
+                  <span className="mb-1 block text-xs text-slate-400">Owner domain</span>
+                  <input
+                    type="text"
+                    value={owner}
+                    onChange={(e) => setOwner(e.target.value)}
+                    placeholder="example.com"
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs text-slate-400">Legal purpose</span>
+                  <input
+                    type="text"
+                    value={legalPurpose}
+                    onChange={(e) => setLegalPurpose(e.target.value)}
+                    placeholder="owner_notification"
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs text-slate-400">Claimed data types (comma-separated)</span>
+                  <input
+                    type="text"
+                    value={claimedDataTypes}
+                    onChange={(e) => setClaimedDataTypes(e.target.value)}
+                    placeholder="email, hashed_password, api_key"
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs text-slate-400">Masked samples (one per line)</span>
+                  <textarea
+                    value={maskedSamples}
+                    onChange={(e) => setMaskedSamples(e.target.value)}
+                    placeholder={'som***@example.com\nsk_live_****a91f'}
+                    rows={2}
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs text-slate-400">Hashes (one per line)</span>
+                  <textarea
+                    value={hashes}
+                    onChange={(e) => setHashes(e.target.value)}
+                    placeholder="sha256:abc123..."
+                    rows={2}
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white placeholder-slate-500 focus:border-emerald-400/50 focus:outline-none"
+                  />
+                </label>
+                <div>
+                  <span className="mb-1 block text-xs text-slate-400">Network route</span>
+                  <div className="flex gap-3">
+                    {(['standard', 'tor', 'unknown'] as const).map((route) => (
+                      <label key={route} className="flex cursor-pointer items-center gap-1.5">
+                        <input type="radio" name="networkRoute" value={route} checked={networkRoute === route} onChange={() => setNetworkRoute(route)} className="accent-emerald-400" />
+                        <span className="text-xs text-slate-300">{route}</span>
+                      </label>
                     ))}
-                  </ul>
-                )}
-              </div>
-
-              <div className="rounded-2xl border border-emerald-900/40 bg-emerald-900/10 p-5">
-                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-emerald-400">Allowed Actions</h3>
-                <ul className="space-y-1">
-                  {result.allowedActions.map((a) => (
-                    <li key={a} className="text-xs text-emerald-300">
-                      ✓ {a}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              <div className="rounded-2xl border border-red-900/40 bg-red-900/10 p-5">
-                <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-red-400">Blocked Actions</h3>
-                <ul className="space-y-1">
-                  {result.blockedActions.map((a) => (
-                    <li key={a} className="text-xs text-red-300">
-                      ✗ {a}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Safety Boundary</p>
-                <p className="mt-1 text-xs text-slate-400">{result.boundary.statement}</p>
-                <div className="mt-2 flex flex-wrap gap-2 text-xs">
-                  <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">
-                    rawDataStored: {String(result.rawDataStored)}
-                  </span>
-                  <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">
-                    darkWebCrawling: {String(result.boundary.darkWebCrawlingEnabled)}
-                  </span>
-                  <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">
-                    torAutomation: {String(result.boundary.torAutomationEnabled)}
-                  </span>
+                  </div>
                 </div>
               </div>
+            </div>
+
+            {/* Risk flags + Confirmation */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Risk Flags</h2>
+                <div className="space-y-2">
+                  {[
+                    ['Raw data included', rawDataIncluded, setRawDataIncluded],
+                    ['Full dump included', fullDumpIncluded, setFullDumpIncluded],
+                    ['Requires login', requiresLogin, setRequiresLogin],
+                    ['Requires payment', requiresPayment, setRequiresPayment],
+                    ['Requires download', requiresDownload, setRequiresDownload],
+                    ['Autonomous agent access', autonomousAgentAccess, setAutonomousAgentAccess],
+                  ].map(([label, value, setter]) => (
+                    <label key={label as string} className="flex cursor-pointer items-center gap-2">
+                      <input type="checkbox" checked={value as boolean} onChange={(e) => (setter as (v: boolean) => void)(e.target.checked)} className="accent-red-400" />
+                      <span className="text-xs text-slate-300">{label as string}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Confirmation</h2>
+                <div className="space-y-2">
+                  {[
+                    ['Owner confirmed', ownerConfirmed, setOwnerConfirmed],
+                    ['Provider confirmed', providerConfirmed, setProviderConfirmed],
+                    ['Internal log confirmed', internalLogConfirmed, setInternalLogConfirmed],
+                  ].map(([label, value, setter]) => (
+                    <label key={label as string} className="flex cursor-pointer items-center gap-2">
+                      <input type="checkbox" checked={value as boolean} onChange={(e) => (setter as (v: boolean) => void)(e.target.checked)} className="accent-emerald-400" />
+                      <span className="text-xs text-slate-300">{label as string}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-emerald-400 disabled:opacity-50"
+            >
+              {loading ? 'Evaluating…' : 'Evaluate Signal'}
+            </button>
+          </form>
+
+          {/* Result panel */}
+          <div className="space-y-4">
+            {apiError && (
+              <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300">
+                <strong>Error:</strong> {apiError}
+              </div>
+            )}
+
+            {!result && !apiError && !loading && (
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 text-center text-sm text-slate-500">
+                Submit a signal to see the evaluation result.
+              </div>
+            )}
+
+            {result && (
+              <div className="space-y-4">
+                {/* Decision header */}
+                <div className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Decision</p>
+                      <span className={`inline-block rounded-xl border px-3 py-1 text-base font-bold ${DECISION_STYLES[result.decision]}`}>
+                        {result.decision}
+                      </span>
+                    </div>
+                    <div className="text-right">
+                      <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Severity</p>
+                      <p className={`font-bold ${SEVERITY_STYLES[result.severity]}`}>{result.severity}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="mb-1 text-xs uppercase tracking-wider text-slate-500">Evidence</p>
+                      <p className="text-sm font-bold text-slate-300">{result.evidenceLevel}</p>
+                    </div>
+                  </div>
+                  <p className="mt-2 text-xs text-slate-500">{EVIDENCE_LABELS[result.evidenceLevel]}</p>
+                </div>
+
+                {/* URL flags */}
+                {result.urlFlags && (
+                  <div className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+                    <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Auto-detected from URL</h3>
+                    <div className="flex flex-wrap gap-2 text-xs">
+                      {result.urlFlags.detectedDomain && (
+                        <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-300">domain: {result.urlFlags.detectedDomain}</span>
+                      )}
+                      <span className={`rounded-lg px-2 py-0.5 ${result.urlFlags.networkRoute === 'tor' ? 'bg-red-500/20 text-red-300' : 'bg-slate-800 text-slate-400'}`}>
+                        route: {result.urlFlags.networkRoute}
+                      </span>
+                      {result.urlFlags.requiresLogin && <span className="rounded-lg bg-amber-500/20 px-2 py-0.5 text-amber-300">login required</span>}
+                      {result.urlFlags.requiresDownload && <span className="rounded-lg bg-amber-500/20 px-2 py-0.5 text-amber-300">download required</span>}
+                    </div>
+                  </div>
+                )}
+
+                {/* HIBP */}
+                {result.hibp && (
+                  <div className={`rounded-2xl border p-4 ${result.hibp.checked && result.hibp.breachCount > 0 ? 'border-orange-500/40 bg-orange-500/10' : 'border-slate-800 bg-slate-900'}`}>
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">HIBP Check</h3>
+                      {result.hibp.checked ? (
+                        <span className={`text-xs font-bold ${result.hibp.breachCount > 0 ? 'text-orange-300' : 'text-emerald-400'}`}>
+                          {result.hibp.breachCount > 0 ? `${result.hibp.breachCount} breach${result.hibp.breachCount > 1 ? 'es' : ''} found` : 'No known breaches'}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-slate-500">{result.hibp.skipReason ?? 'skipped'}</span>
+                      )}
+                    </div>
+                    {result.hibp.elevatedEvidence && (
+                      <p className="mt-1 text-xs text-orange-300">HIBP confirmed — evidence elevated to provider-confirmed level</p>
+                    )}
+                    {result.hibp.breaches.length > 0 && (
+                      <ul className="mt-2 space-y-1">
+                        {result.hibp.breaches.slice(0, 5).map((b) => (
+                          <li key={b.name} className="text-xs text-slate-300">
+                            <span className="font-medium text-white">{b.title}</span>
+                            <span className="ml-1 text-slate-500">({b.breachDate})</span>
+                            <span className="ml-1 text-slate-500">— {b.dataClasses.slice(0, 3).join(', ')}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
+
+                {/* Reasons */}
+                <div className="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">Reasons</h3>
+                  {result.reasons.length === 0 ? (
+                    <p className="text-xs text-slate-500">—</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {result.reasons.map((r) => <li key={r} className="text-xs text-slate-300">• {r}</li>)}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Allowed / Blocked */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-2xl border border-emerald-900/40 bg-emerald-900/10 p-4">
+                    <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-emerald-400">Allowed</h3>
+                    <ul className="space-y-1">
+                      {result.allowedActions.map((a) => <li key={a} className="text-xs text-emerald-300">✓ {a}</li>)}
+                    </ul>
+                  </div>
+                  <div className="rounded-2xl border border-red-900/40 bg-red-900/10 p-4">
+                    <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-red-400">Blocked</h3>
+                    <ul className="space-y-1">
+                      {result.blockedActions.map((a) => <li key={a} className="text-xs text-red-300">✗ {a}</li>)}
+                    </ul>
+                  </div>
+                </div>
+
+                {/* Boundary */}
+                <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Safety Boundary</p>
+                  <p className="mt-1 text-xs text-slate-400">{result.boundary.statement}</p>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                    <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">rawDataStored: false</span>
+                    <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">darkWebCrawling: false</span>
+                    <span className="rounded-lg bg-slate-800 px-2 py-0.5 text-slate-400">torAutomation: false</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === 'history' && (
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-sm text-slate-400">Last 50 evaluations — stored in DB with audit trail.</p>
+            <button
+              onClick={loadHistory}
+              disabled={historyLoading}
+              className="rounded-xl border border-slate-700 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-slate-300 hover:text-white disabled:opacity-50"
+            >
+              {historyLoading ? 'Refreshing…' : 'Refresh'}
+            </button>
+          </div>
+
+          {historyError && (
+            <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300">
+              {historyError}
+            </div>
+          )}
+
+          {!historyError && history.length === 0 && !historyLoading && (
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 text-center text-sm text-slate-500">
+              No evaluations recorded yet. Submit a signal to start the audit trail.
+            </div>
+          )}
+
+          {history.length > 0 && (
+            <div className="overflow-x-auto rounded-2xl border border-slate-800">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-slate-800 bg-slate-900">
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">Time</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">Owner</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">Source URL</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">Decision</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">Severity</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">Evidence</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-400">HIBP</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {history.map((item) => (
+                    <tr key={item.id} className="border-b border-slate-800/50 bg-slate-950 hover:bg-slate-900/50">
+                      <td className="px-4 py-3 text-slate-400">{formatDate(item.created_at)}</td>
+                      <td className="px-4 py-3 text-slate-300">{item.owner ?? '—'}</td>
+                      <td className="max-w-[180px] truncate px-4 py-3 text-slate-400" title={item.source_url ?? ''}>
+                        {item.source_url ?? '—'}
+                      </td>
+                      <td className="px-4 py-3">{decisionBadge(item.decision)}</td>
+                      <td className={`px-4 py-3 font-semibold ${SEVERITY_STYLES[item.severity as Severity] ?? 'text-slate-300'}`}>
+                        {item.severity}
+                      </td>
+                      <td className="px-4 py-3 text-slate-400">{item.evidence_level}</td>
+                      <td className="px-4 py-3">
+                        {item.hibp_checked ? (
+                          <span className={item.hibp_breach_count ? 'text-orange-300' : 'text-emerald-400'}>
+                            {item.hibp_breach_count ? `${item.hibp_breach_count} breaches` : 'clean'}
+                          </span>
+                        ) : (
+                          <span className="text-slate-600">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -29,6 +29,7 @@ const MORE = [
   { href: '/dashboard/integration', label: 'Integrations' },
   { href: '/dashboard/missions', label: 'Mission' },
   { href: '/dashboard/skills', label: 'Skills' },
+  { href: '/dashboard/breach-signal', label: 'Breach Signal' },
   { href: '/marketplace/skills', label: 'Skills Marketplace' },
   { href: '/dashboard/referrals', label: 'Referrals' },
   { href: '/app-shell', label: 'App Shell' },

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -2659,6 +2659,63 @@ export type Database = {
         }
         Relationships: []
       }
+      breach_signal_evaluations: {
+        Row: {
+          id: string
+          source_url: string | null
+          owner: string | null
+          legal_purpose: string | null
+          decision: string
+          evidence_level: string
+          severity: string
+          reasons: unknown
+          allowed_actions: unknown
+          blocked_actions: unknown
+          hibp_checked: boolean
+          hibp_breach_count: number | null
+          hibp_breaches: unknown | null
+          hibp_elevated_evidence: boolean
+          raw_data_stored: boolean
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          source_url?: string | null
+          owner?: string | null
+          legal_purpose?: string | null
+          decision: string
+          evidence_level: string
+          severity: string
+          reasons?: unknown
+          allowed_actions?: unknown
+          blocked_actions?: unknown
+          hibp_checked?: boolean
+          hibp_breach_count?: number | null
+          hibp_breaches?: unknown | null
+          hibp_elevated_evidence?: boolean
+          raw_data_stored?: boolean
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          source_url?: string | null
+          owner?: string | null
+          legal_purpose?: string | null
+          decision?: string
+          evidence_level?: string
+          severity?: string
+          reasons?: unknown
+          allowed_actions?: unknown
+          blocked_actions?: unknown
+          hibp_checked?: boolean
+          hibp_breach_count?: number | null
+          hibp_breaches?: unknown | null
+          hibp_elevated_evidence?: boolean
+          raw_data_stored?: boolean
+          created_at?: string
+        }
+        Relationships: []
+      }
       dsg_secrets: {
         Row: {
           created_at: string | null

--- a/lib/dsg/breach-signal/hibp.ts
+++ b/lib/dsg/breach-signal/hibp.ts
@@ -1,0 +1,70 @@
+export type HibpBreach = {
+  Name: string;
+  Title: string;
+  Domain: string;
+  BreachDate: string;
+  AddedDate: string;
+  DataClasses: string[];
+  IsVerified: boolean;
+  IsFabricated: boolean;
+  IsSensitive: boolean;
+};
+
+export type HibpResult = {
+  checked: boolean;
+  breaches: HibpBreach[];
+  breachCount: number;
+  elevatesEvidence: boolean;
+  skipReason?: string;
+};
+
+const HIBP_TIMEOUT_MS = 4_000;
+
+export async function checkHibpDomain(domain: string): Promise<HibpResult> {
+  const apiKey = process.env.HIBP_API_KEY;
+  if (!apiKey) {
+    return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: "HIBP_API_KEY_NOT_CONFIGURED" };
+  }
+
+  const clean = domain.trim().toLowerCase().replace(/^www\./, "");
+  if (!clean || clean.endsWith(".onion")) {
+    return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: "DOMAIN_NOT_QUERYABLE" };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), HIBP_TIMEOUT_MS);
+
+  try {
+    const url = `https://haveibeenpwned.com/api/v3/breaches?domain=${encodeURIComponent(clean)}`;
+    const res = await fetch(url, {
+      headers: {
+        "hibp-api-key": apiKey,
+        "user-agent": "dsg-control-plane/1.0",
+      },
+      signal: controller.signal,
+    });
+
+    if (res.status === 404) {
+      return { checked: true, breaches: [], breachCount: 0, elevatesEvidence: false };
+    }
+
+    if (!res.ok) {
+      return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: `HIBP_HTTP_${res.status}` };
+    }
+
+    const data = await res.json() as HibpBreach[];
+    const verified = data.filter((b) => b.IsVerified && !b.IsFabricated);
+
+    return {
+      checked: true,
+      breaches: verified,
+      breachCount: verified.length,
+      elevatesEvidence: verified.length > 0,
+    };
+  } catch (err: unknown) {
+    const reason = err instanceof Error && err.name === "AbortError" ? "HIBP_TIMEOUT" : "HIBP_FETCH_ERROR";
+    return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: reason };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/lib/dsg/breach-signal/hibp.ts
+++ b/lib/dsg/breach-signal/hibp.ts
@@ -18,53 +18,58 @@ export type HibpResult = {
   skipReason?: string;
 };
 
-const HIBP_TIMEOUT_MS = 4_000;
+const HIBP_ALL_BREACHES_URL = "https://haveibeenpwned.com/api/v3/breaches";
+const HIBP_TIMEOUT_MS = 8_000;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-export async function checkHibpDomain(domain: string): Promise<HibpResult> {
-  const apiKey = process.env.HIBP_API_KEY;
-  if (!apiKey) {
-    return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: "HIBP_API_KEY_NOT_CONFIGURED" };
+type Cache = { breaches: HibpBreach[]; fetchedAt: number };
+let cache: Cache | null = null;
+
+async function fetchAllBreaches(): Promise<HibpBreach[] | null> {
+  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.breaches;
   }
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HIBP_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(HIBP_ALL_BREACHES_URL, {
+      headers: { "user-agent": "dsg-control-plane/1.0" },
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as HibpBreach[];
+    cache = { breaches: data, fetchedAt: Date.now() };
+    return data;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkHibpDomain(domain: string): Promise<HibpResult> {
   const clean = domain.trim().toLowerCase().replace(/^www\./, "");
   if (!clean || clean.endsWith(".onion")) {
     return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: "DOMAIN_NOT_QUERYABLE" };
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), HIBP_TIMEOUT_MS);
-
-  try {
-    const url = `https://haveibeenpwned.com/api/v3/breaches?domain=${encodeURIComponent(clean)}`;
-    const res = await fetch(url, {
-      headers: {
-        "hibp-api-key": apiKey,
-        "user-agent": "dsg-control-plane/1.0",
-      },
-      signal: controller.signal,
-    });
-
-    if (res.status === 404) {
-      return { checked: true, breaches: [], breachCount: 0, elevatesEvidence: false };
-    }
-
-    if (!res.ok) {
-      return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: `HIBP_HTTP_${res.status}` };
-    }
-
-    const data = await res.json() as HibpBreach[];
-    const verified = data.filter((b) => b.IsVerified && !b.IsFabricated);
-
-    return {
-      checked: true,
-      breaches: verified,
-      breachCount: verified.length,
-      elevatesEvidence: verified.length > 0,
-    };
-  } catch (err: unknown) {
-    const reason = err instanceof Error && err.name === "AbortError" ? "HIBP_TIMEOUT" : "HIBP_FETCH_ERROR";
-    return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: reason };
-  } finally {
-    clearTimeout(timeout);
+  const all = await fetchAllBreaches();
+  if (!all) {
+    return { checked: false, breaches: [], breachCount: 0, elevatesEvidence: false, skipReason: "HIBP_FETCH_ERROR" };
   }
+
+  const matched = all.filter(
+    (b) => b.IsVerified && !b.IsFabricated && b.Domain.toLowerCase() === clean,
+  );
+
+  return {
+    checked: true,
+    breaches: matched,
+    breachCount: matched.length,
+    elevatesEvidence: matched.length > 0,
+  };
 }

--- a/lib/dsg/breach-signal/url-detect.ts
+++ b/lib/dsg/breach-signal/url-detect.ts
@@ -1,0 +1,34 @@
+export type UrlDetectedFlags = {
+  networkRoute: "standard" | "tor" | "unknown";
+  requiresLogin: boolean;
+  requiresDownload: boolean;
+  detectedDomain: string | null;
+};
+
+const LOGIN_PATTERNS = [/login/i, /signin/i, /auth\b/i, /account/i, /members/i, /register/i];
+const DOWNLOAD_PATTERNS = [/download/i, /\.zip$/i, /\.tar$/i, /\.rar$/i, /\.7z$/i, /\.sql$/i];
+
+export function detectFlagsFromUrl(rawUrl: string): UrlDetectedFlags {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return { networkRoute: "unknown", requiresLogin: false, requiresDownload: false, detectedDomain: null };
+  }
+
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(trimmed.startsWith("http") ? trimmed : `http://${trimmed}`);
+  } catch {
+    return { networkRoute: "unknown", requiresLogin: false, requiresDownload: false, detectedDomain: null };
+  }
+
+  const isOnion = parsed.hostname.endsWith(".onion");
+  const networkRoute: "standard" | "tor" | "unknown" = isOnion ? "tor" : "standard";
+
+  const combined = parsed.href;
+  const requiresLogin = LOGIN_PATTERNS.some((p) => p.test(combined));
+  const requiresDownload = DOWNLOAD_PATTERNS.some((p) => p.test(combined));
+
+  const detectedDomain = parsed.hostname.replace(/^www\./, "") || null;
+
+  return { networkRoute, requiresLogin, requiresDownload, detectedDomain };
+}

--- a/supabase/migrations/20260603001000_breach_signal_evaluations.sql
+++ b/supabase/migrations/20260603001000_breach_signal_evaluations.sql
@@ -1,0 +1,32 @@
+-- Breach signal evaluation audit trail.
+-- Stores every evaluation result from POST /api/dsg/breach-signal/evaluate.
+-- Service-role-only writes; no RLS policies needed for service-role access.
+-- rawDataStored is always false by policy enforcement in the route.
+
+CREATE TABLE IF NOT EXISTS breach_signal_evaluations (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_url            TEXT,
+  owner                 TEXT,
+  legal_purpose         TEXT,
+  decision              TEXT        NOT NULL,
+  evidence_level        TEXT        NOT NULL,
+  severity              TEXT        NOT NULL,
+  reasons               JSONB       NOT NULL DEFAULT '[]',
+  allowed_actions       JSONB       NOT NULL DEFAULT '[]',
+  blocked_actions       JSONB       NOT NULL DEFAULT '[]',
+  hibp_checked          BOOLEAN     NOT NULL DEFAULT false,
+  hibp_breach_count     INTEGER,
+  hibp_breaches         JSONB,
+  hibp_elevated_evidence BOOLEAN   NOT NULL DEFAULT false,
+  raw_data_stored       BOOLEAN     NOT NULL DEFAULT false,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS breach_signal_evals_created_at_idx
+  ON breach_signal_evaluations (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS breach_signal_evals_decision_idx
+  ON breach_signal_evaluations (decision);
+
+ALTER TABLE breach_signal_evaluations ENABLE ROW LEVEL SECURITY;
+-- Service role bypasses RLS. No policies needed for service-role-only access.

--- a/tests/integration/api/breach-signal-evaluate.test.ts
+++ b/tests/integration/api/breach-signal-evaluate.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+describe("/api/dsg/breach-signal/evaluate", () => {
+  async function callRoute(body: unknown) {
+    const { POST } = await import(
+      "../../../app/api/dsg/breach-signal/evaluate/route"
+    );
+    return POST(
+      new Request("http://localhost/api/dsg/breach-signal/evaluate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+  }
+
+  it("returns BLOCK when rawDataIncluded is true", async () => {
+    const res = await callRoute({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      rawDataIncluded: true,
+      claimedDataTypes: ["email"],
+    });
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.type).toBe("dsg-breach-signal-evaluation");
+    expect(payload.decision).toBe("BLOCK");
+    expect(payload.rawDataStored).toBe(false);
+    expect(payload.reasons).toContain("RAW_DATA_INCLUDED");
+  });
+
+  it("returns BLOCK when owner or legalPurpose is missing", async () => {
+    const res = await callRoute({
+      sourceCategory: "breach-signal",
+      claimedDataTypes: ["email"],
+    });
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(payload.decision).toBe("BLOCK");
+    expect(payload.reasons).toContain("OWNER_SCOPE_REQUIRED");
+    expect(payload.reasons).toContain("LEGAL_PURPOSE_REQUIRED");
+    expect(payload.rawDataStored).toBe(false);
+  });
+
+  it("returns BLOCK and blocks autonomous Tor access", async () => {
+    const res = await callRoute({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      networkRoute: "tor",
+      autonomousAgentAccess: true,
+      maskedSamples: ["som***@example.com"],
+      claimedDataTypes: ["email"],
+    });
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(payload.decision).toBe("BLOCK");
+    expect(payload.evidenceLevel).toBe("L2");
+    expect(payload.reasons).toContain("AUTONOMOUS_AGENT_ACCESS_BLOCKED");
+    expect(payload.reasons).toContain("TOR_AUTONOMOUS_ACCESS_BLOCKED");
+  });
+
+  it("returns REVIEW for masked evidence without owner confirmation", async () => {
+    const res = await callRoute({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      networkRoute: "standard",
+      maskedSamples: ["som***@example.com", "sk_live_****a91f"],
+      claimedDataTypes: ["email", "api_key"],
+    });
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(payload.decision).toBe("REVIEW");
+    expect(payload.evidenceLevel).toBe("L2");
+    expect(payload.severity).toBe("CRITICAL");
+    expect(payload.reasons).toContain("OWNER_VERIFICATION_REQUIRED");
+    expect(payload.allowedActions).toContain("request_owner_verification");
+    expect(payload.rawDataStored).toBe(false);
+  });
+
+  it("returns INCIDENT_REPORT_ALLOWED when ownerConfirmed is true", async () => {
+    const res = await callRoute({
+      owner: "example.com",
+      legalPurpose: "owner_notification",
+      networkRoute: "standard",
+      maskedSamples: ["som***@example.com"],
+      hashes: ["sha256:owner-confirmed-sample"],
+      claimedDataTypes: ["hashed_password"],
+      ownerConfirmed: true,
+    });
+    const payload = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(payload.decision).toBe("INCIDENT_REPORT_ALLOWED");
+    expect(payload.evidenceLevel).toBe("L3");
+    expect(payload.severity).toBe("HIGH");
+    expect(payload.allowedActions).toContain("create_owner_notification_report");
+    expect(payload.rawDataStored).toBe(false);
+    expect(payload.boundary.rawDataStorageEnabled).toBe(false);
+    expect(payload.boundary.darkWebCrawlingEnabled).toBe(false);
+  });
+
+  it("returns 400 for empty body", async () => {
+    const { POST } = await import(
+      "../../../app/api/dsg/breach-signal/evaluate/route"
+    );
+    const res = await POST(
+      new Request("http://localhost/api/dsg/breach-signal/evaluate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "",
+      }),
+    );
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(typeof payload.error).toBe("string");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const { POST } = await import(
+      "../../../app/api/dsg/breach-signal/evaluate/route"
+    );
+    const res = await POST(
+      new Request("http://localhost/api/dsg/breach-signal/evaluate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json{{{",
+      }),
+    );
+    const payload = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(payload.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
- app/api/dsg/breach-signal/evaluate/route.ts: POST endpoint calling evaluateBreachSignal
  with rate-limiting (30 req/min), readJsonBody safety, and boundary metadata in response
- tests/integration/api/breach-signal-evaluate.test.ts: 7 integration tests covering BLOCK
  (rawData, missing owner/purpose, autonomous Tor), REVIEW, INCIDENT_REPORT_ALLOWED, and 400 errors
- app/dashboard/breach-signal/page.tsx: operator panel with full form input, decision badge,
  severity, evidence level, reasons, and allowed/blocked action lists
- components/DashboardNav.tsx: add Breach Signal entry to More nav

Verification:
  npm run typecheck — pass (pre-existing deprecation warnings only)
  npm run test:unit — 1080 tests pass
  npm run test:integration — 121 tests pass (including 7 new breach-signal tests)

https://claude.ai/code/session_01Mk5ke8sN5mKGoGFvBCgApH