### PR TITLE
fix(ci): resolve pre-existing CI failures (claim readiness, security summary, npm audit script, L1 async cleanup)

### DIFF
--- a/.github/workflows/ccvs-evidence.yml
+++ b/.github/workflows/ccvs-evidence.yml
@@ -503,30 +503,36 @@ jobs:
       - name: Run coverage test for metrics
         run: npm run test:coverage 2>/dev/null || echo "Coverage already collected"
       - name: Build evidence bundle manifest
+        # --output is a directory; the script always writes evidence-bundle-manifest.json
+        # inside it. Exit code 2 means "bundle built with partial data" (some optional
+        # inputs missing) — the manifest is still valid, so treat it as a warning.
         run: |
+          set +e
           node scripts/build-evidence-bundle.mjs \
-            --evidence-dir=./ccvs-evidence-artifacts \
-            --coverage-file=coverage/coverage-final.json \
+            --coverage-file=coverage/coverage-summary.json \
             --mutation-results=./ccvs-evidence-artifacts/ccvs-mutation-evidence.json \
             --sbom-file=./ccvs-evidence-artifacts/sbom.cyclonedx.json \
             --commit=${{ github.sha }} \
-            --policy-version=v1 \
-            --output=artifacts/evidence-bundle-manifest.json
+            --output=artifacts
+          code=$?
+          set -e
+          if [ "$code" -eq 2 ]; then
+            echo "⚠️ Evidence bundle built with partial data — warnings listed above"
+          elif [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
       - name: Display bundle summary
         run: |
           node -e "
             const m=JSON.parse(require('fs').readFileSync('artifacts/evidence-bundle-manifest.json','utf8'));
-            const s=m.summary;
+            const s=m.summary||{};
             console.log('📦 Evidence Bundle Summary');
-            console.log('── Total evidence files: '+m.evidence_count);
-            console.log('── L1 unit: '+m.evidence_levels.L1_unit.count);
-            console.log('── L2 integration: '+m.evidence_levels.L2_integration.count);
-            console.log('── L3 adversarial: '+m.evidence_levels.L3_adversarial.count);
-            console.log('── L4 mutation/proof: '+m.evidence_levels.L4_mutation_proof.count);
-            console.log('── L5 provenance: '+m.evidence_levels.L5_provenance.count);
-            console.log('── Coverage: '+m.metrics.coverage_percent.toFixed(1)+'%');
-            console.log('── Mutation score: '+m.metrics.mutation_score.toFixed(1)+'%');
-            console.log('── Claim eligible: '+(s.claim_pass_eligible?'🟢 YES':'🔴 NO'));
+            console.log('── Artifacts in chain: '+m.artifacts.length);
+            m.artifacts.forEach(a=>console.log('   • '+a.type+'  '+String(a.hash).slice(0,16)+'...'));
+            console.log('── Chain hash: '+m.chain_hash);
+            console.log('── Coverage (lines): '+(s.coverage_lines_pct!=null?s.coverage_lines_pct+'%':'not collected'));
+            console.log('── Mutation score: '+(s.mutation_score!=null?s.mutation_score+'%':'not collected'));
+            console.log('── Tests passed: '+(s.test_passed!=null?s.test_passed:'not collected'));
           "
       - name: Install Cosign for optional signing
         uses: sigstore/cosign-installer@v3
@@ -561,6 +567,11 @@ jobs:
         with:
           name: evidence-bundle-${{ github.run_id }}
           path: ./
+      - name: Download compliance matrix
+        uses: actions/download-artifact@v4
+        with:
+          name: ccvs-compliance-matrix-${{ github.run_id }}
+          path: ./
       - name: Verify bundle manifest is valid JSON
         run: |
           if [ ! -f evidence-bundle-manifest.json ]; then
@@ -568,59 +579,56 @@ jobs:
             exit 1
           fi
           node -e "const m=JSON.parse(require('fs').readFileSync('evidence-bundle-manifest.json'));console.log('✅ Bundle manifest valid JSON')"
-      - name: Check local claim status
+      - name: Check claim readiness from compliance matrix
         id: claims
+        # claim_pass_eligible and per-requirement statuses come from the
+        # compliance matrix — the bundle manifest carries artifact hashes and
+        # chain integrity, not claim decisions.
         run: |
           node -e "
-            const m=JSON.parse(require('fs').readFileSync('evidence-bundle-manifest.json','utf8'));
-            const s=m.summary;
-            const claims=m.summary.claims_ready;
+            const fs=require('fs');
+            const m=JSON.parse(fs.readFileSync('evidence-bundle-manifest.json','utf8'));
+            const matrix=JSON.parse(fs.readFileSync('ccvs-compliance-matrix.json','utf8'));
+            const s=matrix.summary;
             console.log('=== Claim Readiness Status ===');
             console.log('Claim pass eligible: '+(s.claim_pass_eligible?'YES':'NO'));
-            console.log('ISO-42001-A.6: '+(claims.ISO_42001_A6_ready?'READY':'NOT READY'));
-            console.log('NIST-GOVERN-01: '+(claims.NIST_GOVERN_01_ready?'READY':'NOT READY'));
-            console.log('GDPR-AUDIT: '+(claims.GDPR_AUDIT_READY?'READY':'NOT READY'));
-            console.log('SOC2-CONTROL: '+(claims.SOC2_CONTROL_READY?'READY':'NOT READY'));
+            console.log('PASS: '+s.pass+' / '+s.total+'  FAIL: '+s.fail+'  NOT VERIFIED: '+s.not_verified);
+            console.log('Bundle chain hash: '+m.chain_hash);
+            matrix.rows.forEach(r=>console.log('  '+r.status.toUpperCase().padEnd(14)+r.requirement_id));
           "
           echo "claims_checked=true" >> "$GITHUB_OUTPUT"
       - name: Report claim summary to GitHub Actions
         if: always()
         run: |
           node -e "
-            const m=JSON.parse(require('fs').readFileSync('evidence-bundle-manifest.json','utf8'));
-            const s=m.summary;
-            const claims=m.summary.claims_ready;
-            const rows=[
-              ['ISO-42001-A.6',claims.ISO_42001_A6_ready?'✅ READY':'⚠️  NOT READY'],
-              ['NIST-GOVERN-01',claims.NIST_GOVERN_01_ready?'✅ READY':'⚠️  NOT READY'],
-              ['GDPR-AUDIT',claims.GDPR_AUDIT_READY?'✅ READY':'⚠️  NOT READY'],
-              ['SOC2-CONTROL',claims.SOC2_CONTROL_READY?'✅ READY':'⚠️  NOT READY'],
-            ];
+            const fs=require('fs');
+            const m=JSON.parse(fs.readFileSync('evidence-bundle-manifest.json','utf8'));
+            const matrix=JSON.parse(fs.readFileSync('ccvs-compliance-matrix.json','utf8'));
+            const s=matrix.summary;
+            const b=m.summary||{};
+            const rows=matrix.rows.map(r=>{
+              const icon=r.status==='pass'?'✅':r.status==='fail'?'❌':'⚠️';
+              return '| '+icon+' | '+r.requirement_id+' | '+r.control_id+' | '+r.status+' |';
+            });
             const md=[
               '## 📋 CCVS Claim Readiness Report — '+new Date().toISOString().slice(0,10),
               '',
-              '| Claim | Status |',
-              '|-------|--------|',
-              ...rows.map(r=>'| '+r[0]+' | '+r[1]+' |'),
+              '| Field | Value |',
+              '|-------|-------|',
+              '| **claim_pass_eligible** | '+(s.claim_pass_eligible?'🟢 **ELIGIBLE**':'🔴 **NOT ELIGIBLE**')+' |',
+              '| PASS | '+s.pass+' / '+s.total+' |',
+              '| FAIL | '+s.fail+' |',
+              '| NOT VERIFIED | '+s.not_verified+' |',
+              '| Bundle chain hash | \`'+String(m.chain_hash).slice(0,22)+'...\` |',
+              '| Artifacts in chain | '+m.artifacts.length+' |',
+              '| Coverage (lines) | '+(b.coverage_lines_pct!=null?b.coverage_lines_pct+'%':'not collected')+' |',
+              '| Mutation score | '+(b.mutation_score!=null?b.mutation_score+'%':'not collected')+' |',
               '',
-              '### Bundle Metrics',
-              '| Metric | Value |',
-              '|--------|-------|',
-              '| **Evidence files** | '+m.evidence_count+' |',
-              '| **Coverage** | '+m.metrics.coverage_percent.toFixed(1)+'% |',
-              '| **Mutation score** | '+m.metrics.mutation_score.toFixed(1)+'% |',
-              '| **Tests passed** | '+m.metrics.tests_passed+' / '+m.metrics.test_count+' |',
-              '| **Bundle hash** | \`'+m.integrity.bundle_hash.slice(0,22)+'...\` |',
-              '| **Claim eligible** | '+(s.claim_pass_eligible?'🟢 **ELIGIBLE**':'🔴 **NOT ELIGIBLE**')+' |',
-              '',
-              '### Evidence Levels',
-              '- **L1** (unit): '+m.evidence_levels.L1_unit.count+' file(s)',
-              '- **L2** (integration): '+m.evidence_levels.L2_integration.count+' file(s)',
-              '- **L3** (adversarial): '+m.evidence_levels.L3_adversarial.count+' file(s)',
-              '- **L4** (mutation/proof): '+m.evidence_levels.L4_mutation_proof.count+' file(s)',
-              '- **L5** (provenance): '+m.evidence_levels.L5_provenance.count+' file(s)',
+              '| Status | Requirement | Control | Result |',
+              '|--------|-------------|---------|--------|',
+              ...rows,
             ].join('\n');
-            require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY,md+'\n');
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,md+'\n');
           "
       - name: Comment on PR (if applicable)
         if: github.event_name == 'pull_request'
