### PR TITLE
fix(stripe-app): address marketplace review rejection feedback for resubmission

### DIFF
--- a/app/dashboard/stripe-app/connect/page.tsx
+++ b/app/dashboard/stripe-app/connect/page.tsx
@@ -112,9 +112,9 @@ export default function StripeConnectPage() {
         <p className="font-medium text-slate-300">This will authorize:</p>
         <ul className="mt-2 list-inside list-disc space-y-1">
           <li>Read charge details</li>
-          <li>Read/write payment intents</li>
+          <li>Write governance decisions to charges</li>
+          <li>Read payment intents</li>
           <li>Read payouts</li>
-          <li>Read refunds</li>
         </ul>
       </div>
     </div>

--- a/app/stripe/onboarding/page.tsx
+++ b/app/stripe/onboarding/page.tsx
@@ -76,8 +76,8 @@ export default function StripeOnboardingPage() {
 
         <p className="text-center text-xs text-slate-600">
           DSG Governance Gate · pics.dsg.governance ·{' '}
-          <a href="mailto:support@dsg.pics" className="hover:text-slate-400">
-            support@dsg.pics
+          <a href="mailto:t.dealer01@dsg.pics" className="hover:text-slate-400">
+            t.dealer01@dsg.pics
           </a>
         </p>
       </div>

--- a/app/stripe/onboarding/page.tsx
+++ b/app/stripe/onboarding/page.tsx
@@ -24,17 +24,17 @@ export default function StripeOnboardingPage() {
               {
                 icon: '⚡',
                 title: 'Gate active on payments',
-                desc: 'Every charge detail view now shows a real-time ALLOW / BLOCK / REVIEW decision.',
+                desc: 'Charge detail views show an automated ALLOW / BLOCK / REVIEW decision.',
               },
               {
                 icon: '📋',
                 title: 'Audit trail recording',
-                desc: 'All payout activity is logged in your governance audit trail automatically.',
+                desc: 'Payout activity is recorded in your governance decision log.',
               },
               {
                 icon: '🔒',
                 title: 'Policy enforcement',
-                desc: 'Governance rules run before capture — high-risk transactions are flagged instantly.',
+                desc: 'Governance rules run before capture — high-risk transactions are flagged for review.',
               },
             ].map((item) => (
               <li key={item.title} className="flex gap-3">

--- a/docs/phase9-stripe-submission/SUBMISSION_DATA.json
+++ b/docs/phase9-stripe-submission/SUBMISSION_DATA.json
@@ -2,14 +2,14 @@
   "app_metadata": {
     "app_id": "pics.dsg.governance",
     "app_name": "DSG Governance Gate",
-    "version": "1.0.4",
+    "version": "1.1.3",
     "distribution_type": "public",
     "sandbox_install_compatible": true,
     "submission_date": "2026-06-11"
   },
   "app_descriptions": {
     "about": "DSG Governance Gate is a governance platform for Stripe payments and payouts. It evaluates payments and payouts against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard. Audit records for each decision are shown within the app panel for compliance and review purposes.",
-    "about_char_count": 341,
+    "about_char_count": 336,
     "about_max": 1000,
     "subtitle": "Automated policy gates to evaluate payments and manage transaction reviews.",
     "subtitle_char_count": 75,
@@ -19,8 +19,8 @@
         "title": "Automated policy decisions",
         "title_char_count": 26,
         "title_max": 80,
-        "description": "Policy rules evaluate charges and refunds against configurable criteria. Decisions — ALLOW, BLOCK, or REVIEW — appear in the Stripe payment and payout detail panels for each transaction.",
-        "description_char_count": 186,
+        "description": "Policy rules evaluate charges and payment intents against configurable criteria. Decisions — ALLOW, BLOCK, or REVIEW — appear in the Stripe payment detail panel for each transaction.",
+        "description_char_count": 182,
         "description_max": 300
       },
       {
@@ -28,23 +28,23 @@
         "title_char_count": 18,
         "title_max": 80,
         "description": "Each governance decision is recorded with a verifiable reference and timestamp, visible in the app drawer panel. Decision history supports compliance review and internal audit workflows.",
-        "description_char_count": 183,
+        "description_char_count": 186,
         "description_max": 300
       },
       {
         "title": "Policy and approval management",
-        "title_char_count": 31,
+        "title_char_count": 30,
         "title_max": 80,
         "description": "REVIEW-flagged transactions surface in the app drawer for operator awareness. Policy configuration and approval workflows are managed through the DSG platform, with outcomes displayed in the Stripe Dashboard panel.",
-        "description_char_count": 211,
+        "description_char_count": 214,
         "description_max": 300
       }
     ],
     "short_description": "Automated policy gates to evaluate payments and manage transaction reviews.",
     "short_description_char_count": 75,
     "short_description_max": 140,
-    "long_description": "DSG Governance Gate is a governance platform for Stripe operations. It automatically evaluates charges, refunds, and disputes against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard.\n\nKey capabilities:\n- Automated policy evaluation for charges, refunds, and payouts\n- Decision audit log with verifiable records shown in the app panel\n- Approval workflow visibility for REVIEW-flagged transactions\n- OAuth integration with Stripe Connect\n- Policy enforcement across supported Stripe object types\n\nUse cases:\n- Compliance-driven organizations requiring governance workflows\n- Multi-approval processes for high-risk transactions\n- Audit record requirements for regulatory review\n- Risk management with automated policy gates\n\nThe app integrates directly into your Stripe Dashboard via the app drawer, providing governance visibility without requiring custom infrastructure.\n\nPermissions requested:\n- Read charges, payment intents, payouts, refunds for policy evaluation\n- Write decisions to charges for governance enforcement\n- Webhook access for real-time event processing",
-    "long_description_char_count": 905,
+    "long_description": "DSG Governance Gate is a governance platform for Stripe operations. It automatically evaluates charges and payment intents against configurable policy rules, returning an ALLOW, BLOCK, or REVIEW decision displayed directly in your Stripe Dashboard payment detail panel.\n\nKey capabilities:\n- Automated policy evaluation for charges and payment intents\n- Decision audit log with verifiable records shown in the app panel\n- Approval workflow visibility for REVIEW-flagged transactions\n- OAuth integration with Stripe Connect\n- Payout activity recorded in the governance decision log\n\nUse cases:\n- Compliance-driven organizations requiring governance workflows\n- Multi-approval processes for high-risk transactions\n- Audit record requirements for regulatory review\n- Risk management with automated policy gates\n\nThe app integrates directly into your Stripe Dashboard via the app drawer, providing governance visibility without requiring custom infrastructure.\n\nPermissions requested:\n- Read charges, payment intents, and payouts for policy evaluation\n- Write decisions to charges for governance enforcement\n- Webhook access for event processing",
+    "long_description_char_count": 1140,
     "long_description_max": 4000,
     "category": "Risk Management"
   },
@@ -70,28 +70,23 @@
   },
   "permissions": [
     {
-      "permission": "charge:read",
-      "purpose": "Read charge details for governance policy evaluation",
+      "permission": "charge_read",
+      "purpose": "Read charge details to display governance policy decisions in the payment detail view",
       "required": true
     },
     {
-      "permission": "charge:write",
-      "purpose": "Apply governance decisions to charge operations",
+      "permission": "charge_write",
+      "purpose": "Apply governance decisions to charge operations when a policy rule triggers a block or review",
       "required": true
     },
     {
-      "permission": "payment_intent:read",
-      "purpose": "Monitor payment intents for policy compliance",
+      "permission": "payment_intent_read",
+      "purpose": "Monitor payment intents for policy compliance checks before capture",
       "required": true
     },
     {
-      "permission": "payout:read",
-      "purpose": "Track payouts for governance audit trail",
-      "required": true
-    },
-    {
-      "permission": "refund:read",
-      "purpose": "Monitor refunds for compliance evidence",
+      "permission": "payout_read",
+      "purpose": "Track payouts to maintain a complete governance audit trail across all fund movements",
       "required": true
     }
   ],
@@ -107,9 +102,7 @@
       "payment_intent.payment_failed",
       "payout.created",
       "payout.updated",
-      "payout.paid",
-      "refund.created",
-      "refund.updated"
+      "payout.paid"
     ]
   },
   "assets": {
@@ -141,8 +134,8 @@
       },
       {
         "file": "docs/phase9-stripe-submission/assets/screenshot-3-audit-trail.png",
-        "title": "Audit Trail",
-        "description": "Immutable audit trail with cryptographic proof",
+        "title": "Decision Audit Log",
+        "description": "Decision audit log with verifiable records and timestamps",
         "dimensions": "1200x800",
         "format": "PNG",
         "order": 3,
@@ -186,18 +179,13 @@
         "viewport": "stripe.dashboard.payment.detail",
         "component": "ChargeGate",
         "description": "Governance gate in payment detail view"
-      },
-      {
-        "viewport": "stripe.dashboard.payout.detail",
-        "component": "PayoutGate",
-        "description": "Governance gate in payout detail view"
       }
     ],
     "content_security_policy": {
       "connect-src": [
-        "https://tdealer01-crypto-dsg-control-plane.vercel.app/",
-        "https://dsg-stripe-app.vercel.app/",
-        "https://api.dsg.pics/"
+        "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/",
+        "https://dsg-stripe-app.vercel.app/api/",
+        "https://api.dsg.pics/v1/"
       ],
       "purpose": "Connect to DSG governance API for policy evaluation and audit recording"
     }

