### PR TITLE
docs: add sponsor link to README

### DIFF
--- a/.github/workflows/apply-readme-sponsor.yml
+++ b/.github/workflows/apply-readme-sponsor.yml
@@ -1,0 +1,55 @@
+name: Apply README sponsor link
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/apply-readme-sponsor.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  patch-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Insert sponsor link into README
+        run: |
+          python3 <<'PY'
+          from pathlib import Path
+
+          readme = Path('README.md')
+          text = readme.read_text(encoding='utf-8')
+          snippet = """## Support DSG ONE
+
+If DSG ONE helps your work, you can support development here:
+
+[Sponsor @tdealer01-crypto](https://github.com/sponsors/tdealer01-crypto)
+
+"""
+          if '## Support DSG ONE' not in text:
+              marker = '**Production URL:** `https://tdealer01-crypto-dsg-control-plane.vercel.app`\n\n'
+              if marker not in text:
+                  raise SystemExit('README marker not found; refusing to patch')
+              text = text.replace(marker, marker + snippet, 1)
+              readme.write_text(text, encoding='utf-8')
+
+          Path('.github/workflows/apply-readme-sponsor.yml').unlink()
+          PY
+
+      - name: Commit README update
+        run: |
+          if git diff --quiet; then
+            echo "No README/workflow changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md .github/workflows/apply-readme-sponsor.yml
+          git commit -m "docs: add sponsor link to README"
+          git push


### PR DESCRIPTION
## Summary

Add an automated one-time docs patch to insert the GitHub Sponsors link into the top of `README.md` without replacing the large README file by hand.

## How it works

- Adds a temporary workflow: `.github/workflows/apply-readme-sponsor.yml`.
- On merge to `main`, the workflow inserts the `## Support DSG ONE` snippet after the Production URL.
- The workflow deletes itself in the same follow-up commit.

## Truth boundary

- Documentation-only change.
- No production-readiness or certification claim is added.
- The sponsor wording points only to GitHub Sponsors and development support.

## User-visible benefit

Visitors see the sponsor link directly near the top of the repository README.