@@ -629,28 +637,24 @@ jobs:
           script: |
             const fs = require('fs');
             const manifest = JSON.parse(fs.readFileSync('evidence-bundle-manifest.json', 'utf8'));
-            const s = manifest.summary;
-            const claims = manifest.summary.claims_ready;
-            const hash = manifest.integrity.bundle_hash.slice(0, 22);
+            const matrix = JSON.parse(fs.readFileSync('ccvs-compliance-matrix.json', 'utf8'));
+            const s = matrix.summary;
+            const b = manifest.summary || {};
+            const rows = matrix.rows.map(r => '| ' + r.requirement_id + ' | ' + r.control_id + ' | ' + r.status.toUpperCase() + ' |');
             const comment = [
               '## CCVS Evidence Bundle Report',
               '',
-              '**Claim Eligibility:** ' + (s.claim_pass_eligible ? 'ELIGIBLE' : 'NOT ELIGIBLE'),
+              '**Claim Eligibility:** ' + (s.claim_pass_eligible ? 'ELIGIBLE' : 'NOT ELIGIBLE') + ' (' + s.pass + '/' + s.total + ' pass)',
               '',
-              '### Claim Status',
-              '| Claim | Status |',
-              '|-------|--------|',
-              '| ISO-42001-A.6 | ' + (claims.ISO_42001_A6_ready ? 'READY' : 'NOT READY') + ' |',
-              '| NIST-GOVERN-01 | ' + (claims.NIST_GOVERN_01_ready ? 'READY' : 'NOT READY') + ' |',
-              '| GDPR-AUDIT | ' + (claims.GDPR_AUDIT_READY ? 'READY' : 'NOT READY') + ' |',
-              '| SOC2-CONTROL | ' + (claims.SOC2_CONTROL_READY ? 'READY' : 'NOT READY') + ' |',
+              '| Requirement | Control | Status |',
+              '|-------------|---------|--------|',
+              ...rows,
               '',
-              '### Metrics',
-              '- Evidence files: ' + manifest.evidence_count,
-              '- Coverage: ' + manifest.metrics.coverage_percent.toFixed(1) + '%',
-              '- Mutation score: ' + manifest.metrics.mutation_score.toFixed(1) + '%',
-              '- Tests: ' + manifest.metrics.tests_passed + '/' + manifest.metrics.test_count + ' passed',
-              '- Bundle hash: `' + hash + '...`',
+              '### Bundle',
+              '- Artifacts in chain: ' + manifest.artifacts.length,
+              '- Chain hash: `' + String(manifest.chain_hash).slice(0, 22) + '...`',
+              '- Coverage (lines): ' + (b.coverage_lines_pct != null ? b.coverage_lines_pct + '%' : 'not collected'),
+              '- Mutation score: ' + (b.mutation_score != null ? b.mutation_score + '%' : 'not collected'),
             ].join('\n');
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -662,8 +666,8 @@ jobs:
         if: always() && steps.claims.outputs.claims_checked == 'true'
         run: |
           node -e "
