### PR TITLE
Fix Stripe App OAuth disconnect lifecycle gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,10 @@ NEXT_PUBLIC_STRIPE_CLIENT_ID=
 STRIPE_CLIENT_SECRET=
 
 # ============ Stripe Billing ============
+# Live secret key; required for live OAuth token exchange and manual deauthorization.
 STRIPE_SECRET_KEY=
+# Sandbox secret key; required for sandbox OAuth token exchange and manual deauthorization.
+STRIPE_SANDBOX_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_PRICE_PRO=
 STRIPE_PRICE_BUSINESS=
@@ -90,3 +93,15 @@ GITHUB_APP_AGENT_ID=github-app-gate
 # Default: en (English)
 # Examples: th (ไทย), en (English), zh (中文), ja (日本語)
 PREFERRED_LANGUAGE=en
+
+# Stripe App Marketplace install lifecycle (server-side)
+# Copy the clean Live/Sandbox OAuth URLs from Stripe Developer Dashboard Settings.
+STRIPE_LIVE_INSTALL_URL=
+STRIPE_SANDBOX_INSTALL_URL=
+# Mode-specific server-side client IDs used to validate install URLs and revoke access.
+STRIPE_CONNECT_CLIENT_ID=
+STRIPE_SANDBOX_CONNECT_CLIENT_ID=
+# Unique secret used to sign and verify one-time OAuth state values.
+STRIPE_CONNECT_STATE_SECRET=
+# Signing secret for /api/stripe-app/webhook (account.application.deauthorized).
+STRIPE_APP_WEBHOOK_SECRET=

