### PR TITLE
docs: add GitHub Sponsors visibility

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support DSG ONE
+
+Thank you for using, reviewing, or contributing to DSG ONE.
+
+## Sponsor
+
+You can support ongoing development here:
+
+- GitHub Sponsors: https://github.com/sponsors/tdealer01-crypto
+
+Sponsorship helps fund open-source development, testing, documentation, verification tooling, and operator-focused UX improvements.
+
+## What this support page does not claim
+
+This page does not claim third-party certification, independent audit completion, or production readiness beyond evidence already present in the repository.
+
+For current verified claims and boundaries, read the repository README and evidence documents before making any public or customer-facing statement.
+
+## Good support topics
+
+- Evidence-backed runtime governance
+- Deterministic gate behavior
+- Audit/evidence export
+- Stripe App review support
+- Deployment and verification workflows
+- Documentation and onboarding improvements
+
+## Contact path
+
+Use GitHub Issues or Discussions for public project questions. Use GitHub Sponsors if you want to fund continued development.

--- a/docs/SPONSORSHIP.md
+++ b/docs/SPONSORSHIP.md
@@ -1,0 +1,43 @@
+# DSG ONE Sponsorship
+
+## Sponsor link
+
+GitHub Sponsors: https://github.com/sponsors/tdealer01-crypto
+
+The repository already has GitHub Sponsors enabled through `.github/FUNDING.yml`.
+
+## Short public copy
+
+Use this wording when sharing the sponsor link:
+
+> DSG ONE is an evidence-first runtime governance project for safer AI, finance, workflow, and deployment execution. Sponsorship helps fund open-source development, testing, documentation, and verification tooling.
+
+## README snippet
+
+```md
+## Support DSG ONE
+
+If DSG ONE helps your work, you can support development here:
+
+[Sponsor @tdealer01-crypto](https://github.com/sponsors/tdealer01-crypto)
+```
+
+## Truth boundary
+
+Allowed:
+
+- GitHub Sponsors profile is available at the sponsor link.
+- Sponsorship supports development, testing, documentation, and verification tooling.
+- DSG ONE is evidence-first and governance-focused.
+
+Do not claim without fresh evidence:
+
+- independent third-party certification
+- complete legal compliance
+- complete production readiness
+- guaranteed prevention of all unsafe AI actions
+- guaranteed financial/security outcomes
+
+## User benefit
+
+This gives visitors one clear path to fund the project without mixing sponsorship text with unsupported product claims.


### PR DESCRIPTION
## Summary

Add sponsor/support documentation now that GitHub Sponsors is available for `@tdealer01-crypto`.

## Changes

- Add `SUPPORT.md` with the sponsor link and support boundaries.
- Add `docs/SPONSORSHIP.md` with public copy, README snippet, and truth boundary.

## Verified before change

- `.github/FUNDING.yml` already exists on `main` and points to `tdealer01-crypto`.
- This PR is documentation-only.
- No production-readiness or certification claim is added.

## User-visible benefit

Visitors get a clear sponsorship path without mixing funding text with unsupported product claims.