-            const m=JSON.parse(require('fs').readFileSync('evidence-bundle-manifest.json','utf8'));
-            if(m.summary.claim_pass_eligible){
+            const matrix=JSON.parse(require('fs').readFileSync('ccvs-compliance-matrix.json','utf8'));
+            if(matrix.summary.claim_pass_eligible){
               console.log('✅ Claim readiness check PASSED');
             } else {
               console.log('⚠️  Claim readiness check INCOMPLETE (non-blocking in CI)');

--- a/.github/workflows/ccvs-evidence.yml
+++ b/.github/workflows/ccvs-evidence.yml
@@ -555,6 +555,10 @@ jobs:
     # Skip (not fail) when upstream evidence jobs failed — the bundle artifact
     # does not exist in that case, so downloading it can only error out.
     if: needs.build-evidence-bundle.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -632,6 +636,9 @@ jobs:
           "
       - name: Comment on PR (if applicable)
         if: github.event_name == 'pull_request'
+        # Best-effort: fork PRs get a read-only token, so a failed comment
+        # must not fail the claim readiness check itself.
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/ccvs-evidence.yml
+++ b/.github/workflows/ccvs-evidence.yml
@@ -546,7 +546,9 @@ jobs:
     name: "Check claim readiness"
     runs-on: ubuntu-latest
     needs: build-evidence-bundle
-    if: always()
+    # Skip (not fail) when upstream evidence jobs failed — the bundle artifact
+    # does not exist in that case, so downloading it can only error out.
+    if: needs.build-evidence-bundle.result == 'success'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/security-evidence.yml
+++ b/.github/workflows/security-evidence.yml
@@ -91,10 +91,10 @@ jobs:
               console.log('0 vulnerabilities (audit file parse)');
             }
           " || true
-          CRIT=\$(node -e "try{const a=JSON.parse(require('fs').readFileSync('artifacts/security/npm-audit.json','utf8'));console.log(a.metadata?.vulnerabilities?.critical||0)}catch{console.log(0)}" 2>/dev/null || echo "0")
-          HIGH=\$(node -e "try{const a=JSON.parse(require('fs').readFileSync('artifacts/security/npm-audit.json','utf8'));console.log(a.metadata?.vulnerabilities?.high||0)}catch{console.log(0)}" 2>/dev/null || echo "0")
-          echo "critical=\$CRIT" >> "$GITHUB_OUTPUT"
-          echo "high=\$HIGH" >> "$GITHUB_OUTPUT"
+          CRIT=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('artifacts/security/npm-audit.json','utf8'));console.log(a.metadata?.vulnerabilities?.critical||0)}catch{console.log(0)}" 2>/dev/null || echo "0")
+          HIGH=$(node -e "try{const a=JSON.parse(require('fs').readFileSync('artifacts/security/npm-audit.json','utf8'));console.log(a.metadata?.vulnerabilities?.high||0)}catch{console.log(0)}" 2>/dev/null || echo "0")
+          echo "critical=$CRIT" >> "$GITHUB_OUTPUT"
+          echo "high=$HIGH" >> "$GITHUB_OUTPUT"
 
       - name: Upload npm audit artifact
         if: always()

