### PR TITLE
fix(og): remove invalid generateMetadata export from route handler

### DIFF
--- a/app/og/delivery-proof/route.tsx
+++ b/app/og/delivery-proof/route.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
@@ -124,12 +123,4 @@ export async function GET(
       height: 630,
     }
   );
-}
-
-export async function generateMetadata({ params }: { params: Promise<{ run_id: string }> }): Promise<Metadata> {
-  const { run_id } = await params;
-  return {
-    title: `Delivery Proof Report — ${run_id} — DSG ONE`,
-    description: 'AI governance proof report with pre-execution gate verification.',
-  };
 }


### PR DESCRIPTION
generateMetadata is only valid in page.tsx files, not route handlers.
Caused Next.js type error during build.

https://claude.ai/code/session_01ApUQZYueUz1PeVE45AKJUT