### PR TITLE
fix(dsg): implement missing ported modules to restore typecheck

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -53,7 +53,7 @@ export async function POST(req: Request) {
 
   if (event.type === 'invoice.paid') {
     const invoice = event.data.object as Stripe.Invoice;
-    const subRaw = invoice.parent?.subscription_details?.subscription;
+    const subRaw = invoice.subscription;
     const subscriptionId = subRaw
       ? (typeof subRaw === 'string' ? subRaw : subRaw.id)
       : null;

--- a/lib/dsg/ai/openai-adapter.ts
+++ b/lib/dsg/ai/openai-adapter.ts
@@ -1,0 +1,49 @@
+/**
+ * OpenAI adapter status (server-side).
+ *
+ * Reports whether the server-side OpenAI-compatible adapter is configured,
+ * based purely on the presence of environment variables. It never reads,
+ * logs, or returns the API key value itself.
+ */
+
+export type OpenAIAdapterStatus = {
+  /** True when an API key is present in the environment. */
+  configured: boolean;
+  /** Optional custom base URL (e.g. for an OpenAI-compatible proxy), when set. */
+  baseUrl?: string;
+  /** Model id the adapter would default to. */
+  defaultModel: string;
+  /** Honest boundary describing what this status does and does not prove. */
+  truthBoundary: string;
+};
+
+function firstEnv(names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Return the current OpenAI adapter configuration status.
+ *
+ * Configured means an API key exists in the environment. It does NOT prove the
+ * key is valid, that the upstream endpoint is reachable, or that a request
+ * would succeed — only that the adapter is wired up to attempt a call.
+ */
+export function getOpenAIAdapterStatus(): OpenAIAdapterStatus {
+  const apiKey = firstEnv(['OPENAI_API_KEY']);
+  const baseUrl = firstEnv(['OPENAI_BASE_URL', 'OPENAI_API_BASE']);
+  const defaultModel = firstEnv(['OPENAI_DEFAULT_MODEL']) || 'gpt-4o-mini';
+  const configured = Boolean(apiKey);
+
+  return {
+    configured,
+    baseUrl,
+    defaultModel,
+    truthBoundary: configured
+      ? 'OPENAI_API_KEY is present. Adapter is connector-ready, but key validity and upstream reachability are not verified by this status.'
+      : 'OPENAI_API_KEY is not configured. The OpenAI adapter is connector-required and cannot generate text until a key is set server-side.',
+  };
+}

--- a/lib/dsg/app-builder/build-tools.ts
+++ b/lib/dsg/app-builder/build-tools.ts
@@ -1,0 +1,52 @@
+/**
+ * App Builder server-side tool identifiers and descriptors.
+ *
+ * These names identify the governed App Builder tool calls exposed through the
+ * agent runtime service registry. They are stable string identifiers used as
+ * service ids and in tool-call routing. Keeping them centralized avoids
+ * stringly-typed drift between the registry and the route handlers.
+ */
+
+/** Tool that provisions the runtime environment + action-layer contract after plan approval. */
+export const APP_BUILDER_AGENT_RUNTIME_TOOL_NAME = 'dsg.app_builder.agent_runtime' as const;
+
+/** Tool that generates a full-stack GitHub pull request from an approved plan. */
+export const APP_BUILDER_BUILD_TOOL_NAME = 'dsg.app_builder.build' as const;
+
+export type AppBuilderToolName =
+  | typeof APP_BUILDER_AGENT_RUNTIME_TOOL_NAME
+  | typeof APP_BUILDER_BUILD_TOOL_NAME;
+
+export type AppBuilderToolDescriptor = {
+  name: AppBuilderToolName;
+  label: string;
+  /** Secrets required server-side before the tool can run. Names only, never values. */
+  requiredSecrets: string[];
+  /** Whether the tool requires an approved plan before execution. */
+  requiresApproval: boolean;
+};
+
+export const APP_BUILDER_TOOLS: Record<AppBuilderToolName, AppBuilderToolDescriptor> = {
+  [APP_BUILDER_AGENT_RUNTIME_TOOL_NAME]: {
+    name: APP_BUILDER_AGENT_RUNTIME_TOOL_NAME,
+    label: 'Launch App Builder agent runtime',
+    requiredSecrets: ['GITHUB_TOKEN'],
+    requiresApproval: true,
+  },
+  [APP_BUILDER_BUILD_TOOL_NAME]: {
+    name: APP_BUILDER_BUILD_TOOL_NAME,
+    label: 'Generate full-stack GitHub PR',
+    requiredSecrets: ['GITHUB_TOKEN'],
+    requiresApproval: true,
+  },
+};
+
+/** Whether a string is a known App Builder tool name. */
+export function isAppBuilderToolName(value: string): value is AppBuilderToolName {
+  return value === APP_BUILDER_AGENT_RUNTIME_TOOL_NAME || value === APP_BUILDER_BUILD_TOOL_NAME;
+}
+
+/** Resolve a tool descriptor by name, or null when unknown. */
+export function getAppBuilderTool(name: string): AppBuilderToolDescriptor | null {
+  return isAppBuilderToolName(name) ? APP_BUILDER_TOOLS[name] : null;
+}

--- a/lib/dsg/app-builder/proof/create-flow-proof.ts
+++ b/lib/dsg/app-builder/proof/create-flow-proof.ts
@@ -1,0 +1,90 @@
+/**
+ * Deterministic App Builder flow proof.
+ *
+ * Produces a stable, content-addressed description of the App Builder
+ * governance flow for a given goal. It enumerates the ordered gate stages the
+ * flow must pass and derives a deterministic proof hash over them via the
+ * runtime canonical hasher, so the same goal always yields the same proof hash.
+ *
+ * This is evidence-mapping scaffold output. It records the intended flow and a
+ * tamper-evident hash; it is not proof that any external build, deploy, or
+ * production step actually executed.
+ */
+
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+
+export type AppBuilderFlowStage = {
+  id: string;
+  label: string;
+  /** Gate semantics for this stage. */
+  gate: 'plan' | 'approval' | 'runtime' | 'build' | 'evidence';
+  /** What must be true before the flow may advance past this stage. */
+  requirement: string;
+};
+
+export type AppBuilderFlowProof = {
+  ok: true;
+  kind: 'app_builder_flow_proof';
+  goal: string;
+  generatedAt: string;
+  stages: AppBuilderFlowStage[];
+  /** Deterministic hash over goal + ordered stage definitions. */
+  proofHash: string;
+  truthBoundary: string;
+};
+
+const FLOW_STAGES: AppBuilderFlowStage[] = [
+  {
+    id: 'plan',
+    label: 'Visible plan generated',
+    gate: 'plan',
+    requirement: 'A human-readable plan snapshot exists before any execution.',
+  },
+  {
+    id: 'approval',
+    label: 'Plan approved',
+    gate: 'approval',
+    requirement: 'An authorized actor approves the plan; planHash is locked.',
+  },
+  {
+    id: 'runtime',
+    label: 'Runtime environment provisioned',
+    gate: 'runtime',
+    requirement: 'Runtime environment + action-layer contract prepared under approval.',
+  },
+  {
+    id: 'build',
+    label: 'Implementation PR generated',
+    gate: 'build',
+    requirement: 'Generated files written to a branch and a pull request opened.',
+  },
+  {
+    id: 'evidence',
+    label: 'Evidence recorded',
+    gate: 'evidence',
+    requirement: 'Audit event + evidence references captured; no evidence means block.',
+  },
+];
+
+/**
+ * Build a deterministic App Builder flow proof for `goal`.
+ *
+ * The proof hash covers the goal and the ordered stage definitions only, so it
+ * is reproducible. The `generatedAt` timestamp is metadata and intentionally
+ * excluded from the hash.
+ */
+export function createAppBuilderFlowProof(goal: string): AppBuilderFlowProof {
+  const normalizedGoal = goal.trim();
+  const proofHash = sha256Json({ goal: normalizedGoal, stages: FLOW_STAGES });
+
+  return {
+    ok: true,
+    kind: 'app_builder_flow_proof',
+    goal: normalizedGoal,
+    generatedAt: new Date().toISOString(),
+    stages: FLOW_STAGES,
+    proofHash,
+    truthBoundary:
+      'Deterministic flow + proof hash only. Records the governed App Builder stages; not proof that build, CI, deploy, or production steps executed.',
+  };
+}

--- a/lib/dsg/connectors/katzilla.ts
+++ b/lib/dsg/connectors/katzilla.ts
@@ -1,0 +1,162 @@
+/**
+ * Katzilla external connector.
+ *
+ * Real HTTP connector to a Katzilla-compatible API. Configuration comes from
+ * environment variables:
+ *   - KATZILLA_API_BASE (or KATZILLA_API_URL) — base URL, default https://api.katzilla.dev
+ *   - KATZILLA_API_KEY — sent as the `x-api-key` header
+ *
+ * When unconfigured (no API key), helpers fail gracefully and return a typed
+ * disabled/empty result instead of fabricating data. Server-side only; the API
+ * key is never logged or returned in responses.
+ */
+
+const DEFAULT_BASE = 'https://api.katzilla.dev';
+
+export type KatzillaStatus = {
+  configured: boolean;
+  baseUrl: string;
+  reason?: string;
+};
+
+export type KatzillaQueryResult = {
+  ok: boolean;
+  url: string;
+  status: number;
+  data: unknown;
+  error?: string;
+};
+
+export type KatzillaAgent = {
+  id: string;
+  name?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export type KatzillaAgentsResult = {
+  ok: boolean;
+  status: number;
+  agents: KatzillaAgent[];
+  error?: string;
+};
+
+function firstEnv(names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function getBaseUrl(): string {
+  return (firstEnv(['KATZILLA_API_BASE', 'KATZILLA_API_URL']) || DEFAULT_BASE).replace(/\/+$/, '');
+}
+
+function getApiKey(): string | undefined {
+  return firstEnv(['KATZILLA_API_KEY']);
+}
+
+/**
+ * Report whether the Katzilla connector is configured. Does not expose the key.
+ */
+export function getKatzillaStatus(): KatzillaStatus {
+  const baseUrl = getBaseUrl();
+  const configured = Boolean(getApiKey());
+  return {
+    configured,
+    baseUrl,
+    reason: configured ? undefined : 'KATZILLA_API_KEY not configured',
+  };
+}
+
+function buildUrl(path: string, params?: Record<string, string | number | boolean>): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const url = new URL(`${getBaseUrl()}${normalizedPath}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, String(v));
+    }
+  }
+  return url.toString();
+}
+
+/**
+ * Issue an authenticated GET to a Katzilla endpoint.
+ *
+ * Returns a typed result describing ok/status/url/data. Network/parse errors
+ * surface as `{ ok: false, ... }` rather than throwing, except for the
+ * unconfigured case which throws so callers can map it to "unavailable".
+ */
+export async function queryKatzilla(input: {
+  path: string;
+  params?: Record<string, string | number | boolean>;
+}): Promise<KatzillaQueryResult> {
+  const apiKey = getApiKey();
+  const url = buildUrl(input.path, input.params);
+
+  if (!apiKey) {
+    throw new Error('KATZILLA_API_KEY not configured');
+  }
+
+  let status = 0;
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'x-api-key': apiKey, accept: 'application/json' },
+      cache: 'no-store',
+    });
+    status = response.status;
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    return {
+      ok: response.ok,
+      url,
+      status,
+      data,
+      error: response.ok ? undefined : `KATZILLA_HTTP_${status}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      url,
+      status,
+      data: null,
+      error: error instanceof Error ? error.message : 'KATZILLA_QUERY_FAILED',
+    };
+  }
+}
+
+/**
+ * List agents registered in Katzilla. Returns a typed empty list when
+ * unconfigured or on error.
+ */
+export async function listKatzillaAgents(): Promise<KatzillaAgentsResult> {
+  const status = getKatzillaStatus();
+  if (!status.configured) {
+    return { ok: false, status: 503, agents: [], error: 'KATZILLA_API_KEY_REQUIRED' };
+  }
+
+  const path = firstEnv(['KATZILLA_AGENTS_PATH']) || '/v1/agents';
+  const result = await queryKatzilla({ path });
+  if (!result.ok) {
+    return {
+      ok: false,
+      status: result.status || 502,
+      agents: [],
+      error: result.error ?? 'KATZILLA_AGENTS_FAILED',
+    };
+  }
+
+  const data = result.data as unknown;
+  let agents: KatzillaAgent[] = [];
+  if (Array.isArray(data)) {
+    agents = data as KatzillaAgent[];
+  } else if (data && typeof data === 'object' && Array.isArray((data as { agents?: unknown }).agents)) {
+    agents = (data as { agents: KatzillaAgent[] }).agents;
+  } else if (data && typeof data === 'object' && Array.isArray((data as { data?: unknown }).data)) {
+    agents = (data as { data: KatzillaAgent[] }).data;
+  }
+
+  return { ok: true, status: result.status || 200, agents };
+}

--- a/lib/dsg/runtime/hash.ts
+++ b/lib/dsg/runtime/hash.ts
@@ -1,0 +1,51 @@
+/**
+ * DSG runtime canonical hashing.
+ *
+ * Deterministic SHA-256 over a canonical (stable key order) JSON
+ * representation of a value. Pure and reproducible across runs and machines.
+ *
+ * Mirrors the style of lib/dsg/brain/hash-utils.ts (sha256Hash) but exposes
+ * the runtime-facing `sha256Json` name used by executors, seed engine, and
+ * skills.
+ */
+
+import { createHash } from 'crypto';
+
+/**
+ * Recursively sort object keys for stable JSON serialization.
+ * Arrays preserve order; plain objects are sorted by key.
+ */
+function stableSort(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(stableSort);
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = stableSort((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
+/**
+ * Canonical JSON string with stable key ordering.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(stableSort(value));
+}
+
+/**
+ * SHA-256 hex digest of the canonical JSON representation of `value`.
+ */
+export function sha256Json(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value), 'utf8').digest('hex');
+}
+
+/**
+ * SHA-256 hex digest of raw string content.
+ */
+export function sha256Raw(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}

--- a/lib/dsg/server/memory/context.ts
+++ b/lib/dsg/server/memory/context.ts
@@ -1,0 +1,22 @@
+/**
+ * Request context for DSG persistent memory operations.
+ *
+ * Identifies the workspace and actor on whose behalf memory is read or written,
+ * along with the permission scopes granted to that actor for memory access.
+ */
+
+export type DsgMemoryRequestContext = {
+  /** Workspace the memory rows belong to (org/workspace scoping). */
+  workspaceId: string;
+  /** Actor performing the memory operation. */
+  actorId: string;
+  /** Actor's role label (e.g. 'customer', 'operator'). */
+  actorRole: string;
+  /** Granted memory permission scopes (e.g. 'memory:read', 'memory:write'). */
+  permissions: string[];
+};
+
+/** Whether the context grants a specific memory permission scope. */
+export function hasMemoryPermission(ctx: DsgMemoryRequestContext, scope: string): boolean {
+  return ctx.permissions.includes(scope);
+}

--- a/lib/dsg/server/memory/repository.ts
+++ b/lib/dsg/server/memory/repository.ts
@@ -1,0 +1,153 @@
+/**
+ * Supabase-backed repository for DSG persistent memory events.
+ *
+ * Reads and writes the `dsg_memory_events` table via the server-side PostgREST
+ * helpers. Server-only (uses the service-role config). On any database or
+ * configuration failure these functions throw; callers are expected to catch
+ * and degrade gracefully. They never fabricate rows.
+ *
+ * Note: this assumes a `dsg_memory_events` table scoped by `workspace_id` with
+ * the columns mapped below. If the table is absent the underlying REST call
+ * throws and the caller treats memory as unavailable.
+ */
+
+import {
+  getDsgSupabaseRpcConfig,
+  readDsgRest,
+} from '@/lib/dsg/server/supabase-rpc';
+import type { DsgMemoryRequestContext } from './context';
+import type {
+  DsgMemoryEvent,
+  DsgMemoryIngestInput,
+  DsgMemoryKind,
+  DsgMemorySourceType,
+  DsgMemoryStatus,
+  DsgMemoryTrustLevel,
+} from './types';
+
+const TABLE = 'dsg_memory_events';
+
+/** Raw PostgREST row shape (snake_case columns). */
+type MemoryRow = {
+  id: string;
+  workspace_id: string;
+  actor_id: string;
+  memory_kind: string;
+  source_type: string;
+  raw_text: string;
+  normalized_summary: string | null;
+  trust_level: string;
+  status: string;
+  contains_secret: boolean | null;
+  contains_pii: boolean | null;
+  contains_legal_claim: boolean | null;
+  contains_production_claim: boolean | null;
+  content_hash: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+};
+
+function toEvent(row: MemoryRow): DsgMemoryEvent {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    actorId: row.actor_id,
+    memoryKind: row.memory_kind as DsgMemoryKind,
+    sourceType: row.source_type as DsgMemorySourceType,
+    rawText: row.raw_text,
+    normalizedSummary: row.normalized_summary ?? '',
+    trustLevel: row.trust_level as DsgMemoryTrustLevel,
+    status: row.status as DsgMemoryStatus,
+    containsSecret: Boolean(row.contains_secret),
+    containsPii: Boolean(row.contains_pii),
+    containsLegalClaim: Boolean(row.contains_legal_claim),
+    containsProductionClaim: Boolean(row.contains_production_claim),
+    contentHash: row.content_hash,
+    metadata: row.metadata ?? {},
+    createdAt: row.created_at,
+  };
+}
+
+const SELECT_COLUMNS =
+  'id,workspace_id,actor_id,memory_kind,source_type,raw_text,normalized_summary,trust_level,status,contains_secret,contains_pii,contains_legal_claim,contains_production_claim,content_hash,metadata,created_at';
+
+/**
+ * Insert a memory event for the actor/workspace in `ctx` and return the stored
+ * row. Uses a PostgREST insert with `Prefer: return=representation`.
+ */
+export async function ingestMemory(
+  ctx: DsgMemoryRequestContext,
+  payload: DsgMemoryIngestInput,
+): Promise<DsgMemoryEvent> {
+  const config = getDsgSupabaseRpcConfig();
+
+  const body = {
+    workspace_id: ctx.workspaceId,
+    actor_id: ctx.actorId,
+    memory_kind: payload.memoryKind,
+    source_type: payload.sourceType,
+    raw_text: payload.rawText,
+    normalized_summary: payload.normalizedSummary,
+    trust_level: payload.trustLevel,
+    status: payload.status,
+    contains_secret: payload.containsSecret,
+    contains_pii: payload.containsPii,
+    contains_legal_claim: payload.containsLegalClaim,
+    contains_production_claim: payload.containsProductionClaim,
+    content_hash: payload.contentHash,
+    metadata: payload.metadata ?? {},
+  };
+
+  const res = await fetch(`${config.url}/rest/v1/${TABLE}?select=${encodeURIComponent(SELECT_COLUMNS)}`, {
+    method: 'POST',
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.key}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Memory ingest failed (${res.status}): ${detail}`);
+  }
+
+  const rows = (await res.json()) as MemoryRow[];
+  if (!rows.length) {
+    throw new Error('Memory ingest returned no row');
+  }
+  return toEvent(rows[0]);
+}
+
+/**
+ * Search memory events for the workspace in `ctx`. When `query` is provided it
+ * is matched (case-insensitive substring) against `normalized_summary` via
+ * PostgREST `ilike`. Results are newest-first and limited by `opts.limit`.
+ */
+export async function searchMemory(
+  ctx: DsgMemoryRequestContext,
+  opts: { query?: string; limit: number },
+): Promise<DsgMemoryEvent[]> {
+  const config = getDsgSupabaseRpcConfig();
+
+  const params: Record<string, string> = {
+    select: SELECT_COLUMNS,
+    workspace_id: `eq.${ctx.workspaceId}`,
+    order: 'created_at.desc',
+    limit: String(Math.max(1, opts.limit)),
+  };
+
+  const query = opts.query?.trim();
+  if (query) {
+    // Escape PostgREST ilike wildcards in the user-provided fragment.
+    const safe = query.replace(/[%*,]/g, ' ').trim();
+    if (safe) params.normalized_summary = `ilike.*${safe}*`;
+  }
+
+  const rows = await readDsgRest<MemoryRow[]>(config, TABLE, params);
+  return rows.map(toEvent);
+}

--- a/lib/dsg/server/memory/route-utils.ts
+++ b/lib/dsg/server/memory/route-utils.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure helpers for shaping and gating DSG memory before it is injected into a
+ * prompt context. No I/O — these operate on in-memory rows only.
+ *
+ * The memory gate enforces the boundary that memory is context, not evidence:
+ * it filters out secret-bearing rows, downgrades or excludes unverified claims
+ * when verified evidence is required, and reports the reasons for its decision.
+ */
+
+import { createHash } from 'crypto';
+import type { DsgMemoryEvent } from './types';
+
+/** SHA-256 hex digest of a raw string. */
+export function sha256(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+export type MemoryGateOptions = {
+  /** What the memory is being assembled for (informational, recorded in reasons). */
+  purpose: string;
+  /** When true, only verified-evidence-grade rows may carry legal/production claims. */
+  requireVerifiedEvidence: boolean;
+};
+
+export type MemoryGateResult = {
+  /** Ids of memories cleared for inclusion in the context. */
+  allowedMemoryIds: string[];
+  /** Overall gate status. */
+  status: 'allow' | 'partial' | 'block';
+  /** Human-readable reasons for the decision. */
+  reasons: string[];
+};
+
+/**
+ * Decide which memory rows may be injected into the context.
+ *
+ * Rules:
+ *  - Rows flagged `containsSecret` are always excluded.
+ *  - Rows with status `rejected` or `archived` are excluded.
+ *  - When `requireVerifiedEvidence` is true, rows carrying legal or production
+ *    claims are excluded unless their trust level is `verified_evidence`.
+ *  - Remaining rows are allowed.
+ */
+export function evaluateMemoryGate(
+  memories: DsgMemoryEvent[],
+  opts: MemoryGateOptions,
+): MemoryGateResult {
+  const allowedMemoryIds: string[] = [];
+  const reasons: string[] = [`purpose:${opts.purpose}`];
+  let excluded = 0;
+
+  for (const memory of memories) {
+    if (memory.containsSecret) {
+      excluded += 1;
+      reasons.push(`excluded:${memory.id}:CONTAINS_SECRET`);
+      continue;
+    }
+    if (memory.status === 'rejected' || memory.status === 'archived') {
+      excluded += 1;
+      reasons.push(`excluded:${memory.id}:STATUS_${memory.status.toUpperCase()}`);
+      continue;
+    }
+    if (
+      opts.requireVerifiedEvidence &&
+      (memory.containsLegalClaim || memory.containsProductionClaim) &&
+      memory.trustLevel !== 'verified_evidence'
+    ) {
+      excluded += 1;
+      reasons.push(`excluded:${memory.id}:UNVERIFIED_CLAIM_REQUIRES_EVIDENCE`);
+      continue;
+    }
+    allowedMemoryIds.push(memory.id);
+  }
+
+  let status: MemoryGateResult['status'];
+  if (allowedMemoryIds.length === 0 && memories.length > 0) {
+    status = 'block';
+  } else if (excluded > 0) {
+    status = 'partial';
+  } else {
+    status = 'allow';
+  }
+
+  if (excluded === 0) reasons.push('no_rows_excluded');
+
+  return { allowedMemoryIds, status, reasons };
+}
+
+/**
+ * Render the allowed memories into a compact text block for prompt injection.
+ * Only rows present in `gate.allowedMemoryIds` are included.
+ */
+export function buildContextText(
+  memories: DsgMemoryEvent[],
+  gate: MemoryGateResult,
+): string {
+  const allowed = new Set(gate.allowedMemoryIds);
+  const lines = memories
+    .filter((memory) => allowed.has(memory.id))
+    .map((memory) => {
+      const summary = (memory.normalizedSummary || memory.rawText).replace(/\s+/g, ' ').trim();
+      return `- [${memory.memoryKind}] (${memory.trustLevel}) ${summary}`;
+    });
+
+  if (!lines.length) {
+    return '[NO_ALLOWED_PERSISTENT_MEMORY]';
+  }
+
+  return [
+    `Persistent memory (gate: ${gate.status}, ${lines.length} item${lines.length === 1 ? '' : 's'}):`,
+    ...lines,
+  ].join('\n');
+}

--- a/lib/dsg/server/memory/types.ts
+++ b/lib/dsg/server/memory/types.ts
@@ -1,0 +1,75 @@
+/**
+ * DSG persistent memory types.
+ *
+ * A memory event is durable context captured from conversations and other
+ * sources. Memory is context, not evidence: it can inform planning but must
+ * never override current user input, verified evidence, database truth, or
+ * permission gates.
+ */
+
+/** Category of a memory event, used for retrieval and gating. */
+export type DsgMemoryKind =
+  | 'requirement'
+  | 'workflow'
+  | 'risk'
+  | 'evidence'
+  | 'policy'
+  | 'project_context';
+
+/** Where the memory originated. */
+export type DsgMemorySourceType =
+  | 'conversation'
+  | 'document'
+  | 'system'
+  | 'import'
+  | 'agent';
+
+/** How much the memory content can be trusted by default. */
+export type DsgMemoryTrustLevel =
+  | 'user_supplied'
+  | 'system_generated'
+  | 'verified_evidence'
+  | 'untrusted';
+
+/** Lifecycle status of a memory row. */
+export type DsgMemoryStatus = 'active' | 'conflicted' | 'archived' | 'rejected';
+
+/**
+ * Payload accepted by `ingestMemory`. Identity, workspace, and audit fields are
+ * supplied by the repository from the request context; everything else is the
+ * caller-provided content and classification.
+ */
+export type DsgMemoryIngestInput = {
+  memoryKind: DsgMemoryKind;
+  sourceType: DsgMemorySourceType;
+  rawText: string;
+  normalizedSummary: string;
+  trustLevel: DsgMemoryTrustLevel;
+  status: DsgMemoryStatus;
+  containsSecret: boolean;
+  containsPii: boolean;
+  containsLegalClaim: boolean;
+  containsProductionClaim: boolean;
+  contentHash: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** A stored memory event row. */
+export type DsgMemoryEvent = {
+  id: string;
+  workspaceId: string;
+  actorId: string;
+  memoryKind: DsgMemoryKind;
+  sourceType: DsgMemorySourceType;
+  rawText: string;
+  normalizedSummary: string;
+  trustLevel: DsgMemoryTrustLevel;
+  status: DsgMemoryStatus;
+  containsSecret: boolean;
+  containsPii: boolean;
+  containsLegalClaim: boolean;
+  containsProductionClaim: boolean;
+  contentHash: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+};

--- a/lib/dsg/server/supabase-rpc.ts
+++ b/lib/dsg/server/supabase-rpc.ts
@@ -1,0 +1,122 @@
+/**
+ * DSG server-side Supabase REST/RPC helpers.
+ *
+ * Thin, dependency-free wrappers over Supabase PostgREST. Used by DSG API
+ * route handlers and server-side libraries. Server-only: relies on the
+ * service-role key by default and must never run in client components.
+ *
+ * Secrets are never logged or returned in error messages.
+ */
+
+export type DsgSupabaseRpcConfig = {
+  /** Supabase project base URL (no trailing slash). */
+  url: string;
+  /** apikey used for PostgREST/RPC requests (service-role on the server). */
+  key: string;
+};
+
+/**
+ * Parse a Bearer token from an `Authorization` header.
+ * Returns the raw token (no `Bearer ` prefix) or null when absent/malformed.
+ */
+export function getBearerToken(headers: Headers): string | null {
+  const raw = headers.get('authorization') ?? headers.get('Authorization');
+  if (!raw) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(raw.trim());
+  if (!match) return null;
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Resolve the Supabase RPC config for server-side calls.
+ *
+ * The URL comes from NEXT_PUBLIC_SUPABASE_URL. The key is the service-role
+ * key (privileged server access). An optional caller access token is accepted
+ * for callers that wish to act on behalf of a user; it is surfaced via the
+ * returned config's `key` only when a service-role key is not configured, so
+ * that least-privilege still applies. Secrets are never logged.
+ */
+export function getDsgSupabaseRpcConfig(userAccessToken?: string): DsgSupabaseRpcConfig {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
+  }
+
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  // Prefer service-role on the server. Fall back to the supplied user token,
+  // then the public anon key, so reads still work in less-privileged contexts.
+  const key = serviceRoleKey ?? userAccessToken ?? anonKey;
+  if (!key) {
+    throw new Error('Missing Supabase server credentials');
+  }
+
+  return { url: url.replace(/\/+$/, ''), key };
+}
+
+function buildHeaders(config: DsgSupabaseRpcConfig, extra?: Record<string, string>): HeadersInit {
+  return {
+    apikey: config.key,
+    Authorization: `Bearer ${config.key}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...extra,
+  };
+}
+
+/**
+ * Read rows from a PostgREST table.
+ *
+ * `query` is a flat map of PostgREST query params, e.g.
+ * `{ select: 'id,name', id: 'eq.123', limit: '1' }`.
+ */
+export async function readDsgRest<T>(
+  config: DsgSupabaseRpcConfig,
+  table: string,
+  query: Record<string, string>,
+): Promise<T> {
+  const target = new URL(`${config.url}/rest/v1/${table}`);
+  for (const [k, v] of Object.entries(query)) {
+    target.searchParams.set(k, v);
+  }
+
+  const res = await fetch(target, {
+    method: 'GET',
+    headers: buildHeaders(config),
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Supabase REST read failed for ${table} (${res.status}): ${detail}`);
+  }
+
+  return (await res.json()) as T;
+}
+
+/**
+ * Invoke a PostgREST RPC (database function).
+ */
+export async function callDsgRpc<T = unknown>(
+  config: DsgSupabaseRpcConfig,
+  fnName: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${config.url}/rest/v1/rpc/${fnName}`, {
+    method: 'POST',
+    headers: buildHeaders(config),
+    body: JSON.stringify(params ?? {}),
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Supabase RPC ${fnName} failed (${res.status}): ${detail}`);
+  }
+
+  const text = await res.text();
+  if (!text) return undefined as T;
+  return JSON.parse(text) as T;
+}

--- a/lib/dsg/tools/governed-tools.ts
+++ b/lib/dsg/tools/governed-tools.ts
@@ -1,0 +1,108 @@
+/**
+ * Governed tool request preparation.
+ *
+ * A deterministic pre-execution gate for tool/skill actions. It does not
+ * execute anything itself; it validates the request shape, requires evidence
+ * for write-class actions, and returns a gate decision plus a content-addressed
+ * audit id. Callers run the action only when `ok` is true and `status` is
+ * `ready`.
+ *
+ * Boundary: this is a static governance scaffold. A `ready` decision means the
+ * request satisfied the deterministic checks here — it is not proof that the
+ * downstream tool executed or succeeded.
+ */
+
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+
+export type GovernedToolKind = 'api' | 'browser' | 'filesystem' | 'shell' | 'mcp';
+
+export type GovernedToolAction = 'query' | 'create' | 'update' | 'delete' | 'execute';
+
+export type GovernedToolRequest = {
+  tool: GovernedToolKind;
+  action: GovernedToolAction;
+  goal: string;
+  args?: Record<string, unknown>;
+  evidence?: string[];
+};
+
+export type GovernedToolGateStatus = 'ready' | 'review' | 'blocked';
+
+export type GovernedToolAudit = {
+  id: string;
+  tool: GovernedToolKind;
+  action: GovernedToolAction;
+  decidedAt: string;
+};
+
+export type GovernedToolDecision = {
+  ok: boolean;
+  status: GovernedToolGateStatus;
+  blockedReasons: string[];
+  reviewReasons: string[];
+  requestHash: string;
+  audit: GovernedToolAudit;
+};
+
+/** Write-class actions mutate external state and require evidence to proceed. */
+const WRITE_ACTIONS: GovernedToolAction[] = ['create', 'update', 'delete', 'execute'];
+
+/**
+ * Evaluate a governed tool request and return a deterministic gate decision.
+ *
+ * Rules:
+ *  - A goal is always required.
+ *  - Write-class actions must carry at least one evidence item, otherwise they
+ *    are blocked. Read-class actions without evidence drop to review, not pass.
+ *  - The audit id is derived from a canonical hash of the request so equal
+ *    requests produce equal audit ids.
+ */
+export function prepareGovernedToolRequest(request: GovernedToolRequest): GovernedToolDecision {
+  const blockedReasons: string[] = [];
+  const reviewReasons: string[] = [];
+
+  const goal = request.goal?.trim() ?? '';
+  if (!goal) {
+    blockedReasons.push('GOAL_REQUIRED');
+  }
+
+  const evidence = (request.evidence ?? []).filter((item) => typeof item === 'string' && item.trim().length > 0);
+  const isWrite = WRITE_ACTIONS.includes(request.action);
+
+  if (isWrite && evidence.length === 0) {
+    blockedReasons.push('EVIDENCE_REQUIRED_FOR_WRITE_ACTION');
+  } else if (!isWrite && evidence.length === 0) {
+    reviewReasons.push('NO_EVIDENCE_PROVIDED_FOR_READ_ACTION');
+  }
+
+  const requestHash = sha256Json({
+    tool: request.tool,
+    action: request.action,
+    goal,
+    args: request.args ?? {},
+    evidence,
+  });
+
+  let status: GovernedToolGateStatus;
+  if (blockedReasons.length > 0) {
+    status = 'blocked';
+  } else if (reviewReasons.length > 0) {
+    status = 'review';
+  } else {
+    status = 'ready';
+  }
+
+  return {
+    ok: status === 'ready',
+    status,
+    blockedReasons,
+    reviewReasons,
+    requestHash,
+    audit: {
+      id: `gov:${request.tool}:${request.action}:${requestHash.slice(0, 16)}`,
+      tool: request.tool,
+      action: request.action,
+      decidedAt: new Date().toISOString(),
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "^15.5.18",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "recharts": "^2.15.4",
         "stripe": "^14.0.0"
       },
       "devDependencies": {
@@ -588,6 +589,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3821,6 +3831,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5685,6 +5758,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
@@ -5801,8 +5883,128 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5891,6 +6093,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -6007,6 +6215,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dotenv": {
@@ -6834,6 +7052,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6886,6 +7110,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -7699,6 +7932,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8496,6 +8738,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
@@ -9005,7 +9253,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9619,7 +9866,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9708,8 +9954,38 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -9743,6 +10019,45 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -11108,6 +11423,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11555,6 +11876,28 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "next": "^15.5.18",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "recharts": "^2.15.4",
     "stripe": "^14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closed without merging — redundant and unsafe.

Root cause: this branch was built from a severely stale local checkout (94386d5). On that stale snapshot the dsg modules appeared "missing", so they were reconstructed here. But current `main` (aa042e1) ALREADY contains all of them with fuller implementations — e.g. `lib/dsg/tools/governed-tools.ts` is ~55KB on main vs the ~108-line reconstruction here, and `recharts` is already pinned at `^3.8.1` (this PR would have downgraded it to ^2.15.4). Merging would clobber canonical code and downgrade a dependency.

No action needed on main — the modules exist and typecheck is not broken there. Closing to avoid overwriting better code.

https://claude.ai/code/session_01Sc63G8Mzha2WmjLpGUHLZe