--- a/app/api/spine/execute/route.ts
+++ b/app/api/spine/execute/route.ts
@@ -258,15 +258,24 @@ export async function POST(request: Request) {
 
     // Count executions only on success (2xx)
     if (result.status >= 200 && result.status < 300) {
-      void incrementQuota(orgId, agentId);
+      // Fire-and-forget side effects must not become unhandled rejections —
+      // a rejected floating promise can take down the worker after the
+      // response has already been returned.
+      void incrementQuota(orgId, agentId).catch((error) => {
+        console.error('[api/spine/execute] incrementQuota failed:', error);
+      });
       void fireWebhook(orgId, 'execution.completed', {
         agent_id: agentId,
         decision: (result.body as Record<string, unknown>)?.decision ?? null,
+      }).catch((error) => {
+        console.error('[api/spine/execute] fireWebhook failed:', error);
       });
       const executionId =
         ((result.body as Record<string, unknown>)?.execution_id as string | undefined) ??
         randomUUID();
-      void meterExecution(orgId, 1, executionId);
+      void meterExecution(orgId, 1, executionId).catch((error) => {
+        console.error('[api/spine/execute] meterExecution failed:', error);
+      });
     }
 
     // Add stop_reason to response (Phase 2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/node": "^20.17.0",
         "@types/react": "^18.2.79",
-        "@vitest/coverage-v8": "^2.1.9",
+        "@vitest/coverage-v8": "^3.2.6",
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.15",
@@ -39,7 +39,7 @@
         "supabase": "^2.89.0",
         "tailwindcss": "^3.4.3",
         "typescript": "5.8.3",
-        "vitest": "^2.1.9",
+        "vitest": "^3.2.6",
         "z3-solver": "^4.16.0"
       }
     },
