### PR TITLE
docs: GraphMap Plugin spec + agent rules (from dsg-one-v1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,53 @@ Coverage currently expected:
 
 ---
 
+## DSG GraphMap Plugin — กฎการใช้งานสำหรับ agent (2026-05-26)
+
+### ใช้เมื่อไหร่
+
+ก่อนตอบคำถามเกี่ยวกับโครงสร้าง repo ต้อง query GraphMap ก่อนเสมอ ตัวอย่างคำถามที่ต้อง query ก่อน:
+
+- "route ไหนแตะ table ไหน"
+- "policy / gate ไหนคุม API ไหน"
+- "test ไหนควรเกี่ยวกับไฟล์นี้"
+- "ไฟล์นี้ import จากที่ไหนบ้าง"
+- "อะไรอยู่ใน directory เดียวกันกับไฟล์นี้"
+
+### วิธีใช้
+
+```
+GET  /api/plugins/graphmap/status
+  → ถ้า status=EMPTY หรือ isStale=true → POST /api/plugins/graphmap/build ก่อน
+
+POST /api/plugins/graphmap/build
+  body: {} (ใช้ default include/exclude patterns)
+  → รอ ok: true, nodeCount > 0
+
+POST /api/plugins/graphmap/query
+  body: { "question": "<คำถามเกี่ยวกับ repo>", "max_depth": 2 }
+  → อ่าน decision + evidence ก่อนตอบ
+```
+
+### กฎการตีความ decision
+
+| decision | ความหมาย | สิ่งที่ agent ควรทำ |
+|---|---|---|
+| `ALLOW` | หลักฐาน EXTRACTED ≥3 ชิ้น graph ไม่เก่า | ตอบได้โดยอ้างอิง evidence |
+| `REVIEW` | มี INFERRED หรือ graph เก่ากว่า 24h | ตอบแบบ "น่าจะ" บอก confidence ด้วย |
+| `BLOCK` | ไม่มี evidence | ห้ามเดา — บอก user ว่าต้อง build graph ก่อน |
+
+### ห้ามทำ
+
+- ห้ามตอบคำถาม repo structure โดยไม่ query GraphMap ก่อน
+- ห้าม claim ว่า "route X แตะ table Y" ถ้า decision เป็น BLOCK หรือ REVIEW + confidence INFERRED
+- ห้าม build graph ถ้า status=READY และ isStale=false (ใช้ของเดิมได้)
+
+### Auth
+
+ทุก endpoint ต้องส่ง `Authorization: Bearer <supabase_jwt>` — ดึง token จาก user session ที่ login อยู่
+
+---
+
 ## งานที่ทำไปแล้ว (2026-05-16) — branch `claude/analyze-files-RHRKg` → merged to `main`
 
 ### Security fixes

--- a/README.md
+++ b/README.md
@@ -796,6 +796,30 @@ Not claimed:
 
 ---
 
+## GraphMap Plugin (spec — 2026-05-26)
+
+```
+GET  /api/plugins/graphmap/status  — EMPTY | READY, isStale boolean
+POST /api/plugins/graphmap/build   — scan repo → build graph → Supabase
+POST /api/plugins/graphmap/query   — keyword BFS → evidence + gate
+```
+
+Edge confidence:
+- import / link   → EXTRACTED (direct parse evidence)
+- co-located      → INFERRED  (same-directory heuristic)
+
+Gate:
+- ALLOW  — ≥3 EXTRACTED evidence + graph age < 24h
+- REVIEW — any INFERRED, stale, or < 3 EXTRACTED
+- BLOCK  — no evidence or all AMBIGUOUS
+
+Plugin manifest: `plugins/graphmap/plugin.json`
+- `read_repo: true` | `write_repo: false` | `call_dsg_gate: true`
+
+Agent usage rules in `AGENTS.md` — agents MUST query GraphMap before answering repo structure questions.
+
+---
+
 ## Formal verification artifact
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18225586.svg)](https://doi.org/10.5281/zenodo.18225586)


### PR DESCRIPTION
## Summary
Port GraphMap Plugin specification and agent usage rules from `tdealer01-crypto/dsg-one-v1`.

## Changes
| File | Change |
|------|--------|
| `AGENTS.md` | Added **DSG GraphMap Plugin — กฎการใช้งานสำหรับ agent** section with trigger conditions, API sequence (status → build → query), decision interpretation table (ALLOW/REVIEW/BLOCK), prohibited behaviors, and auth requirements |
| `README.md` | Added **GraphMap Plugin (spec)** section documenting endpoints, edge confidence levels (EXTRACTED vs INFERRED), gate thresholds, plugin manifest, and reference to AGENTS.md rules |

## Specification
**Endpoints:**
- `GET /api/plugins/graphmap/status` — returns `EMPTY | READY`, `isStale` boolean
- `POST /api/plugins/graphmap/build` — scans repo, builds knowledge graph to Supabase
- `POST /api/plugins/graphmap/query` — keyword BFS search, returns evidence + gate decision

**Edge confidence:**
- `import / link` → `EXTRACTED` (direct parse evidence)
- `co-located` → `INFERRED` (same-directory heuristic)

**Gate thresholds:**
- `ALLOW` — ≥3 EXTRACTED evidence + graph age < 24h
- `REVIEW` — any INFERRED, stale, or < 3 EXTRACTED
- `BLOCK` — no evidence or all AMBIGUOUS

**Agent rules (AGENTS.md):**
- Agents MUST query GraphMap before answering repo structure questions
- Trigger: questions like "route X touches table Y", "policy Z controls API W"
- Sequence: status → build (if EMPTY/stale) → query
- On BLOCK: must tell user to build graph, cannot guess
- Auth: `Authorization: Bearer <supabase_jwt>` required

## Origin
From `tdealer01-crypto/dsg-one-v1` main branch (commits 7cdfd0b6, 0a5233a, 34f8d712)

## Note
⚠️ This is a **SPECIFICATION ONLY** — the `/api/plugins/graphmap/*` endpoints are **not yet implemented**. Future PR will implement the GraphMap plugin runtime.