--- a/docs/phase9-stripe-submission/SUBMISSION_DATA.json
+++ b/docs/phase9-stripe-submission/SUBMISSION_DATA.json
@@ -49,10 +49,10 @@
     "category": "Risk Management"
   },
   "contact_info": {
-    "support_email": "support@dsg.pics",
+    "support_email": "t.dealer01@dsg.pics",
     "support_url": "https://dsg.pics/support",
     "support_phone": null,
-    "contact_email": "support@dsg.pics",
+    "contact_email": "t.dealer01@dsg.pics",
     "contact_timezone": "US/Eastern"
   },
   "legal_urls": {

--- a/packages/stripe-app/docs/SETUP.md
+++ b/packages/stripe-app/docs/SETUP.md
@@ -1,8 +1,8 @@
 # DSG Governance Gate - Setup & Installation Guide
 
-**Version**: 1.0.0  
-**Last Updated**: 2025-06-06  
-**Support**: t.dealer01@dsg.pics
+**Version**: 1.1.3  
+**Last Updated**: 2026-06-11  
+**Support**: support@dsg.pics
 
 ---
 
@@ -10,7 +10,7 @@
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Installation from Stripe Marketplace](#installation-from-stripe-marketplace)
+3. [Installation (Connect from the DSG Platform)](#installation-connect-from-the-dsg-platform)
 4. [Account Connection](#account-connection)
 5. [Configuration](#configuration)
 6. [First Time Setup](#first-time-setup)
@@ -28,7 +28,7 @@
 
 - **Policy-Based Gating**: Define rules for charges, payments, and payouts
 - **Deterministic Decisions**: ALLOW, BLOCK, or REVIEW operations based on policies
-- **Audit Trail**: Complete immutable record of all gated operations
+- **Audit Trail**: Recorded decision log for gated operations
 - **Risk-Based Approval**: Route high-risk operations to manual review
 - **Dashboard Integration**: Seamless integration with Stripe Dashboard
 
@@ -75,15 +75,26 @@ Before installing, you need:
 
 ---
 
-## Installation from Stripe Marketplace
+## Installation (Connect from the DSG Platform)
 
-### Step 1: Locate the App
+Installation starts from the DSG platform, not from the Stripe App Marketplace. If you found the app on the marketplace listing, clicking **"Install from partner"** will route you to the DSG platform login first — then you connect Stripe from inside the DSG dashboard.
 
-1. Go to [Stripe Marketplace](https://marketplace.stripe.com) (or via Stripe Dashboard → Apps)
-2. Search for **"DSG Governance Gate"**
-3. Click on the app card
+### Step 1: Sign in to the DSG Platform
 
-### Step 2: Review Permissions
+1. Go to https://tdealer01-crypto-dsg-control-plane.vercel.app
+2. Sign in, or create an account if you don't have one yet
+
+### Step 2: Open the Stripe App page
+
+1. In the DSG dashboard, navigate to **Dashboard → DSG Stripe App** (`/dashboard/stripe-app`)
+2. Find **"Step 1 — Connect your Stripe account"**
+
+### Step 3: Click "Connect Stripe Account"
+
+1. Click the **"Connect Stripe Account"** button
+2. You will be redirected to Stripe's Live mode authorization page (`https://marketplace.stripe.com/oauth/v2/authorize`)
+
+### Step 4: Review Permissions and Authorize
 
 The app requests the following permissions:
 
@@ -92,33 +103,22 @@ The app requests the following permissions:
 | **Read Charges** | Evaluate governance policies on charge operations |
 | **Write Charges** | Apply governance decisions (approve/block charges) |
 | **Read Payment Intents** | Monitor payment intent flows for compliance |
-| **Read Payouts** | Track fund movements for audit trail |
-| **Read Refunds** | Monitor refund operations for governance |
+| **Read Payouts** | Track fund movements for the decision audit log |
 
 **Note**: This app:
 - Never reads customer PII beyond what's necessary for policy evaluation
 - Never modifies payment method data
 - Never initiates transactions
-- Only records decisions and audit trails
+- Only records decisions and audit logs
 
-### Step 3: Click Install
-
-1. Click the **"Install"** button
-2. Review the permissions dialog
-3. Click **"Authorize"**
-4. You will be redirected to the DSG Control Plane onboarding
-
-### Step 4: Authorize in DSG Control Plane
-
-1. You'll arrive at: `https://tdealer01-crypto-dsg-control-plane.vercel.app/stripe/onboarding`
-2. Click **"Complete Setup"** or **"Connect Stripe Account"**
-3. You'll see your Stripe account details
+1. Review the permissions dialog
+2. Click **"Authorize"**
 
 ### Step 5: Installation Complete
 
+- You are redirected back to the DSG platform OAuth callback page
 - The app is now installed in your Stripe account
 - You can see it in Stripe Dashboard → Apps → Installed Apps
-- Onboarding is complete
 
 ---
 

--- a/packages/stripe-app/docs/SETUP.md
+++ b/packages/stripe-app/docs/SETUP.md
@@ -2,7 +2,7 @@
 
 **Version**: 1.1.3  
 **Last Updated**: 2026-06-11  
-**Support**: support@dsg.pics
+**Support**: t.dealer01@dsg.pics
 
 ---
 

--- a/packages/stripe-app/src/views/ChargeGate.tsx
+++ b/packages/stripe-app/src/views/ChargeGate.tsx
@@ -50,7 +50,20 @@ const ChargeGate = ({ extensionContext }: { extensionContext: ExtensionContextVa
           }),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        setDecision(await res.json() as GatewayDecision);
+        const raw = (await res.json()) as Partial<GatewayDecision> | null;
+        // Unknown/missing verdicts fall back to REVIEW so the badge/banner
+        // lookups never receive an unmapped key and crash the view.
+        const verdict =
+          raw?.decision === 'ALLOW' || raw?.decision === 'BLOCK' || raw?.decision === 'REVIEW'
+            ? raw.decision
+            : 'REVIEW';
+        setDecision({
+          decision: verdict,
+          reason: typeof raw?.reason === 'string' && raw.reason.length > 0
+            ? raw.reason
+            : 'No reason provided — held for review',
+          proof: typeof raw?.proof === 'string' ? raw.proof : undefined,
+        });
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error';
         setFetchError(msg);

--- a/packages/stripe-app/stripe-app.dev.json
+++ b/packages/stripe-app/stripe-app.dev.json
@@ -1,66 +1,15 @@
 {
-  "app_id": "com.governance.dsg.dev",
-  "name": "DSG Governance Gate (Local Dev)",
-  "description": "Pre-execution governance gates for Stripe operations - LOCAL DEVELOPMENT",
-  "version": "1.0.0",
-  "homepage": "http://localhost:3000",
-  "support_email": "t.dealer01@dsg.pics",
-  "distribution_type": "public",
-  "sandbox_install_compatible": true,
-  "stripe_api_access_type": "oauth",
-  "allowed_redirect_uris": [
-    "http://localhost:3000/stripe/oauth/callback",
-    "http://localhost:3001/api/stripe-app/oauth/callback"
-  ],
-  "permissions": [
-    {
-      "permission": "charge_read",
-      "purpose": "Read charge details for governance policy evaluation"
-    },
-    {
-      "permission": "charge_write",
-      "purpose": "Apply governance decisions to charge operations"
-    },
-    {
-      "permission": "payment_intent_read",
-      "purpose": "Monitor payment intents for policy compliance"
-    },
-    {
-      "permission": "payout_read",
-      "purpose": "Track payouts for governance audit trail"
-    },
-    {
-      "permission": "refund_read",
-      "purpose": "Monitor refunds for compliance evidence"
-    }
-  ],
+  "extends": "stripe-app.json",
   "ui_extension": {
-    "views": [
-      {
-        "viewport": "stripe.dashboard.charge.detail",
-        "component": "ChargeGate"
-      },
-      {
-        "viewport": "stripe.dashboard.payment_intent.detail",
-        "component": "PaymentIntentGate"
-      },
-      {
-        "viewport": "stripe.dashboard.payout.detail",
-        "component": "PayoutGate"
-      }
-    ],
     "content_security_policy": {
       "connect-src": [
-        "http://localhost:3000/",
-        "http://localhost:3001/",
-        "http://localhost:8642/"
-      ],
-      "purpose": "Connect to DSG governance API for policy evaluation and audit recording"
+        "http://localhost:3000/api/"
+      ]
     }
   },
   "post_install_action": {
     "type": "external",
-    "url": "http://localhost:3000/stripe/onboarding"
+    "url": "http://localhost:3000/dashboard/stripe-app"
   },
   "constants": {
     "DSG_API_BASE": "http://localhost:3000"

--- a/packages/stripe-app/stripe-app.json
+++ b/packages/stripe-app/stripe-app.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://stripe.com/stripe-app.schema.json",
   "id": "pics.dsg.governance",
   "name": "DSG Governance Gate",
   "version": "1.1.3",
@@ -20,7 +19,6 @@
       "purpose": "Connect to DSG governance API for policy evaluation and audit recording"
     }
   },
-  "extensions": null,
   "permissions": [
     {
       "permission": "charge_read",

--- a/packages/stripe-app/stripe-app.json
+++ b/packages/stripe-app/stripe-app.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://stripe.com/stripe-app.schema.json",
   "id": "pics.dsg.governance",
   "name": "DSG Governance Gate",
   "version": "1.1.3",
@@ -19,6 +20,7 @@
       "purpose": "Connect to DSG governance API for policy evaluation and audit recording"
     }
   },
+  "extensions": null,
   "permissions": [
     {
       "permission": "charge_read",

--- a/packages/stripe-app/stripe-app.prod.json
+++ b/packages/stripe-app/stripe-app.prod.json
@@ -4,7 +4,7 @@
   "description": "Automated policy gates to evaluate payments and manage transaction reviews.",
   "version": "1.1.3",
   "homepage": "https://dsg.pics",
-  "support_email": "support@dsg.pics",
+  "support_email": "t.dealer01@dsg.pics",
   "icons": {
     "square_64": "./docs/assets/icon-64x64.png",
     "square_128": "./docs/assets/icon-128x128.png",


### PR DESCRIPTION
Goal:
Address all Required feedback from the Stripe App review rejection report (DSG Governance Gate 1.0.2) so version 1.1.3 can be resubmitted to the Stripe App Marketplace, and align all in-repo listing/docs/UI copy with the actual app manifest.

Files changed:
- packages/stripe-app/stripe-app.json — manifest kept in the form regenerated by Stripe CLI during the successful 1.1.3 upload
- packages/stripe-app/stripe-app.dev.json — converted to documented extends-based dev override (was a standalone non-schema file registering unreviewed viewports)
- packages/stripe-app/src/views/ChargeGate.tsx — unknown/missing API verdicts normalized to REVIEW so badge/banner lookups can never crash the registered viewport (review feedback #3)
- packages/stripe-app/docs/SETUP.md — install guide rewritten to integration-first flow: sign in at DSG platform → Connect Stripe button → Live mode OAuth (review feedback #1); removed unrequested "Read Refunds" permission row; support email t.dealer01@dsg.pics
- packages/stripe-app/stripe-app.prod.json — support email t.dealer01@dsg.pics
- docs/phase9-stripe-submission/SUBMISSION_DATA.json — version 1.1.3; views/permissions aligned with manifest (payment.detail only, 4 permissions, no refund events); softened "immutable/cryptographic" copy; recomputed character counts (listing feedback #1–#3)
- app/stripe/onboarding/page.tsx — softened absolute claims (every/instantly/automatically); support email t.dealer01@dsg.pics
- app/dashboard/stripe-app/connect/page.tsx — permission list aligned with manifest: removed "Read refunds", corrected payment-intent write claim to charge write

Verification:
- [x] npm run typecheck — pass
- [x] packages/stripe-app vitest tests/unit — 157 passed
- [x] JSON validity checked for all edited JSON files
- [x] stripe apps upload — "Uploaded version 1.1.3 of DSG Governance Gate" (acct_1Tft0OAZNzhgTUPV)
- [x] Live probes: GET /api/health → 200; GET /api/stripe/connect/install → 302 to https://marketplace.stripe.com/oauth/v2/authorize (Live mode, client_id configured); GET /dashboard/stripe-app → 307 to /login (integration-first flow enforced)
- [ ] Runtime render test of payment.detail viewport — Not run (requires stripe apps start with a browser session); code has REVIEW fallback paths for all error cases

Known limits:
- Marketplace listing fields (Subtitle / About / Key Features / support email) must be updated manually in the Stripe Dashboard from SUBMISSION_DATA.json — they are not part of the manifest upload.
- "Submit for review" has no CLI command; it must be clicked in the Stripe Dashboard.
- Setup video guides referenced by the reviewer live outside this repo and must be re-recorded to show the integration-first flow.
- Support email is an individual mailbox (t.dealer01@dsg.pics) per owner decision; the reviewer's Recommended item suggests a group alias.

User-visible benefit:
The connect/onboarding pages and setup docs now describe exactly the permissions and flow the app actually uses, and the Stripe app version 1.1.3 with the crash-safe payment-detail view is uploaded and ready for marketplace resubmission.

Next step:
Update listing fields in the Stripe Dashboard from SUBMISSION_DATA.json, then click "Submit for review" for version 1.1.3.

https://claude.ai/code/session_01Vc1XsRyLJZjnLiudcKFfo4