@@ -641,11 +641,14 @@
       }
     },
     "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -681,9 +684,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -698,9 +701,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -715,9 +718,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -732,9 +735,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -749,9 +752,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -766,9 +769,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -783,9 +786,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -800,9 +803,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -817,9 +820,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -834,9 +837,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -851,9 +854,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -868,9 +871,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -885,9 +888,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -902,9 +905,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -919,9 +922,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -936,9 +939,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -953,9 +956,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -970,9 +973,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -987,9 +990,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1004,9 +1007,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1021,9 +1024,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1038,9 +1041,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1055,9 +1058,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1072,9 +1075,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1089,9 +1092,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1106,9 +1109,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -3874,6 +3877,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3935,6 +3949,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -4643,31 +4664,32 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
-      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^0.2.3",
-        "debug": "^4.3.7",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.12",
+        "magic-string": "^0.30.17",
         "magicast": "^0.3.5",
-        "std-env": "^3.8.0",
+        "std-env": "^3.9.0",
         "test-exclude": "^7.0.1",
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "2.1.9",
-        "vitest": "2.1.9"
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4676,38 +4698,39 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4719,70 +4742,71 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5363,6 +5387,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -6531,9 +6574,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6544,32 +6587,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -9669,9 +9712,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -11085,6 +11128,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stripe": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
@@ -11643,9 +11706,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11653,9 +11716,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12050,21 +12113,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -12073,17 +12139,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -12106,79 +12178,123 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
@@ -12196,6 +12312,19 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "^20.17.0",
     "@types/react": "^18.2.79",
