### PR TITLE
fix: address all Stripe App Review 1.0.2 rejection feedback

### DIFF
--- a/app/api/stripe/connect/install/route.ts
+++ b/app/api/stripe/connect/install/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 
-const DEFAULT_CONNECT_LINK_ID = 'chnlink_61UpJ0wqNe8NQ3pYF41AZNzhgTUPV4R6';
 const DEFAULT_CLIENT_ID = 'ca_UfEPAC4NcvG2nYAYjohDQ9GtDlIdajy6';
 const DEFAULT_CALLBACK_PATH = '/stripe/oauth/callback';
 
@@ -16,12 +15,12 @@ export function GET(request: Request) {
     return NextResponse.redirect(installUrl, { status: 302 });
   }
 
-  const linkId = process.env.STRIPE_CONNECT_LINK_ID || DEFAULT_CONNECT_LINK_ID;
   const clientId = process.env.STRIPE_CONNECT_CLIENT_ID || DEFAULT_CLIENT_ID;
   const callbackPath = process.env.STRIPE_CONNECT_CALLBACK_PATH || DEFAULT_CALLBACK_PATH;
   const redirectUri = new URL(callbackPath, getAppOrigin(request.url));
 
-  const url = new URL(`/oauth/v2/${linkId}/authorize`, 'https://marketplace.stripe.com');
+  // Use live mode public OAuth path — no channel/test link parameters
+  const url = new URL('/oauth/v2/authorize', 'https://marketplace.stripe.com');
   url.searchParams.set('client_id', clientId);
   url.searchParams.set('redirect_uri', redirectUri.toString());
 

--- a/app/dashboard/stripe-app/page.tsx
+++ b/app/dashboard/stripe-app/page.tsx
@@ -15,42 +15,36 @@ export default async function StripeAppPage() {
     redirect('/login?next=/dashboard/stripe-app');
   }
 
