### PR TITLE
feat(design-system): DSG ONE primitive UI components + CSS token system

### DIFF
--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface BadgeProps {
+  children: React.ReactNode;
+  variant?: 'default' | 'success' | 'error' | 'warning' | 'info';
+  className?: string;
+}
+
+export function Badge({ children, variant = 'default', className = '', ...props }: BadgeProps) {
+  const variants: Record<string, string> = {
+    default:
+      'bg-[rgba(212,175,55,0.12)] border border-[rgba(212,175,55,0.28)] text-[#F7DC78]',
+    success:
+      'bg-[rgba(51,209,122,0.12)] border border-[rgba(51,209,122,0.28)] text-emerald-300',
+    error:
+      'bg-[rgba(225,6,0,0.12)] border border-[rgba(225,6,0,0.28)] text-red-300',
+    warning:
+      'bg-[rgba(245,197,66,0.12)] border border-[rgba(245,197,66,0.28)] text-yellow-300',
+    info:
+      'bg-[rgba(79,140,255,0.12)] border border-[rgba(79,140,255,0.28)] text-blue-300',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-bold uppercase tracking-widest ${variants[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React from 'react';
+
+interface ButtonProps {
+  children: React.ReactNode;
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'success';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  type?: 'button' | 'submit' | 'reset';
+}
+
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  onClick,
+  className = '',
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  const base = 'inline-flex items-center justify-center font-semibold rounded-lg transition-all border focus-visible:outline-2 focus-visible:outline-offset-2';
+
+  const variants: Record<string, string> = {
+    primary:
+      'bg-gradient-to-br from-[#F7DC78] to-[#D4AF37] text-[#050507] border-transparent shadow-lg hover:shadow-xl hover:brightness-105 focus-visible:outline-[#D4AF37]',
+    secondary:
+      'bg-[#14151C] border-[rgba(247,220,120,0.16)] text-[#F8FAFC] hover:bg-[#191A22] focus-visible:outline-[#D4AF37]',
+    ghost:
+      'bg-transparent border-[rgba(247,220,120,0.16)] text-[#F8FAFC] hover:bg-[rgba(247,220,120,0.06)] focus-visible:outline-[#D4AF37]',
+    danger:
+      'bg-[rgba(225,6,0,0.15)] border-[rgba(225,6,0,0.35)] text-red-200 hover:bg-[rgba(225,6,0,0.25)] focus-visible:outline-[#E10600]',
+    success:
+      'bg-[rgba(51,209,122,0.15)] border-[rgba(51,209,122,0.35)] text-emerald-200 hover:bg-[rgba(51,209,122,0.25)] focus-visible:outline-[#33D17A]',
+  };
+
+  const sizes: Record<string, string> = {
+    sm: 'px-3 py-1.5 text-sm gap-1.5',
+    md: 'px-4 py-2 text-sm gap-2',
+    lg: 'px-6 py-2.5 text-base gap-2',
+  };
+
+  return (
+    <button
+      type={type}
+      className={`${base} ${variants[variant]} ${sizes[size]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+      disabled={disabled}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface CardProps {
+  children: React.ReactNode;
+  variant?: 'default' | 'blue' | 'red' | 'gold';
+  className?: string;
+}
+
+export function Card({ children, variant = 'default', className = '', ...props }: CardProps) {
+  const variants: Record<string, string> = {
+    default:
+      'border-[rgba(247,220,120,0.16)] bg-gradient-to-br from-white/[0.055] to-white/[0.02] backdrop-blur-sm shadow-xl',
+    blue:
+      'border-[rgba(79,140,255,0.26)] bg-gradient-to-br from-[rgba(15,82,186,0.12)] to-[rgba(5,5,7,0.15)] shadow-xl',
+    red:
+      'border-[rgba(225,6,0,0.28)] bg-gradient-to-br from-[rgba(225,6,0,0.10)] to-[rgba(5,5,7,0.15)] shadow-xl',
+    gold:
+      'border-[rgba(212,175,55,0.28)] bg-gradient-to-br from-[rgba(212,175,55,0.10)] to-[rgba(5,5,7,0.15)] shadow-xl',
+  };
+
+  return (
+    <div className={`rounded-xl p-6 border ${variants[variant]} ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+  hint?: string;
+  leftIcon?: React.ReactNode;
+}
+
+export function Input({ label, error, hint, leftIcon, className = '', id, ...props }: InputProps) {
+  const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && (
+        <label htmlFor={inputId} className="text-xs font-semibold uppercase tracking-widest text-[#AAB3C5]">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        {leftIcon && (
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#AAB3C5]">{leftIcon}</span>
+        )}
+        <input
+          id={inputId}
+          className={`w-full rounded-lg border bg-[rgba(255,255,255,0.04)] px-3 py-2 text-sm text-[#F8FAFC] placeholder-[#AAB3C5] outline-none transition-all ${
+            leftIcon ? 'pl-9' : ''
+          } ${
+            error
+              ? 'border-[rgba(225,6,0,0.5)] focus:border-[#E10600] focus:ring-1 focus:ring-[rgba(225,6,0,0.3)]'
+              : 'border-[rgba(247,220,120,0.16)] focus:border-[rgba(212,175,55,0.5)] focus:ring-1 focus:ring-[rgba(212,175,55,0.15)]'
+          } ${className}`}
+          {...props}
+        />
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      {hint && !error && <p className="text-xs text-[#AAB3C5]">{hint}</p>}
+    </div>
+  );
+}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { useEffect } from 'react';
+
+interface ModalAction {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'secondary' | 'danger';
+}
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  actions?: ModalAction[];
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeMap: Record<string, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-lg',
+  lg: 'max-w-3xl',
+};
+
+export function Modal({ isOpen, onClose, title, children, actions = [], size = 'md' }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className={`relative w-[90%] ${sizeMap[size]} max-h-[90vh] flex flex-col rounded-2xl border border-[rgba(247,220,120,0.16)] bg-[#0B0B0F] shadow-2xl`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[rgba(247,220,120,0.10)]">
+          <h2 className="text-base font-semibold text-[#F8FAFC]">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-[#AAB3C5] hover:text-[#F8FAFC] transition-colors text-xl leading-none p-1"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 flex-1 overflow-y-auto text-[#AAB3C5]">{children}</div>
+
+        {/* Footer */}
+        {actions.length > 0 && (
+          <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-[rgba(247,220,120,0.10)]">
+            {actions.map((action, i) => (
+              <button
+                key={i}
+                onClick={action.onClick}
+                className={`px-4 py-2 rounded-lg text-sm font-semibold border transition-all ${
+                  action.variant === 'danger'
+                    ? 'bg-[rgba(225,6,0,0.15)] border-[rgba(225,6,0,0.35)] text-red-200 hover:bg-[rgba(225,6,0,0.25)]'
+                    : action.variant === 'primary'
+                    ? 'bg-gradient-to-br from-[#F7DC78] to-[#D4AF37] text-[#050507] border-transparent'
+                    : 'bg-transparent border-[rgba(247,220,120,0.16)] text-[#AAB3C5] hover:text-[#F8FAFC]'
+                }`}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/Table.tsx
+++ b/components/ui/Table.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface Column<T = Record<string, unknown>> {
+  key: string;
+  label: string;
+  align?: 'left' | 'center' | 'right';
+  render?: (value: unknown, row: T) => React.ReactNode;
+}
+
+interface TableProps<T = Record<string, unknown>> {
+  columns: Column<T>[];
+  rows: T[];
+  onRowClick?: (row: T) => void;
+  sortable?: boolean;
+  selectable?: boolean;
+  emptyMessage?: string;
+}
+
+export function Table<T extends Record<string, unknown>>({
+  columns,
+  rows,
+  onRowClick,
+  sortable = true,
+  selectable = false,
+  emptyMessage = 'No data',
+}: TableProps<T>) {
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  const handleSort = (key: string) => {
+    if (!sortable) return;
+    if (sortKey === key) setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortKey(key); setSortDir('asc'); }
+  };
+
+  const sorted = [...rows].sort((a, b) => {
+    if (!sortKey) return 0;
+    const av = a[sortKey]; const bv = b[sortKey];
+    if (typeof av === 'string' && typeof bv === 'string')
+      return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+    return sortDir === 'asc' ? Number(av) - Number(bv) : Number(bv) - Number(av);
+  });
+
+  const toggleRow = (i: number) =>
+    setSelected(prev => { const s = new Set(prev); s.has(i) ? s.delete(i) : s.add(i); return s; });
+  const toggleAll = () =>
+    setSelected(selected.size === sorted.length ? new Set() : new Set(sorted.map((_, i) => i)));
+
+  const thBase = 'px-4 py-3 text-left text-xs font-semibold uppercase tracking-widest text-[#AAB3C5] border-b border-[rgba(247,220,120,0.10)]';
+  const tdBase = 'px-4 py-3 text-sm text-[#F8FAFC]';
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-[rgba(247,220,120,0.16)]">
+      <table className="w-full border-collapse">
+        <thead className="bg-[rgba(255,255,255,0.03)]">
+          <tr>
+            {selectable && (
+              <th className={`${thBase} w-10`}>
+                <input
+                  type="checkbox"
+                  checked={selected.size === sorted.length && sorted.length > 0}
+                  onChange={toggleAll}
+                  className="cursor-pointer"
+                />
+              </th>
+            )}
+            {columns.map(col => (
+              <th
+                key={col.key}
+                onClick={() => handleSort(col.key)}
+                className={`${thBase} ${sortable ? 'cursor-pointer hover:text-[#F7DC78] transition-colors' : ''}`}
+                style={{ textAlign: col.align || 'left' }}
+              >
+                {col.label}
+                {sortable && sortKey === col.key && (
+                  <span className="ml-1 text-[#D4AF37]">{sortDir === 'asc' ? '↑' : '↓'}</span>
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row, i) => (
+            <tr
+              key={i}
+              onClick={() => onRowClick?.(row)}
+              className={`border-b border-[rgba(247,220,120,0.06)] transition-colors ${
+                onRowClick ? 'cursor-pointer' : ''
+              } ${selected.has(i) ? 'bg-[rgba(212,175,55,0.08)]' : 'hover:bg-[rgba(255,255,255,0.025)]'}`}
+            >
+              {selectable && (
+                <td className={tdBase}>
+                  <input
+                    type="checkbox"
+                    checked={selected.has(i)}
+                    onChange={e => { e.stopPropagation(); toggleRow(i); }}
+                    className="cursor-pointer"
+                  />
+                </td>
+              )}
+              {columns.map(col => (
+                <td key={col.key} className={tdBase} style={{ textAlign: col.align || 'left' }}>
+                  {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {sorted.length === 0 && (
+        <div className="py-10 text-center text-sm text-[#AAB3C5]">{emptyMessage}</div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/Tabs.tsx
+++ b/components/ui/Tabs.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface Tab {
+  key: string;
+  label: string;
+  content: React.ReactNode;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  defaultTab?: string;
+  className?: string;
+}
+
+export function Tabs({ tabs, defaultTab, className = '' }: TabsProps) {
+  const [active, setActive] = useState(defaultTab ?? tabs[0]?.key);
+  const current = tabs.find(t => t.key === active);
+
+  return (
+    <div className={className}>
+      <div className="flex gap-0 border-b border-[rgba(247,220,120,0.12)]">
+        {tabs.map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => setActive(tab.key)}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              active === tab.key
+                ? 'border-[#D4AF37] text-[#F7DC78]'
+                : 'border-transparent text-[#AAB3C5] hover:text-[#F8FAFC]'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="pt-4">{current?.content}</div>
+    </div>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,7 @@
+export { Button } from './Button';
+export { Card } from './Card';
+export { Badge } from './Badge';
+export { Modal } from './Modal';
+export { Table } from './Table';
+export { Input } from './Input';
+export { Tabs } from './Tabs';

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,17 @@
+# DSG ONE Design System
+
+Token-first design system for the DSG ONE ProofGate Control Plane.
+
+## Usage
+
+Link `design-system/styles.css` to pick up all tokens and fonts. Then reference tokens via CSS custom properties in your components or Tailwind arbitrary values.
+
+## Tokens
+
+- **Colors** — `--color-red`, `--color-gold`, `--color-sapphire`, neutrals, semantics
+- **Typography** — `--font-sans`, `--font-mono`, `--text-*`, `--font-weight-*`
+- **Spacing** — `--space-*`, `--radius-*`, `--shadow-*`, `--transition-*`
+
+## Source
+
+GitHub: https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane

--- a/design-system/styles.css
+++ b/design-system/styles.css
@@ -1,0 +1,5 @@
+/* DSG ONE Design System — Root Entry Point */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap');
+@import "tokens/colors.css";
+@import "tokens/typography.css";
+@import "tokens/spacing.css";

--- a/design-system/tokens/colors.css
+++ b/design-system/tokens/colors.css
@@ -1,0 +1,20 @@
+/* DSG ONE Color Tokens */
+:root {
+  --color-red: #E10600;
+  --color-red-deep: #7F0509;
+  --color-gold: #D4AF37;
+  --color-gold-soft: #F7DC78;
+  --color-sapphire: #0F52BA;
+  --color-sapphire-soft: #4F8CFF;
+  --color-black: #050507;
+  --color-black-2: #090B12;
+  --color-surface: #14151C;
+  --color-surface-2: #191A22;
+  --color-text: #F8FAFC;
+  --color-text-muted: #AAB3C5;
+  --color-border: rgba(247, 220, 120, 0.16);
+  --color-success: #33D17A;
+  --color-warning: #F5C542;
+  --color-error: #FF4D4D;
+  --color-info: #4F8CFF;
+}

--- a/design-system/tokens/spacing.css
+++ b/design-system/tokens/spacing.css
@@ -1,0 +1,25 @@
+/* DSG ONE Spacing & Layout Tokens */
+:root {
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --radius-sm: 0.375rem;
+  --radius-base: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+  --radius-full: 9999px;
+  --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.1);
+  --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.1);
+  --shadow-xl: 0 20px 25px -5px rgba(0,0,0,0.1);
+  --transition-fast: 0.15s ease;
+  --transition-base: 0.2s ease;
+  --transition-slow: 0.3s ease;
+}

--- a/design-system/tokens/typography.css
+++ b/design-system/tokens/typography.css
@@ -1,0 +1,23 @@
+/* DSG ONE Typography Tokens */
+:root {
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'Cascadia Code', 'Source Code Pro', 'SF Mono', Monaco, Menlo, Consolas, 'Courier New', monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-black: 900;
+  --line-height-tight: 1.1;
+  --line-height-normal: 1.5;
+  --letter-spacing-wide: 0.025em;
+  --letter-spacing-wider: 0.05em;
+  --letter-spacing-widest: 0.1em;
+}


### PR DESCRIPTION
## Summary

- Adds a token-first **DSG ONE Design System** extracted from the Claude Design handoff bundle
- 7 typed React components in `components/ui/` styled to match the DSG mission-control dark theme
- 3 CSS token files covering colors, typography, and spacing

## Components (`components/ui/`)

| Component | Variants | Notes |
|-----------|----------|-------|
| `Button` | primary / secondary / ghost / danger / success, 3 sizes | Gold gradient primary, dark theme |
| `Card` | default / blue / red / gold | Glassmorphic, border-glow variants |
| `Badge` | default / success / error / warning / info | Pill, uppercase tracking |
| `Modal` | sm / md / lg | Esc key, scroll lock, backdrop dismiss |
| `Table` | — | Typed generics, client-sort, row selection |
| `Input` | — | Label + error + hint + left icon slots |
| `Tabs` | — | Gold active indicator |

## Design Tokens (`design-system/tokens/`)

- **`colors.css`** — `--color-red` (#E10600), `--color-gold` (#D4AF37), `--color-sapphire` (#0F52BA), plus surface/text/semantic tokens
- **`typography.css`** — `--font-sans`, `--font-mono`, `--text-*` scale, `--font-weight-*`
- **`spacing.css`** — `--space-*`, `--radius-*`, `--shadow-*`, `--transition-*`
- **`styles.css`** — entry-point `@import` for all three files

## Test plan

- [ ] Import `Button`, `Card`, `Badge` from `components/ui` in any dashboard page and verify dark-theme rendering
- [ ] Open a `Modal` and test Esc key, backdrop click, and footer actions
- [ ] Render `Table` with sample execution data and verify sort + selection
- [ ] Confirm design tokens resolve correctly in Tailwind arbitrary-value classes (`bg-[--color-gold]`)
- [ ] `npm run typecheck` passes with zero new errors

https://claude.ai/code/session_0123EcpH4ZLP4ihKiPxzo74Y