### PR TITLE
fix: Stripe App Review 1.0.2 rejection — all 6 required issues + connect flow + fail-open

### DIFF
--- a/app/dashboard/stripe-app/connect/page.tsx
+++ b/app/dashboard/stripe-app/connect/page.tsx
@@ -38,7 +38,7 @@ export default function StripeConnectPage() {
         setStatus('success');
         // Redirect after success
         setTimeout(() => {
-          router.push('/dashboard/stripe-app?success=true');
+          router.push('/dashboard/stripe-app?connected=true');
         }, 2000);
       } else {
         const error = await response.json();
@@ -51,23 +51,9 @@ export default function StripeConnectPage() {
     }
   };
 
-  const handleConnectClick = async () => {
+  const handleConnectClick = () => {
     setStatus('connecting');
-    try {
-      const response = await fetch('/api/stripe-app/oauth/authorize', {
-        method: 'GET',
-      });
-      const data = await response.json();
-      if (data.url) {
-        window.location.href = data.url;
-      } else {
-        setStatus('error');
-        setErrorMessage('Failed to get authorization URL');
-      }
-    } catch (error) {
-      setStatus('error');
-      setErrorMessage(error instanceof Error ? error.message : 'Failed to initiate OAuth');
-    }
+    window.location.href = '/api/stripe/connect/install';
   };
 
   return (

--- a/app/stripe/oauth/callback/page.tsx
+++ b/app/stripe/oauth/callback/page.tsx
@@ -38,7 +38,7 @@ function CallbackContent() {
       .then(async (res) => {
         if (res.ok) {
           setStatus('success');
-          setTimeout(() => router.push('/stripe/onboarding'), 1500);
+          setTimeout(() => router.push('/dashboard/stripe-app?connected=true'), 1500);
         } else {
           const data = await res.json() as { message?: string };
           setStatus('error');

--- a/docs/phase9-stripe-submission/SUBMISSION_DATA.json
+++ b/docs/phase9-stripe-submission/SUBMISSION_DATA.json
@@ -8,8 +8,8 @@
     "submission_date": "2026-06-11"
   },
   "app_descriptions": {
-    "about": "DSG Governance Gate is a governance platform for Stripe operations. It automatically evaluates charges, refunds, and disputes against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard. Audit records for each decision are shown within the app panel for compliance and review purposes.",
-    "about_char_count": 355,
+    "about": "DSG Governance Gate is a governance platform for Stripe payments and payouts. It evaluates payments and payouts against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard. Audit records for each decision are shown within the app panel for compliance and review purposes.",
+    "about_char_count": 341,
     "about_max": 1000,
     "subtitle": "Automated policy gates to evaluate payments and manage transaction reviews.",
     "subtitle_char_count": 75,

--- a/packages/stripe-app/src/views/ChargeGate.tsx
+++ b/packages/stripe-app/src/views/ChargeGate.tsx
@@ -39,7 +39,7 @@ const ChargeGate: React.FC = () => {
         setDecision(await res.json() as GatewayDecision);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'error');
-        setDecision({ decision: 'ALLOW', reason: 'DSG unavailable — fail-open mode' });
+        setDecision({ decision: 'REVIEW', reason: 'DSG unavailable — held for review' });
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary

Addresses all feedback from the Stripe App Review rejection report for version 1.0.2, plus follow-up UX and safety fixes.

### App Experience (3 Required)
- **Issue 1**: Remove direct marketplace link as activation entry point; `post_install_action` now points to `/dashboard/stripe-app` so users log in to DSG first
- **Issue 2**: Replace `chnlink_...` test channel link with live mode OAuth path (`/oauth/v2/authorize`) in the install route
- **Issue 3**: Fix crash in `ChargeGate` and `PayoutGate` — `userContext.account.id` accessed without null guards; fix `stripe-app.json` viewport mismatch (`customer.detail` → `payout.detail`)

### App Listing (3 Required + 1 Recommended)
- Rewrite About, subtitle, and all three key features — remove absolutes (every/instant/tamper-proof/immutable)
- About scoped to payments and payouts only (matches registered viewports)
- Subtitle under 80 chars, no performance absolutes
- Support email: `t.dealer01@dsg.pics` → `support@dsg.pics`

### Connect flow + safety fixes
- Connect button → `/api/stripe/connect/install` directly (no intermediate fetch)
- OAuth success callback → `/dashboard/stripe-app?connected=true` (both pages)
- `ChargeGate` fail-open: `ALLOW` → `REVIEW` (consistent with `PayoutGate`)

### Manifest sync
- `stripe-app.prod.json` and `SUBMISSION_DATA.json` aligned to version 1.0.4 + `pics.dsg.governance`

## Verification
- [x] `npm run typecheck` — only pre-existing deprecation warnings, no new errors
- [x] `curl /api/agent/status` on production confirmed prior deploy at `3882f3a` (previous merge)
- [ ] Runtime tests not run — no Supabase credentials in this environment
- [ ] `stripe apps upload` must be run locally after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhZovaBfnigjmgMvsxdQXP)_