### PR TITLE
feat(agent-chat): OpenRouter free-model provider (give DadBot a brain)

### DIFF
--- a/app/api/agent/chat/route.ts
+++ b/app/api/agent/chat/route.ts
@@ -1,4 +1,6 @@
-// DadBot streaming chat endpoint — proxies to Anthropic Claude with DSG command tools
+// DadBot streaming chat endpoint — DSG command tools.
+// Provider: OpenRouter (free models, e.g. Nemotron) when OPENROUTER_API_KEY is
+// set, otherwise Anthropic Claude. Model is overridable via DSG_DADBOT_MODEL.
 import { NextRequest } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -25,42 +27,66 @@ const SYSTEM_PROMPT = `คุณคือ DadBot (แดดบอท) ผู้�
 - เมื่อผู้ใช้สั่งให้ทำอะไรบนเครื่อง ให้ใช้ tool queue_command ทันที ไม่ต้องถามซ้ำ
 - แจ้งผู้ใช้สั้น ๆ ว่ากำลังทำอะไร แล้วค่อย call tool`;
 
-const DSG_TOOLS = [
-  {
-    name: 'queue_command',
-    description: "Queue a command for immediate execution on the owner's Android device",
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        command_type: {
-          type: 'string',
-          enum: [
-            'OPEN_URL', 'OPEN_APP', 'OPEN_SETTINGS', 'BACK', 'HOME', 'SCROLL_DOWN',
-            'STATUS', 'FILE_LIST_ROOT', 'FILE_PREVIEW', 'FILE_RENAME', 'FILE_MOVE', 'FILE_DELETE',
-          ],
-        },
-        target: { type: 'string', description: 'Target for the command (URL, package, path, etc.)' },
-        reason: { type: 'string', description: 'Short human-readable reason' },
-      },
-      required: ['command_type', 'target', 'reason'],
-    },
-  },
+const COMMAND_ENUM = [
+  'OPEN_URL', 'OPEN_APP', 'OPEN_SETTINGS', 'BACK', 'HOME', 'SCROLL_DOWN',
+  'STATUS', 'FILE_LIST_ROOT', 'FILE_PREVIEW', 'FILE_RENAME', 'FILE_MOVE', 'FILE_DELETE',
 ];
 