--- a/app/api/stripe-app/disconnect/route.ts
+++ b/app/api/stripe-app/disconnect/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getSupabaseAdmin } from "@/lib/supabase-server";
+import { isStripeInstallMode } from "@/lib/stripe-app/oauth-config";
+import { deauthorizeStripeAccount } from "@/lib/stripe-app/deauthorize";
+
+const CONNECTED_COOKIES = [
+  "dsg_stripe_connected",
+  "dsg_stripe_account_id",
+  "dsg_stripe_connected_mode",
+  "dsg_stripe_connected_at",
+];
+
+export async function POST(request: NextRequest) {
+  const supabaseAuth = await createClient();
+  const {
+    data: { user },
+  } = await supabaseAuth.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const formData = await request.formData();
+  const submittedAccountId = formData.get("stripe_account_id");
+  if (typeof submittedAccountId !== "string" || !submittedAccountId.startsWith("acct_")) {
+    return NextResponse.json({ error: "valid_stripe_account_id_required" }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin() as any;
+  const { data: memberships, error: membershipError } = await supabase
+    .from("org_members")
+    .select("org_id, organization_id")
+    .eq("user_id", user.id);
+  if (membershipError) return NextResponse.json({ error: "membership_lookup_failed" }, { status: 503 });
+
+  const orgIds = (memberships ?? [])
+    .map((membership: { org_id?: string; organization_id?: string }) => membership.org_id || membership.organization_id)
+    .filter(Boolean);
+  if (orgIds.length === 0) return NextResponse.json({ error: "organization_membership_required" }, { status: 403 });
+
+  const { data: account, error: accountError } = await supabase
+    .from("stripe_app_accounts")
+    .select("stripe_account_id, status, metadata")
+    .eq("stripe_account_id", submittedAccountId)
+    .in("dsg_org_id", orgIds)
+    .maybeSingle();
+  if (accountError) return NextResponse.json({ error: "connected_account_lookup_failed" }, { status: 503 });
+  if (!account || account.status !== "active") return NextResponse.json({ error: "active_connected_account_not_found" }, { status: 404 });
+
+  const mode = account.metadata?.install_mode;
+  if (!isStripeInstallMode(mode)) return NextResponse.json({ error: "connected_account_mode_unknown" }, { status: 409 });
+
+  try {
+    await deauthorizeStripeAccount(mode, submittedAccountId);
+  } catch (error) {
+    console.error("[stripe-app/disconnect] Stripe OAuth deauthorization failed:", error);
+    return NextResponse.json({ error: "stripe_deauthorization_failed" }, { status: 502 });
+  }
+
+  const disconnectedAt = new Date().toISOString();
+  const { error } = await supabase
+    .from("stripe_app_accounts")
+    .update({ status: "inactive", disconnected_at: disconnectedAt, disconnect_reason: "manual_disconnect", updated_at: disconnectedAt })
+    .eq("stripe_account_id", submittedAccountId)
+    .in("dsg_org_id", orgIds)
+    .eq("status", "active");
+  if (error) return NextResponse.json({ error: "disconnect_persist_failed" }, { status: 503 });
+
+  const response = NextResponse.redirect(new URL("/dashboard/stripe-app?disconnected=true", request.url), { status: 303 });
+  for (const cookie of CONNECTED_COOKIES) response.cookies.delete(cookie);
+  return response;
+}

--- a/app/api/stripe-app/oauth/callback/route.ts
+++ b/app/api/stripe-app/oauth/callback/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { createClient } from '@/lib/supabase/server';
+import { isStripeInstallMode, resolveStripeSecretKey, type StripeInstallMode } from '@/lib/stripe-app/oauth-config';
+import { deauthorizeStripeAccount } from '@/lib/stripe-app/deauthorize';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,8 +18,6 @@ const CONNECTED_AT_COOKIE = 'dsg_stripe_connected_at';
 const CONNECTED_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
 const STATE_MAX_AGE_SECONDS = 30 * 60;
 
-type InstallMode = 'live' | 'sandbox';
-
 type SignedState = {
   nonce?: string;
   mode?: string;
@@ -25,18 +25,8 @@ type SignedState = {
   iat?: number;
 };
 
-function isInstallMode(value: string | undefined): value is InstallMode {
-  return value === 'live' || value === 'sandbox';
-}
-
 function getStateSecret() {
-  return (
-    process.env.STRIPE_CONNECT_STATE_SECRET ||
-    process.env.NEXTAUTH_SECRET ||
-    process.env.AUTH_SECRET ||
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    'dsg-local-state-secret'
-  );
+  return process.env.STRIPE_CONNECT_STATE_SECRET || process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET || null;
 }
 
 function safeCompare(left: string, right: string) {
@@ -49,7 +39,9 @@ function verifySignedState(state: string): SignedState | null {
   const [encoded, signature] = state.split('.');
   if (!encoded || !signature) return null;
 
-  const expected = createHmac('sha256', getStateSecret()).update(encoded).digest('base64url');
+  const secret = getStateSecret();
+  if (!secret) return null;
+  const expected = createHmac('sha256', secret).update(encoded).digest('base64url');
   if (!safeCompare(signature, expected)) return null;
 
   try {
@@ -58,7 +50,8 @@ function verifySignedState(state: string): SignedState | null {
     const ageSeconds = Math.floor(Date.now() / 1000) - issuedAt;
 
     if (ageSeconds < 0 || ageSeconds > STATE_MAX_AGE_SECONDS) return null;
-    if (!isInstallMode(payload.mode)) return null;
+    if (!isStripeInstallMode(payload.mode)) return null;
+    if (typeof payload.nonce !== 'string' || payload.nonce.length < 16) return null;
     if (typeof payload.userId !== 'string' || payload.userId.length === 0) return null;
 
     return payload;
@@ -70,7 +63,7 @@ function verifySignedState(state: string): SignedState | null {
 function jsonWithConnectionCookies(
   body: Record<string, unknown>,
   status: number,
-  connection?: { accountId: string; mode: InstallMode; connectedAt: string },
+  connection?: { accountId: string; mode: StripeInstallMode; connectedAt: string },
 ) {
   const response = NextResponse.json(body, { status });
 
@@ -113,7 +106,7 @@ function jsonWithConnectionCookies(
   return response;
 }
 
-async function resolveOrgId(userId: string): Promise<string> {
+async function resolveOrgId(userId: string): Promise<string | null> {
   const supabase = getSupabaseAdmin();
 
   try {
@@ -132,10 +125,10 @@ async function resolveOrgId(userId: string): Promise<string> {
       .limit(1);
 
     const membership = data?.[0];
-    return membership?.org_id || membership?.organization_id || userId;
+    return membership?.org_id || membership?.organization_id || null;
   } catch (error) {
-    console.warn('[stripe-app/oauth/callback] Could not resolve org membership; falling back to user id:', error);
-    return userId;
+    console.error('[stripe-app/oauth/callback] Could not resolve org membership:', error);
+    return null;
   }
 }
 
@@ -159,8 +152,8 @@ export async function POST(request: NextRequest) {
     const installUserId = cookieStore.get(USER_COOKIE)?.value;
     const signedState = verifySignedState(state);
 
-    if (!signedState && expectedState && expectedState !== state) {
-      console.warn('[stripe-app/oauth/callback] Rejecting request: state mismatch');
+    if (!signedState || !expectedState || !safeCompare(expectedState, state)) {
+      console.warn('[stripe-app/oauth/callback] Rejecting request: invalid, expired, or mismatched state');
       return NextResponse.json({ message: 'Invalid state parameter' }, { status: 400 });
     }
 
@@ -169,16 +162,20 @@ export async function POST(request: NextRequest) {
       data: { user },
     } = await supabaseAuth.auth.getUser();
 
-    const userId = user?.id || signedState?.userId || installUserId;
-    const mode = isInstallMode(signedState?.mode)
-      ? signedState.mode
-      : isInstallMode(installMode)
-        ? installMode
-        : 'live';
+    if (!user || user.id !== signedState.userId || installUserId !== signedState.userId) {
+      console.warn('[stripe-app/oauth/callback] Rejecting request: OAuth state user mismatch');
+      return NextResponse.json({ message: 'Invalid state user' }, { status: 403 });
+    }
+
+    const userId = user.id;
+    if (!isStripeInstallMode(signedState.mode) || installMode !== signedState.mode) {
+      return NextResponse.json({ message: 'Invalid install mode state' }, { status: 400 });
+    }
+    const mode = signedState.mode;
 
     console.info('[stripe-app/oauth/callback] State accepted for mode:', mode);
 
-    const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+    const stripeSecretKey = resolveStripeSecretKey(mode);
     if (!stripeSecretKey) {
       return NextResponse.json({ message: 'Stripe not configured' }, { status: 503 });
     }
@@ -222,7 +219,10 @@ export async function POST(request: NextRequest) {
 
     try {
       const supabase = getSupabaseAdmin();
-      const dsgOrgId = userId ? await resolveOrgId(userId) : stripeAccountId;
+      const dsgOrgId = await resolveOrgId(userId);
+      if (!dsgOrgId) {
+        return NextResponse.json({ message: 'No DSG organization membership found' }, { status: 403 });
+      }
       const { error: upsertError } = await (supabase as unknown as {
         from: (table: string) => {
           upsert: (
@@ -245,8 +245,11 @@ export async function POST(request: NextRequest) {
               install_mode: mode,
               linked_user_id: userId ?? null,
               dashboard_sync: true,
-              state_verified: Boolean(signedState),
+              state_verified: true,
             },
+            disconnected_at: null,
+            disconnect_reason: null,
+            last_lifecycle_event_id: null,
           },
           { onConflict: 'stripe_account_id' },
         );
@@ -260,6 +263,24 @@ export async function POST(request: NextRequest) {
     } catch (dbErr) {
       persistError = dbErr instanceof Error ? dbErr.message : 'Unknown DB error';
       console.error('[stripe-app/oauth/callback] DB error:', dbErr);
+    }
+
+    if (!persisted) {
+      let compensationSucceeded = false;
+      try {
+        await deauthorizeStripeAccount(mode, stripeAccountId);
+        compensationSucceeded = true;
+      } catch (compensationError) {
+        console.error('[stripe-app/oauth/callback] Failed to compensate unpersisted OAuth connection:', compensationError);
+      }
+      return NextResponse.json(
+        {
+          message: 'Stripe connection could not be persisted',
+          persist_error: persistError,
+          stripe_access_revoked: compensationSucceeded,
+        },
+        { status: 503 },
+      );
     }
 
     return jsonWithConnectionCookies(

--- a/app/api/stripe-app/webhook/route.ts
+++ b/app/api/stripe-app/webhook/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { getSupabaseAdmin } from "@/lib/supabase-server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const webhookSecret = process.env.STRIPE_APP_WEBHOOK_SECRET;
+  if (!webhookSecret) return NextResponse.json({ error: "stripe_app_webhook_not_configured" }, { status: 503 });
+
+  const signature = request.headers.get("stripe-signature");
+  if (!signature) return NextResponse.json({ error: "missing_stripe_signature" }, { status: 400 });
+
+  let event: Stripe.Event;
+  try {
+    event = Stripe.webhooks.constructEvent(await request.text(), signature, webhookSecret);
+  } catch {
+    return NextResponse.json({ error: "invalid_signature" }, { status: 400 });
+  }
+
+  if (event.type !== "account.application.deauthorized") {
+    return NextResponse.json({ received: true, handled: false });
+  }
+
+  const stripeAccountId = typeof event.account === "string" ? event.account : null;
+  if (!stripeAccountId) return NextResponse.json({ error: "missing_stripe_account_id" }, { status: 400 });
+
+  const disconnectedAt = new Date(event.created * 1000).toISOString();
+  const supabase = getSupabaseAdmin() as any;
+  const { data, error } = await supabase
+    .from("stripe_app_accounts")
+    .update({
+      status: "revoked",
+      disconnected_at: disconnectedAt,
+      disconnect_reason: "account.application.deauthorized",
+      last_lifecycle_event_id: event.id,
+      updated_at: disconnectedAt,
+    })
+    .eq("stripe_account_id", stripeAccountId)
+    .lte("installed_at", disconnectedAt)
+    .select("stripe_account_id");
+
+  if (error) {
+    console.error("[stripe-app/webhook] Failed to persist deauthorization:", error.message);
+    return NextResponse.json({ error: "deauthorization_persist_failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true, handled: Boolean(data?.length) });
+}

--- a/app/api/stripe/connect/install/route.ts
+++ b/app/api/stripe/connect/install/route.ts
@@ -1,35 +1,25 @@
 import { createHmac, randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { buildStripeInstallUrl, resolveStripeInstallMode } from '@/lib/stripe-app/install-url';
+import { resolveStripeClientId, resolveStripeConfiguredInstallUrl, type StripeInstallMode } from '@/lib/stripe-app/oauth-config';
 
 const DEFAULT_CALLBACK_PATH = '/stripe/oauth/callback';
 const STATE_COOKIE = 'dsg_stripe_connect_state';
 const MODE_COOKIE = 'dsg_stripe_connect_mode';
 const USER_COOKIE = 'dsg_stripe_connect_user_id';
 const STATE_MAX_AGE_SECONDS = 30 * 60;
-const DEFAULT_STRIPE_INSTALL_URL =
-  'https://marketplace.stripe.com/oauth/v2/' +
-  'chnlink_61UpJ0wqNe8NQ3pYF41AZNzhgTUPV4R6' +
-  '/authorize?client_id=' +
-  'ca_UfEPAC4NcvG2nYAYjohDQ9GtDlIdajy6';
-
-type InstallMode = 'live' | 'sandbox';
-
 type StripeStatePayload = {
   nonce: string;
-  mode: InstallMode;
+  mode: StripeInstallMode;
   userId: string;
   iat: number;
 };
 
 function getStateSecret() {
-  return (
-    process.env.STRIPE_CONNECT_STATE_SECRET ||
-    process.env.NEXTAUTH_SECRET ||
-    process.env.AUTH_SECRET ||
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    'dsg-local-state-secret'
-  );
+  const secret = process.env.STRIPE_CONNECT_STATE_SECRET || process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET;
+  if (!secret) throw new Error('STRIPE_CONNECT_STATE_SECRET is not configured');
+  return secret;
 }
 
 function toBase64Url(value: string) {
@@ -48,65 +38,6 @@ function getAppOrigin(requestUrl: string) {
   return new URL(requestUrl).origin;
 }
 
-function resolveMode(request: NextRequest): InstallMode {
-  return request.nextUrl.searchParams.get('mode') === 'sandbox' ? 'sandbox' : 'live';
-}
-
-function resolveClientId(mode: InstallMode) {
-  if (mode === 'sandbox') {
-    return (
-      process.env.NEXT_PUBLIC_STRIPE_SANDBOX_CLIENT_ID ||
-      process.env.STRIPE_SANDBOX_CONNECT_CLIENT_ID ||
-      process.env.NEXT_PUBLIC_STRIPE_CLIENT_ID ||
-      process.env.STRIPE_CONNECT_CLIENT_ID
-    );
-  }
-
-  return process.env.NEXT_PUBLIC_STRIPE_CLIENT_ID || process.env.STRIPE_CONNECT_CLIENT_ID;
-}
-
-function resolveConfiguredInstallUrl(mode: InstallMode) {
-  if (mode === 'sandbox') {
-    return (
-      process.env.STRIPE_SANDBOX_INSTALL_URL ||
-      process.env.NEXT_PUBLIC_STRIPE_SANDBOX_INSTALL_URL ||
-      process.env.STRIPE_EXTERNAL_TEST_URL ||
-      DEFAULT_STRIPE_INSTALL_URL
-    );
-  }
-
-  return (
-    process.env.STRIPE_LIVE_INSTALL_URL ||
-    process.env.NEXT_PUBLIC_STRIPE_LIVE_INSTALL_URL ||
-    DEFAULT_STRIPE_INSTALL_URL
-  );
-}
-
-function buildAuthorizeUrl({
-  mode,
-  clientId,
-  redirectUri,
-  state,
-}: {
-  mode: InstallMode;
-  clientId: string | null;
-  redirectUri: URL;
-  state: string;
-}) {
-  const configuredUrl = resolveConfiguredInstallUrl(mode);
-  const url = new URL(configuredUrl);
-
-  if (!url.searchParams.get('client_id')) {
-    if (!clientId) throw new Error(`${mode} Stripe client_id is not configured`);
-    url.searchParams.set('client_id', clientId);
-  }
-
-  url.searchParams.set('redirect_uri', redirectUri.toString());
-  url.searchParams.set('state', state);
-
-  return url;
-}
-
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -119,20 +50,42 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(loginUrl.toString(), { status: 302 });
   }
 
-  const mode = resolveMode(request);
-  const clientId = resolveClientId(mode) ?? null;
+  let mode: StripeInstallMode;
+  try {
+    mode = resolveStripeInstallMode(request.nextUrl.searchParams.get('mode'));
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Invalid Stripe install mode' },
+      { status: 400 },
+    );
+  }
+  const clientId = resolveStripeClientId(mode) ?? null;
   const callbackPath = process.env.STRIPE_CONNECT_CALLBACK_PATH || DEFAULT_CALLBACK_PATH;
   const redirectUri = new URL(callbackPath, getAppOrigin(request.url));
-  const state = signState({
-    nonce: randomUUID(),
-    mode,
-    userId: user.id,
-    iat: Math.floor(Date.now() / 1000),
-  });
+  let state: string;
+  try {
+    state = signState({
+      nonce: randomUUID(),
+      mode,
+      userId: user.id,
+      iat: Math.floor(Date.now() / 1000),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Stripe OAuth state is not configured' },
+      { status: 503 },
+    );
+  }
 
   let authorizeUrl: URL;
   try {
-    authorizeUrl = buildAuthorizeUrl({ mode, clientId, redirectUri, state });
+    authorizeUrl = buildStripeInstallUrl({
+      mode,
+      configuredUrl: resolveStripeConfiguredInstallUrl(mode),
+      clientId: clientId ?? undefined,
+      redirectUri: redirectUri.toString(),
+      state,
+    });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Stripe OAuth link is not configured' },

--- a/app/dashboard/stripe-app/page.tsx
+++ b/app/dashboard/stripe-app/page.tsx
@@ -23,10 +23,19 @@ export default async function StripeAppPage({ searchParams }: PageProps) {
   if (!user) redirect('/login?next=/dashboard/stripe-app');
 
   const params = searchParams ? await searchParams : {};
-  const connected = getParam(params, 'connected') === 'true';
-  const mode = getParam(params, 'mode') || 'live';
-  const accountId = getParam(params, 'account_id');
-  const connectedAt = getParam(params, 'connected_at');
+  const { data: activeAccounts } = await (supabase as any)
+    .from('stripe_app_accounts')
+    .select('stripe_account_id, status, installed_at, metadata')
+    .eq('status', 'active')
+    .order('updated_at', { ascending: false })
+    .limit(1);
+  const activeAccount = activeAccounts?.[0];
+  const connected = activeAccount?.status === 'active';
+  const mode = typeof activeAccount?.metadata?.install_mode === 'string'
+    ? activeAccount.metadata.install_mode
+    : getParam(params, 'mode') || 'live';
+  const accountId = activeAccount?.stripe_account_id;
+  const connectedAt = activeAccount?.installed_at;
 
   return (
     <div className="mx-auto max-w-7xl space-y-8 px-6 py-8">
@@ -68,6 +77,14 @@ export default async function StripeAppPage({ searchParams }: PageProps) {
             >
               {connected ? 'Reconnect Live Mode' : 'Connect Stripe Account'}
             </Link>
+            {connected && (
+              <form action="/api/stripe-app/disconnect" method="post">
+                <input type="hidden" name="stripe_account_id" value={accountId} />
+                <button type="submit" className="w-full shrink-0 rounded-lg border border-rose-600 px-6 py-3 text-center text-sm font-semibold text-rose-200 transition-colors hover:bg-rose-950">
+                  Disconnect
+                </button>
+              </form>
+            )}
           </div>
         </div>
       </section>

--- a/docs/STRIPE_APP_REVIEW_1_0_5_END_TO_END_GATE_2026-06-12.md
+++ b/docs/STRIPE_APP_REVIEW_1_0_5_END_TO_END_GATE_2026-06-12.md
@@ -1,0 +1,55 @@
+# Stripe App Review 1.0.5 — End-to-End Resubmission Gate (2026-06-12)
+
+## Decision
+
+**NO-GO for Stripe resubmission.** Repository-side fixes are in progress and automated compile/tests can prove only local behavior. A new submission remains blocked until the deployed Live and Sandbox installation flows, deauthorization webhook, Stripe Dashboard payment-detail viewport, listing text, and three authentic screenshots are verified with current production evidence.
+
+## Locked review requirements
+
+1. Live and Sandbox install buttons must use clean OAuth URLs without `channel_link`.
+2. OAuth callback must reject missing, expired, forged, replayed, mismatched, or wrong-user `state` values.
+3. A connection is successful only after the active account record is persisted.
+4. Manual disconnect and Stripe `account.application.deauthorized` must persist a non-active connection state.
+5. `stripe.dashboard.payment.detail` must render a safe loading, empty, REVIEW fallback, or decision state; it must not crash the drawer.
+6. Listing description must not contain template labels or unsupported claims.
+7. Three listing screenshots must be authentic Stripe Dashboard captures, at least 1600px wide, under 5MB, and contain no PII or testing indicators.
+8. The public support address should be a monitored shared mailbox before resubmission.
+
+## Deterministic invariants
+
+- `install_success -> valid_state AND authenticated_same_user AND persisted_active_account`
+- `invalid_state OR missing_membership OR persistence_failure -> no_connected_cookie AND no_success_claim`
+- `deauthorized_event AND valid_signature -> persisted_status = revoked`
+- `manual_disconnect AND authorized_org_member -> persisted_status = inactive`
+- `missing_context OR API_failure -> safe_view_state != drawer_crash`
+- `GO -> every required review item has current deployed evidence`
+
+## Local repository evidence added in this change
+
+- Public OAuth URL validation rejects `channel_link`, non-Stripe hosts/paths, missing client IDs, and client-ID mismatches instead of silently rewriting unsafe configuration.
+- Install route no longer falls back to an External Test URL and requires a configured state-signing secret.
+- OAuth callback requires a signed state, matching state cookie, same authenticated user, organization membership, and successful DB persistence before setting connected cookies.
+- Dedicated Stripe App webhook verifies its signature, persists `account.application.deauthorized` evidence as `revoked`, and ignores stale deauthorization events from an older installation.
+- Authenticated manual disconnect first revokes Stripe OAuth access with mode-matched credentials, then persists `inactive` evidence and clears connection cookies.
+- Stripe App package compile blockers were removed so the registered viewport code can be built locally.
+
+## Evidence still required before GO
+
+- [ ] Configure clean `STRIPE_LIVE_INSTALL_URL` and `STRIPE_SANDBOX_INSTALL_URL` from Stripe Developer Dashboard Settings.
+- [ ] Configure `STRIPE_CONNECT_STATE_SECRET`, `STRIPE_APP_WEBHOOK_SECRET`, mode-specific client IDs, and mode-specific Stripe secret keys in production secrets.
+- [ ] Apply `20260612000001_stripe_app_connection_lifecycle.sql` before deploying the lifecycle routes.
+- [ ] Register `/api/stripe-app/webhook` for `account.application.deauthorized` in Stripe.
+- [ ] Deploy the current commit and prove Live install end-to-end.
+- [ ] Deploy the current commit and prove Sandbox install end-to-end.
+- [ ] Prove manual Disconnect changes the DB-backed state and UI after refresh.
+- [ ] Prove uninstall from Stripe Dashboard triggers deauthorization and changes DB state to `revoked`.
+- [ ] Open the installed app on a real `stripe.dashboard.payment.detail` view and prove no drawer crash.
+- [ ] Verify ALLOW, BLOCK, REVIEW, missing-context, and API-unavailable viewport states with non-PII data.
+- [ ] Replace all three conceptual listing images with authentic compliant screenshots.
+- [ ] Confirm listing description contains no template label and every claim matches observed behavior.
+- [ ] Confirm a monitored shared support mailbox and update the Stripe listing.
+- [ ] Record a final review video showing install, viewport, disconnect, uninstall, and resulting connection state.
+
+## Final gate rule
+
+Keep **NO-GO** until every checkbox above has current deployed evidence. Passing local tests or a successful build alone does not prove Stripe Marketplace readiness.

--- a/lib/stripe-app/deauthorize.ts
+++ b/lib/stripe-app/deauthorize.ts
@@ -1,0 +1,26 @@
+import {
+  resolveStripeClientId,
+  resolveStripeSecretKey,
+  type StripeInstallMode,
+} from "@/lib/stripe-app/oauth-config";
+
+export async function deauthorizeStripeAccount(mode: StripeInstallMode, stripeAccountId: string) {
+  const clientId = resolveStripeClientId(mode);
+  const secretKey = resolveStripeSecretKey(mode);
+  if (!clientId || !secretKey) {
+    throw new Error(`${mode} Stripe deauthorization is not configured`);
+  }
+
+  const response = await fetch("https://connect.stripe.com/oauth/deauthorize", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${secretKey}:`).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ client_id: clientId, stripe_user_id: stripeAccountId }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Stripe OAuth deauthorization failed with HTTP ${response.status}`);
+  }
+}

--- a/lib/stripe-app/install-url.ts
+++ b/lib/stripe-app/install-url.ts
@@ -1,0 +1,51 @@
+import type { StripeInstallMode } from "@/lib/stripe-app/oauth-config";
+
+const FORBIDDEN_INSTALL_PARAMS = ["channel_link"];
+const OAUTH_AUTHORIZE_URL = "https://marketplace.stripe.com/oauth/v2/authorize";
+
+export function resolveStripeInstallMode(value: string | null): StripeInstallMode {
+  if (value === null || value === "live") return "live";
+  if (value === "sandbox") return "sandbox";
+  throw new Error("Stripe install mode must be live or sandbox");
+}
+
+export function buildStripeInstallUrl({
+  mode,
+  configuredUrl,
+  clientId,
+  redirectUri,
+  state,
+}: {
+  mode: StripeInstallMode;
+  configuredUrl?: string;
+  clientId?: string;
+  redirectUri: string;
+  state: string;
+}) {
+  if (!configuredUrl) {
+    throw new Error(`${mode} public Stripe OAuth URL is not configured`);
+  }
+
+  const url = new URL(configuredUrl);
+  if (url.origin !== new URL(OAUTH_AUTHORIZE_URL).origin || url.pathname !== new URL(OAUTH_AUTHORIZE_URL).pathname) {
+    throw new Error("Stripe OAuth URL must use the public marketplace authorize endpoint");
+  }
+
+  for (const param of FORBIDDEN_INSTALL_PARAMS) {
+    if (url.searchParams.has(param)) {
+      throw new Error(`${mode} Stripe OAuth URL contains forbidden ${param}`);
+    }
+  }
+
+  const configuredClientId = url.searchParams.get("client_id");
+  if (!configuredClientId) {
+    throw new Error(`${mode} public Stripe OAuth URL is missing client_id`);
+  }
+  if (clientId && configuredClientId !== clientId) {
+    throw new Error(`${mode} Stripe OAuth URL client_id does not match configured client_id`);
+  }
+
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("state", state);
+  return url;
+}

--- a/lib/stripe-app/oauth-config.ts
+++ b/lib/stripe-app/oauth-config.ts
@@ -1,0 +1,23 @@
+export type StripeInstallMode = "live" | "sandbox";
+
+export function isStripeInstallMode(value: unknown): value is StripeInstallMode {
+  return value === "live" || value === "sandbox";
+}
+
+export function resolveStripeClientId(mode: StripeInstallMode) {
+  return mode === "sandbox"
+    ? process.env.STRIPE_SANDBOX_CONNECT_CLIENT_ID || process.env.NEXT_PUBLIC_STRIPE_SANDBOX_CLIENT_ID
+    : process.env.STRIPE_CONNECT_CLIENT_ID || process.env.NEXT_PUBLIC_STRIPE_CLIENT_ID;
+}
+
+export function resolveStripeSecretKey(mode: StripeInstallMode) {
+  return mode === "sandbox"
+    ? process.env.STRIPE_SANDBOX_SECRET_KEY
+    : process.env.STRIPE_SECRET_KEY;
+}
+
+export function resolveStripeConfiguredInstallUrl(mode: StripeInstallMode) {
+  return mode === "sandbox"
+    ? process.env.STRIPE_SANDBOX_INSTALL_URL
+    : process.env.STRIPE_LIVE_INSTALL_URL;
+}

--- a/packages/stripe-app/src/lib/dsg-client.ts
+++ b/packages/stripe-app/src/lib/dsg-client.ts
@@ -1,3 +1,16 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let supabaseClient: SupabaseClient | null = null;
+
+export function getSupabase(): SupabaseClient {
+  if (supabaseClient) return supabaseClient;
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required');
+  supabaseClient = createClient(url, key, { auth: { persistSession: false } });
+  return supabaseClient;
+}
+
 /**
  * DSG Client
  *

--- a/packages/stripe-app/src/lib/stripe-secret-store.ts
+++ b/packages/stripe-app/src/lib/stripe-secret-store.ts
@@ -9,8 +9,7 @@
  * - Integrates with DSG policy evaluation for access control
  */
 
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { getSupabase, getDsgApiKey } from './dsg-client';
+import { getSupabase } from './dsg-client';
 
 export interface SecretMetadata {
   id: string;

--- a/packages/stripe-app/src/routes/webhooks.ts
+++ b/packages/stripe-app/src/routes/webhooks.ts
@@ -11,7 +11,6 @@
  */
 
 import { Hono } from 'hono';
-import { json } from 'hono/utils/body';
 import Stripe from 'stripe';
 
 const router = new Hono();
@@ -25,7 +24,7 @@ function getStripeClient(): Stripe {
     if (!secretKey) {
       throw new Error('STRIPE_SECRET_KEY is required');
     }
-    stripeClient = new Stripe(secretKey, { apiVersion: '2024-04-10' });
+    stripeClient = new Stripe(secretKey);
   }
   return stripeClient;
 }

--- a/packages/stripe-app/src/server.ts
+++ b/packages/stripe-app/src/server.ts
@@ -6,7 +6,6 @@
  */
 
 import { Hono } from 'hono';
-import { serve } from 'hono/node';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 
@@ -80,14 +79,4 @@ export function initializeStripeApp(): Hono {
   return app;
 }
 
-// Start server if running as CLI
-if (import.meta.url === `file://${process.argv[1]}`) {
-  const app = initializeStripeApp();
-
-  const port = parseInt(process.env.PORT || '3001', 10);
-  console.log(`🚀 Stripe App server running on http://localhost:${port}`);
-
-  serve({ fetch: app.fetch, port });
-}
-
-export default initializeStripeApp();
+export default initializeStripeApp;

--- a/supabase/migrations/20260612000001_stripe_app_connection_lifecycle.sql
+++ b/supabase/migrations/20260612000001_stripe_app_connection_lifecycle.sql
@@ -1,0 +1,9 @@
+-- Persist observable Stripe App disconnect/deauthorization evidence.
+ALTER TABLE stripe_app_accounts
+  ADD COLUMN IF NOT EXISTS disconnected_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS disconnect_reason TEXT,
+  ADD COLUMN IF NOT EXISTS last_lifecycle_event_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_stripe_app_accounts_lifecycle_event
+  ON stripe_app_accounts(last_lifecycle_event_id)
+  WHERE last_lifecycle_event_id IS NOT NULL;

--- a/tests/unit/stripe-app/deauthorization-webhook.test.ts
+++ b/tests/unit/stripe-app/deauthorization-webhook.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { constructEvent, select, lte, eq, update, from } = vi.hoisted(() => {
+  const constructEvent = vi.fn();
+  const select = vi.fn();
+  const lte = vi.fn(() => ({ select }));
+  const eq = vi.fn(() => ({ lte }));
+  const update = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ update }));
+  return { constructEvent, select, lte, eq, update, from };
+});
+
+vi.mock('stripe', () => ({
+  default: { webhooks: { constructEvent } },
+}));
+
+vi.mock('@/lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({ from }),
+}));
+
+import { POST } from '@/app/api/stripe-app/webhook/route';
+
+const deauthorizedEvent = {
+  id: 'evt_deauthorized',
+  type: 'account.application.deauthorized',
+  account: 'acct_revoked',
+  created: 1_750_000_000,
+  data: { object: {} },
+};
+
+describe('Stripe App deauthorization webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_APP_WEBHOOK_SECRET = 'whsec_example';
+    select.mockResolvedValue({ data: [{ stripe_account_id: 'acct_revoked' }], error: null });
+  });
+
+  afterEach(() => delete process.env.STRIPE_APP_WEBHOOK_SECRET);
+
+  it('only requires the dedicated webhook signing secret', async () => {
+    constructEvent.mockReturnValue(deauthorizedEvent);
+    const response = await POST(new Request('https://dsg.example/api/stripe-app/webhook', {
+      method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
+    }) as any);
+    expect(response.status).toBe(200);
+  });
+
+  it('fails closed when the dedicated Stripe App webhook is not configured', async () => {
+    delete process.env.STRIPE_APP_WEBHOOK_SECRET;
+    const response = await POST(new Request('https://dsg.example/api/stripe-app/webhook', { method: 'POST' }) as any);
+    expect(response.status).toBe(503);
+  });
+
+  it('rejects missing signatures before processing', async () => {
+    const response = await POST(new Request('https://dsg.example/api/stripe-app/webhook', { method: 'POST' }) as any);
+    expect(response.status).toBe(400);
+    expect(constructEvent).not.toHaveBeenCalled();
+  });
+
+  it('persists deauthorization evidence and protects a newer reconnect from stale events', async () => {
+    constructEvent.mockReturnValue(deauthorizedEvent);
+    const response = await POST(new Request('https://dsg.example/api/stripe-app/webhook', {
+      method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
+    }) as any);
+
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'revoked', disconnect_reason: 'account.application.deauthorized', last_lifecycle_event_id: 'evt_deauthorized',
+    }));
+    expect(eq).toHaveBeenCalledWith('stripe_account_id', 'acct_revoked');
+    expect(lte).toHaveBeenCalledWith('installed_at', new Date(deauthorizedEvent.created * 1000).toISOString());
+  });
+
+  it('returns handled false when a stale event does not match the current installation', async () => {
+    constructEvent.mockReturnValue(deauthorizedEvent);
+    select.mockResolvedValue({ data: [], error: null });
+    const response = await POST(new Request('https://dsg.example/api/stripe-app/webhook', {
+      method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
+    }) as any);
+    expect(await response.json()).toEqual({ received: true, handled: false });
+  });
+
+  it('returns 500 so Stripe retries when persistence fails', async () => {
+    constructEvent.mockReturnValue(deauthorizedEvent);
+    select.mockResolvedValue({ data: null, error: { message: 'db unavailable' } });
+    const response = await POST(new Request('https://dsg.example/api/stripe-app/webhook', {
+      method: 'POST', headers: { 'stripe-signature': 'valid' }, body: '{}',
+    }) as any);
+    expect(response.status).toBe(500);
+  });
+});

--- a/tests/unit/stripe-app/deauthorize.test.ts
+++ b/tests/unit/stripe-app/deauthorize.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { deauthorizeStripeAccount } from '@/lib/stripe-app/deauthorize';
+
+describe('Stripe OAuth deauthorization', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    process.env.STRIPE_CONNECT_CLIENT_ID = 'ca_live';
+    process.env.STRIPE_SECRET_KEY = 'sk_live_example';
+    process.env.STRIPE_SANDBOX_CONNECT_CLIENT_ID = 'ca_sandbox';
+    process.env.STRIPE_SANDBOX_SECRET_KEY = 'sk_test_example';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.STRIPE_CONNECT_CLIENT_ID;
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SANDBOX_CONNECT_CLIENT_ID;
+    delete process.env.STRIPE_SANDBOX_SECRET_KEY;
+  });
+
+  it('uses mode-matched credentials and the Stripe deauthorize endpoint', async () => {
+    await deauthorizeStripeAccount('sandbox', 'acct_sandbox');
+    expect(fetch).toHaveBeenCalledWith('https://connect.stripe.com/oauth/deauthorize', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: `Basic ${Buffer.from('sk_test_example:').toString('base64')}` }),
+      body: new URLSearchParams({ client_id: 'ca_sandbox', stripe_user_id: 'acct_sandbox' }),
+    }));
+  });
+
+  it('fails closed when mode-matched credentials are absent', async () => {
+    delete process.env.STRIPE_SANDBOX_SECRET_KEY;
+    await expect(deauthorizeStripeAccount('sandbox', 'acct_sandbox')).rejects.toThrow('sandbox Stripe deauthorization is not configured');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('fails when Stripe does not confirm revocation', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 400 } as Response);
+    await expect(deauthorizeStripeAccount('live', 'acct_live')).rejects.toThrow('HTTP 400');
+  });
+});

--- a/tests/unit/stripe-app/install-url.test.ts
+++ b/tests/unit/stripe-app/install-url.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildStripeInstallUrl, resolveStripeInstallMode } from '@/lib/stripe-app/install-url';
+
+const baseInput = {
+  mode: 'live' as const,
+  configuredUrl: 'https://marketplace.stripe.com/oauth/v2/authorize?client_id=ca_live',
+  clientId: 'ca_live',
+  redirectUri: 'https://dsg.example/stripe/oauth/callback',
+  state: 'signed-state',
+};
+
+describe('Stripe public OAuth install URLs', () => {
+  it('adds only the callback and signed state to a configured public URL', () => {
+    const url = buildStripeInstallUrl(baseInput);
+    expect(url.origin).toBe('https://marketplace.stripe.com');
+    expect(url.pathname).toBe('/oauth/v2/authorize');
+    expect(url.searchParams.get('client_id')).toBe('ca_live');
+    expect(url.searchParams.get('redirect_uri')).toBe(baseInput.redirectUri);
+    expect(url.searchParams.get('state')).toBe(baseInput.state);
+  });
+
+  it('rejects external-test channel links instead of silently turning them into a different URL', () => {
+    expect(() => buildStripeInstallUrl({
+      ...baseInput,
+      configuredUrl: `${baseInput.configuredUrl}&channel_link=external-test`,
+    })).toThrow('forbidden channel_link');
+  });
+
+  it('rejects arbitrary HTTPS hosts and incorrect paths', () => {
+    expect(() => buildStripeInstallUrl({ ...baseInput, configuredUrl: 'https://example.com/oauth?client_id=ca_live' }))
+      .toThrow('public marketplace authorize endpoint');
+    expect(() => buildStripeInstallUrl({ ...baseInput, configuredUrl: 'https://marketplace.stripe.com/not-oauth?client_id=ca_live' }))
+      .toThrow('public marketplace authorize endpoint');
+  });
+
+  it('rejects missing and mismatched client IDs', () => {
+    expect(() => buildStripeInstallUrl({ ...baseInput, configuredUrl: 'https://marketplace.stripe.com/oauth/v2/authorize' }))
+      .toThrow('missing client_id');
+    expect(() => buildStripeInstallUrl({ ...baseInput, configuredUrl: 'https://marketplace.stripe.com/oauth/v2/authorize?client_id=ca_other' }))
+      .toThrow('does not match');
+  });
+
+  it('requires an explicit public URL from Stripe Settings', () => {
+    expect(() => buildStripeInstallUrl({ ...baseInput, configuredUrl: undefined })).toThrow('public Stripe OAuth URL is not configured');
+  });
+
+  it('rejects unknown modes instead of silently installing live', () => {
+    expect(resolveStripeInstallMode('sandbox')).toBe('sandbox');
+    expect(resolveStripeInstallMode('live')).toBe('live');
+    expect(resolveStripeInstallMode(null)).toBe('live');
+    expect(() => resolveStripeInstallMode('test')).toThrow('must be live or sandbox');
+  });
+});


### PR DESCRIPTION
### Motivation

- Address gaps in the previous Stripe App lifecycle implementation that allowed unsafe install URLs, left OAuth state/credentials ambiguous across modes, and did not reliably revoke or persist disconnect/deauthorization evidence.  
- Ensure the system meets Stripe review invariants: clean install URLs, signed/one-time `state`, DB-backed connection state, webhook-signed deauthorization handling, and an observable disconnect lifecycle.

### Description

- Validate and enforce public Stripe Marketplace OAuth install URLs by rejecting `channel_link`, non-Stripe hosts/paths, missing `client_id`, and client-id mismatches via `lib/stripe-app/install-url.ts` and `lib/stripe-app/oauth-config.ts`.  
- Separate live/sandbox credentials and flows (mode-specific client IDs and secret keys), use mode-matched token exchange in the OAuth callback, and require `STRIPE_CONNECT_STATE_SECRET` for signed `state`.  
- Add reliable lifecycle handlers: manual disconnect now revokes Stripe OAuth via `deauthorize` before persisting `inactive` evidence in `app/api/stripe-app/disconnect/route.ts`, and the deauthorization webhook `app/api/stripe-app/webhook/route.ts` verifies signatures, persists `revoked` evidence, and ignores stale events.  
- Add compensation for failed persistence: if OAuth succeeds but DB upsert fails, the callback attempts to revoke Stripe access; add migration to persist `disconnected_at`, `disconnect_reason`, and `last_lifecycle_event_id`; expose a Disconnect UI and strengthen tests/docs for the resubmission gate.

### Testing

- Unit and focused tests: ran `npm test -- --run tests/unit/stripe-app` and `npm --prefix packages/stripe-app test -- --run` and both test suites passed (`15` tests in root Stripe unit suite and `257` tests in `packages/stripe-app`).  
- Typecheck/build/manifest: ran `npm run typecheck`, `npm run build`, and `node scripts/verify-production-manifest.mjs` which all passed (production manifest passed `186` paths), with two pre-existing lint warnings reported during build.  
- Migration and auxiliary checks: ran `npm run test:migrations` which passed, and `git diff --check` which passed; `bash scripts/validate-stripe-config.sh` could not fully validate because this environment lacks a production `.env` (warning).  
- GO/NO-GO: `./scripts/go-no-go-gate.sh http://127.0.0.1:3000` returned **NO-GO** because no runtime was listening on `:3000`, so trust/health/readiness and end-to-end Stripe Dashboard evidence remain required before resubmission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c1a4a03588328ae9764c162129920)