### PR TITLE
fix(proofs): Proof list 500 — use runtime access + admin client

### DIFF
--- a/app/api/proofs/route.ts
+++ b/app/api/proofs/route.ts
@@ -1,31 +1,23 @@
 import { NextResponse } from "next/server";
-import { createClient } from "../../../lib/supabase/server";
+import { requireRuntimeAccess } from "../../../lib/authz-runtime";
+import { getSupabaseAdmin } from "../../../lib/supabase-server";
 import { logServerError, serverErrorResponse } from "../../../lib/security/error-response";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
-    const supabase = await createClient();
-
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
-
-    if (userError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    // Match the sibling read routes (/api/executions, /api/audit): a
+    // server-verified runtime access check + the service-role admin client
+    // scoped by org_id. The previous cookie-SSR client ran the audit_logs
+    // query under RLS as the `authenticated` role, which failed and surfaced
+    // as a generic 500 to callers such as the Hermes "Proof list" tool.
+    const access = await requireRuntimeAccess(request, "executions_read");
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
     }
 
-    const { data: profile, error: profileError } = await supabase
-      .from("users")
-      .select("org_id, is_active")
-      .eq("auth_user_id", user.id)
-      .maybeSingle();
-
-    if (profileError || !profile?.org_id || !profile.is_active) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const supabase = getSupabaseAdmin();
 
     const url = new URL(request.url);
     const limit = Math.min(Number(url.searchParams.get("limit") || "20"), 100);
@@ -40,7 +32,7 @@ export async function GET(request: Request) {
         evidence,
         created_at
       `)
-      .eq("org_id", profile.org_id)
+      .eq("org_id", access.orgId)
       .order("created_at", { ascending: false })
       .limit(limit);
 


### PR DESCRIPTION
Goal:
Fix the production bug where the Hermes "Proof list" tool (and the Proofs surface) returns **"Internal server error"**.

Root cause:
`GET /api/proofs` was the only read route using the cookie-SSR Supabase client (`createClient()` + `auth.getUser()`), so its `audit_logs` SELECT ran under RLS as the `authenticated` role. That query fails and is returned as a generic `serverErrorResponse()` → "Internal server error". Auth itself passed (the Hermes `callJson` forwards the operator cookie), so it was a 500, not a 401. Every sibling read route (`/api/executions`, `/api/audit`) instead uses `requireRuntimeAccess` + the service-role admin client.

Files changed:
- `app/api/proofs/route.ts` — replaced `createClient()` + `auth.getUser()` + `users` lookup with `requireRuntimeAccess(request, 'executions_read')` + `getSupabaseAdmin()`, scoping the `audit_logs` query by `access.orgId`. The mapping/response shape is unchanged. `requireRuntimeAccess` accepts both cookie sessions (dashboard) and internal-service/Bearer (Hermes), so both callers work.

Verification:
- [x] `npm run typecheck` — pass (only the 2 pre-existing tsconfig deprecation warnings).
- [x] `npm run build` — success (`/api/proofs` compiles).
- [ ] Live re-check — pending deploy (will confirm the Hermes "Proof list" tool returns `{ ok: true, items: [...] }` after merge).

Known limits:
- This aligns the auth/data-access pattern; it does not change the response shape or add new tests for this route (the route has no existing unit test). Behavior is now identical to `/api/executions`' access path.

User-visible benefit:
- The Proofs surface / Hermes "Proof list" tool returns proof artifacts instead of "Internal server error".

https://claude.ai/code/session_01CTUzurotRq5RmVSRbr68MA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTUzurotRq5RmVSRbr68MA)_