### PR TITLE
fix: build errors — og route metadata + spine type cast

### DIFF
--- a/app/api/spine/execute/route.ts
+++ b/app/api/spine/execute/route.ts
@@ -138,7 +138,7 @@ export async function POST(request: Request) {
         decision: (result.body as Record<string, unknown>)?.decision ?? null,
       });
       const executionId =
-        (result.body as Record<string, unknown>)?.execution_id ??
+        ((result.body as Record<string, unknown>)?.execution_id as string | undefined) ??
         randomUUID();
       void meterExecution(orgId, 1, executionId);
     }

--- a/app/og/delivery-proof/route.tsx
+++ b/app/og/delivery-proof/route.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
@@ -124,12 +123,4 @@ export async function GET(
       height: 630,
     }
   );
-}
-
-export async function generateMetadata({ params }: { params: Promise<{ run_id: string }> }): Promise<Metadata> {
-  const { run_id } = await params;
-  return {
-    title: `Delivery Proof Report — ${run_id} — DSG ONE`,
-    description: 'AI governance proof report with pre-execution gate verification.',
-  };
 }


### PR DESCRIPTION
Fix two Next.js build errors blocking Vercel deployment.

**Changes:**
- `app/og/delivery-proof/route.tsx` — remove invalid `generateMetadata` export (only valid in page.tsx)
- `app/api/spine/execute/route.ts` — cast `execution_id` to `string` to fix TypeScript type error

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApUQZYueUz1PeVE45AKJUT)_