### PR TITLE
DecisionExplainer render test + automatic JSX in vitest + README changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,51 @@ DSG ONE is a runtime governance layer for AI agents. Connect it in one line, gat
 
 ---
 
+## 🟢 Guided Onboarding UX + Decision Explainer — 2026-06-05
+
+**PRs #676 · #677 · #678 merged to `main` | Deployed:** production live (`GET /api/agent/status` → `version: 98069ae…`, `db:true`) | **Typecheck:** 0 errors | **Build:** `next build` success
+
+Making governed AI usable for real operators, not only developers — one onboarding path, plain-language decisions, and progress backed by real evidence.
+
+### What's new
+
+#### Onboarding (PR #676)
+
+| Area | Change |
+|---|---|
+| Single path | `/api/onboarding/state` `next_action` now points to Quick Setup on the Welcome page (was the stale "Skills" location) |
+| Generated code | Copyable `dsg_gate.py` / `dsg_gate.js` and the inline Python/JS/cURL snippets are English-only — no Thai comments in code users paste into their own repos |
+| Evidence-based progress | The dashboard onboarding checklist derives completion from real workspace state (`progress` from `/api/onboarding/state`) instead of manual self-attested checkboxes |
+| Default safety posture | The Auto-Setup success screen explains what the starter policy enforces: BLOCK ≥ 0.80, STABILIZE ≥ 0.40, ALLOW < 0.40 (no threshold change) |
+| Mascot guide | A decorative, `aria-hidden`, reduced-motion-aware SVG guide reacts to real flow state (walking / thumbs-up / blocked / pointing / waving); it never gates a decision |
+
+#### Plain-language decision explainer (PR #677 · #678)
+
+`components/DecisionExplainer.tsx` turns a raw `ALLOW` / `STABILIZE` / `BLOCK` decision into a clear what / why / next-action summary with fix links (Adjust policy · Review approvals · Open audit). Evidence-first: it renders only data actually present (decision, reason, policy version, optional risk score) and invents nothing.
+
+- Wired into `/dashboard/executions` (above the raw evidence rows + JSON) and the gateway monitor's "Latest visible proof" card.
+- Recognizes gateway decision synonyms: `pass`/`allowed` → ALLOW, `review`/`needs_review`/`manual_review` → review, `deny`/`denied`/`blocked` → BLOCK.
+
+#### Cleanup (PR #677)
+
+- Removed `POST /api/onboarding/seed` (no UI caller; superseded by `POST /api/setup/auto`).
+- Removed the manual `completedStepIds` checklist model from `/api/onboarding/state` — the widget now persists only the `dismissed` preference.
+
+### Verification — 2026-06-05
+
+```
+npm run typecheck             # 0 errors (only 2 pre-existing tsconfig deprecations)
+npm run build                 # success — 124 pages
+vitest onboarding-state-route # 4 passed
+vitest decision-explainer     # 13 passed (render test — PR #680)
+GET /api/agent/status         # version 98069ae…, env production, db:true ✅
+POST /api/gateway/plan-check   → decision "block" + request/decision/record hashes ✅ (live)
+```
+
+Live check: a real `ALLOW` execution and live `block` gateway decisions were rendered through `DecisionExplainer`, producing the correct plain-language output for each. The `/gateway/monitor` page itself is auth-gated (Supabase operator session required), so its rendered HTML is not fetched anonymously.
+
+---
+
 ## 🟢 Hermes Managed Agents API + Security Hardening — 2026-06-04
 
 **Commit:** `c44e4a240` merged to `main` | **Deployed:** production live | **Typecheck:** 0 errors