-    "@vitest/coverage-v8": "^2.1.9",
+    "@vitest/coverage-v8": "^3.2.6",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.15",
@@ -94,7 +94,7 @@
     "supabase": "^2.89.0",
     "tailwindcss": "^3.4.3",
     "typescript": "5.8.3",
-    "vitest": "^2.1.9",
+    "vitest": "^3.2.6",
     "z3-solver": "^4.16.0"
   },
   "overrides": {

--- a/scripts/build-evidence-bundle.mjs
+++ b/scripts/build-evidence-bundle.mjs
@@ -324,7 +324,8 @@ function extractMutationSummary(data) {
       noCoverage: data.metrics.noCoverage || 0,
       timeout: data.metrics.timeout || 0,
       runtimeError: data.metrics.runtimeError || 0,
-      score: data.metrics.mutationScore || 0,
+      // Stryker reports use mutationScore; CCVS evidence envelopes use mutation_score.
+      score: data.metrics.mutationScore ?? data.metrics.mutation_score ?? 0,
     };
   }
   return null;

--- a/tests/integration/api/spine-execute-safe-dom.test.ts
+++ b/tests/integration/api/spine-execute-safe-dom.test.ts
@@ -46,12 +46,14 @@ vi.mock('../../../lib/spine/verify-safe-dom-intent', () => ({
   verifySafeDomIntentOrPass: verifySafeDomIntentOrPassMock,
 }));
 
+// Both are async in the real modules — the route chains .catch() on them,
+// so the mocks must return promises.
 vi.mock('../../../lib/webhooks/deliver', () => ({
-  fireWebhook: vi.fn(),
+  fireWebhook: vi.fn(async () => undefined),
 }));
 
 vi.mock('../../../lib/billing/metered', () => ({
-  meterExecution: vi.fn(),
+  meterExecution: vi.fn(async () => undefined),
 }));
 
 function request(body: unknown, headers: Record<string, string> = {}) {

--- a/tests/integration/api/spine-execute.test.ts
+++ b/tests/integration/api/spine-execute.test.ts
@@ -304,7 +304,7 @@ describe('/api/spine/execute', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ request_id: 'req_1', decision: 'ALLOW' });
+    expect(body).toEqual({ request_id: 'req_1', decision: 'ALLOW', stop_reason: 'NONE' });
     expect(resolveAgentFromApiKey).toHaveBeenCalledWith('agt_1', 'dsg_live_good');
     expect(executeSpineIntent).toHaveBeenCalledWith({
       orgId: 'org_1',
@@ -384,7 +384,7 @@ describe('/api/spine/execute', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ request_id: 'req_2', decision: 'ALLOW' });
+    expect(body).toEqual({ request_id: 'req_2', decision: 'ALLOW', stop_reason: 'NONE' });
     expect(issueSpineIntent).toHaveBeenCalledOnce();
     expect(executeSpineIntent).toHaveBeenCalledTimes(2);
   });

--- a/tests/integration/delegation-end-to-end.test.ts
+++ b/tests/integration/delegation-end-to-end.test.ts
@@ -88,7 +88,9 @@ function checkPermission(step: AgentWorkStep, delegation: DelegationContract): {
   return { allowed: true, reason: 'Permission granted' };
 }
 
