### PR TITLE
Reuse decision explainer on the gateway monitor

### DIFF
--- a/app/gateway/monitor/page.tsx
+++ b/app/gateway/monitor/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
+import DecisionExplainer from '../../../components/DecisionExplainer';
 
 export const dynamic = 'force-dynamic';
 
@@ -172,13 +173,20 @@ export default async function GatewayMonitorPage({ searchParams }: { searchParam
           <div className="dsg-card rounded-[1.5rem] p-6">
             <p className="text-xs font-bold uppercase tracking-[0.24em] text-amber-200">Latest visible proof</p>
             {latest ? (
-              <dl className="mt-5 space-y-4 text-sm">
+              <>
+              <DecisionExplainer
+                decision={latest.decision}
+                reason={`${latest.tool_name} / ${latest.action}`}
+                className="mt-5"
+              />
+              <dl className="mt-4 space-y-4 text-sm">
                 <div><dt className="text-slate-400">Action</dt><dd className="mt-1 font-bold text-white">{latest.tool_name} / {latest.action}</dd></div>
                 <div><dt className="text-slate-400">Decision</dt><dd className="mt-1"><span className={`rounded-full border px-3 py-1 text-xs font-bold uppercase ${decisionClass(latest.decision)}`}>{latest.decision}</span></dd></div>
                 <div><dt className="text-slate-400">Risk</dt><dd className="mt-1 font-mono text-slate-200">{latest.risk ?? 'unclassified'}</dd></div>
                 <div><dt className="text-slate-400">Request hash</dt><dd className="mt-1 font-mono text-xs text-blue-200">{shortHash(latest.request_hash)}</dd></div>
                 <div><dt className="text-slate-400">Record hash</dt><dd className="mt-1 font-mono text-xs text-amber-200">{shortHash(latest.record_hash)}</dd></div>
               </dl>
+              </>
             ) : (
               <p className="mt-5 text-sm leading-7 text-slate-300">No proof event yet. Use command 1 below to create the first visible event, then refresh this page.</p>
             )}

--- a/components/DecisionExplainer.tsx
+++ b/components/DecisionExplainer.tsx
@@ -26,9 +26,11 @@ type Props = {
 
 function classify(decision?: string | null): DecisionKind {
   const d = String(decision || "").toUpperCase();
-  if (d === "ALLOW") return "ALLOW";
-  if (d === "STABILIZE") return "STABILIZE";
-  if (d === "BLOCK" || d === "FREEZE") return "BLOCK";
+  if (["ALLOW", "PASS", "ALLOWED"].includes(d)) return "ALLOW";
+  if (["STABILIZE", "REVIEW", "NEEDS_REVIEW", "MANUAL_REVIEW"].includes(d))
+    return "STABILIZE";
+  if (["BLOCK", "FREEZE", "BLOCKED", "DENY", "DENIED"].includes(d))
+    return "BLOCK";
   return "UNKNOWN";
 }
 


### PR DESCRIPTION
Goal:
Bring the plain-language `DecisionExplainer` (shipped in #677) to the gateway monitor — the buyer/operator/auditor surface whose whole promise is "see what DSG decided, why, and what to do next." Reuse, not reinvention.

Files changed:
- `components/DecisionExplainer.tsx` — `classify()` now recognizes gateway decision synonyms: `PASS`/`ALLOWED` → ALLOW; `REVIEW`/`NEEDS_REVIEW`/`MANUAL_REVIEW` → review (STABILIZE branch); `BLOCKED`/`DENY`/`DENIED` → BLOCK. The executions page (which already uses `ALLOW`/`STABILIZE`/`BLOCK`) is unaffected.
- `app/gateway/monitor/page.tsx` — renders `DecisionExplainer` at the top of the "Latest visible proof" card. The plain-language what/why/next-action + fix links lead; the existing raw decision badge, risk, and evidence hashes remain visible below.

Deliberately out of scope:
- The Auto-Setup error state was NOT changed to use `DecisionExplainer`. A setup failure is not a gate decision (ALLOW/STABILIZE/BLOCK), so reusing a decision component there would be semantically wrong. It keeps its existing blocked-mascot + real error text + retry button.

Verification:
- [x] `npm run typecheck` — pass (only the 2 pre-existing tsconfig deprecation warnings; tsconfig not touched).
- [x] `npm run build` — success (`/gateway/monitor` compiles).
- [ ] Live/browser check — not run (no authenticated session / seeded gateway events in this environment).

Known limits:
- The gateway monitor has no numeric risk score or free-text reason per event, so the explainer shows the action identifier as its reason context and omits the numeric score (never fabricated).
- `DecisionExplainer` fix links point at `/dashboard/*` routes (auth-gated); appropriate for an operator viewing the monitor.

User-visible benefit:
- The monitor's latest decision now reads as a clear sentence with a next action, matching the page's stated promise, instead of only a badge + hashes.

https://claude.ai/code/session_01CTUzurotRq5RmVSRbr68MA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTUzurotRq5RmVSRbr68MA)_