### PR TITLE
Add execution role boundary, sandbox/path fixes, validation tweaks, and UI text escapes

### DIFF
--- a/app/api/readiness/config/route.ts
+++ b/app/api/readiness/config/route.ts
@@ -103,8 +103,9 @@ export async function PATCH(request: NextRequest) {
     // 4. Log change to audit trail
     // 5. Notify org members of config change
 
-    const changedFields = Object.keys(validation.data || {}).filter(
-      key => (currentConfig as Record<string, unknown>)[key] !== (validation.data as Record<string, unknown>)[key]
+    const configPatch = validation.data ?? {};
+    const changedFields = (Object.keys(configPatch) as Array<keyof ReadinessConfig>).filter(
+      key => currentConfig[key] !== configPatch[key]
     );
 
     console.log('[readiness-config] Updated', {

--- a/app/products/agent-governance/page.tsx
+++ b/app/products/agent-governance/page.tsx
@@ -336,7 +336,7 @@ export default function AgentGovernancePage() {
           <div>
             <h3 className="text-xl font-bold mb-2">How do I install the GitHub App?</h3>
             <p className="text-gray-600">
-              Click the "Install" button, authorize the app in your GitHub account, and select which
+              Click the &quot;Install&quot; button, authorize the app in your GitHub account, and select which
               repositories to protect. Setup takes 30 seconds.
             </p>
           </div>
@@ -350,7 +350,7 @@ export default function AgentGovernancePage() {
           </div>
 
           <div>
-            <h3 className="text-xl font-bold mb-2">What's the difference between Freemium and Pro?</h3>
+            <h3 className="text-xl font-bold mb-2">What&apos;s the difference between Freemium and Pro?</h3>
             <p className="text-gray-600">
               Freemium is 10 gate decisions/month (perfect for trying it out). Pro is unlimited decisions,
               approval workflows, notifications, and support.

--- a/app/products/readiness-gate/page.tsx
+++ b/app/products/readiness-gate/page.tsx
@@ -155,7 +155,7 @@ export default function ReadinessGatePage() {
             <div className="pb-8">
               <h3 className="text-2xl font-bold mb-2">Post Check Result</h3>
               <p className="text-gray-600">
-                GitHub check shows "ready", "review required", or "blocked". Blocking checks prevent merge. Blocking checks prevent merge.
+                GitHub check shows &quot;ready&quot;, &quot;review required&quot;, or &quot;blocked&quot;. Blocking checks prevent merge.
               </p>
             </div>
           </div>
@@ -169,7 +169,7 @@ export default function ReadinessGatePage() {
             <div>
               <h3 className="text-2xl font-bold mb-2">Auto-merge or Manual Deploy</h3>
               <p className="text-gray-600">
-                If enabled: auto-merge when ready. Otherwise: show "Ready to Deploy" button. All decisions logged with timestamps.
+                If enabled: auto-merge when ready. Otherwise: show &quot;Ready to Deploy&quot; button. All decisions logged with timestamps.
               </p>
             </div>
           </div>

--- a/components/BetaSignupForm.tsx
+++ b/components/BetaSignupForm.tsx
@@ -66,9 +66,9 @@ export default function BetaSignupForm({
     return (
       <div className="bg-green-50 border-2 border-green-200 rounded-lg p-6 text-center">
         <CheckCircle2 className="w-12 h-12 text-green-600 mx-auto mb-4" />
-        <h3 className="text-xl font-bold text-green-900 mb-2">You're in!</h3>
+        <h3 className="text-xl font-bold text-green-900 mb-2">You&apos;re in!</h3>
         <p className="text-green-700 mb-4">
-          Check your email for next steps. We'll be in touch within 24 hours.
+          Check your email for next steps. We&apos;ll be in touch within 24 hours.
         </p>
         {promoCode && (
           <div className="bg-white border-2 border-green-600 rounded p-4 inline-block">
@@ -148,7 +148,7 @@ export default function BetaSignupForm({
       </div>
 
       <p className="text-xs text-gray-600 mt-4 text-center">
-        No spam, no credit card. We'll email you when it's your turn.
+        No spam, no credit card. We&apos;ll email you when it&apos;s your turn.
       </p>
     </form>
   );

--- a/lib/dsg/brain/execution-role-boundary.ts
+++ b/lib/dsg/brain/execution-role-boundary.ts
@@ -1,0 +1,97 @@
+/**
+ * Deterministic Hermes / Nango / DSG execution boundary.
+ *
+ * Invariants:
+ * - Hermes is the worker: plans, uses skills, and executes only plan-authorized work.
+ * - Nango is the credential/API authority: it holds credentials and performs real API connection work.
+ * - DSG is the control plane: it locks scope, verifies alignment, handles approval, audit, and evidence.
+ * - DSG must not block execution that is already plan-authorized, scope-aligned, approval-satisfied,
+ *   and evidence-writable; it only denies unsupported claims or actions outside the approved plan.
+ */
+
+export type ExecutionBoundaryActor = 'hermes' | 'nango' | 'dsg';
+
+export type ExecutionBoundaryAction =
+  | 'plan'
+  | 'use_skill'
+  | 'execute_authorized_plan'
+  | 'hold_credentials'
+  | 'connect_real_api'
+  | 'verify_plan_alignment'
+  | 'lock_scope'
+  | 'approve'
+  | 'record_audit'
+  | 'record_evidence'
+  | 'deny_unsupported_claim';
+
+export type ExecutionBoundaryDecision = 'allow' | 'needs_user_takeover' | 'deny';
+
+export interface ExecutionBoundaryInput {
+  actor: ExecutionBoundaryActor;
+  action: ExecutionBoundaryAction;
+  planAuthorized: boolean;
+  scopeAligned: boolean;
+  approvalSatisfied: boolean;
+  auditWritable: boolean;
+  evidenceWritable: boolean;
+  unsupportedClaim?: boolean;
+  outsideApprovedPlan?: boolean;
+  requiresRealCredential?: boolean;
+}
+
+export interface ExecutionBoundaryVerdict {
+  decision: ExecutionBoundaryDecision;
+  reasons: string[];
+}
+
+const HERMES_ACTIONS = new Set<ExecutionBoundaryAction>([
+  'plan',
+  'use_skill',
+  'execute_authorized_plan',
+]);
+
+const NANGO_ACTIONS = new Set<ExecutionBoundaryAction>([
+  'hold_credentials',
+  'connect_real_api',
+]);
+
+const DSG_ACTIONS = new Set<ExecutionBoundaryAction>([
+  'verify_plan_alignment',
+  'lock_scope',
+  'approve',
+  'record_audit',
+  'record_evidence',
+  'deny_unsupported_claim',
+]);
+
+export function decideExecutionBoundary(input: ExecutionBoundaryInput): ExecutionBoundaryVerdict {
+  const reasons: string[] = [];
+
+  if (input.unsupportedClaim) reasons.push('unsupported_claim');
+  if (input.outsideApprovedPlan) reasons.push('outside_approved_plan');
+  if (!input.scopeAligned) reasons.push('scope_not_aligned');
+  if (!input.auditWritable) reasons.push('audit_not_writable');
+  if (!input.evidenceWritable) reasons.push('evidence_not_writable');
+
+  if (input.actor === 'hermes') {
+    if (!HERMES_ACTIONS.has(input.action)) reasons.push('hermes_must_not_hold_credentials_or_approve');
+    if (input.action === 'execute_authorized_plan' && !input.planAuthorized) reasons.push('plan_not_authorized');
+    if (input.requiresRealCredential) reasons.push('route_real_credentials_through_nango');
+  }
+
+  if (input.actor === 'nango' && !NANGO_ACTIONS.has(input.action)) {
+    reasons.push('nango_is_not_planner_or_approval_authority');
+  }
+
+  if (input.actor === 'dsg' && !DSG_ACTIONS.has(input.action)) {
+    reasons.push('dsg_is_control_plane_not_worker_or_credential_holder');
+  }
+
+  if (input.action === 'approve' && !input.approvalSatisfied) {
+    return { decision: 'needs_user_takeover', reasons: [...reasons, 'approval_required'] };
+  }
+
+  if (reasons.length > 0) return { decision: 'deny', reasons };
+
+  return { decision: 'allow', reasons: ['plan_aligned_and_evidence_bound'] };
+}

--- a/lib/executors/terminal-sandbox.ts
+++ b/lib/executors/terminal-sandbox.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { createHash } from 'crypto';
 
 export interface TerminalSandboxOptions {
@@ -96,7 +96,7 @@ export function runInSandbox(
   }
 
   const safeEnv: Record<string, string> = {
-    PATH: '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin',
+    PATH: `${dirname(process.execPath)}:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin`,
     HOME: cwd,
     TMPDIR: cwd,
     ...Object.fromEntries(
@@ -116,7 +116,7 @@ export function runInSandbox(
     });
 
     const stdout = String(result.stdout ?? '').slice(0, maxOutputBytes);
-    const stderr = String(result.stderr ?? '').slice(0, maxOutputBytes);
+    const stderr = String(result.stderr ?? result.error?.message ?? '').slice(0, maxOutputBytes);
     const timedOut = result.signal === 'SIGTERM';
 
     return {

--- a/lib/readiness/check-engine.ts
+++ b/lib/readiness/check-engine.ts
@@ -1,7 +1,5 @@
-import type { Database } from '@/lib/database.types';
-
 export type CheckType = 'ci_status' | 'migrations' | 'secrets' | 'coverage' | 'reviews';
-export type CheckStatus = 'pass' | 'fail' | 'pending' | 'blocked';
+export type CheckStatus = 'pass' | 'fail' | 'pending' | 'blocked' | 'review_required';
 
 export interface ReadinessCheck {
   type: CheckType;

--- a/lib/validation/approval-validation.ts
+++ b/lib/validation/approval-validation.ts
@@ -1,5 +1,3 @@
-import type { Database } from '@/lib/database.types';
-
 export interface ApprovalValidationError {
   field: string;
   message: string;
@@ -195,7 +193,7 @@ export function validatePaginationParams(
 
   if (offset !== undefined) {
     const num = typeof offset === 'string' ? parseInt(offset, 10) : offset;
-    if (!Number.isInteger(num) || num < 0) {
+    if (typeof num !== 'number' || !Number.isInteger(num) || num < 0) {
       errors.push({
         field: 'offset',
         message: 'offset must be a non-negative integer',
@@ -214,7 +212,7 @@ export function validatePaginationParams(
 
   if (limit !== undefined) {
     const num = typeof limit === 'string' ? parseInt(limit, 10) : limit;
-    if (!Number.isInteger(num) || num < 1) {
+    if (typeof num !== 'number' || !Number.isInteger(num) || num < 1) {
       errors.push({
         field: 'limit',
         message: 'limit must be a positive integer',

--- a/tests/unit/dsg/execution-role-boundary.test.ts
+++ b/tests/unit/dsg/execution-role-boundary.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { decideExecutionBoundary } from '@/lib/dsg/brain/execution-role-boundary';
+
+const BASE = {
+  planAuthorized: true,
+  scopeAligned: true,
+  approvalSatisfied: true,
+  auditWritable: true,
+  evidenceWritable: true,
+};
+
+describe('Hermes / Nango / DSG execution boundary', () => {
+  it('allows Hermes to execute plan-authorized work when DSG evidence gates are satisfied', () => {
+    const verdict = decideExecutionBoundary({
+      ...BASE,
+      actor: 'hermes',
+      action: 'execute_authorized_plan',
+    });
+
+    expect(verdict).toEqual({
+      decision: 'allow',
+      reasons: ['plan_aligned_and_evidence_bound'],
+    });
+  });
+
+  it('denies Hermes when real credentials are required instead of routing through Nango', () => {
+    const verdict = decideExecutionBoundary({
+      ...BASE,
+      actor: 'hermes',
+      action: 'execute_authorized_plan',
+      requiresRealCredential: true,
+    });
+
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.reasons).toContain('route_real_credentials_through_nango');
+  });
+
+  it('allows Nango to hold credentials and connect real APIs without making approval decisions', () => {
+    expect(decideExecutionBoundary({ ...BASE, actor: 'nango', action: 'hold_credentials' }).decision).toBe('allow');
+    expect(decideExecutionBoundary({ ...BASE, actor: 'nango', action: 'connect_real_api' }).decision).toBe('allow');
+  });
+
+  it('denies Nango when it attempts to plan or approve', () => {
+    const verdict = decideExecutionBoundary({
+      ...BASE,
+      actor: 'nango',
+      action: 'approve',
+    });
+
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.reasons).toContain('nango_is_not_planner_or_approval_authority');
+  });
+
+  it('allows DSG to verify scope and record audit/evidence but denies work outside the approved plan', () => {
+    expect(decideExecutionBoundary({ ...BASE, actor: 'dsg', action: 'record_audit' }).decision).toBe('allow');
+
+    const verdict = decideExecutionBoundary({
+      ...BASE,
+      actor: 'dsg',
+      action: 'verify_plan_alignment',
+      outsideApprovedPlan: true,
+    });
+
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.reasons).toContain('outside_approved_plan');
+  });
+
+  it('does not let DSG block a plan-authorized aligned action with audit and evidence available', () => {
+    const verdict = decideExecutionBoundary({
+      ...BASE,
+      actor: 'dsg',
+      action: 'verify_plan_alignment',
+    });
+
+    expect(verdict.decision).toBe('allow');
+  });
+
+  it('requires user takeover for DSG approval when approval is not yet satisfied', () => {
+    const verdict = decideExecutionBoundary({
+      ...BASE,
+      actor: 'dsg',
+      action: 'approve',
+      approvalSatisfied: false,
+    });
+
+    expect(verdict.decision).toBe('needs_user_takeover');
+    expect(verdict.reasons).toContain('approval_required');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "module": "esnext",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
### Motivation

- Introduce a deterministic execution boundary to enforce role separation between Hermes, Nango, and DSG for safe agent execution.
- Fix sandbox execution environment and stderr handling to make terminal command runs more robust and secure.
- Tighten input validation and small UX/formatting fixes to prevent edge cases and rendering problems.

### Description

- Add `lib/dsg/brain/execution-role-boundary.ts` which defines `ExecutionBoundaryInput`, `ExecutionBoundaryVerdict`, and `decideExecutionBoundary` to centralize allow/deny logic for `hermes`, `nango`, and `dsg` actors.
- Add unit tests in `tests/unit/dsg/execution-role-boundary.test.ts` exercising the new decision logic with `vitest`.
- Improve sandbox runner in `lib/executors/terminal-sandbox.ts` by importing `dirname`, adding `dirname(process.execPath)` to the `PATH`, and falling back to `result.error?.message` when constructing `stderr`.
- Correct readiness config patch handling in `app/api/readiness/config/route.ts` by using a typed `configPatch` and `keyof ReadinessConfig` when computing `changedFields`.
- Extend readiness model in `lib/readiness/check-engine.ts` by adding a `review_required` check status and overall state.
- Harden pagination parsing in `lib/validation/approval-validation.ts` to ensure parsed values are numeric before integer checks.
- Escape single/double quotes in various UI components (`components/BetaSignupForm.tsx`, `app/products/*/page.tsx`) to avoid JSX string issues.
- Bump `tsconfig.json` `ignoreDeprecations` to `"5.0"`.

### Testing

- Ran unit tests with `vitest`, including `tests/unit/dsg/execution-role-boundary.test.ts`, and they passed.
- Performed a TypeScript type check with `tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21374bc6b4832894643d77eeca71e6)