-describe('User-Delegated AGI Runtime E2E', () => {
+// Live-DB suite: requires a real Supabase project. Skipped when the service
+// role key / URL are not configured (e.g. unit-evidence CI jobs).
+describe.skipIf(!process.env.SUPABASE_SERVICE_ROLE_KEY || !process.env.NEXT_PUBLIC_SUPABASE_URL)('User-Delegated AGI Runtime E2E', () => {
   let supabase: SupabaseClient;
 
   beforeEach(() => {

--- a/tests/integration/delegation-multiagent.test.ts
+++ b/tests/integration/delegation-multiagent.test.ts
@@ -16,7 +16,9 @@ import {
   makeTestId,
 } from './helpers/supabase-test-factory';
 
-describe('Delegation Multi-Agent Isolation', () => {
+// Live-DB suite: requires a real Supabase project. Skipped when the service
+// role key / URL are not configured (e.g. unit-evidence CI jobs).
+describe.skipIf(!process.env.SUPABASE_SERVICE_ROLE_KEY || !process.env.NEXT_PUBLIC_SUPABASE_URL)('Delegation Multi-Agent Isolation', () => {
   let supabase: SupabaseClient;
 
   beforeEach(() => {

--- a/tests/integration/local-browser-executor.e2e.test.ts
+++ b/tests/integration/local-browser-executor.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import http from 'node:http';
+import fs from 'node:fs';
 import type { AddressInfo } from 'node:net';
 import { buildSafeManifest } from '@/lib/dsg/safe-dom/manifest';
 import type { RawDomElement, SafeDomCommand } from '@/lib/dsg/safe-dom/types';
@@ -17,6 +18,19 @@ const TEST_PAGE = `<!doctype html>
     <button id="next-step" type="button">Next</button>
   </form>
 </body></html>`;
+
+// The "live" test needs a downloaded Chromium (npx playwright-core install
+// chromium). CI unit jobs do not install browsers, so skip it there instead of
+// failing on browserType.launch.
+function chromiumInstalled(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { chromium } = require('playwright-core') as typeof import('playwright-core');
+    return fs.existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+}
 
 describe('Local self-hosted browser executor (real Chromium, local page)', () => {
   let server: http.Server;
@@ -157,7 +171,7 @@ describe('Local self-hosted browser executor (real Chromium, local page)', () =>
     delete process.env.HERMES_LOCAL_BROWSER_LIVE;
   });
 
-  it('live: drives a real Chromium, types into a real DOM input, captures evidence', async () => {
+  it.skipIf(!chromiumInstalled())('live: drives a real Chromium, types into a real DOM input, captures evidence', async () => {
     process.env.HERMES_LOCAL_BROWSER_LIVE = 'true';
 
     const rawElements: RawDomElement[] = [

--- a/tests/smoke/deployment.test.ts
+++ b/tests/smoke/deployment.test.ts
@@ -6,11 +6,16 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
  * Validates core API endpoints and deployment health after deploying
  * to production or staging environments.
  *
- * Run with: npm run test tests/smoke/deployment.test.ts
- * Or against production: SMOKE_TEST_URL=https://prod.example.com npm run test tests/smoke/deployment.test.ts
+ * Requires a reachable target, so the suite only runs when SMOKE_TEST_URL is set:
+ *   Local dev server: SMOKE_TEST_URL=http://localhost:3000 npm run test tests/smoke/deployment.test.ts
+ *   Production:       SMOKE_TEST_URL=https://prod.example.com npm run test tests/smoke/deployment.test.ts
+ *
+ * Without SMOKE_TEST_URL (e.g. plain `npm run test` in CI) the suite is skipped —
+ * there is no server to probe and every request would fail with status 0.
  */
 
 // Configuration
+const SMOKE_TEST_ENABLED = Boolean(process.env.SMOKE_TEST_URL);
 const BASE_URL = process.env.SMOKE_TEST_URL || 'http://localhost:3000';
 const AUTH_TOKEN = process.env.SMOKE_TEST_TOKEN || '';
 const CURL_TIMEOUT = 10000; // 10 seconds
@@ -85,7 +90,7 @@ async function measureResponseTime(fn: () => Promise<unknown>): Promise<number> 
   return end - start;
 }
 
-describe('Post-Deployment Smoke Tests', () => {
+describe.skipIf(!SMOKE_TEST_ENABLED)('Post-Deployment Smoke Tests', () => {
   beforeAll(() => {
     console.log(`\n🚀 Running smoke tests against: ${BASE_URL}`);
     console.log(`📝 Auth token: ${AUTH_TOKEN ? AUTH_TOKEN.slice(0, 20) + '...' : 'none'}`);


### PR DESCRIPTION
Goal:

Fix the four pre-existing CI failures observed on main (ccvs-evidence run 27401456491, security-evidence run 27401456613):

1. "npm audit — Production dependencies" — bash syntax error (`syntax error near unexpected token '('`, exit 2) caused by stray `\$` escapes in the "Count vulnerabilities" step.
2. "Security evidence summary" — BLOCK status caused by 2 real critical npm audit findings in vitest@2.x (GHSA-5xrq-8626-4rwp). Fixed at the source by upgrading vitest, not by weakening the gate.
3. "Check claim readiness" — job ran with `if: always()` and hard-failed downloading the `evidence-bundle-*` artifact that does not exist when upstream evidence jobs fail. Now skips instead; the real failure stays visible on the upstream job.
4. "L1 — Unit evidence" — unhandled rejections from fire-and-forget calls in `app/api/spine/execute/route.ts` (`incrementQuota` / `fireWebhook` / `meterExecution` without `.catch()`), plus environment-dependent suites (deployment smoke, live-DB delegation, live Chromium) failing in CI where their environment is absent, plus stale spine-execute expectations missing the `stop_reason` field the route now returns.

Files changed:

- `.github/workflows/security-evidence.yml` — remove `\$` escapes in npm-audit "Count vulnerabilities" step
- `.github/workflows/ccvs-evidence.yml` — "Check claim readiness" skips when `build-evidence-bundle` did not succeed
- `package.json` / `package-lock.json` — vitest + @vitest/coverage-v8 `^2.1.9` → `^3.2.6` (clears both critical advisories; `npm audit` now reports 0 vulnerabilities)
- `app/api/spine/execute/route.ts` — `.catch()` + error log on the three fire-and-forget side-effect calls
- `tests/integration/api/spine-execute.test.ts` — expect `stop_reason: 'NONE'` in success responses
- `tests/integration/api/spine-execute-safe-dom.test.ts` — async mocks return promises (route now chains `.catch()`)
- `tests/smoke/deployment.test.ts` — suite skips unless `SMOKE_TEST_URL` is set (no server exists in unit CI)
- `tests/integration/delegation-end-to-end.test.ts`, `tests/integration/delegation-multiagent.test.ts` — live-DB suites skip without `SUPABASE_SERVICE_ROLE_KEY` + `NEXT_PUBLIC_SUPABASE_URL`
- `tests/integration/local-browser-executor.e2e.test.ts` — live Chromium test skips when the browser executable is not installed

Verification:

- [x] `npm run test` — 1983 passed / 56 skipped / 0 failed, no unhandled rejections (main was 34 failed)
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass (placeholder Supabase env, same as CI)
- [x] `npm audit` — 0 vulnerabilities (was 2 critical + 3 moderate)
- [x] Workflow YAML parsed successfully
- [ ] Branch CI (ccvs-evidence run 27415442633 + security-evidence) — pending at PR creation time; merge only after green

Known limits:

- vitest 2 → 3 is a semver-major upgrade; the full suite, typecheck, and build pass locally, but Stryker mutation run (L4) uses `@stryker-mutator/vitest-runner` (peer `vitest >=2.0.0`) and is first exercised end-to-end in this CI run.
- The skipped live suites (smoke, delegation live-DB, live Chromium) still need a configured environment to run; skipping is honest reporting, not a pass.
- 2 critical vulnerabilities were dev-dependency only (vitest tooling), but the security gate correctly counted them; this PR clears them rather than relabeling.

User-visible benefit:

CI signal becomes trustworthy again: evidence jobs fail only on real regressions, the security gate reports 0 known vulnerabilities, and governed-execution responses no longer risk crashing workers via unhandled rejections.

Next step:

Wait for branch/PR CI to pass, merge to main, then verify the production deployment (`/api/health`, `/api/agent/status`, readiness) before claiming GO.

https://claude.ai/code/session_013ZC1jHpkuoXKb8tCkSjGzh

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZC1jHpkuoXKb8tCkSjGzh)_