### PR TITLE
fix: tool timeout + chat history persistence in Hermes chat

### DIFF
--- a/app/api/dsg/hermes/execute/route.ts
+++ b/app/api/dsg/hermes/execute/route.ts
@@ -41,6 +41,20 @@ export const dynamic = "force-dynamic";
 // ── constants ─────────────────────────────────────────────────────────────────
 const HAIKU = "claude-haiku-4-5-20251001";
 const MAX_RETRIES = 2;
+// Vercel Hobby plan hard-caps serverless functions at 10 s.
+// Per-tool timeout leaves room for synthesis; handler deadline triggers early exit.
+const TOOL_TIMEOUT_MS = 4_500;
+const HANDLER_DEADLINE_MS = 8_000;
+
+function raceTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const id = setTimeout(() => reject(new Error(`tool timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => { clearTimeout(id); resolve(v); },
+      (e) => { clearTimeout(id); reject(e); },
+    );
+  });
+}
 
 // ── synthesis ──────────────────────────────────────────────────────────────────
 async function synthesize(
@@ -141,7 +155,7 @@ async function runStep(
     success = true;
   } else {
     try {
-      const result = await executeToolSafely(tool, step.params ?? {}, agentCtx);
+      const result = await raceTimeout(executeToolSafely(tool, step.params ?? {}, agentCtx), TOOL_TIMEOUT_MS);
       output = JSON.stringify(result).slice(0, 2000);
       const r = result as Record<string, unknown>;
       success = !(r.blocked === true);
@@ -273,7 +287,7 @@ export async function POST(req: NextRequest) {
                 if (!tool) continue;
                 send({ type: "step_start", step: step.id, tool: step.toolId });
                 try {
-                  const result = await executeToolSafely(tool, step.params, agentCtx);
+                  const result = await raceTimeout(executeToolSafely(tool, step.params, agentCtx), TOOL_TIMEOUT_MS);
                   send({ type: "step_result", step: step.id, result });
                   addToolResultToMemory(sessionKey, step.toolId, result);
                 } catch { /* non-fatal */ }
@@ -291,7 +305,7 @@ export async function POST(req: NextRequest) {
                   if (!tool) continue;
                   send({ type: "step_start", step: step.id, tool: step.toolId });
                   try {
-                    const result = await executeToolSafely(tool, step.params, agentCtx);
+                    const result = await raceTimeout(executeToolSafely(tool, step.params, agentCtx), TOOL_TIMEOUT_MS);
                     send({ type: "step_result", step: step.id, result });
                   } catch { /* non-fatal */ }
                 }
@@ -346,8 +360,13 @@ export async function POST(req: NextRequest) {
         // 4. Execute each step with gate + evidence (streaming)
         const toolResults: Array<{ toolId: string; result: unknown }> = [];
         const allEvidence: EvidenceItem[] = [];
+        const deadline = Date.now() + HANDLER_DEADLINE_MS;
 
         for (const step of plan.steps) {
+          if (Date.now() > deadline) {
+            send({ type: "step_error", step: step.stepId, error: "deadline exceeded — skipping remaining steps to stay within function timeout" });
+            break;
+          }
           send({ type: "step_start", step: step.stepId, tool: step.worker });
 
           let outcome = await runStep(step, plan, contract, agentCtx, access.orgId, sessionId);

--- a/app/dashboard/hermes/page.tsx
+++ b/app/dashboard/hermes/page.tsx
@@ -436,6 +436,19 @@ function HermesRuntimePanel({ data }: { data: HermesRuntimeStatus | null }) {
   );
 }
 
+const HISTORY_KEY = 'hermes-chat-history';
+const HISTORY_MAX = 120;
+
+function loadHistory(): Message[] | null {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Message[];
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+    return parsed;
+  } catch { return null; }
+}
+
 export default function HermesAgentPage() {
   const [messages, setMessages] = useState<Message[]>([
     {
@@ -513,6 +526,20 @@ export default function HermesAgentPage() {
   const cameraCanvasRef = useRef<HTMLCanvasElement>(null);
   const cameraStreamRef = useRef<MediaStream | null>(null);
   const recognitionRef = useRef<any>(null);
+
+  // Restore chat history from localStorage on first mount
+  useEffect(() => {
+    const saved = loadHistory();
+    if (saved) setMessages(saved);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist chat history to localStorage on every change (capped at HISTORY_MAX)
+  useEffect(() => {
+    try {
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(messages.slice(-HISTORY_MAX)));
+    } catch { /* storage full — ignore */ }
+  }, [messages]);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -885,6 +912,22 @@ export default function HermesAgentPage() {
           </div>
         </div>
         <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              try { localStorage.removeItem(HISTORY_KEY); } catch { /* ignore */ }
+              setMessages([{
+                id: 'welcome',
+                role: 'agent',
+                content: 'สวัสดี — ประวัติถูกล้างแล้ว พิมพ์คำถามได้เลย',
+                ts: Date.now(),
+              }]);
+            }}
+            className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-400 transition hover:bg-white/10 hover:text-slate-200"
+            title="ล้างประวัติ"
+          >
+            ล้างประวัติ
+          </button>
           <Link
             href="/dashboard/hermes/skills"
             className="rounded-lg border border-violet-400/30 bg-violet-500/10 px-3 py-1.5 text-xs font-semibold text-violet-300 transition hover:bg-violet-500/20"


### PR DESCRIPTION
## Goal

Fix two production bugs in Hermes chat:
1. **"Thinking..." stuck forever** — tools hang past Vercel Hobby 10s function timeout, stream gets cut before `assistant_reply` arrives
2. **Chat history lost on page refresh** — messages state was never persisted

## Files changed

- `app/api/dsg/hermes/execute/route.ts` — tool timeout + handler deadline
- `app/dashboard/hermes/page.tsx` — localStorage persistence + "ล้างประวัติ" button

## Root cause (Thinking... bug)

Vercel Hobby plan hard-caps serverless functions at **10 seconds**. The execution chain is:

```
callLLMForPlan  (~3-5s)
+ tool: readiness  (~1s)
+ tool: list_agents  (Supabase query, can take 2-4s)
= 6-10s before synthesis even starts
```

When the budget is exceeded, Vercel cuts the SSE stream. The UI received `step_start` for `list_agents` but never `step_result` or `assistant_reply`, so it shows "Thinking..." forever.

## Fix

```
TOOL_TIMEOUT_MS = 4500   → each tool gets max 4.5s via Promise.race
HANDLER_DEADLINE_MS = 8000  → if step loop exceeds 8s, skip remaining steps
synthesize() already has AbortSignal.timeout(15_000) but now runs sooner
```

## Chat history fix

- `loadHistory()` reads from `localStorage` on mount
- `useEffect` saves `messages.slice(-120)` to `localStorage` on every change
- Header "ล้างประวัติ" button clears storage + resets to empty welcome

## Verification

- [x] Inspected both files
- [x] `npm run typecheck` — 0 errors (only pre-existing TS deprecation warnings)
- [ ] Live test not run — deployed fix needs Vercel redeploy

## Known limits

- 4.5s per tool is still tight if Supabase cold-starts. Upgrading to Vercel Pro removes the 10s cap entirely.
- localStorage is tab-local; multiple tabs see the same history but writes from concurrent tabs may interleave.

## User-visible benefit

- Hermes chat replies correctly instead of showing "Thinking..." forever
- Refreshing the page restores the full conversation history
- "ล้างประวัติ" button lets users start fresh

## Next step

Merge → Vercel redeploy → test live

https://claude.ai/code/session_01AETftJ4RGMoRc9AE4rSKn7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AETftJ4RGMoRc9AE4rSKn7)_