+const TOOL_PARAMETERS = {
+  type: 'object' as const,
+  properties: {
+    command_type: { type: 'string', enum: COMMAND_ENUM },
+    target: { type: 'string', description: 'Target for the command (URL, package, path, etc.)' },
+    reason: { type: 'string', description: 'Short human-readable reason' },
+  },
+  required: ['command_type', 'target', 'reason'],
+};
+
+const TOOL_DESCRIPTION = "Queue a command for immediate execution on the owner's Android device";
+
+// Anthropic tool shape
+const DSG_TOOLS = [
+  { name: 'queue_command', description: TOOL_DESCRIPTION, input_schema: TOOL_PARAMETERS },
+];
+
+// OpenAI / OpenRouter tool shape
+const OPENAI_TOOLS = [
+  { type: 'function', function: { name: 'queue_command', description: TOOL_DESCRIPTION, parameters: TOOL_PARAMETERS } },
+];
+
+const DEFAULT_OPENROUTER_MODEL = 'nvidia/nemotron-3-ultra-550b-a55b:free';
+const DEFAULT_ANTHROPIC_MODEL = 'claude-haiku-4-5-20251001';
+
+function activeProvider(): { provider: 'openrouter' | 'anthropic'; model: string } | null {
+  if (process.env.OPENROUTER_API_KEY) {
+    return {
+      provider: 'openrouter',
+      model: process.env.DSG_DADBOT_MODEL || process.env.OPENROUTER_MODEL || DEFAULT_OPENROUTER_MODEL,
+    };
+  }
+  if (process.env.ANTHROPIC_API_KEY) {
+    return { provider: 'anthropic', model: process.env.DSG_DADBOT_MODEL || DEFAULT_ANTHROPIC_MODEL };
+  }
+  return null;
+}
+
 export async function GET() {
+  const active = activeProvider();
   return Response.json({
     ok: true,
     endpoint: 'POST /api/agent/chat',
     body: '{ messages: [{role: "user"|"assistant", content: string}] }',
     stream: 'text/event-stream — {"type":"text","delta":"..."} | {"type":"command",...} | {"type":"done"} | {"type":"error",...}',
-    model: 'claude-haiku-4-5-20251001',
+    provider: active?.provider ?? 'none',
+    model: active?.model ?? null,
+    note: 'Set OPENROUTER_API_KEY for free models (default nemotron-3-ultra:free) or ANTHROPIC_API_KEY. Override the model with DSG_DADBOT_MODEL.',
   });
 }
 
 export async function POST(request: NextRequest) {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return sseError('ANTHROPIC_API_KEY not configured on server');
+  const active = activeProvider();
+  if (!active) {
+    return sseError('No LLM provider configured. Set OPENROUTER_API_KEY (free models) or ANTHROPIC_API_KEY on the server.');
   }
 
   let messages: { role: string; content: string }[] = [];
@@ -70,9 +96,125 @@ export async function POST(request: NextRequest) {
   } catch {
     return sseError('Invalid JSON body');
   }
-
   if (messages.length === 0) return sseError('messages array is empty');
 
+  return active.provider === 'openrouter'
+    ? streamOpenRouter(process.env.OPENROUTER_API_KEY!, active.model, messages)
+    : streamAnthropic(process.env.ANTHROPIC_API_KEY!, active.model, messages);
+}
+
+// ── OpenRouter (OpenAI-compatible, free models e.g. Nemotron) ────────────────
+async function streamOpenRouter(
+  apiKey: string,
+  model: string,
+  messages: { role: string; content: string }[],
+): Promise<Response> {
+  let upstream: Response;
+  try {
+    upstream = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://tdealer01-crypto-dsg-control-plane.vercel.app',
+        'X-Title': 'DSG ONE ProofGate',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1024,
+        stream: true,
+        messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
+        tools: OPENAI_TOOLS,
+      }),
+    });
+  } catch (e) {
+    return sseError(`Failed to reach OpenRouter: ${e instanceof Error ? e.message : e}`);
+  }
+  if (!upstream.ok || !upstream.body) {
+    const errText = await upstream.text().catch(() => '');
+    return sseError(`OpenRouter ${upstream.status} (${model}): ${errText.slice(0, 200)}`);
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      const emit = (obj: unknown) => controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+      const reader = upstream.body!.getReader();
+      const dec = new TextDecoder();
+      let buf = '';
+      const toolCalls = new Map<number, { name: string; args: string }>();
+
+      const flushTools = () => {
+        for (const tc of toolCalls.values()) {
+          let args: Record<string, unknown> = {};
+          try { args = JSON.parse(tc.args || '{}'); } catch { /* skip */ }
+          emit({
+            type: 'command',
+            commandType: args.command_type ?? 'STATUS',
+            target: args.target ?? '',
+            reason: args.reason ?? tc.name,
+          });
+        }
+        toolCalls.clear();
+      };
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += dec.decode(value, { stream: true });
+          const lines = buf.split('\n');
+          buf = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const raw = line.slice(6).trim();
+            if (!raw || raw === '[DONE]') continue;
+            let ev: Record<string, unknown>;
+            try { ev = JSON.parse(raw); } catch { continue; }
+
+            const choice = (ev.choices as Array<Record<string, unknown>> | undefined)?.[0];
+            if (!choice) continue;
+            const delta = choice.delta as Record<string, unknown> | undefined;
+
+            if (typeof delta?.content === 'string' && delta.content.length > 0) {
+              emit({ type: 'text', delta: delta.content });
+            }
+
+            const tcs = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+            if (tcs) {
+              for (const tc of tcs) {
+                const idx = (tc.index as number) ?? 0;
+                const fn = tc.function as Record<string, unknown> | undefined;
+                const cur = toolCalls.get(idx) ?? { name: '', args: '' };
+                if (typeof fn?.name === 'string') cur.name = fn.name;
+                if (typeof fn?.arguments === 'string') cur.args += fn.arguments;
+                toolCalls.set(idx, cur);
+              }
+            }
+
+            if (choice.finish_reason) flushTools();
+          }
+        }
+        flushTools();
+        emit({ type: 'done' });
+      } catch (e) {
+        emit({ type: 'error', message: e instanceof Error ? e.message : 'Stream read error' });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return sseResponse(stream);
+}
+
+// ── Anthropic Claude ─────────────────────────────────────────────────────────
+async function streamAnthropic(
+  apiKey: string,
+  model: string,
+  messages: { role: string; content: string }[],
+): Promise<Response> {
   let anthropicRes: Response;
   try {
     anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
@@ -83,7 +225,7 @@ export async function POST(request: NextRequest) {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
+        model,
         max_tokens: 1024,
         stream: true,
         system: SYSTEM_PROMPT,
@@ -103,8 +245,7 @@ export async function POST(request: NextRequest) {
   const stream = new ReadableStream({
     async start(controller) {
       const enc = new TextEncoder();
-      const emit = (obj: unknown) =>
-        controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+      const emit = (obj: unknown) => controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
 
       const reader = anthropicRes.body!.getReader();
       const dec = new TextDecoder();
@@ -163,6 +304,10 @@ export async function POST(request: NextRequest) {
     },
   });
 
+  return sseResponse(stream);
+}
+
+function sseResponse(stream: ReadableStream): Response {
   return new Response(stream, {
     headers: {
       'Content-Type': 'text/event-stream',


### PR DESCRIPTION
Goal:
Give DadBot a working "brain" using a free model. `/api/agent/chat` was hardcoded to Anthropic Claude Haiku; with no working key it produced canned fallback replies. This adds an OpenRouter (OpenAI-compatible) streaming provider so free models work — default `nvidia/nemotron-3-ultra-550b-a55b:free` (the slug for "nemotron-3-ultra:free").

What changed (1 file: `app/api/agent/chat/route.ts`):
- Provider auto-select: `OPENROUTER_API_KEY` → OpenRouter; else `ANTHROPIC_API_KEY` → Claude; else a clear error.
- Model overridable via `DSG_DADBOT_MODEL` (or `OPENROUTER_MODEL`).
- OpenAI-format streaming + `tool_calls` parsed into the SAME `queue_command` SSE events the Android app already consumes (`{type:"text"}` / `{type:"command"}` / `{type:"done"}`). Anthropic path unchanged.
- `GET` reports the active provider/model.

Enablement (config — not in this PR): set `OPENROUTER_API_KEY` on the server (Vercel). Optionally `DSG_DADBOT_MODEL=nvidia/nemotron-3-ultra-550b-a55b:free` (it's the default). No secret is committed.

Verification:
- [x] `npm run typecheck` — no code errors. Local tsc is 6.0.2 and only emits the pre-existing tsconfig deprecation warnings (TS5101/TS5107); CI uses pinned tsc 5.8.3 which passes. No errors reference app/lib/route code.
- [ ] Live call not exercised here (needs `OPENROUTER_API_KEY` on the server).

Known limits:
- Runtime "brain" depends on the owner setting `OPENROUTER_API_KEY`. Until then it falls back to Anthropic (or errors if neither key is set).
- Free models can be rate-limited / slower; `DSG_DADBOT_MODEL` lets you switch (e.g. a nemotron nano/super variant).

https://claude.ai/code/session_01Sc63G8Mzha2WmjLpGUHLZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sc63G8Mzha2WmjLpGUHLZe)_