--- a/tests/unit/components/decision-explainer.test.tsx
+++ b/tests/unit/components/decision-explainer.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DecisionExplainer } from "../../../components/DecisionExplainer";
+
+function render(props: Record<string, unknown>) {
+  return renderToStaticMarkup(createElement(DecisionExplainer, props as any));
+}
+
+describe("DecisionExplainer", () => {
+  it("explains a BLOCK with a fix path and surfaces the real reason", () => {
+    const html = render({ decision: "BLOCK", reason: "risk above policy bound" });
+    expect(html).toContain("Blocked before it could run");
+    expect(html).toContain("risk above policy bound");
+    // Fix actions for a block.
+    expect(html).toContain("Adjust policy");
+    expect(html).toContain("Open audit");
+    // Decision badge echoes the raw value.
+    expect(html).toContain("BLOCK");
+  });
+
+  it("explains a STABILIZE as flagged-for-review with approval path", () => {
+    const html = render({ decision: "STABILIZE" });
+    expect(html).toContain("Flagged for review");
+    expect(html).toContain("Review approvals");
+  });
+
+  it("explains an ALLOW as passed", () => {
+    const html = render({ decision: "ALLOW" });
+    expect(html).toContain("Allowed");
+  });
+
+  it("renders an optional numeric risk score and policy version", () => {
+    const html = render({
+      decision: "STABILIZE",
+      riskScore: 0.42,
+      policyVersion: "v1",
+    });
+    expect(html).toContain("0.42");
+    expect(html).toContain("v1");
+  });
+
+  it("omits the risk score row when none is provided", () => {
+    const html = render({ decision: "ALLOW" });
+    expect(html).not.toContain("Risk/stability score");
+  });
+
+  // Gateway vocabulary (PR #678) maps onto the same three explanations.
+  it.each([
+    ["pass", "Allowed"],
+    ["allowed", "Allowed"],
+    ["review", "Flagged for review"],
+    ["needs_review", "Flagged for review"],
+    ["manual_review", "Flagged for review"],
+    ["deny", "Blocked before it could run"],
+    ["denied", "Blocked before it could run"],
+    ["blocked", "Blocked before it could run"],
+  ])("maps gateway decision %s to the right explanation", (decision, headline) => {
+    const html = render({ decision });
+    expect(html).toContain(headline);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  // Use the automatic JSX runtime so Next.js components (which do not import
+  // React explicitly) can be rendered in tests without "React is not defined".
+  esbuild: { jsx: 'automatic' },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
Goal:
Provide a real, repeatable verification that `DecisionExplainer` (used on the executions page and the gateway monitor) renders the right plain-language explanation for every decision — since the live gateway-monitor render cannot be checked from CI/sandbox.

Why not a live browser check:
`middleware.ts` protects `/gateway/monitor` behind a Supabase SSR session (it's in the protected-path list). An unauthenticated request redirects to `/login`, and this environment has no operator credentials — so the rendered monitor HTML can't be fetched/grepped here. The plan-check API is unauthenticated and could create an event, but the page that displays it is auth-gated. A render test is therefore the strongest feasible, repeatable proof (and runs in CI).

Files changed:
- `tests/unit/components/decision-explainer.test.tsx` (new) — renders `DecisionExplainer` via `react-dom/server` (matching the existing `tests/integration/ui` pattern) and asserts: the BLOCK/STABILIZE/ALLOW headlines, the real `reason` text, the fix-action links (Adjust policy / Review approvals / Open audit), optional numeric risk score + policy version (and their omission when absent), and the gateway decision synonyms added in #678 (`pass`/`allowed`, `review`/`needs_review`/`manual_review`, `deny`/`denied`/`blocked`). 13 cases.
- `vitest.config.ts` — set `esbuild.jsx = 'automatic'` so Next.js components (which don't import React) can render in tests without "React is not defined".

Verification:
- [x] `npm run typecheck` — pass (only the 2 pre-existing tsconfig deprecation warnings).
- [x] `vitest tests/unit/components/decision-explainer.test.tsx` — 13 passed.
- [x] Regression: all 4 `.tsx` UI test files pass (23 tests) under the new JSX runtime config — no breakage from the config change.

Known limits:
- This verifies the component's rendered output, not the live authenticated gateway-monitor page. A true end-to-end browser check still requires an operator session against a deployment.

User-visible benefit:
- Locks in the plain-language decision copy and the #678 gateway-vocabulary mapping with CI coverage, so future changes can't silently break what buyers/operators read.

Next step:
- For a full live check, run it from an authenticated operator session: `POST /api/gateway/plan-check` (headers `x-org-id`/`x-actor-id`/`x-actor-role`) to create an event, then open `/gateway/monitor?orgId=<org>` while logged in.

https://claude.ai/code/session_01CTUzurotRq5RmVSRbr68MA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTUzurotRq5RmVSRbr68MA)_