-  const installUrl =
-    process.env.STRIPE_APP_INSTALL_URL ||
-    'https://marketplace.stripe.com/oauth/v2/authorize?client_id=ca_UfEPAC4NcvG2nYAYjohDQ9GtDlIdajy6&redirect_uri=https%3A%2F%2Ftdealer01-crypto-dsg-control-plane.vercel.app%2Fstripe%2Foauth%2Fcallback';
-
   return (
     <div className="mx-auto max-w-7xl space-y-8 px-6 py-8">
       <div>
         <h1 className="text-3xl font-bold text-white">DSG Stripe App</h1>
         <p className="mt-2 text-slate-400">
-          Governance for Stripe operations - pre-execution gating + audit trails
+          Governance for Stripe operations — pre-execution gating and audit trails
         </p>
       </div>
 
-      {/* Install banner — primary entry point for Stripe marketplace install */}
+      {/* Primary CTA: Connect Stripe from this platform */}
       <div className="rounded-xl border border-violet-700/50 bg-violet-950/40 p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-wider text-violet-400">
-              Step 1 — Install on Stripe
+              Step 1 — Connect your Stripe account
             </p>
             <h2 className="mt-1 text-lg font-semibold text-white">
-              Add DSG Governance Gate to your Stripe account
+              Link Stripe to enable governance controls
             </h2>
             <p className="mt-1 text-sm text-slate-400">
-              Click the button to open the Stripe marketplace install flow. Authorize the
-              requested permissions and you will be redirected back here automatically.
+              Click below to authorize DSG Governance Gate. You will be taken through
+              Stripe&apos;s OAuth flow and returned here automatically.
             </p>
           </div>
-          <a
-            href={installUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            href="/dashboard/stripe-app/connect"
             className="shrink-0 rounded-lg bg-violet-600 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-violet-500"
           >
-            Install on Stripe ↗
-          </a>
+            Connect Stripe Account
+          </Link>
         </div>
       </div>
 

--- a/docs/phase9-stripe-submission/SUBMISSION_DATA.json
+++ b/docs/phase9-stripe-submission/SUBMISSION_DATA.json
@@ -1,11 +1,11 @@
 {
   "app_metadata": {
-    "app_id": "com.governance.dsg",
+    "app_id": "pics.dsg.governance",
     "app_name": "DSG Governance Gate",
-    "version": "1.0.0",
+    "version": "1.0.4",
     "distribution_type": "public",
     "sandbox_install_compatible": true,
-    "submission_date": "2026-06-07"
+    "submission_date": "2026-06-11"
   },
   "app_descriptions": {
     "about": "DSG Governance Gate is a governance platform for Stripe operations. It automatically evaluates charges, refunds, and disputes against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard. Audit records for each decision are shown within the app panel for compliance and review purposes.",
@@ -183,14 +183,9 @@
   "ui_extensions": {
     "views": [
       {
-        "viewport": "stripe.dashboard.charge.detail",
+        "viewport": "stripe.dashboard.payment.detail",
         "component": "ChargeGate",
-        "description": "Governance gate in charge detail view"
-      },
-      {
-        "viewport": "stripe.dashboard.payment_intent.detail",
-        "component": "PaymentIntentGate",
-        "description": "Governance gate in payment intent detail view"
+        "description": "Governance gate in payment detail view"
       },
       {
         "viewport": "stripe.dashboard.payout.detail",
@@ -209,7 +204,7 @@
   },
   "post_install_action": {
     "type": "external",
-    "url": "https://tdealer01-crypto-dsg-control-plane.vercel.app/stripe/onboarding"
+    "url": "https://tdealer01-crypto-dsg-control-plane.vercel.app/dashboard/stripe-app"
   },
   "submission_checklist": {
     "pre_submission": [

--- a/docs/phase9-stripe-submission/SUBMISSION_DATA.json
+++ b/docs/phase9-stripe-submission/SUBMISSION_DATA.json
@@ -8,19 +8,51 @@
     "submission_date": "2026-06-07"
   },
   "app_descriptions": {
-    "short_description": "Pre-execution governance gates for Stripe operations with deterministic audit trails and approval workflows",
-    "short_description_char_count": 138,
+    "about": "DSG Governance Gate is a governance platform for Stripe operations. It automatically evaluates charges, refunds, and disputes against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard. Audit records for each decision are shown within the app panel for compliance and review purposes.",
+    "about_char_count": 355,
+    "about_max": 1000,
+    "subtitle": "Automated policy gates to evaluate payments and manage transaction reviews.",
+    "subtitle_char_count": 75,
+    "subtitle_max": 80,
+    "key_features": [
+      {
+        "title": "Automated policy decisions",
+        "title_char_count": 26,
+        "title_max": 80,
+        "description": "Policy rules evaluate charges and refunds against configurable criteria. Decisions — ALLOW, BLOCK, or REVIEW — appear in the Stripe payment and payout detail panels for each transaction.",
+        "description_char_count": 186,
+        "description_max": 300
+      },
+      {
+        "title": "Decision audit log",
+        "title_char_count": 18,
+        "title_max": 80,
+        "description": "Each governance decision is recorded with a verifiable reference and timestamp, visible in the app drawer panel. Decision history supports compliance review and internal audit workflows.",
+        "description_char_count": 183,
+        "description_max": 300
+      },
+      {
+        "title": "Policy and approval management",
+        "title_char_count": 31,
+        "title_max": 80,
+        "description": "REVIEW-flagged transactions surface in the app drawer for operator awareness. Policy configuration and approval workflows are managed through the DSG platform, with outcomes displayed in the Stripe Dashboard panel.",
+        "description_char_count": 211,
+        "description_max": 300
+      }
+    ],
+    "short_description": "Automated policy gates to evaluate payments and manage transaction reviews.",
+    "short_description_char_count": 75,
     "short_description_max": 140,
-    "long_description": "DSG Governance Gate provides risk-managed pre-execution governance for Stripe operations.\n\nKey capabilities:\n- Deterministic policy evaluation before charges, refunds, and payouts execute\n- Immutable audit trails with cryptographic proof\n- Flexible approval workflows with role-based access control\n- Seamless OAuth integration with Stripe Connect\n- Real-time policy enforcement across your entire Stripe account\n\nUse cases:\n- Compliance-driven organizations requiring pre-execution governance\n- Multi-approval workflows for high-risk transactions\n- Audit trail requirements for regulatory compliance\n- Risk management with automated policy gates\n\nThe app integrates directly into your Stripe Dashboard, providing governance without requiring custom infrastructure.\n\nPermissions requested:\n- Read charges, payment intents, payouts, refunds for policy evaluation\n- Write decisions to charges for governance enforcement\n- Webhook access for real-time event processing\n\nAll governance decisions are recorded with cryptographic proof in an immutable ledger.",
-    "long_description_char_count": 915,
+    "long_description": "DSG Governance Gate is a governance platform for Stripe operations. It automatically evaluates charges, refunds, and disputes against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard.\n\nKey capabilities:\n- Automated policy evaluation for charges, refunds, and payouts\n- Decision audit log with verifiable records shown in the app panel\n- Approval workflow visibility for REVIEW-flagged transactions\n- OAuth integration with Stripe Connect\n- Policy enforcement across supported Stripe object types\n\nUse cases:\n- Compliance-driven organizations requiring governance workflows\n- Multi-approval processes for high-risk transactions\n- Audit record requirements for regulatory review\n- Risk management with automated policy gates\n\nThe app integrates directly into your Stripe Dashboard via the app drawer, providing governance visibility without requiring custom infrastructure.\n\nPermissions requested:\n- Read charges, payment intents, payouts, refunds for policy evaluation\n- Write decisions to charges for governance enforcement\n- Webhook access for real-time event processing",
+    "long_description_char_count": 905,
     "long_description_max": 4000,
     "category": "Risk Management"
   },
   "contact_info": {
-    "support_email": "t.dealer01@dsg.pics",
+    "support_email": "support@dsg.pics",
     "support_url": "https://dsg.pics/support",
     "support_phone": null,
-    "contact_email": "t.dealer01@dsg.pics",
+    "contact_email": "support@dsg.pics",
     "contact_timezone": "US/Eastern"
   },
   "legal_urls": {

--- a/packages/stripe-app/src/views/ChargeGate.tsx
+++ b/packages/stripe-app/src/views/ChargeGate.tsx
@@ -11,8 +11,8 @@ const DSG_API_BASE = 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
 
 const ChargeGate: React.FC = () => {
   const { environment, userContext } = useExtensionContext();
-  const chargeId = environment.objectContext?.id ?? null;
-  const accountId = userContext.account.id;
+  const chargeId = environment?.objectContext?.id ?? null;
+  const accountId = userContext?.account?.id ?? null;
 
   const [decision, setDecision] = useState<GatewayDecision | null>(null);
   const [loading, setLoading] = useState(true);
@@ -56,11 +56,11 @@ const ChargeGate: React.FC = () => {
     backgroundColor: '#f8fafc',
   };
 
-  if (!chargeId) {
+  if (!chargeId || !accountId) {
     return (
       <div style={containerStyle}>
         <p style={{ margin: 0, fontSize: '13px', color: '#64748b' }}>
-          DSG Governance Gate — no charge context
+          DSG Governance Gate — {!chargeId ? 'no payment context' : 'initializing…'}
         </p>
       </div>
     );
@@ -81,11 +81,12 @@ const ChargeGate: React.FC = () => {
 
   if (!decision) return null;
 
-  const palette = {
+  const palette = ({
     ALLOW:  { bg: '#f0fdf4', border: '#86efac', text: '#15803d', badge: '#22c55e', label: '✓ ALLOW' },
     BLOCK:  { bg: '#fef2f2', border: '#fca5a5', text: '#b91c1c', badge: '#ef4444', label: '✕ BLOCK' },
     REVIEW: { bg: '#fffbeb', border: '#fcd34d', text: '#92400e', badge: '#f59e0b', label: '⊙ REVIEW' },
-  }[decision.decision];
+  } as Record<string, { bg: string; border: string; text: string; badge: string; label: string }>)[decision.decision]
+    ?? { bg: '#f8fafc', border: '#e2e8f0', text: '#374151', badge: '#64748b', label: decision.decision };
 
   return (
     <div style={{ ...containerStyle, backgroundColor: palette.bg, border: `1px solid ${palette.border}` }}>

--- a/packages/stripe-app/src/views/PayoutGate.tsx
+++ b/packages/stripe-app/src/views/PayoutGate.tsx
@@ -12,8 +12,8 @@ const DSG_API_BASE = 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
 
 const PayoutGate: React.FC = () => {
   const { environment, userContext } = useExtensionContext();
-  const payoutId = environment.objectContext?.id ?? null;
-  const accountId = userContext.account.id;
+  const payoutId = environment?.objectContext?.id ?? null;
+  const accountId = userContext?.account?.id ?? null;
 
   const [decision, setDecision] = useState<GatewayDecision | null>(null);
   const [loading, setLoading] = useState(true);
@@ -78,11 +78,11 @@ const PayoutGate: React.FC = () => {
     backgroundColor: '#f8fafc',
   };
 
-  if (!payoutId) {
+  if (!payoutId || !accountId) {
     return (
       <div style={containerStyle}>
         <p style={{ margin: 0, fontSize: '13px', color: '#64748b' }}>
-          DSG Governance Gate — no payout context
+          DSG Governance Gate — {!payoutId ? 'no payout context' : 'initializing…'}
         </p>
       </div>
     );
@@ -103,11 +103,12 @@ const PayoutGate: React.FC = () => {
 
   if (!decision) return null;
 
-  const palette = {
+  const palette = ({
     ALLOW:  { bg: '#f0fdf4', border: '#86efac', text: '#15803d', badge: '#22c55e', label: '✓ ALLOW' },
     BLOCK:  { bg: '#fef2f2', border: '#fca5a5', text: '#b91c1c', badge: '#ef4444', label: '✕ BLOCK' },
     REVIEW: { bg: '#fffbeb', border: '#fcd34d', text: '#92400e', badge: '#f59e0b', label: '⊙ REVIEW' },
-  }[decision.decision];
+  } as Record<string, { bg: string; border: string; text: string; badge: string; label: string }>)[decision.decision]
+    ?? { bg: '#f8fafc', border: '#e2e8f0', text: '#374151', badge: '#64748b', label: decision.decision };
 
   return (
     <div style={{ ...containerStyle, backgroundColor: palette.bg, border: `1px solid ${palette.border}` }}>

--- a/packages/stripe-app/stripe-app.json
+++ b/packages/stripe-app/stripe-app.json
@@ -11,7 +11,7 @@
         "component": "ChargeGate"
       },
       {
-        "viewport": "stripe.dashboard.customer.detail",
+        "viewport": "stripe.dashboard.payout.detail",
         "component": "PayoutGate"
       }
     ],
@@ -45,7 +45,7 @@
   ],
   "post_install_action": {
     "type": "external",
-    "url": "https://tdealer01-crypto-dsg-control-plane.vercel.app/stripe/onboarding"
+    "url": "https://tdealer01-crypto-dsg-control-plane.vercel.app/dashboard/stripe-app"
   },
   "constants": {
     "DSG_API_BASE": "https://tdealer01-crypto-dsg-control-plane.vercel.app"

--- a/packages/stripe-app/stripe-app.prod.json
+++ b/packages/stripe-app/stripe-app.prod.json
@@ -4,7 +4,7 @@
   "description": "Pre-execution governance gates for Stripe operations with deterministic audit trails and approval workflows",
   "version": "1.0.0",
   "homepage": "https://dsg.pics",
-  "support_email": "t.dealer01@dsg.pics",
+  "support_email": "support@dsg.pics",
   "icons": {
     "square_64": "./docs/assets/icon-64x64.png",
     "square_128": "./docs/assets/icon-128x128.png",

--- a/packages/stripe-app/stripe-app.prod.json
+++ b/packages/stripe-app/stripe-app.prod.json
@@ -1,8 +1,8 @@
 {
-  "app_id": "com.governance.dsg",
+  "app_id": "pics.dsg.governance",
   "name": "DSG Governance Gate",
-  "description": "Pre-execution governance gates for Stripe operations with deterministic audit trails and approval workflows",
-  "version": "1.0.0",
+  "description": "Automated policy gates to evaluate payments and manage transaction reviews.",
+  "version": "1.0.4",
   "homepage": "https://dsg.pics",
   "support_email": "support@dsg.pics",
   "icons": {
@@ -14,40 +14,32 @@
   "sandbox_install_compatible": true,
   "stripe_api_access_type": "oauth",
   "allowed_redirect_uris": [
-    "https://dsg-stripe-app.vercel.app/api/stripe-app/oauth/callback",
-    "https://tdealer01-crypto-dsg-control-plane.vercel.app/stripe/oauth/callback"
+    "https://tdealer01-crypto-dsg-control-plane.vercel.app/stripe/oauth/callback",
+    "https://dsg-stripe-app.vercel.app/api/stripe-app/oauth/callback"
   ],
   "permissions": [
     {
       "permission": "charge_read",
-      "purpose": "Read charge details for governance policy evaluation"
+      "purpose": "Read charge details to display governance policy decisions in the payment detail view"
     },
     {
       "permission": "charge_write",
-      "purpose": "Apply governance decisions to charge operations"
+      "purpose": "Apply governance decisions to charge operations when a policy rule triggers a block or review"
     },
     {
       "permission": "payment_intent_read",
-      "purpose": "Monitor payment intents for policy compliance"
+      "purpose": "Monitor payment intents for policy compliance checks before capture"
     },
     {
       "permission": "payout_read",
-      "purpose": "Track payouts for governance audit trail"
-    },
-    {
-      "permission": "refund_read",
-      "purpose": "Monitor refunds for compliance evidence"
+      "purpose": "Track payouts to maintain a complete governance audit trail across all fund movements"
     }
   ],
   "ui_extension": {
     "views": [
       {
-        "viewport": "stripe.dashboard.charge.detail",
+        "viewport": "stripe.dashboard.payment.detail",
         "component": "ChargeGate"
-      },
-      {
-        "viewport": "stripe.dashboard.payment_intent.detail",
-        "component": "PaymentIntentGate"
       },
       {
         "viewport": "stripe.dashboard.payout.detail",
@@ -56,16 +48,16 @@
     ],
     "content_security_policy": {
       "connect-src": [
-        "https://dsg-stripe-app.vercel.app/",
-        "https://tdealer01-crypto-dsg-control-plane.vercel.app/",
-        "https://api.dsg.pics/"
+        "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/",
+        "https://dsg-stripe-app.vercel.app/api/",
+        "https://api.dsg.pics/v1/"
       ],
       "purpose": "Connect to DSG governance API for policy evaluation and audit recording"
     }
   },
   "post_install_action": {
     "type": "external",
-    "url": "https://tdealer01-crypto-dsg-control-plane.vercel.app/stripe/onboarding"
+    "url": "https://tdealer01-crypto-dsg-control-plane.vercel.app/dashboard/stripe-app"
   },
   "constants": {
     "DSG_API_BASE": "https://tdealer01-crypto-dsg-control-plane.vercel.app"


### PR DESCRIPTION
App experience fixes:
- Issue 1: Remove direct marketplace link as activation entry point;
  make Connect Stripe (OAuth) the primary CTA in the platform dashboard.
  post_install_action now redirects to /dashboard/stripe-app so users
  log in to DSG first before connecting.
- Issue 2: Replace chnlink_... test channel link with live mode OAuth path
  (marketplace.stripe.com/oauth/v2/authorize) in the install route.
- Issue 3: Fix unhandled crash in ChargeGate and PayoutGate caused by
  userContext.account.id accessed without null guards. Add optional
  chaining and safe fallbacks throughout both components.
  Fix stripe-app.json viewport mismatch: replace stripe.dashboard.customer.detail
  with stripe.dashboard.payout.detail so PayoutGate receives payout context.

App listing fixes:
- Rewrite About, subtitle, and all three key features to remove absolute
  guarantees (every/instant/tamper-proof/immutable) and replace with
  factual, qualified language per Stripe listing guidelines.
- Subtitle now under 80 chars and free of performance absolutes.
- Key feature 3 accurately states approvals are managed via the DSG platform,
  not implying they occur inside the Stripe app drawer.
- Update support email from individual alias to support@dsg.pics.

https://claude.ai/code/session_01GhZovaBfnigjmgMvsxdQXP