### PR TITLE
docs: refresh README with implemented surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1219 +1,135 @@
 # DSG ONE — ProofGate Control Plane
 
-> **Block before the AI agent acts — not after the damage is done.**
+> Runtime control-plane scaffold for governed AI, agent, workflow, finance, and deployment actions.
 
-DSG ONE is a runtime governance layer for AI agents. Connect it in one line, gate every action before execution, and keep a verifiable audit trail with deterministic evidence lineage for regulated AI-agent operations.
+This README is intentionally written from the current codebase surface, not from historical marketing copy. Treat it as a repository map and claim boundary, not as a production certification.
 
-**Production URL:** `https://tdealer01-crypto-dsg-control-plane.vercel.app`
+## What is in this repository
 
----
+DSG ONE combines a Next.js application, API routes, deterministic gate/proof types, Supabase-backed auth/evidence schema, and Stripe App package code.
 
-## 🆕 Phase C: Evidence-Backed Compliance System (WORM + Proof Gateway) — 2026-06-12
+At code level, the main surfaces are:
 
-**Status:** ✅ Rounds 1-4 Complete | ✅ All Verifications Passed | 🚀 Merged to Main (PR#718) | ✅ PRODUCTION-READY
+- Next.js App Router application under `app/`.
+- Runtime execution API under `app/api/execute/` and `app/api/spine/execute/`.
+- DSG deterministic proof/gate API under `app/api/dsg/v1/`.
+- Compliance claim-readiness API under `app/api/proof/claim-readiness/`.
+- Deterministic gate/proof types and engines under `lib/dsg/deterministic/`.
+- DSG route auth helper under `lib/dsg/auth/require-dsg-auth.ts`.
+- Supabase migrations under `supabase/migrations/`.
+- Stripe App package under `packages/stripe-app/`.
+- Verification, deployment, smoke, evidence, and operations scripts under `scripts/`.
 
-Transform compliance claims into machine-verifiable proofs — no more unverifiable assertions. Every claim (ISO-42001, NIST AI RMF, EU AI Act, supply chain, security, runtime) backed by executable evidence chains, immutable storage, and automated security scanning.
+## Current codebase-derived status
 
-### What Shipped
-
-| Round | Component | Status | Artifacts |
-|-------|-----------|--------|-----------|
-| **1** | Claim-Readiness Foundation | ✅ | `docs/CLAIM_EVIDENCE_STANDARD.md`, `/api/proof/claim-readiness`, `build-evidence-bundle.mjs` |
-| **2** | Immutable Storage + Schema | ✅ | `claim_readiness_artifacts` table (append-only), `WORM_AUDIT_STORAGE_POLICY.md`, ccvs-evidence workflow |
-| **3** | Security Evidence | ✅ | security-evidence workflow (npm-audit, gitleaks, CodeQL, SBOM), `generate-sbom.mjs`, security claims |
-| **4** | Load Proof | ✅ | k6 load test (1000 VUs, p99 <1s), results, scalability analysis |
-
-### System Architecture
-
-```
-Claim (ISO-42001, NIST, EU AI Act, SUPPLY-CHAIN, SECURITY, RUNTIME, LOAD-PROOF)
-  ↓
-Required Evidence (unit tests, integration, adversarial, mutation, SBOM, provenance, audit chain)
-  ↓
-Collected Artifacts (coverage.json, mutation.json, npm-audit.json, gitleaks.json, codeql.sarif, sbom.cdx.json)
-  ↓
-SHA256 Hash + Canonicalize + Chain Link
-  ↓
-Manifest JSON + Cosign Signature (optional)
-  ↓
-Immutable Storage: Supabase (append-only RLS) + S3 Object Lock (365-day retention)
-  ↓
-GET /api/proof/claim-readiness → PASS/PARTIAL/BLOCK status with security_breakdown
-```
-
-### Compliance Claims Now Backed by Proof
-
-| Claim | Evidence | Status | How to Verify |
-|-------|----------|--------|---------------|
-| **ISO-42001-A.6** | AI system scope & design docs | ✅ PASS-Ready | `/api/proof/claim-readiness?claims=ISO-42001-A.6` |
-| **NIST-GOVERN-01** | Governance structure + policy | ✅ PASS-Ready | `/api/proof/claim-readiness?claims=NIST-GOVERN-01` |
-| **EU-AI-ACT Annex IV** | Technical documentation + risk management | ✅ PASS-Ready | `docs/compliance/EU_AI_ACT_ANNEX_IV_TECHNICAL_FILE.md` |
-| **SUPPLY-CHAIN-01** | Build provenance (GitHub attestation ready) | ✅ PASS-Ready | `scripts/build-evidence-bundle.mjs --sign` |
-| **SECURITY-HARDENING** | npm audit, gitleaks, CodeQL, SBOM | ✅ AUTOMATED | `.github/workflows/security-evidence.yml` (runs on every push) |
-| **RUNTIME-INTEGRITY** | Immutable audit trail (WORM) | ✅ PASS-Ready | `docs/compliance/WORM_AUDIT_STORAGE_POLICY.md` |
-| **LOAD-PROOF** | 1000 concurrent agents, p99 <1s | ✅ TESTED | `load/parallel-1000-agents.k6.js`, results in `qa-logs/` |
-
-### New Endpoints & Scripts
-
-**Endpoints:**
-```bash
-GET /api/proof/claim-readiness                    # Query claim status (PASS/PARTIAL/BLOCK)
-GET /api/proof/claim-readiness?claims=ISO-42001-A.6,NIST-GOVERN-01&includeEvidence=true
-```
-
-**Scripts:**
-```bash
-npm run build-evidence-bundle                      # Collects artifacts, hashes, chains
-npm run generate-sbom                              # CycloneDX 1.4 SBOM generation
-k6 run load/parallel-1000-agents.k6.js            # 1000 VU load test (requires k6)
-```
-
-**Workflows:**
-- `.github/workflows/security-evidence.yml` — Runs on every push (npm audit, gitleaks, CodeQL, SBOM)
-- `.github/workflows/ccvs-evidence.yml` — Builds evidence bundle + claim-readiness check
-
-### Database Schema
-
-**New Table:** `claim_readiness_artifacts`
-- 13 columns: id, claim_id, evidence_type, artifact_hash, chain_hash, s3_version_id, s3_retain_until, signature_bundle, artifact_data, status, immutable_at, created_at, updated_at
-- 6 indexes for fast queries: claim_id, evidence_type, artifact_hash, chain_hash, status, immutable_at
-- Append-only RLS: SELECT allowed, UPDATE/DELETE blocked
-- Immutability enforcement: no updates after creation
-
-**Migration:** `supabase/migrations/20260612041000_create_claim_readiness_artifacts.sql` (230 lines, idempotent)
-
-### Verification & Load Test Results
-
-**Load Test (1000 concurrent agents):**
-- ✅ 5,847 requests/second average
-- ✅ Error rate: 0.45% (below 1% threshold)
-- ✅ p50 latency: 87ms, p95: 425ms, p99: 892ms
-- ✅ All SLA thresholds met
-- ✅ Test results: `qa-logs/load-1000-agents-latest.json`
-
-**Security Scanning (Automated):**
-- ✅ npm audit: critical = 0, high ≤ 2
-- ✅ Secret scanning (gitleaks): 0 secrets detected
-- ✅ CodeQL: 0 critical issues
-- ✅ SBOM: CycloneDX 1.4 generated, 245+ components
-
-**Compliance Readiness:**
-- ✅ TypeScript: 0 errors
-- ✅ Node scripts: syntax verified
-- ✅ YAML workflows: syntax verified
-- ✅ SQL migrations: idempotent, tested
-- ✅ No secrets in code or docs
-
-### Next Steps
-
-1. **Run locally:** `npm run build && GET /api/proof/claim-readiness`
-2. **Test load:** `k6 run load/parallel-1000-agents.k6.js`
-3. **Apply migration:** `supabase migration up`
-4. **Configure S3:** Setup `dsg-compliance-evidence` bucket with Object Lock
-5. **Enable GitHub Actions:** security-evidence + ccvs-evidence workflows
-
-### Documentation
-
-- **Claim Standard:** `docs/CLAIM_EVIDENCE_STANDARD.md` (574 lines) — complete claim-to-evidence mapping
-- **WORM Storage:** `docs/compliance/WORM_AUDIT_STORAGE_POLICY.md` (736 lines) — Supabase + S3 Object Lock architecture
-- **Load Proof:** `docs/compliance/LOAD_PROOF_READINESS.md` (9.2 KB) — scalability analysis + bottleneck findings
-- **Load Test:** `load/README.md` (183 lines) — k6 usage guide + troubleshooting
-
-                                                                                                                                          ✅ Pipeline Completed Successfully - PRs Created!
-
-    ✅ Run Completed Successfully                                                       
-    | Metric    | Result                       |
-    |-----------|------------------------------|                                            | Status    | ✅ SUCCESS (green checkmark) |
-    | Duration  | 5m 43s                       |
-    | Artifacts | ✅ Uploaded (47KB)           |                                        
-                                                                                                                                                                                    📦 PRs Created Successfully!
-
-    | PR   | Branch                      | Status  | Created   |                            |------|-----------------------------|---------|-----------|                            | #734 | ccvs-3b7de578-1781454810533 | ✅ OPEN | 16:33:33Z |
-    | #733 | ccvs-3b7de578-1781454731861 | ✅ OPEN | 16:32:15Z |                                                                                                                                                                                                        
-    ✅ Complete Pipeline Success
-                                                                                            | Component         | Status                         |                                  |-------------------|--------------------------------|
-    | 8 Agents (L1-L5)  | ✅ 100% converged              |
-    | L1-L5 Pipeline    | ✅ All converged (score 1.000) |
-    | 66 Evidence Items | ✅ Generated                   |
-    | 69 Artifacts      | ✅ Uploaded (47KB)             |
-    | Diffusion Loop    | ✅ Working                     |
-    | Test Suite        | ✅ 5/5 passing                 |
-    | TypeScript        | ✅ Clean                       |
-    | GitHub PRs        | ✅ 2 PRs Created               |                                  | Artifacts         | ✅ Uploaded                    |                              
-                                                                                                                                                                                    🎯 Complete - Multi-Agent Pipeline Production Ready                                 
-    System fully operational with:
-    - ✅ 8 agents across L1-L5 (parallel execution)
-    - ✅ Diffusion loop (draft → verify → repair → converge)                                - ✅ 100% convergence with evidence
-    - ✅ Auto PR creation with evidence pack                                                - ✅ Artifacts uploaded for audit
-    - ✅ Test suite passing
-                                                                                            System is production-ready and self-operating. 🚀
-╰──────────────────────────────────────────────────────────────────────────────────────╯
-## 🆕 Phase B: Hermes Dashboard Human-in-the-Loop + Parallel Infrastructure — 2026-06-11
-
-**Status:** ✅ Phase A+B Complete | ✅ QA Verified (195/195 tests PASS) | 🚀 Merged to Main (PR#710) | ⏳ Vercel Deployment In Progress
-
-Human-in-the-loop collaboration features enabling operators to approve, monitor, and audit AI agent actions in real-time.
-
-### Phase B Features Delivered
-
-| Feature | Type | Status | Performance |
-|---------|------|--------|-------------|
-| **Review Gate (Gatekeeper)** | UX | ✅ | Operator approval for HIGH-risk actions |
-| **Smart Alerts** | UX | ✅ | Real-time queue/cache degradation notifications |
-| **Execution Comparison** | UX | ✅ | Diff view for multi-execution auditing |
-| **Harmony Engine** | Backend | ✅ | O(1) semantic matching <5ms (fallback <50ms) |
-| **Parallel Orchestrator** | Backend | ✅ | Per-agent isolated execution contexts |
-| **Request Queue** | Backend | ✅ | Priority fairness (P1/P2/P3 + FIFO) |
-| **Executor Throttle** | Backend | ✅ | Per-org capacity (VPC:50, BB:100, Terminal:200) |
-| **Audit Batch Writer** | Backend | ✅ | SHA256 hash chain for tamper detection |
-
-### QA & Testing Results
-
-**Compilation & Type Safety:**
-- ✅ Build: 164/164 pages compiled successfully
-- ✅ TypeScript: 0 type errors
-
-**Test Coverage:**
-- ✅ Integration Tests: 195/195 PASS
-  - Safe DOM: 16/16 ✓
-  - Queue + Harmony: 24/24 ✓
-  - Tool routing: 27/27 ✓
-  - Spine execute: 8/8 ✓
-  - Audit trail: 22/22 ✓
-  - Delegation: 26/26 ✓
-  - Agents API: 6/6 ✓
-
-**Complete Report:** See [`QA_TEST_REPORT.md`](./QA_TEST_REPORT.md)
-
-### Performance Verified
-
-| Metric | Target | Status |
-|--------|--------|--------|
-| Command latency (p50) | <100ms | ✅ Verified |
-| Command latency (p99) | <1s | ✅ Verified |
-| Cache hit rate | >80% | ✅ ~80% |
-| Concurrent agents | 1000+ | ✅ Queued properly |
-| Audit write latency | <10ms | ✅ Batch writes |
-
-### Deployment Status
-
-**Latest:**
-- ✅ Merged to main (commit: 56a2ed5)
-- ⏳ Vercel deployment auto-triggered
-- 📋 Monitor at: `GET /api/health`
-
-**Environment Variables Needed (Production):**
-```
-NEXT_PUBLIC_SUPABASE_URL=...
-SUPABASE_SERVICE_ROLE_KEY=...
-UPSTASH_REDIS_REST_URL=...  (rate limiting)
-NEXTAUTH_SECRET=...
-```
-
-### Next Steps
-
-1. ✅ **Merge** — PR#710 merged to main
-2. ⏳ **Deploy** — Vercel auto-deployment in progress
-3. 📊 **Verify** — Check `/api/health` for green status
-4. 📝 **Document** — Add to operations runbook
-
----
-
-## 🆕 Infinite Loop Protection + Phase B UX Completion — 2026-06-11
-
-**Status:** ✅ ALL COMPLETE | ✅ 85+ Tests PASS | 🚀 Merged to Main (PR#712) | ✅ PRODUCTION READY
-
-Complete implementation of executor infinite loop protection system with 5 critical safety guards and comprehensive Phase B UX feature testing.
-
-### Infinite Loop Protection — 6 Phases Complete
-
-| Phase | Component | Status | Tests | Coverage |
-|-------|-----------|--------|-------|----------|
-| **0** | Task Status Model | ✅ | Type system | TaskStatus (12 values), StopReason (5 values) |
-| **1-2** | Max Retries + Break Condition | ✅ | 34 tests | Fingerprinting, 3-retry limit, timeout/failure breaks |
-| **3-4** | Queue Cleanup + Monitoring | ✅ | 19 tests | Protected statuses, health endpoint, DLQ management |
-| **5-6** | Extended Tests + Integration | ✅ | 32 tests | All guards verified, end-to-end scenarios |
-| **Total** | **All Systems** | ✅ | **85+ tests** | **1,890+ existing tests still passing** |
-
-### The 5 Safety Guards
-
-| Guard | Purpose | Implementation | Status |
-|-------|---------|-----------------|--------|
-| **1. Task Fingerprint** | Block duplicate failures | SHA256 deterministic hash, 3-retry blocking | ✅ |
-| **2. Release Executor Slot** | Guaranteed cleanup | Finally block on success/error | ✅ |
-| **3. Clear Stop Reason** | Explicit termination | TIMEOUT, MAX_RETRIES, TOO_MANY_FAILURES, QUEUE_EMPTY | ✅ |
-| **4. Safe Queue Cleanup** | Protect active work | Never delete RUNNING/LOCKED/WAITING_* tasks | ✅ |
-| **5. Complete Monitoring** | System visibility | `/api/parallel/health` endpoint with full metrics | ✅ |
-
-### Phase B UX Features — ALL TESTED & VERIFIED
-
-| Feature | Tests | Performance | Status |
-|---------|-------|-------------|--------|
-| **Gatekeeper Review Gate** | 4 PASS | <1ms | ✅ Production Ready |
-| **Smart Alerts System** | 4 PASS | <10ms | ✅ Production Ready |
-| **Execution Comparison** | 4 PASS | 0.90ms (99% faster than target) | ✅ Production Ready |
-
-### Health Monitoring Endpoint
-
-New endpoint: `GET /api/parallel/health`
-
-Returns comprehensive metrics:
-- Queue state (size, by priority, by status, stale items, DLQ)
-- Executor utilization (deploy/VPC/Browserbase)
-- Latency percentiles (p50, p95, p99)
-- Loop protection metrics (max retries, blocked fingerprints, DLQ count)
-- System health status + detected issues
-
-**Example:**
-```bash
-curl https://tdealer01-crypto-dsg-control-plane.vercel.app/api/parallel/health
-```
-
-### Test Coverage & Verification
-
-**Infinite Loop Protection:**
-- ✅ 85+ new tests — ALL PASSING
-- ✅ 1,890+ existing tests — STILL PASSING (0 regressions)
-- ✅ TypeScript: 0 errors
-- ✅ Build: 164/164 pages success
-
-**Pre-Merge Gates (All Passing):**
-- ✅ All safety guards implemented and verified
-- ✅ Health endpoint operational
-- ✅ Protected statuses never deleted
-- ✅ Fingerprint blocking prevents loops
-
-### Documentation & Reports
-
-Complete implementation details:
-- **[FINAL_SESSION_REPORT_2026_06_11.md](./FINAL_SESSION_REPORT_2026_06_11.md)** — Full session summary (445+ lines)
-- **[PHASE_B_UX_TEST_RESULTS.md](./PHASE_B_UX_TEST_RESULTS.md)** — UX feature test results (350+ lines)
-- **[PHASE_5_6_COMPLETION_REPORT.md](./PHASE_5_6_COMPLETION_REPORT.md)** — Test suite & integration verification
-
-### Deployment Status
-
-**Latest:**
-- ✅ Merged to main (PR#712, commit: cc94d6e)
-- ✅ Ready for Vercel auto-deployment
-- 📊 Monitor via `/api/parallel/health` endpoint
-
----
-
-## 🆕 Stripe App Marketplace Integration — 2026-06-07
-
-**Status:** ✅ Phase 1-9 Scaffold Complete | ⏳ Marketing & Launch Documentation Ready | 🔧 Governance backend persistence and audit enforcement in progress
-
-Stripe App UI extension live in Stripe Dashboard (payment detail view). Governance gate scaffold connected; backend approval persistence and audit enforcement in progress. Gate charges, payouts, and refunds before execution with real-time policy evaluation and logged audit trails.
-
-### What's included
-
-| Phase | Component | Status | Files | Documentation |
-|-------|-----------|--------|-------|---|
-| 1-8 | Setup through Deployment Config | ✅ | 55 | See PHASE_8_ENV_VARS_QUICKSTART.md |
-| 9 | Marketing & Launch Documentation | ✅ | 25+ | **[PHASE9_INDEX.md](./docs/PHASE9_INDEX.md)** — Complete guide |
-
-### Phase 9 Deliverables (Marketing & Launch)
-
-All files are templates ready for customization. No external dashboard access required.
-
-**Core Documents:**
-- **[PHASE9_MARKETPLACE_SUBMISSION.md](./docs/PHASE9_MARKETPLACE_SUBMISSION.md)** — 50-item pre-submission checklist
-- **[PHASE9_POST_APPROVAL_SETUP.md](./docs/PHASE9_POST_APPROVAL_SETUP.md)** — Post-launch execution guide
-- **[PHASE9_SUCCESS_METRICS.md](./docs/PHASE9_SUCCESS_METRICS.md)** — KPI tracking dashboard
-- **[PHASE9_SUPPORT_PLAYBOOK.md](./docs/PHASE9_SUPPORT_PLAYBOOK.md)** — Support & incident response
-- **[PHASE9_DEPLOYMENT_RUNBOOK.md](./docs/PHASE9_DEPLOYMENT_RUNBOOK.md)** — Launch day checklist
-- **[PHASE9_PARTNERSHIP.md](./docs/PHASE9_PARTNERSHIP.md)** — Stripe partnership strategy
-
-**Marketing Materials Directory:** `docs/PHASE9_MARKETING/` (25+ templates)
-- App descriptions, positioning, API scope declarations
-- Email sequences, social media templates, blog post templates
-- Legal templates (privacy policy, ToS, DPA)
-- Test plans (OAuth, webhooks, load, accessibility, browser compatibility)
-- Asset guides and brand guidelines
-
-**Customer Onboarding:** `docs/PHASE9_CUSTOMER_ONBOARDING/` (5+ guides)
-- Welcome email sequence (5 emails over 2 weeks)
-- Getting started guide (10 minutes)
-- Integration tutorial (30 minutes)
-- Success metrics dashboard setup
-- Support resources and escalation path
-
-**Total Phase 9 Content:** ~25 files, ~15,000 words, 100% ready to customize
-
-### Quick start (after PR merge)
-
-```bash
-# 1. Merge PR #700 to main
-git checkout main && git pull
-
-# 2. Deploy to Vercel (follow step-by-step guide)
-# See: PHASE8_DEPLOYMENT_EXECUTION.md
-
-# 3. Verify green status
-curl https://[YOUR_VERCEL_URL]/api/health
-# Expected: {"status":"ok","database":"connected","redis":"connected"}
-
-# 4. Implement Phase 5 APIs (webhook handler, OAuth, routes)
-# See: IMPLEMENTATION_GUIDANCE.md
-```
-
-### Documentation
-
-- **Deployment Guide**: [`PHASE8_DEPLOYMENT_EXECUTION.md`](./PHASE8_DEPLOYMENT_EXECUTION.md) — 10-step Vercel setup
-- **Implementation Guidance**: [`IMPLEMENTATION_GUIDANCE.md`](./IMPLEMENTATION_GUIDANCE.md) — API + testing + marketplace
-- **Architecture**: [`packages/stripe-app/docs/ARCHITECTURE.md`](./packages/stripe-app/docs/ARCHITECTURE.md) — System design + SQL schema
-- **API Reference**: [`packages/stripe-app/docs/API.md`](./packages/stripe-app/docs/API.md) — 13 endpoints documented
-- **Phase Index**: [`STRIPE_APP_SETUP_INDEX.md`](./STRIPE_APP_SETUP_INDEX.md) — All 9 phases mapped
-
-### Next steps
-
-1. **Merge & Deploy** (Week 1)
-   - Merge PR #700
-   - Deploy Phase 8 to Vercel (~1 hour)
-
-2. **Implement APIs** (Week 1-2)
-   - Replace Phase 5 stubs with Stripe SDK
-   - Implement webhook handler, OAuth, routes
-
-3. **Testing & Verification** (Week 2-3)
-   - Populate Phase 7 test stubs (302 tests)
-   - Achieve >80% coverage
-
-4. **Stripe Marketplace** (Week 4-6)
-   - Submit for review (2-4 week approval)
-   - Launch marketing campaign (50 target companies)
-
----
-
-## 🟢 Guided Onboarding UX + Decision Explainer — 2026-06-05
-
-**PRs #676 · #677 · #678 merged to `main` | Deployed:** production live (`GET /api/agent/status` → `version: 98069ae…`, `db:true`) | **Typecheck:** 0 errors | **Build:** `next build` success
-
-Making governed AI usable for real operators, not only developers — one onboarding path, plain-language decisions, and progress backed by real evidence.
-
-### What's new
-
-#### Onboarding (PR #676)
-
-| Area | Change |
-|---|---|
-| Single path | `/api/onboarding/state` `next_action` now points to Quick Setup on the Welcome page (was the stale "Skills" location) |
-| Generated code | Copyable `dsg_gate.py` / `dsg_gate.js` and the inline Python/JS/cURL snippets are English-only — no Thai comments in code users paste into their own repos |
-| Evidence-based progress | The dashboard onboarding checklist derives completion from real workspace state (`progress` from `/api/onboarding/state`) instead of manual self-attested checkboxes |
-| Default safety posture | The Auto-Setup success screen explains what the starter policy enforces: BLOCK ≥ 0.80, STABILIZE ≥ 0.40, ALLOW < 0.40 (no threshold change) |
-| Mascot guide | A decorative, `aria-hidden`, reduced-motion-aware SVG guide reacts to real flow state (walking / thumbs-up / blocked / pointing / waving); it never gates a decision |
-
-#### Plain-language decision explainer (PR #677 · #678)
-
-`components/DecisionExplainer.tsx` turns a raw `ALLOW` / `STABILIZE` / `BLOCK` decision into a clear what / why / next-action summary with fix links (Adjust policy · Review approvals · Open audit). Evidence-first: it renders only data actually present (decision, reason, policy version, optional risk score) and invents nothing.
-
-- Wired into `/dashboard/executions` (above the raw evidence rows + JSON) and the gateway monitor's "Latest visible proof" card.
-- Recognizes gateway decision synonyms: `pass`/`allowed` → ALLOW, `review`/`needs_review`/`manual_review` → review, `deny`/`denied`/`blocked` → BLOCK.
-
-#### Cleanup (PR #677)
-
-- Removed `POST /api/onboarding/seed` (no UI caller; superseded by `POST /api/setup/auto`).
-- Removed the manual `completedStepIds` checklist model from `/api/onboarding/state` — the widget now persists only the `dismissed` preference.
-
-### Verification — 2026-06-05
-
-```
-npm run typecheck             # 0 errors (only 2 pre-existing tsconfig deprecations)
-npm run build                 # success — 124 pages
-vitest onboarding-state-route # 4 passed
-vitest decision-explainer     # 13 passed (render test — PR #680)
-GET /api/agent/status         # version 98069ae…, env production, db:true ✅
-POST /api/gateway/plan-check   → decision "block" + request/decision/record hashes ✅ (live)
-```
-
-Live check: a real `ALLOW` execution and live `block` gateway decisions were rendered through `DecisionExplainer`, producing the correct plain-language output for each. The `/gateway/monitor` page itself is auth-gated (Supabase operator session required), so its rendered HTML is not fetched anonymously.
-
----
-
-## 🟢 Hermes Managed Agents API + Security Hardening — 2026-06-04
-
-**Commit:** `c44e4a240` merged to `main` | **Deployed:** production live | **Typecheck:** 0 errors
-
-PR #673 — consolidated fixes across Hermes chat UX, security, and the full Managed Agents API surface.
-
-### What's new
-
-#### Hermes chat — UI fixes
-
-| Fix | Before | After |
+| Area | What the code supports | Boundary |
 |---|---|---|
-| Tool count display | "25 tools" | "33 tools" (dynamic from `DSG_TOOLS.length`) |
-| SSE event names | `agent.message` / `session.status_idle` etc. | `assistant_reply` / `done` / `step_start` / `step_result` / `step_error` — aligned to dashboard renderer |
-| Stuck "Thinking..." | Tool steps stayed as WAIT forever | Steps render correctly; replies stream to UI |
-| Synthesis fallback | Silent empty reply if `ANTHROPIC_API_KEY` missing | Error text delivered as `assistant_reply` |
-| `tool_calls` continuation | OpenAI tool_calls/tool_call_id dropped on loop | Preserved across every continuation turn |
+| Deterministic gate API | `POST /api/dsg/v1/gates/evaluate` authenticates the caller, rate-limits by org, validates request body, runs `evaluateDeterministicGate`, returns `PASS` / `BLOCK` / `REVIEW`, and writes an audit record asynchronously. | This is a deterministic gate adapter. It is not evidence of external SMT/Z3 invocation in production. |
+| Deterministic proof API | `POST /api/dsg/v1/proofs/prove` requires DSG auth, nonce, idempotency key, and context, then returns a deterministic proof object from `proveDeterministicPlan`. | Proof output includes explicit boundary fields; do not upgrade those fields into certification claims. |
+| Policy manifest API | `GET /api/dsg/v1/policies/manifest` returns the deterministic policy manifest and solver metadata. | Manifest readiness is not a full launch/go-live claim. |
+| Runtime execution | `POST /api/execute` re-exports `POST` and `OPTIONS` from `app/api/spine/execute/route.ts`. The spine route resolves agent API keys, applies rate limits, checks quota, verifies Safe DOM intent when applicable, issues/executes spine intents, and emits fire-and-forget quota, webhook, and metering side effects on success. | Queue size is currently represented by a placeholder in the route. Treat execution orchestration as code present, not as externally certified production capacity. |
+| DSG route auth | `/api/dsg/v1/*` route auth supports Bearer API key lookup by `key_hash` and Supabase session fallback. Successful API key resolution calls `touch_api_key_last_used`; DSG route calls can be logged to `dsg_api_calls`. | This is not a standalone JWT/JWKS gateway claim. |
+| Compliance claim readiness | `GET /api/proof/claim-readiness` maps known claim IDs to required evidence types, queries Supabase-backed evidence tables, reports `PASS` / `PARTIAL` / `BLOCK`, and returns warnings when evidence backend data is empty or unavailable. | Claim readiness is evidence-dependent. Empty or missing evidence must remain `BLOCK`/warning, not marketing pass. |
+| Evidence artifact schema | `claim_readiness_artifacts` migration defines artifact hashes, chain hashes, S3 Object Lock metadata fields, lifecycle status, indexes, and no delete grant. | The migration also explicitly disables RLS for now and contains schema fields for S3 Object Lock; this is not proof that an external WORM-certified bucket is configured. |
+| API key hardening schema | DSG auth migration adds `api_keys.key_hash` indexes, `touch_api_key_last_used`, `expire_api_keys`, `dsg_api_calls`, RLS on the audit table, and an API key usage summary view. | Requires migrations to be applied in the target Supabase project before relying on this behavior in deployment. |
 
-#### Security hardening (MCP route)
+## Explicit non-claims
 
-| Finding | Fix |
-|---|---|
-| Hermes tools dispatched unauthenticated | `requireOrgRole(['operator','org_admin'])` gate added before any Hermes tool call |
-| `orgId` read from caller-supplied args | Now uses `access.orgId` from `requireOrgRole` (server-verified) |
-| `role` escalation via JSON-RPC args | `role` hardcoded to `'operator'` in `buildAgentContext`; never read from args |
-| Webhook SSRF via `http://` URLs | POST/PATCH `/api/hermes/webhooks` enforce `https://` — non-HTTPS returns 400 |
+The current codebase should not be described as any of the following unless new code and deployment evidence are added:
 
-#### Managed Agents REST API
+- external Z3/SMT solver invoked on every production request;
+- third-party certified platform;
+- independently audited platform;
+- WORM-certified external storage already configured end-to-end;
+- completed standalone JWT/JWKS gateway;
+- complete production/go-live evidence solely from repository contents.
 
-Full Anthropic-spec Managed Agents surface — 26 route handlers under `/api/hermes/`:
+The deterministic proof type itself carries boundary fields such as `externalSolverInvoked`, `certificationClaim`, `independentAuditClaim`, `wormStorageCertifiedClaim`, and `cryptographicSigningCompleteClaim`. Keep public claims aligned to those fields.
 
-| Resource | Routes |
-|---|---|
-| Agents | CRUD + archive |
-| Sessions | CRUD + archive + events (GET/POST) + event stream (SSE) + threads |
-| Memory stores | CRUD + archive |
-| Memories | CRUD |
-| Vaults | CRUD + archive |
-| Skills | CRUD |
-| Environments | CRUD + archive |
-| User profiles | CRUD + enrollment-url |
-| Webhooks | CRUD |
+## Important API surfaces
 
-**Key endpoint fixes:**
-- `GET /api/hermes/enroll?token=...` — enrollment token validation (was 404)
-- `GET /api/hermes/sessions/:id/events/stream` — polls for live events up to 25 s (was closing immediately)
-- `session.status_idle` with `stop_reason.type === requires_action` kept open (non-terminal)
-- `POST /api/hermes/sessions/:id/events` — validates session exists before inserting
-- `listSessionEvents` — `event_types` filter pushed to DB query (accurate pagination)
+### Runtime execution
 
-**Supabase migration:** `supabase/migrations/20260604_hermes_managed_agents.sql` — 11 tables with RLS and org isolation.
+```text
+POST /api/execute
+POST /api/spine/execute
+```
 
-### MCP tool surface
+`/api/execute` is a compatibility entry that re-exports the spine execution handler. The spine handler requires a Bearer token, `agent_id`, quota availability, and successful agent API key resolution before execution.
 
-`POST /api/mcp` now exposes **33 Hermes tools** (`hermes.*`) alongside DSG and Android tools.
+### DSG deterministic gate/proof
+
+```text
+GET  /api/dsg/v1/policies/manifest
+POST /api/dsg/v1/gates/evaluate
+POST /api/dsg/v1/proofs/prove
+```
+
+The `gates/evaluate` route requires DSG auth, rate-limits per org, validates body size and structure, runs the deterministic gate, returns the proof payload, and logs route usage. The `proofs/prove` route requires nonce and idempotency key.
+
+### Compliance claim readiness
+
+```text
+GET /api/proof/claim-readiness
+GET /api/proof/claim-readiness?claims=SECURITY-HARDENING&includeSecurityBreakdown=true
+GET /api/proof/claim-readiness?claims=ISO-42001-A.6-PLANNING,NIST-GOVERN-01&includeEvidence=true
+```
+
+Supported default claim IDs in the route include:
+
+- `ISO-42001-A.6-PLANNING`
+- `NIST-GOVERN-01`
+- `SUPPLY-CHAIN-01`
+- `SECURITY-HARDENING`
+- `SBOM-GENERATED`
+- `RUNTIME-INTEGRITY`
+
+## Local development
 
 ```bash
-curl -X POST /api/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
-# returns Android tools + 10 DSG tools + 33 hermes.* tools
+npm install
+npm run typecheck
+npm test
+npm run build
 ```
 
-Auth required for all `hermes.*` calls (`operator` or `org_admin` session).
-
-### Verification — 2026-06-04
-
-```
-npm run typecheck   # 0 errors (pre-merge)
-production version  # c44e4a240687b911854c482a02c14c94dbdec3ad ✅
-GET /api/agent/status → {"ok":true,"checks":{"db":true}} ✅
-```
-
----
-
-## 🟢 Hermes Agent Control Center — 2026-06-02
-
-**Branch:** `claude/hermes-agent-v2-fixes` merged to `main`  
-**Audit:** 2026-06-02 | **Typecheck:** 0 errors | **Unit tests:** 1,055 passed · 0 failed
-
-Chat-based AI agent that governs and controls the entire DSG ONE system via natural language (Thai/English).
-
-### What works (verified from code + audit 2026-06-02)
-
-| ความสามารถ | Tool | สถานะ |
-|---|---|---|
-| ตรวจสถานะระบบ | `readiness` | ✅ |
-| ดูรายการ Agent | `list_agents` | ✅ |
-| สร้าง Agent | `create_agent` | ✅ |
-| จัดการ Agent (detail/update/rotate/delete) | `get_agent_detail` ・ `update_agent` ・ `rotate_agent_key` ・ `delete_agent` | ✅ |
-| ดู Policy | `list_policies` | ✅ |
-| ดู Execution + Proof | `list_executions` ・ `get_execution_proof` ・ `list_proofs` | ✅ |
-| ดู Audit Log | `get_audit` | ✅ |
-| ดู Usage / Billing | `get_usage` ・ `capacity` | ✅ |
-| ดู Ledger | `get_ledger` | ✅ |
-| CCVS Compliance Status | `get_compliance_status` | ✅ |
-| Delivery Proof Scan | `get_delivery_proof` | ✅ |
-| ดึงข้อมูล URL (HTTP) | `fetch_url` | ✅ |
-| เปิด Browser (Browserbase cloud) | `browser_navigate` | ✅ (optional — HTTP fallback if no Browserbase key) |
-| เขียน Code ไฟล์ | `write_code_file` | ✅ |
-| รัน Code (node/python3/bash) | `run_code` | ✅ (ผ่าน Hermes Brain) |
-| ค้นหาเว็บ | `realtime_web_search` | ✅ |
-| ส่ง Telegram | `telegram_send` | ✅ |
-| Auto Setup | `auto_setup` | ✅ |
-
-### Model & Gate
-
-- **Model:** `claude-haiku-4-5-20251001` (synthesis ทุก reply)
-- **DSG Answer Gate:** Pure deterministic Boolean logic (zero LLM) — ตรวจทุก reply ก่อนส่งออก บล็อกอัตโนมัติถ้าอ้าง production-ready / deployed / tests passed โดยไม่มีหลักฐาน
-
-### Environment variables
-
-| Var | Required for |
-|---|---|
-| `ANTHROPIC_API_KEY` | AI synthesis + `run_code` (Hermes Brain) |
-| `BROWSERBASE_API_KEY` | Cloud browser sessions (optional — HTTP fallback if absent) |
-| `BROWSERBASE_PROJECT_ID` | Cloud browser sessions (optional) |
-
-### Architecture
-
-```
-User → /dashboard/hermes (SSE stream)
-     → /api/agent-chat (planGoal regex → tool selection)
-     → DSG_TOOLS (execute each tool against real API routes)
-     → synthesizeWithClaude (Haiku 4.5)
-     → DSG Answer Gate (pure logic check)
-     → reply streamed to UI
-```
-
-### System Audit — 2026-06-02
-
-Full read-only audit of all routes, auth, security, and tools. Scope: very thorough (89 tool calls).
-
-**Routes (40+ checked):** PASS — health, readiness, agent/status, execute/spine, agents CRUD, policies, executions, audit, usage, metrics, capacity, ledger, proofs, agent-chat SSE, dsg/brain/execute, dsg/code/write, dsg/v1/gates, ccvs/compliance-status, delivery-proof/scan, mcp/manifest, mcp/call, defi/config — all present and reachable.
-
-**Auth & Security:** PASS
-- `requireOrgRole()` on all sensitive routes
-- Middleware protects `/dashboard`, `/approvals`, `/gateway/monitor`
-- Cron returns 503 in production if `CRON_SECRET` missing (fail-closed)
-- `readJsonBody()` with 64 KB limit on POST routes
-- `/api/dsg/code/write`: secret pattern block (`sk-ant-*`, `SUPABASE_SERVICE_ROLE`, etc.) + path traversal guard
-
-**Hermes chat pipeline:** PASS — `synthesizeWithClaude()`, `evaluateAnswerGate()`, `detectClaimsInReply()`, `collectedResults` array all correctly wired.
-
-**Code execution path:** PASS — `/api/dsg/brain/execute` accepts `runtime`/`code`/`filename`; shell-executor enforces allowedCommands + allowedPaths; `/api/dsg/code/write` sandbox-only write.
-
-**TypeScript build:**
-```
-npm run typecheck   # 0 errors
-npm run test:unit   # 1,055 passed · 0 failed (2026-06-02)
-```
-
----
-
-## 🟢 DSG Answer Gate + DeFi Config UI — 2026-06-02
-
-**Branch:** `claude/dsg-answer-gate-z3-VZtbQ` | **Tests:** 1,245 passed · 0 failed | **Typecheck:** 0 errors
-
-### Answer Gate (Z3 → TypeScript)
-
-AI response governance layer — blocks AI replies that assert unverified claims before they reach users.
-
-| File | Description |
-|---|---|
-| `tools/proofs/dsg_answer_gate.py` | Z3 SAT encoding — 6 decision types, 3 Buddhist-mark constraints |
-| `tools/proofs/prove_answer_gate.py` | 22 deterministic invariant proofs across all decision paths |
-| `lib/dsg/answer-gate/answer-gate-evaluator.ts` | TypeScript port — same logic, no external solver at runtime |
-| `lib/dsg/answer-gate/claim-detector.ts` | Regex claim scanner for AI reply text |
-| `app/api/dsg/v1/gates/answer-evaluate/route.ts` | `POST /api/dsg/v1/gates/answer-evaluate` — external gate endpoint |
-| `app/api/agent-chat-v2/route.ts` | Gate wired in — `BLOCK_UNSUPPORTED_CLAIM` replaces reply with governance notice |
-
-**Decision boundary (highest priority wins):**
-```
-BLOCK_UNSUPPORTED_CLAIM → NEED_TOOL_VERIFICATION → SPLIT_VERIFIED_AND_INFERRED
-→ ANSWER_VERIFIED → ANSWER_WITH_LIMITS → NEED_REVIEW
-```
-
-### DeFi Yield Optimizer — Bitkub Chain
-
-| File | Description |
-|---|---|
-| `supabase/migrations/20260602_defi_config.sql` | `defi_config` table — stores contract addresses + enabled flag |
-| `app/api/defi/config/route.ts` | `GET/PUT /api/defi/config` — org_admin only |
-| `app/dashboard/settings/defi/page.tsx` | Settings UI — toggle + 6 address fields; private key stays in Vercel env |
-| `lib/defi/yield-optimizer.ts` | Reads config from Supabase first, env fallback |
-| `lib/defi/supabase-defi.ts` | `getLatestPoolProtocol()` — pool position from `defi_txns`; `getDefiConfig/upsertDefiConfig` |
-
-**Configure at:** `/dashboard/settings/defi` — no redeployment needed
-
-### Production status — 2026-06-02
-
-| Check | Result |
-|---|---|
-| `GET /api/health` | ✅ 200 `rateLimiter.ok:true` (Upstash Redis active) |
-| `POST /api/execute` | ✅ 401 (auth gate — not 429) |
-| `GET /api/readiness` | ✅ 200 |
-| go-no-go gate | ✅ PASS |
-| E2E credentials | ✅ provisioned in GitHub Secrets |
-
-### Verification
-
-```
-npm run typecheck   # 0 errors
-npm run test        # 1245 passed, 0 failed
-npm run proof:answer-gate  # 22 proofs PASS (requires: npm run proof:install)
-```
-
----
-
-## 🟢 Test coverage expansion — 2026-06-01
-
-**Branch:** `claude/test-coverage-analysis-M8Gng`
-
-Path-audited coverage gaps filled with 7 new unit test files (50 new tests). All
-previously uncovered decision-point modules now have dedicated unit tests.
-
-### New test files
-
-| File | Tests | Module covered |
-|---|:---:|---|
-| `tests/unit/authz-runtime.test.ts` | 5 | `lib/authz-runtime.ts` — internal service vs user session auth paths |
-| `tests/unit/agent-auth.test.ts` | 4 | `lib/agent-auth.ts` — API key SHA-256 hash lookup |
-| `tests/unit/release-gate/checker.test.ts` | 7 | `lib/release-gate/checker.ts` — GO/NO-GO verdict, network error handling |
-| `tests/unit/release-gate/entitlements.test.ts` | 5 | `lib/release-gate/entitlements.ts` — null guard, DB error, active entitlement |
-| `tests/unit/release-gate/plans.test.ts` | 5 | `lib/release-gate/plans.ts` — static plan shape |
-| `tests/unit/security/api-error.test.ts` | 12 | `lib/security/api-error.ts` — sensitive key redaction, safe response bodies, Sentry |
-| `tests/unit/agent-governance/service.test.ts` | 12 | `lib/agent-governance/service.ts` — execution request creation, tool dispatch routing, proof assembly |
-
-### Verification
-
-```
-./node_modules/.bin/vitest run tests/unit/
-```
-
-```
- Test Files  108 passed (108)
-      Tests  1027 passed (1027)
-   Start at  2026-06-01
-   Duration  14.11s
-```
-
-- `tests/unit/authz-runtime.test.ts` → 5/5 passed (internal service path, user session path, forbidden path, role forwarding)
-- `tests/unit/agent-auth.test.ts` → 4/4 passed (valid hash lookup, null on error, hash verification)
-- `tests/unit/release-gate/` → 17/17 passed (GO verdict, NO-GO on failure, network error, plan shape)
-- `tests/unit/security/api-error.test.ts` → 12/12 passed (redaction, 5xx/4xx response bodies, headers, Sentry call)
-- `tests/unit/agent-governance/service.test.ts` → 12/12 passed (request insert, explicit plan, tool routing, proof + approval map)
-
-No regressions: pre-existing 977 tests remain green.
-
-**Coverage thresholds remain enforced** (vitest.config.ts): global 60/65/55/60, per-file governance floors unchanged.
-
----
-
-## 🟢 GO / NO-GO — 2026-05-29 (CCVS v1.2 + AI Delivery Proof MVP + Agency Pricing)
-
-### New in this release
-| Feature | Path | Description |
-|---|---|---|
-| AI Delivery Proof | `/delivery-proof` | Agency-facing live proof check — paste URL, get GO/NO-GO + share link |
-| Live proof scan API | `POST /api/delivery-proof/scan` | 5 checks (homepage, readiness, health, auth gate, repo URL) |
-| Shareable report | `/delivery-proof/report/[run_id]` | Persistent Supabase-backed report link per CI run |
-| Agency pricing | `/pricing` | Business→Agency $299/mo — unlimited proof checks, white-label reports |
-| EU AI Act Annex IV | `GET /api/compliance-evidence-pack/annex4` | 9-item checklist, 7 covered, 2 partial |
-| MCP server marketing | `/pricing`, `/compliance-evidence-pack` | Positioned as differentiator vs Vanta/Sonar |
-| Zenodo DOI trust | `/pricing`, `/compliance-evidence-pack` | doi.org/10.5281/zenodo.18225586 prominently surfaced |
-| Android APK | `apps/android` | Hermes Agent stack — memory, skills, scheduler, Telegram gateway, subagents, Local API :8642 |
-
----
-
-## 📱 Android Agent APK — Hermes Stack (2026-05-30)
-
-**Download:** [android-apk-latest release](https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane/releases/tag/android-apk-latest)
-
-DSG Agent Android app — no-code AI work-session agent with a Hermes-inspired self-improvement stack built entirely on Android SDK (no extra Gradle dependencies).
-
-| Feature | Description |
-|---|---|
-| 🧠 Memory | Persistent entries (SharedPreferences JSON) auto-injected as `[ความจำ]` context block into every DadBot message; auto-captured from bot responses |
-| 🛠 Skills | Custom skill sequences; DadBot self-creates them via `[SKILL:name\|DESC:desc\|STEPS:CMD:target]` syntax in responses |
-| ⏰ Scheduler | `AlarmManager` cron tasks that fire DadBot automatically at configured intervals; results logged to audit trail |
-| 🌐 Telegram Gateway | Long-poll Telegram Bot → DadBot → reply; token + allowed chat ID stored in SharedPreferences |
-| 🤖 Subagents | `@sub1: prompt @sub2: prompt` — parallel DadBot instances, each with amber-bordered bubble |
-| 🔧 Tool call cards | Amber-bordered command card inserted into chat on every `onCommand()` event |
-| 🌐 Local API `:8642` | Pure-`ServerSocket` HTTP server — OpenAI `POST /v1/chat/completions` (stream + non-stream) and Anthropic `POST /v1/messages`; CORS enabled |
-| 8-tab nav | Chat · Sessions · Memory · Skills · Cron · Gateway · Files · Logs — horizontally scrollable |
-
-**Connect any OpenAI-compatible client to the on-device agent:**
-
-```python
-from openai import OpenAI
-client = OpenAI(base_url="http://<device-ip>:8642/v1", api_key="x")
-resp = client.chat.completions.create(
-    model="dsg-agent",
-    messages=[{"role": "user", "content": "ตรวจระบบ"}],
-    stream=True,
-)
-for chunk in resp:
-    print(chunk.choices[0].delta.content or "", end="", flush=True)
-```
-
-**Or Anthropic SDK:**
-
-```python
-import anthropic
-client = anthropic.Anthropic(base_url="http://<device-ip>:8642", api_key="x")
-msg = client.messages.create(model="dsg-agent", max_tokens=1024,
-    messages=[{"role": "user", "content": "แสดงไฟล์"}])
-print(msg.content[0].text)
-```
-
----
-
-## 🟢 GO / NO-GO — 2026-05-28 (CCVS v1.2 + Security Hardening)
-
-```
-GO/NO-GO RESULT: PASS  ✅  (all scripted checks green)
-```
-
-| Gate | Result | Command / Evidence |
-|---|:---:|---|
-| TypeScript typecheck | ✅ 0 errors | `npm run typecheck` |
-| Unit + integration tests | ✅ **998 passed** / 1010 total | `npm run test` — 133 files passed, 4 skipped |
-| Policy Z3 proofs | ✅ 8 theorems UNSAT | `npm run verify:policy` |
-| Revenue Z3 proofs | ✅ 16 theorems FORMAL PROOF PASS | `npm run proof:revenue` |
-| Mutation score gate | ✅ **72.08%** ≥70% (break=70) | `npm run test:mutation:ci` — Stryker verified locally |
-| Stryker timeout safety | ✅ 840s bash timeout, deferred on CI timeout | `ccvs-evidence.yml` L4 job |
-| Cosign OIDC availability | ✅ gated on `ACTIONS_ID_TOKEN_REQUEST_URL` | L1/L4/L5 `oidc_check` step |
-| gate.ts coverage floor | ✅ lines/fn/stmt 100%, branch 100% | `vitest.config.ts` per-file threshold |
-| CCVS Phase-2 coverage | ✅ 5 per-file floors (evidence-collector 83%, drift 90%) | `vitest.config.ts` |
-| compliance-status API | ✅ GET/POST `/api/ccvs/compliance-status` | shield badge, claim_pass_eligible cache |
-| EU AI Act Annex IV | ✅ 9 items mapped, Aug 2026 deadline | `GET /api/compliance-evidence-pack/annex4` |
-| claim_pass_eligible | ✅ Step Summary badge 🟢/🔴 | `ccvs-evidence.yml` compliance-matrix job |
-| npm vulnerability gate | ✅ **6 moderate (dev-only)**, 0 high/critical | `npm audit --audit-level=high` — CI enforced |
-| Request body safety | ✅ 5 critical routes → `readJsonBody` (size-limited) | `scripts/check-request-body-safety.sh` |
-| Production homepage | ✅ HTTP 200 | `GET /` |
-| Runtime readiness | ✅ HTTP 200 `status=ready` | `GET /api/readiness` |
-| Health + rate limiter | ✅ HTTP 200 `rateLimiter.ok: true` | `GET /api/health` |
-| Trust surface pages | ✅ HTTP 200 × 4 | `/terms` `/privacy` `/security` `/support` |
-| User-flow E2E | ✅ PASS | finance-governance submit → approve → Supabase persisted |
-| **go:no-go gate** | ✅ **PASS** | `npm run go:no-go https://tdealer01-crypto-dsg-control-plane.vercel.app` |
-
-### Full test output — 2026-05-28 (CCVS v1.2)
-
-```
- Test Files  133 passed | 4 skipped (137)
-      Tests  998 passed | 12 skipped (1010)
-   Start at  2026-05-28
-```
-
-+60 new tests vs v1.1: gate boundary (no-arg default, exact spread=0.35), drift-detector env var `??` behavior and sha256 prefix, evidence-collector branch coverage (bundleRef, verificationPolicyRef, RUNNER_OS, metrics fallback), SpineInfraError constructor/error cases, normalize.ts (sha256, normalizeArgs, buildCommandEnvelope, isExpired), compliance-status GET/POST round-trip, Annex IV 9-item structure.
-
-Stryker mutation score: **72.08%** (191/265 killed) — verified locally before CI gate activated.
-
-```
-npm run typecheck     ✅  0 errors
-npm run verify:policy ✅  8 theorems proved, 0 failed
-npm run proof:revenue ✅  16 theorems — VERDICT: FORMAL PROOF PASS
-npm run go:no-go      ✅  GO/NO-GO RESULT: PASS
-```
-
----
-
-## 🔐 Evidence-Driven Compliance Pipeline — CCVS v1.2 (2026-05-28)
-
-Every passing test is automatically upgraded into a **cryptographically-chained, audit-ready evidence artifact**.
-
-### Evidence Severity Levels
-
-| Level | Type | Description | Minimum for |
-|-------|------|-------------|-------------|
-| L1 | `unit` | Test results + coverage metrics | Internal quality |
-| L2 | `integration` | API & workflow coverage | Feature readiness |
-| L3 | `adversarial` / `replay` | Tamper / replay rejection tests | Security review |
-| L4 | `mutation` / `oversight` | Stryker mutation score ≥90% (break=70), Z3 formal proofs | Compliance claims |
-| L5 | `provenance` | SLSA provenance, reproducible build | Regulatory assertion |
-
-### CI Evidence Chain
-
-```
-L1 Unit → L2 Integration → L3 Adversarial+Replay → L4 Mutation(Stryker)+Z3 Proof → L5 SBOM+Provenance → Compliance Matrix → Drift Detection
-```
-
-Each job computes a `chain_hash = sha256(canonicalized_envelope)` and passes it to the next job as `previous_chain_hash`. The chain is tamper-evident.
-
-**Enforcement on main (v1.1 hardening):**
-- Mutation score **≥70% required** before compliance matrix runs (exits 1 if below)
-- Cosign `.sigstore.json` bundles **required** at L1, L4, L5 — missing bundle fails the job
-- `lib/runtime/gate.ts` coverage floor **lines/fn/stmt ≥90%, branch ≥85%** enforced via vitest per-file threshold
-- `claim_pass_eligible` badge (🟢/🔴) written to GitHub Actions Step Summary on every main push
-
-### Compliance Matrix
-
-Auto-generated from test results — maps every regulatory requirement to a control, test file, and evidence hash:
-
-| Framework | Requirement | Control | Min Level |
-|-----------|-------------|---------|-----------|
-| EU AI Act | Art. 14 Human oversight | CTRL-HUMAN-GATE | L2 |
-| EU AI Act | Art. 12 Record-keeping | CTRL-IMMUTABLE-AUDIT | L3 |
-| ISO 42001 | A.7.3 Risk assessment | CTRL-RISK-GATE | L3 |
-| ISO 42001 | A.9.2 Internal audit | CTRL-AUDIT-TRAIL | L2 |
-| NIST AI RMF | GOVERN 1.1 | CTRL-POLICY-ENGINE | L1 |
-| NIST AI RMF | MAP 2.1 | CTRL-PROOF-VALIDITY | L4 |
-| SLSA | Level 2 Provenance | CTRL-BUILD-PROVENANCE | L5 |
-
-### npm scripts
+Useful scripts exposed by `package.json` include:
 
 ```bash
-npm run ccvs:emit      # emit evidence envelope after test run
-npm run ccvs:verify    # verify chain_hash integrity on all envelopes
-npm run ccvs:matrix    # generate compliance matrix JSON
-npm run ccvs:pipeline  # full: coverage → emit → verify → matrix
+npm run dev
+npm run lint
+npm run typecheck
+npm test
+npm run test:coverage
+npm run test:ci
+npm run verify:deterministic
+npm run verify:production-manifest
+npm run go:no-go
+npm run ccvs:verify
+npm run deploy:preview
+npm run deploy:prod
 ```
 
-### Evidence Chain + Compliance Status API
+## Environment and deployment notes
 
-```
-GET  /api/ccvs/evidence-chain          # severity table, requirement catalog, drift status
-GET  /api/ccvs/compliance-status       # claim_pass_eligible badge + shield (lightgrey/green/red)
-POST /api/ccvs/compliance-status       # CI uploads { matrix, run_id, mutation_score } after each run
-GET  /api/compliance-evidence-pack/annex4          # EU AI Act Annex IV — 9 items → DSG controls (JSON)
-GET  /api/compliance-evidence-pack/annex4?format=html  # styled HTML checklist
-```
+This repository uses Supabase, Vercel, Stripe, Upstash Redis, and related service credentials depending on which surface is being deployed.
 
-`compliance-status` uses an in-memory cache (resets on cold start); CI re-uploads after every deploy via `CCVS_UPLOAD_URL` env var in `generate-compliance-matrix.mjs`.
+Do not treat local tests alone as production readiness. Before a production claim, verify at minimum:
 
-### EU AI Act Annex IV (August 2026 enforcement)
+1. required environment variables are present in the target environment;
+2. Supabase migrations are applied to the target database;
+3. public smoke endpoints respond on the deployed URL;
+4. authenticated/operator flows are checked with real target credentials;
+5. evidence APIs return populated evidence rather than empty-backend warnings;
+6. Stripe App/package behavior is tested in the intended Stripe environment when relevant.
 
-9 Annex IV technical documentation items mapped to DSG ONE controls:
+## Documentation index
 
-| # | Annex IV Item | DSG Control | Status |
-|---|---|---|---|
-| 1 | General description + intended purpose | CTRL-POLICY-ENGINE | covered |
-| 2 | Version + update history | CTRL-BUILD-PROVENANCE | covered |
-| 3 | Technical specifications + accuracy | CTRL-RISK-GATE | covered |
-| 4 | Monitoring + logging systems | CTRL-IMMUTABLE-AUDIT | covered |
-| 5 | Input data specifications | CTRL-POLICY-ENGINE | partial |
-| 6 | Human oversight measures | CTRL-HUMAN-GATE | covered |
-| 7 | Post-market monitoring | CTRL-REPLAY-REJECTION | covered |
-| 8 | Incident reporting | CTRL-AUDIT-TRAIL | partial |
-| 9 | Instructions for use | CTRL-MIDMARKET-GATE | covered |
+Start here:
 
-`certificationClaim: false` · `independentAuditClaim: false` — pre-audit evidence mapping, not legal certification.
+- [`docs/README.md`](docs/README.md) — documentation index.
+- [`docs/CODEBASE_REVIEW_2026-06-15.md`](docs/CODEBASE_REVIEW_2026-06-15.md) — codebase-only review used for this README refresh.
 
----
+## Maintainer rule
 
-## 📋 Compliance Evidence Pack — 2026-05-28
-
-Pre-formatted evidence report for EU AI Act and ISO 42001 compliance review.
-
-- **24 Z3 theorems** — 8 policy + 16 billing, design-time formal proofs (TypeScript static checks at runtime)
-- **998 test assertions** — 133 test files, 0 failures
-- **Verifiable hash lineage** — SHA-256 `requestHash → decisionHash → recordHash → bundleHash` stored in auditable DB; integrity verifiable, not WORM-certified storage
-- **EU AI Act Art. 12/14** — Record keeping and human oversight control mapping
-- **ISO/IEC 42001** — A.6, A.9, A.10 AI management system controls
-
-```
-GET /api/compliance-evidence-pack          # Printable HTML report
-GET /api/compliance-evidence-pack?print=1  # Auto-print PDF mode
-/compliance-evidence-pack                  # Landing page
-```
-
-Evidence boundary: `certificationClaim = false` · `independentAuditClaim = false` — see report footer.
-
----
-
-## 💳 Revenue Hardening — Issue #577 (2026-05-24)
-
-Four P0/P1 bugs fixed and verified in production before this release.
-
-### P0-1 · Stripe Meter Idempotency
-
-**Bug:** idempotency key was `dsg-meter-{orgId}-{timestamp}` — two executions in the same second shared the same key, Stripe deduped them → silent revenue leak.
-
-**Fix:** key is now `dsg-meter-{executionId}` — each execution row has a unique ID, guaranteed distinct.
-
-```typescript
-// Before (broken)
-const idempotencyKey = `dsg-meter-${orgId}-${timestamp}`;
-
-// After (fixed)
-const idempotencyKey = `dsg-meter-${executionId}`;
-```
-
-### P0-2 · Billing Outbox (no silent loss)
-
-**Bug:** `reportMeterEvent` fired directly to Stripe — if Stripe was unavailable the usage event was lost with no retry path.
-
-**Fix:** write-first-then-flush pattern:
-
-1. Write `pending` row to `billing_meter_outbox` (Supabase) before any network call
-2. Attempt immediate Stripe delivery → update row to `sent` or `failed`
-3. Hourly cron `flush-meter-outbox` retries all `pending` rows older than 5 min
-
-```
-billing_meter_outbox schema:
-  execution_id  (unique — idempotency key)
-  status        pending → sent | failed
-  stripe_event_id, error, flushed_at
-```
-
-Migration: `supabase/migrations/20260523000000_billing_meter_outbox.sql`
-
-### P0-3 · Cron Auth Fail-Closed
-
-**Bug:** `if (cronSecret && ...)` — if `CRON_SECRET` was not set, the condition was never entered → cron ran unauthenticated.
-
-**Fix:**
-
-```typescript
-// Before (fail-open)
-if (cronSecret && authHeader !== `Bearer ${cronSecret}`) { return 401 }
-
-// After (fail-closed)
-if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-  return !cronSecret ? 503 : 401;
-}
-```
-
-Applies to both `/api/cron/usage-alerts` and `/api/cron/flush-meter-outbox`.
-
-### P1-1 · Analytics Period Parameter
-
-**Bug:** `GET /api/usage/analytics?period=2026-04` always returned current month data — `period` param was parsed but ignored.
-
-**Fix:** `getOrgUsageSnapshot(orgId, period?)` now accepts an optional period; analytics route passes it through to both the snapshot query and `topAgents` query.
-
-```bash
-# Now works correctly:
-GET /api/usage/analytics?period=2026-04  →  "period": "2026-04"
-```
-
----
-
-## 🛡️ Security Hardening — 2026-05-28
-
-### Dependency Vulnerability Reduction (15 → 6 moderate)
-
-`package.json` npm `overrides` force safe transitive dep versions:
-
-```json
-"overrides": {
-  "qs":      ">=6.15.2",
-  "ws":      ">=8.20.1",
-  "postcss": ">=8.5.15"
-}
-```
-
-| Package | Issue | Fix |
-|---|---|---|
-| `qs` <6.15.2 | Prototype pollution via `typed-rest-client` | override to ≥6.15.2 |
-| `ws` <8.20.1 | DoS via `ethers` transitive dep | `ethers` ^6.13→^6.16 + override |
-| `postcss` <8.5.10 | Line-return injection | override to ≥8.5.15 |
-
-**Remaining 6 moderate**: all `vitest`/`esbuild` dev-only (CVSS 5.3, no dev server in CI `vitest run` mode). Require vitest v4 major bump — tracked via Dependabot.
-
-CI enforcement: `npm audit --audit-level=high` in `ci-security.yml` — 0 high/critical blocks the build.
-
-### Request Body Safety
-
-5 critical API routes migrated from raw `request.json()` to `readJsonBody` (size-limited, depth-checked):
-
-| Route | Max body | Purpose |
-|---|---|---|
-| `gateway/tools/execute` | 32 KB | AI tool execution gateway |
-| `mcp-server` | 64 KB | JSON-RPC MCP endpoint |
-| `agent-execute` | 64 KB | Agent execution planner |
-| `ccvs/compliance-status` | 256 KB | CI compliance matrix upload |
-| `finance-governance/submit` | 4 KB | Finance case submission |
-
-`scripts/check-request-body-safety.sh` — CI linter (informational, non-blocking) flags any new `request.json()` regressions in POST/PUT/PATCH handlers. Wired into `ci-security.yml`.
-
----
-
-## 🔐 Z3 Formal Verification (Design-Time Proofs)
-
-**Note:** Z3 proofs are design-time verification tools used in CI. At runtime, DSG gates use TypeScript static checks, not external Z3 solver invocation. These proofs verify the correctness of the gate logic itself.
-
-### Policy Engine — 8 theorems (Python Z3)
-
-```
-npm run verify:policy
-✓ PROVED  [role_safety]            allow → role ∈ valid set
-✓ PROVED  [plan_safety]            allow → plan ∈ {enterprise, business, pro}
-✓ PROVED  [approval_safety]        allow ∧ approvalRequired → token ≠ ∅
-✓ PROVED  [audit_completeness]     decision always in valid enum
-✓ PROVED  [non_triviality]         ∃ valid request where decision = allow
-✓ PROVED  [amount_bound]           DeFi amount ≤ $1,000 and daily ≤ $10,000
-✓ PROVED  [slippage_bound]         slippage ≤ 50 bps
-✓ PROVED  [constraint_consistency] DeFi constraint set is satisfiable
-Policy theorems: 8 proved, 0 failed (design-time verification)
-```
-
-### Billing & Quota — 16 theorems (TypeScript z3-solver WASM)
-
-```
-npm run proof:revenue
-Quota ordering:          enterprise > business > pro > trial > free > 0
-Safe floor:              getQuotaForPlan never returns 0
-Status partition:        ACTIVE_STATUSES ∩ REVOKED_STATUSES = ∅
-Revenue monotonicity:    upgrading plan never decreases quota
-Rate-limit conservation: remaining + used = limit (always)
-No-bypass theorem:       cannot be allowed AND blocked simultaneously
-Stripe pricing:          yearly = 9×monthly exactly (25% discount proven)
-Quota gate:              post-increment used ≤ limit (single-threaded)
-VERDICT: FORMAL PROOF PASS — 16 theorems, 0 failed (design-time verification)
-```
-
-**Method:** prove theorem P by asserting ¬P and checking UNSAT. If Z3 finds no countermodel, P holds for every possible input.
-
----
-
-## Infrastructure
-
-| Component | Status | Detail |
-|---|:---:|---|
-| Supabase auth + Postgres | ✅ LIVE | Magic-link OTP, RLS on all tables |
-| Upstash Redis | ✅ LIVE | Rate limiting — per-email 3/min, per-IP tiers |
-| Stripe billing | ✅ LIVE | Webhook live, metered billing ready, outbox flush hourly |
-| Resend email | ✅ CONFIGURED | Upgrade nudge emails, magic-link OTP |
-| `CRON_SECRET` | ✅ CONFIGURED | Fail-closed on both cron routes |
-| Vercel crons | ✅ ACTIVE | `usage-alerts` 07:00 UTC daily, `flush-meter-outbox` hourly |
-
----
-
-## REST API
-
-### Gate an action
-
-```bash
-curl -X POST https://tdealer01-crypto-dsg-control-plane.vercel.app/api/try/gate \
-  -H "Content-Type: application/json" \
-  -d '{"session_id": "my-agent-run-001", "action": "send email to user@example.com"}'
-```
-
-```json
-{
-  "decision": "ALLOW",
-  "stamp": "DSG-X9K3M7P2",
-  "action": "send email to user@example.com"
-}
-```
-
-### Usage analytics
-
-```bash
-# Current month
-GET /api/usage/analytics
-
-# Specific period
-GET /api/usage/analytics?period=2026-04
-```
-
----
-
-## Tech stack
-
-```
-Next.js 15 App Router + TypeScript
-Supabase auth + Postgres (RLS)
-Stripe billing + metered usage
-Upstash Redis rate limiting
-Resend transactional email
-Vitest 1027 tests (unit + integration)
-Playwright E2E
-Z3 SMT Solver — 24 theorems at design time
-GitHub Actions + DSG Secure Deploy Gate
-npm overrides — qs/ws/postcss transitive dep hardening
-```
-
----
-
-## Verification commands
-
-```bash
-npm run typecheck          # TypeScript — 0 errors
-npm run test               # 1027 tests
-npm run verify:policy      # Z3 policy proofs (Python)
-npm run proof:revenue      # Z3 billing proofs (Python)
-npm run go:no-go <url>     # Full production gate
-npm audit --audit-level=high          # 0 high/critical (6 dev-only moderate)
-bash scripts/check-request-body-safety.sh  # request body safety linter
-```
-
----
-
-## Production Status — 2026-06-04
-
-✅ **Production-connected** (live and responding) — commit `c44e4a240`
-- REST API live: health ✅, readiness ✅, agent-status ✅
-- Database connected ✅
-- Rate limiter (Upstash Redis) active ✅
-- Hermes Managed Agents API surface live (26 routes) ✅
-- MCP `tools/list` returns 33 Hermes tools + DSG + Android tools ✅
-- Hermes chat replies correctly (no "Thinking..." stuck state) ✅
-- MCP Hermes tools auth-gated (`requireOrgRole`) ✅
-
-⚠️ **Not "production-ready"** (per CLAUDE.md evidence-first policy):
-- "Production-ready" claim blocked unless fresh full verification evidence
-- Safe claims: "production-connected", "audit-ready", "evidence-ready"
-
----
-
-## Supported claims — verified evidence only
-
-```
-✓ Hermes Managed Agents REST API live — 26 routes under /api/hermes/ (verified 2026-06-04).
-✓ MCP server exposes 33 Hermes tools (hermes.*) + DSG + Android tools, auth-gated (verified 2026-06-04).
-✓ MCP Hermes tools require requireOrgRole — unauthenticated access blocked (verified 2026-06-04).
-✓ Hermes chat SSE emits correct event names — dashboard renders replies, no stuck "Thinking..." (verified 2026-06-04).
-✓ Webhook POST/PATCH enforce https:// only — SSRF via http:// blocked with 400 (verified 2026-06-04).
-✓ GET /api/hermes/enroll validates enrollment token (was 404, now live — verified 2026-06-04).
-✓ REST API gate endpoint is live and returns correct ALLOW/BLOCK decisions (verified 2026-06-03).
-✓ Runtime readiness is green (HTTP 200, status=ready, verified 2026-06-03).
-✓ 1027 unit + integration tests pass, 0 failures (108 unit files; +50 new tests covering authz-runtime, agent-auth, release-gate, security/api-error, agent-governance/service).
-✓ TypeScript compiles with 0 errors.
-✓ Gateway policy engine formally verified — 8 Z3 theorems, design-time CI verification.
-✓ Billing quota model formally verified — 16 Z3 theorems, design-time CI verification (runtime uses TypeScript static checks, not external solver).
-✓ DeFi transaction bounds mathematically proven (amount ≤ $1k, slippage ≤ 50bps).
-✓ Stripe metered billing idempotent — per-execution key, no same-second dedup.
-✓ Billing outbox — no silent loss on Stripe outage, hourly retry.
-✓ Cron routes fail-closed — missing CRON_SECRET returns 503, not 200.
-✓ Mutation score gate 72.08% ≥70% (191/265 killed) — Stryker verified locally.
-✓ CCVS compliance-status API live — GET /api/ccvs/compliance-status returns ok:true (commit da78ef0).
-✓ EU AI Act Annex IV 9-item checklist live — GET /api/compliance-evidence-pack/annex4 (7 covered, 2 partial).
-✓ go:no-go gate PASS on 2026-05-28 (CCVS v1.2).
-✓ Compliance Evidence Pack — pre-audit PDF report served at /api/compliance-evidence-pack.
-✓ npm dependency hardening — qs/ws/postcss overrides, 15 → 6 moderate vulns, 0 high/critical.
-✓ Request body safety — 5 critical routes use readJsonBody with explicit size limits (4–256 KB).
-✓ CI body-safety linter — scripts/check-request-body-safety.sh flags raw request.json() regressions.
-✓ Hash lineage verifiable — SHA-256 `requestHash → decisionHash → recordHash → bundleHash` stored in auditable DB with integrity verification.
-```
-
-Not claimed:
-
-```
-✗ Independent third-party audit or certification.
-✗ WORM-certified or tamper-proof audit storage (hash lineage is DB-backed and auditable, not cryptographically tamper-proof storage).
-✗ Published public npm/PyPI SDK.
-✗ External Z3 solver invocation at runtime (design-time proofs only; runtime gates use TypeScript static checks).
-```
-
----
-
-## GraphMap Plugin (spec — 2026-05-26)
-
-```
-GET  /api/plugins/graphmap/status  — EMPTY | READY, isStale boolean
-POST /api/plugins/graphmap/build   — scan repo → build graph → Supabase
-POST /api/plugins/graphmap/query   — keyword BFS → evidence + gate
-```
-
-Edge confidence:
-- import / link   → EXTRACTED (direct parse evidence)
-- co-located      → INFERRED  (same-directory heuristic)
-
-Gate:
-- ALLOW  — ≥3 EXTRACTED evidence + graph age < 24h
-- REVIEW — any INFERRED, stale, or < 3 EXTRACTED
-- BLOCK  — no evidence or all AMBIGUOUS
-
-Plugin manifest: `plugins/graphmap/plugin.json`
-- `read_repo: true` | `write_repo: false` | `call_dsg_gate: true`
-
-Agent usage rules in `AGENTS.md` — agents MUST query GraphMap before answering repo structure questions.
-
----
-
-## Formal verification artifact
-
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18225586.svg)](https://doi.org/10.5281/zenodo.18225586)
-
-**Peer-archived reference implementation — CERN/OpenAIRE indexed**
-
-```
-DOI:   https://doi.org/10.5281/zenodo.18225586
-Title: Deterministic State Gate (DSG): Formally Verified Control Primitive
-       for Safety-Critical AI Systems
-```
-
-## GitHub Marketplace action
-
-```yaml
-- name: DSG Secure Deploy Gate
-  uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1.1.0
-```
-
-Launch page: `https://tdealer01-crypto-dsg-control-plane.vercel.app/proofgate-github-action`
+When updating this README, use code and directly inspected repository files first. Avoid copying old status claims forward unless the current codebase and target deployment evidence still support them.

--- a/README.md
+++ b/README.md
@@ -1,81 +1,80 @@
 # DSG ONE — ProofGate Control Plane
 
-> Runtime control-plane scaffold for governed AI, agent, workflow, finance, and deployment actions.
+Runtime control-plane scaffold for governed AI, agent, workflow, finance, and deployment actions.
 
-This README is intentionally written from the current codebase surface, not from historical marketing copy. Treat it as a repository map and claim boundary, not as a production certification.
+This README is a codebase map for developers and reviewers.
 
-## What is in this repository
+## Repository surfaces
 
-DSG ONE combines a Next.js application, API routes, deterministic gate/proof types, Supabase-backed auth/evidence schema, and Stripe App package code.
+- `app/` — Next.js application and API routes.
+- `lib/` — shared application logic.
+- `supabase/migrations/` — database migrations.
+- `packages/stripe-app/` — Stripe App package.
+- `scripts/` — project scripts.
+- `docs/` — documentation.
 
-At code level, the main surfaces are:
+## Implemented surfaces
 
-- Next.js App Router application under `app/`.
-- Runtime execution API under `app/api/execute/` and `app/api/spine/execute/`.
-- DSG deterministic proof/gate API under `app/api/dsg/v1/`.
-- Compliance claim-readiness API under `app/api/proof/claim-readiness/`.
-- Deterministic gate/proof types and engines under `lib/dsg/deterministic/`.
-- DSG route auth helper under `lib/dsg/auth/require-dsg-auth.ts`.
-- Supabase migrations under `supabase/migrations/`.
-- Stripe App package under `packages/stripe-app/`.
-- Verification, deployment, smoke, evidence, and operations scripts under `scripts/`.
+| Area | Files |
+|---|---|
+| Runtime execution | `app/api/execute/route.ts`, `app/api/spine/execute/route.ts` |
+| Deterministic policy manifest | `app/api/dsg/v1/policies/manifest/route.ts` |
+| Deterministic gate decision | `app/api/dsg/v1/gates/evaluate/route.ts` |
+| Deterministic proof response | `app/api/dsg/v1/proofs/prove/route.ts` |
+| Deterministic types | `lib/dsg/deterministic/types.ts` |
+| DSG route helper | `lib/dsg/auth/require-dsg-auth.ts` |
+| Claim-readiness report | `app/api/proof/claim-readiness/route.ts` |
+| Evidence artifact table | `supabase/migrations/20260612041000_create_claim_readiness_artifacts.sql` |
+| DSG route usage schema | `supabase/migrations/20260613000002_dsg_auth_indexes_and_audit.sql` |
 
-## Current codebase-derived status
+## Main routes
 
-| Area | What the code supports | Boundary |
-|---|---|---|
-| Deterministic gate API | `POST /api/dsg/v1/gates/evaluate` authenticates the caller, rate-limits by org, validates request body, runs `evaluateDeterministicGate`, returns `PASS` / `BLOCK` / `REVIEW`, and writes an audit record asynchronously. | This is a deterministic gate adapter. It is not evidence of external SMT/Z3 invocation in production. |
-| Deterministic proof API | `POST /api/dsg/v1/proofs/prove` requires DSG auth, nonce, idempotency key, and context, then returns a deterministic proof object from `proveDeterministicPlan`. | Proof output includes explicit boundary fields; do not upgrade those fields into certification claims. |
-| Policy manifest API | `GET /api/dsg/v1/policies/manifest` returns the deterministic policy manifest and solver metadata. | Manifest readiness is not a full launch/go-live claim. |
-| Runtime execution | `POST /api/execute` re-exports `POST` and `OPTIONS` from `app/api/spine/execute/route.ts`. The spine route resolves agent API keys, applies rate limits, checks quota, verifies Safe DOM intent when applicable, issues/executes spine intents, and emits fire-and-forget quota, webhook, and metering side effects on success. | Queue size is currently represented by a placeholder in the route. Treat execution orchestration as code present, not as externally certified production capacity. |
-| DSG route auth | `/api/dsg/v1/*` route auth supports Bearer API key lookup by `key_hash` and Supabase session fallback. Successful API key resolution calls `touch_api_key_last_used`; DSG route calls can be logged to `dsg_api_calls`. | This is not a standalone JWT/JWKS gateway claim. |
-| Compliance claim readiness | `GET /api/proof/claim-readiness` maps known claim IDs to required evidence types, queries Supabase-backed evidence tables, reports `PASS` / `PARTIAL` / `BLOCK`, and returns warnings when evidence backend data is empty or unavailable. | Claim readiness is evidence-dependent. Empty or missing evidence must remain `BLOCK`/warning, not marketing pass. |
-| Evidence artifact schema | `claim_readiness_artifacts` migration defines artifact hashes, chain hashes, S3 Object Lock metadata fields, lifecycle status, indexes, and no delete grant. | The migration also explicitly disables RLS for now and contains schema fields for S3 Object Lock; this is not proof that an external WORM-certified bucket is configured. |
-| API key hardening schema | DSG auth migration adds `api_keys.key_hash` indexes, `touch_api_key_last_used`, `expire_api_keys`, `dsg_api_calls`, RLS on the audit table, and an API key usage summary view. | Requires migrations to be applied in the target Supabase project before relying on this behavior in deployment. |
+| Route | Purpose |
+|---|---|
+| `POST /api/execute` | Runtime execution compatibility route. |
+| `POST /api/spine/execute` | Spine execution route. |
+| `GET /api/dsg/v1/policies/manifest` | Deterministic policy manifest. |
+| `POST /api/dsg/v1/gates/evaluate` | Deterministic gate decision. |
+| `POST /api/dsg/v1/proofs/prove` | Deterministic proof response. |
+| `GET /api/proof/claim-readiness` | Claim-readiness report. |
 
-## Explicit non-claims
+## Runtime execution flow
 
-The current codebase should not be described as any of the following unless new code and deployment evidence are added:
+The spine execution route includes:
 
-- external Z3/SMT solver invoked on every production request;
-- third-party certified platform;
-- independently audited platform;
-- WORM-certified external storage already configured end-to-end;
-- completed standalone JWT/JWKS gateway;
-- complete production/go-live evidence solely from repository contents.
+1. request normalization;
+2. agent ID requirement;
+3. agent lookup;
+4. active-agent check;
+5. quota check;
+6. Safe DOM verification when applicable;
+7. execution-state setup;
+8. spine intent issue/execute flow;
+9. task outcome tracking;
+10. quota, webhook, and metering side effects on success;
+11. `stop_reason` in the response.
 
-The deterministic proof type itself carries boundary fields such as `externalSolverInvoked`, `certificationClaim`, `independentAuditClaim`, `wormStorageCertifiedClaim`, and `cryptographicSigningCompleteClaim`. Keep public claims aligned to those fields.
+## Deterministic gate/proof flow
 
-## Important API surfaces
+The DSG v1 deterministic routes include:
 
-### Runtime execution
+1. policy manifest output;
+2. gate request validation;
+3. gate status output: `PASS`, `BLOCK`, `REVIEW`;
+4. proof generation;
+5. nonce and idempotency-key handling;
+6. proof hash and replay-protection fields in the type surface;
+7. route usage logging for gate evaluation.
 
-```text
-POST /api/execute
-POST /api/spine/execute
-```
+## Claim-readiness flow
 
-`/api/execute` is a compatibility entry that re-exports the spine execution handler. The spine handler requires a Bearer token, `agent_id`, quota availability, and successful agent API key resolution before execution.
+The claim-readiness route supports:
 
-### DSG deterministic gate/proof
+- `claims`
+- `includeEvidence`
+- `includeSecurityBreakdown`
 
-```text
-GET  /api/dsg/v1/policies/manifest
-POST /api/dsg/v1/gates/evaluate
-POST /api/dsg/v1/proofs/prove
-```
-
-The `gates/evaluate` route requires DSG auth, rate-limits per org, validates body size and structure, runs the deterministic gate, returns the proof payload, and logs route usage. The `proofs/prove` route requires nonce and idempotency key.
-
-### Compliance claim readiness
-
-```text
-GET /api/proof/claim-readiness
-GET /api/proof/claim-readiness?claims=SECURITY-HARDENING&includeSecurityBreakdown=true
-GET /api/proof/claim-readiness?claims=ISO-42001-A.6-PLANNING,NIST-GOVERN-01&includeEvidence=true
-```
-
-Supported default claim IDs in the route include:
+Default claim IDs:
 
 - `ISO-42001-A.6-PLANNING`
 - `NIST-GOVERN-01`
@@ -93,7 +92,7 @@ npm test
 npm run build
 ```
 
-Useful scripts exposed by `package.json` include:
+Useful scripts:
 
 ```bash
 npm run dev
@@ -110,26 +109,8 @@ npm run deploy:preview
 npm run deploy:prod
 ```
 
-## Environment and deployment notes
+## Documentation
 
-This repository uses Supabase, Vercel, Stripe, Upstash Redis, and related service credentials depending on which surface is being deployed.
-
-Do not treat local tests alone as production readiness. Before a production claim, verify at minimum:
-
-1. required environment variables are present in the target environment;
-2. Supabase migrations are applied to the target database;
-3. public smoke endpoints respond on the deployed URL;
-4. authenticated/operator flows are checked with real target credentials;
-5. evidence APIs return populated evidence rather than empty-backend warnings;
-6. Stripe App/package behavior is tested in the intended Stripe environment when relevant.
-
-## Documentation index
-
-Start here:
-
-- [`docs/README.md`](docs/README.md) — documentation index.
-- [`docs/CODEBASE_REVIEW_2026-06-15.md`](docs/CODEBASE_REVIEW_2026-06-15.md) — codebase-only review used for this README refresh.
-
-## Maintainer rule
-
-When updating this README, use code and directly inspected repository files first. Avoid copying old status claims forward unless the current codebase and target deployment evidence still support them.
+- [`docs/README.md`](docs/README.md)
+- [`docs/CODEBASE_REVIEW_2026-06-15.md`](docs/CODEBASE_REVIEW_2026-06-15.md)
+- [`docs/IMPLEMENTED_SURFACES_2026-06-15.md`](docs/IMPLEMENTED_SURFACES_2026-06-15.md)

--- a/README_IMPLEMENTED_SURFACES_DRAFT.md
+++ b/README_IMPLEMENTED_SURFACES_DRAFT.md
@@ -1,0 +1,116 @@
+# DSG ONE — ProofGate Control Plane
+
+Runtime control-plane scaffold for governed AI, agent, workflow, finance, and deployment actions.
+
+This README is a codebase map for developers and reviewers.
+
+## Repository surfaces
+
+- `app/` — Next.js application and API routes.
+- `lib/` — shared application logic.
+- `supabase/migrations/` — database migrations.
+- `packages/stripe-app/` — Stripe App package.
+- `scripts/` — project scripts.
+- `docs/` — documentation.
+
+## Implemented surfaces
+
+| Area | Files |
+|---|---|
+| Runtime execution | `app/api/execute/route.ts`, `app/api/spine/execute/route.ts` |
+| Deterministic policy manifest | `app/api/dsg/v1/policies/manifest/route.ts` |
+| Deterministic gate decision | `app/api/dsg/v1/gates/evaluate/route.ts` |
+| Deterministic proof response | `app/api/dsg/v1/proofs/prove/route.ts` |
+| Deterministic types | `lib/dsg/deterministic/types.ts` |
+| DSG route helper | `lib/dsg/auth/require-dsg-auth.ts` |
+| Claim-readiness report | `app/api/proof/claim-readiness/route.ts` |
+| Evidence artifact table | `supabase/migrations/20260612041000_create_claim_readiness_artifacts.sql` |
+| DSG route usage schema | `supabase/migrations/20260613000002_dsg_auth_indexes_and_audit.sql` |
+
+## Main routes
+
+| Route | Purpose |
+|---|---|
+| `POST /api/execute` | Runtime execution compatibility route. |
+| `POST /api/spine/execute` | Spine execution route. |
+| `GET /api/dsg/v1/policies/manifest` | Deterministic policy manifest. |
+| `POST /api/dsg/v1/gates/evaluate` | Deterministic gate decision. |
+| `POST /api/dsg/v1/proofs/prove` | Deterministic proof response. |
+| `GET /api/proof/claim-readiness` | Claim-readiness report. |
+
+## Runtime execution flow
+
+The spine execution route includes:
+
+1. request normalization;
+2. agent ID requirement;
+3. agent lookup;
+4. active-agent check;
+5. quota check;
+6. Safe DOM verification when applicable;
+7. execution-state setup;
+8. spine intent issue/execute flow;
+9. task outcome tracking;
+10. quota, webhook, and metering side effects on success;
+11. `stop_reason` in the response.
+
+## Deterministic gate/proof flow
+
+The DSG v1 deterministic routes include:
+
+1. policy manifest output;
+2. gate request validation;
+3. gate status output: `PASS`, `BLOCK`, `REVIEW`;
+4. proof generation;
+5. nonce and idempotency-key handling;
+6. proof hash and replay-protection fields in the type surface;
+7. route usage logging for gate evaluation.
+
+## Claim-readiness flow
+
+The claim-readiness route supports:
+
+- `claims`
+- `includeEvidence`
+- `includeSecurityBreakdown`
+
+Default claim IDs:
+
+- `ISO-42001-A.6-PLANNING`
+- `NIST-GOVERN-01`
+- `SUPPLY-CHAIN-01`
+- `SECURITY-HARDENING`
+- `SBOM-GENERATED`
+- `RUNTIME-INTEGRITY`
+
+## Local development
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run build
+```
+
+Useful scripts:
+
+```bash
+npm run dev
+npm run lint
+npm run typecheck
+npm test
+npm run test:coverage
+npm run test:ci
+npm run verify:deterministic
+npm run verify:production-manifest
+npm run go:no-go
+npm run ccvs:verify
+npm run deploy:preview
+npm run deploy:prod
+```
+
+## Documentation
+
+- [`docs/README.md`](docs/README.md)
+- [`docs/CODEBASE_REVIEW_2026-06-15.md`](docs/CODEBASE_REVIEW_2026-06-15.md)
+- [`docs/IMPLEMENTED_SURFACES_2026-06-15.md`](docs/IMPLEMENTED_SURFACES_2026-06-15.md)

--- a/docs/CODEBASE_REVIEW_2026-06-15.md
+++ b/docs/CODEBASE_REVIEW_2026-06-15.md
@@ -1,0 +1,234 @@
+# DSG ONE — Codebase Review
+
+**Date:** 2026-06-15  
+**Scope:** current repository code and schema only. Historical status docs and prior marketing copy are not used as source-of-truth for this review.
+
+## Files inspected
+
+| Area | Files |
+|---|---|
+| Package/scripts | `package.json` |
+| Runtime execution | `app/api/execute/route.ts`, `app/api/spine/execute/route.ts` |
+| Deterministic API | `app/api/dsg/v1/policies/manifest/route.ts`, `app/api/dsg/v1/gates/evaluate/route.ts`, `app/api/dsg/v1/proofs/prove/route.ts` |
+| Deterministic types | `lib/dsg/deterministic/types.ts` |
+| DSG route auth | `lib/dsg/auth/require-dsg-auth.ts` |
+| Compliance claim readiness | `app/api/proof/claim-readiness/route.ts` |
+| Evidence schema | `supabase/migrations/20260612041000_create_claim_readiness_artifacts.sql` |
+| DSG API auth/audit schema | `supabase/migrations/20260613000002_dsg_auth_indexes_and_audit.sql` |
+
+## 1. Runtime execution surface
+
+`app/api/execute/route.ts` is a compatibility entry point. It exports `OPTIONS` and `POST` directly from `app/api/spine/execute/route.ts`.
+
+The spine execution route currently performs these checks/actions:
+
+1. applies per-route rate limiting;
+2. extracts a Bearer token;
+3. normalizes the request body;
+4. requires `agent_id`;
+5. resolves the agent from API key;
+6. blocks inactive agents;
+7. checks execution quota;
+8. verifies Safe DOM intent when a Safe DOM session is present;
+9. initializes in-memory execution state and break-condition tracking;
+10. executes an existing spine intent or issues one and then executes it;
+11. tracks success/failure for break conditions;
+12. on success, runs quota increment, webhook delivery, and metering as fire-and-forget side effects;
+13. returns `stop_reason` in the response.
+
+### Boundary
+
+The route includes a placeholder `queueSize = 1`. Therefore, the README should not claim fully verified queue-depth orchestration from this code path alone.
+
+## 2. DSG deterministic gate/proof API
+
+The codebase contains these DSG v1 route handlers:
+
+```text
+GET  /api/dsg/v1/policies/manifest
+POST /api/dsg/v1/gates/evaluate
+POST /api/dsg/v1/proofs/prove
+```
+
+### `policies/manifest`
+
+The manifest route returns:
+
+- deterministic policy manifest;
+- solver metadata;
+- a boundary object containing `externalSolverInvoked` and `productionReadyClaim`.
+
+### `gates/evaluate`
+
+The gate route:
+
+- requires DSG auth;
+- rate-limits by org;
+- reads JSON with a max body size;
+- validates deterministic proof request shape;
+- runs `evaluateDeterministicGate`;
+- returns gate status, proof status, risk level, proof, caller metadata, and explicit boundary data;
+- writes a DSG API call audit log asynchronously.
+
+### `proofs/prove`
+
+The proof route:
+
+- requires DSG auth;
+- rate-limits by org;
+- requires `context`;
+- requires `nonce` and `idempotencyKey` either in JSON body or headers;
+- calls `proveDeterministicPlan`;
+- returns proof and explicit boundary data.
+
+## 3. Deterministic proof type boundary
+
+`lib/dsg/deterministic/types.ts` defines:
+
+- `DeterministicProofStatus`: `PASS`, `BLOCK`, `REVIEW`, `UNSUPPORTED`;
+- `DeterministicGateStatus`: `PASS`, `BLOCK`, `REVIEW`;
+- `DeterministicSolverName`: `z3`, `rule_engine`, `static_check`, `none`;
+- replay protection fields: `nonce`, `idempotencyKey`, `requestHash`;
+- hash fields: `inputHash`, `constraintSetHash`, `proofHash`, optional `previousProofHash`;
+- evidence boundary fields:
+  - `externalSolverInvoked`
+  - `productionReadyClaim`
+  - `externalZ3ProductionSolverClaim: false`
+  - `certificationClaim: false`
+  - `independentAuditClaim: false`
+  - `wormStorageCertifiedClaim: false`
+  - `cryptographicSigningCompleteClaim: false`
+
+### Boundary
+
+The type system explicitly models non-claims. README copy must preserve those boundaries and should not turn static proof metadata into external certification language.
+
+## 4. DSG route authentication
+
+`lib/dsg/auth/require-dsg-auth.ts` supports two caller types:
+
+1. Supabase session user;
+2. Bearer API key.
+
+For Bearer API keys, the helper:
+
+- SHA-256 hashes the raw key;
+- queries `public.api_keys` by `key_hash`;
+- requires `status = ACTIVE`;
+- checks DSG-compatible scopes when scopes are present;
+- calls `touch_api_key_last_used` after successful resolution;
+- returns unified `DsgCaller` with `orgId`, `actorType`, and user/API-key identity.
+
+The same file also contains `logDsgApiCall`, which inserts call metadata into `dsg_api_calls` and intentionally never throws to the client path.
+
+### Boundary
+
+The inspected auth path is API-key plus Supabase-session based. Do not describe it as a complete standalone JWT/JWKS gateway unless that code path is added and reviewed.
+
+## 5. Compliance claim-readiness API
+
+`app/api/proof/claim-readiness/route.ts` defines an in-memory claim evidence standard and evaluates claim readiness from backend evidence.
+
+Default claim IDs:
+
+```text
+ISO-42001-A.6-PLANNING
+NIST-GOVERN-01
+SUPPLY-CHAIN-01
+SECURITY-HARDENING
+SBOM-GENERATED
+RUNTIME-INTEGRITY
+```
+
+The route:
+
+- supports `claims`, `includeEvidence`, and `includeSecurityBreakdown` query params;
+- rejects invalid claim IDs with HTTP 400;
+- reads deployment metadata from env variables;
+- queries `claim_readiness_artifacts` for security evidence types;
+- queries `delivery_proof_reports` for matrix evidence;
+- returns `PASS`, `PARTIAL`, or `BLOCK` per claim;
+- warns when the evidence backend is empty or unavailable.
+
+### Boundary
+
+This route is useful because missing evidence remains visible as `BLOCK` or warnings. It should not be summarized as automatic compliance certification.
+
+## 6. Evidence artifact schema
+
+`20260612041000_create_claim_readiness_artifacts.sql` creates `claim_readiness_artifacts` with:
+
+- `claim_id`;
+- `evidence_type`;
+- unique `artifact_hash`;
+- optional `chain_hash`;
+- `artifact_path`;
+- `artifact_data` JSONB;
+- `signature_bundle` JSONB;
+- `immutable_at`;
+- `s3_version_id`;
+- `s3_retain_until`;
+- lifecycle `status` constrained to `PENDING`, `VERIFIED`, `ARCHIVED`, `FAILED`;
+- indexes for claim ID, evidence type, artifact hash, chain hash, status, and immutability timestamp.
+
+Important boundary from the migration itself:
+
+- RLS is explicitly disabled for now.
+- No delete grant is issued.
+- S3 Object Lock fields exist, but field presence is not proof that an Object Lock bucket is configured or that artifacts are archived in external WORM storage.
+
+## 7. DSG API-key indexes and audit schema
+
+`20260613000002_dsg_auth_indexes_and_audit.sql` adds:
+
+- unique index on `api_keys.key_hash`;
+- org/expiry indexes for API keys;
+- service-role policy for server-side key lookup;
+- `touch_api_key_last_used(p_key_hash)`;
+- `expire_api_keys()`;
+- `dsg_api_calls` audit table;
+- RLS policies for service-role full access and org-member read access;
+- `api_key_usage_summary` view.
+
+### Boundary
+
+These schema features only apply where the migration has been applied to the target Supabase project.
+
+## 8. Package and script surface
+
+`package.json` defines the root package as private `dsg-platform`. Important scripts include:
+
+- `dev`, `build`, `start`, `lint`, `typecheck`;
+- `test`, `test:unit`, `test:integration`, `test:coverage`, `test:ci`;
+- live DB and E2E scripts;
+- deployment scripts for Vercel preview/prod;
+- deterministic verification and production manifest scripts;
+- CCVS/evidence scripts;
+- proof scripts.
+
+Dependencies include Next.js, React, Supabase, Stripe, Upstash Redis, Octokit, Sentry, and a `z3-solver` dev dependency. The presence of a dependency alone does not prove per-request production invocation.
+
+## 9. README rewrite rationale
+
+The previous root README contained broad status blocks and production-ready language. This review replaces that with a codebase-derived map and explicit non-claims.
+
+New README claims should be limited to:
+
+- route handlers that exist;
+- type boundaries that exist;
+- migrations that exist;
+- scripts present in `package.json`;
+- explicit schema/route behavior visible in inspected files.
+
+## 10. Recommended next checks
+
+Before making a stronger public claim, run and record fresh evidence for:
+
+1. `npm run typecheck`;
+2. `npm test` or `npm run test:ci`;
+3. `npm run verify:deterministic`;
+4. `npm run verify:production-manifest`;
+5. `npm run go:no-go`;
+6. target deployment smoke checks;
+7. Supabase applied-migration verification on the target project;
+8. populated evidence backend checks for `/api/proof/claim-readiness`.

--- a/docs/IMPLEMENTED_SURFACES_2026-06-15.md
+++ b/docs/IMPLEMENTED_SURFACES_2026-06-15.md
@@ -1,0 +1,256 @@
+# DSG ONE — Implemented Surfaces Review
+
+**Date:** 2026-06-15  
+**Scope:** current codebase surfaces only.
+
+This document lists the parts that are present in the repository and where to inspect them.
+
+## Runtime execution
+
+### Files
+
+- `app/api/execute/route.ts`
+- `app/api/spine/execute/route.ts`
+
+### Implemented flow
+
+`app/api/execute/route.ts` is a compatibility entry. It re-exports `OPTIONS` and `POST` from the spine execution route.
+
+The spine route implements:
+
+1. per-route rate limit setup;
+2. Bearer token extraction;
+3. request payload normalization;
+4. `agent_id` requirement;
+5. agent lookup through the provided key;
+6. active-agent check;
+7. quota check;
+8. Safe DOM verification when a Safe DOM session is present;
+9. in-memory execution state initialization;
+10. execution break-condition handling;
+11. spine intent execution;
+12. fallback intent issue then execute when no pending intent exists;
+13. task success/failure tracking;
+14. quota increment on success;
+15. webhook event on success;
+16. metered billing event on success;
+17. `stop_reason` included in the response.
+
+## DSG deterministic API
+
+### Files
+
+- `app/api/dsg/v1/policies/manifest/route.ts`
+- `app/api/dsg/v1/gates/evaluate/route.ts`
+- `app/api/dsg/v1/proofs/prove/route.ts`
+- `lib/dsg/deterministic/types.ts`
+
+### Implemented routes
+
+```text
+GET  /api/dsg/v1/policies/manifest
+POST /api/dsg/v1/gates/evaluate
+POST /api/dsg/v1/proofs/prove
+```
+
+### Policy manifest route
+
+The manifest route returns:
+
+- policy manifest;
+- solver metadata;
+- policy reference;
+- policy version;
+- constraint-set hash;
+- constraint inventory.
+
+### Gate evaluation route
+
+The gate route implements:
+
+1. DSG route caller resolution;
+2. org-scoped rate limiting;
+3. JSON body size handling;
+4. deterministic request validation;
+5. deterministic gate evaluation;
+6. structured response with gate status, proof status, risk level, reason, proof, and caller metadata;
+7. asynchronous route usage logging.
+
+### Proof route
+
+The proof route implements:
+
+1. DSG route caller resolution;
+2. org-scoped rate limiting;
+3. context requirement;
+4. nonce resolution from body or `x-dsg-nonce` header;
+5. idempotency key resolution from body or `idempotency-key` header;
+6. deterministic proof generation;
+7. structured proof response.
+
+### Type surface
+
+`lib/dsg/deterministic/types.ts` defines:
+
+- proof statuses: `PASS`, `BLOCK`, `REVIEW`, `UNSUPPORTED`;
+- gate statuses: `PASS`, `BLOCK`, `REVIEW`;
+- risk levels: `low`, `medium`, `high`, `critical`;
+- solver names: `z3`, `rule_engine`, `static_check`, `none`;
+- replay-protection fields: `nonce`, `idempotencyKey`, `requestHash`;
+- proof hash fields: `inputHash`, `constraintSetHash`, `proofHash`, `previousProofHash`;
+- constraint result entries;
+- failure reason entries;
+- deterministic gate decision output.
+
+## DSG route caller resolution and logging
+
+### File
+
+- `lib/dsg/auth/require-dsg-auth.ts`
+
+### Implemented behavior
+
+The route helper implements:
+
+1. Bearer header parsing;
+2. SHA-256 hashing of raw keys;
+3. `api_keys` lookup by `key_hash`;
+4. active key check;
+5. scope check when scopes are present;
+6. last-used/request-count touch through `touch_api_key_last_used`;
+7. Supabase session fallback;
+8. user profile lookup;
+9. unified caller result shape;
+10. route usage insert into `dsg_api_calls`.
+
+## Claim-readiness API
+
+### File
+
+- `app/api/proof/claim-readiness/route.ts`
+
+### Implemented route
+
+```text
+GET /api/proof/claim-readiness
+```
+
+### Query parameters
+
+- `claims`
+- `includeEvidence`
+- `includeSecurityBreakdown`
+
+### Default claim IDs
+
+- `ISO-42001-A.6-PLANNING`
+- `NIST-GOVERN-01`
+- `SUPPLY-CHAIN-01`
+- `SECURITY-HARDENING`
+- `SBOM-GENERATED`
+- `RUNTIME-INTEGRITY`
+
+### Implemented behavior
+
+The route implements:
+
+1. claim query parsing;
+2. invalid claim rejection;
+3. deployment metadata extraction from environment variables;
+4. security evidence lookup from `claim_readiness_artifacts`;
+5. evidence matrix lookup from `delivery_proof_reports`;
+6. status calculation as `PASS`, `PARTIAL`, or `BLOCK`;
+7. optional evidence artifact output;
+8. optional security breakdown output;
+9. summary counts;
+10. checkpoint metadata.
+
+## Evidence artifact schema
+
+### File
+
+- `supabase/migrations/20260612041000_create_claim_readiness_artifacts.sql`
+
+### Implemented table
+
+`claim_readiness_artifacts` includes:
+
+- `id`
+- `claim_id`
+- `evidence_type`
+- `artifact_hash`
+- `chain_hash`
+- `artifact_path`
+- `artifact_data`
+- `signature_bundle`
+- `immutable_at`
+- `s3_version_id`
+- `s3_retain_until`
+- `created_at`
+- `updated_at`
+- `status`
+
+### Implemented indexes
+
+- `idx_claim_readiness_claim_id`
+- `idx_claim_readiness_evidence_type_created`
+- `idx_claim_readiness_artifact_hash`
+- `idx_claim_readiness_chain_hash`
+- `idx_claim_readiness_status_created`
+- `idx_claim_readiness_immutable_at`
+
+## DSG API usage schema
+
+### File
+
+- `supabase/migrations/20260613000002_dsg_auth_indexes_and_audit.sql`
+
+### Implemented database objects
+
+- unique index on `api_keys.key_hash`;
+- index on `api_keys(org_id, created_at desc)`;
+- index for expiring keys;
+- service-role policy on `api_keys`;
+- `touch_api_key_last_used(p_key_hash)`;
+- `expire_api_keys()`;
+- `dsg_api_calls` table;
+- RLS policies for `dsg_api_calls`;
+- route/caller indexes for `dsg_api_calls`;
+- `api_key_usage_summary` view.
+
+## Package scripts
+
+### File
+
+- `package.json`
+
+### Useful commands
+
+- `npm run dev`
+- `npm run build`
+- `npm run start`
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- `npm run test:coverage`
+- `npm run test:ci`
+- `npm run verify:deterministic`
+- `npm run verify:production-manifest`
+- `npm run go:no-go`
+- `npm run ccvs:verify`
+- `npm run deploy:preview`
+- `npm run deploy:prod`
+
+## Suggested README structure
+
+Use this order:
+
+1. repository purpose;
+2. main directories;
+3. implemented surfaces table;
+4. main routes;
+5. local commands;
+6. documentation links;
+7. verification checklist.
+
+Keep public-facing text focused on implemented code paths and inspection paths.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# DSG ONE Documentation Index
+
+This index is curated from the current repository layout. It does not certify that every older document in `docs/` is current.
+
+## Start here
+
+| Document | Purpose |
+|---|---|
+| [`../README.md`](../README.md) | Codebase-derived repository overview and claim boundary. |
+| [`CODEBASE_REVIEW_2026-06-15.md`](./CODEBASE_REVIEW_2026-06-15.md) | Detailed codebase-only review used to refresh the root README. |
+
+## Code surfaces to inspect first
+
+| Surface | Files/directories |
+|---|---|
+| Runtime execution | `app/api/execute/route.ts`, `app/api/spine/execute/route.ts`, `lib/spine/` |
+| Deterministic proof/gate | `app/api/dsg/v1/`, `lib/dsg/deterministic/` |
+| DSG auth | `lib/dsg/auth/require-dsg-auth.ts`, `supabase/migrations/20260613000002_dsg_auth_indexes_and_audit.sql` |
+| Claim readiness | `app/api/proof/claim-readiness/route.ts`, `supabase/migrations/20260612041000_create_claim_readiness_artifacts.sql` |
+| Stripe App package | `packages/stripe-app/` |
+| Scripts and CI entry points | `package.json`, `scripts/`, `.github/workflows/` |
+| Database schema | `supabase/migrations/`, `lib/database.types.ts` |
+
+## Recently added analysis docs
+
+These are useful context docs but should not override direct code inspection:
+
+- [`COMPETITIVE_BRIEF_CISCO_PANW_2026-06-15.md`](./COMPETITIVE_BRIEF_CISCO_PANW_2026-06-15.md)
+- [`DSG_ONE_DEV_ACTIVITY_REPORT_2026-06-15.md`](./DSG_ONE_DEV_ACTIVITY_REPORT_2026-06-15.md)
+- [`DSG_ONE_BUILD_IN_PUBLIC_POST_2026-06-15.md`](./DSG_ONE_BUILD_IN_PUBLIC_POST_2026-06-15.md)
+
+## Documentation rule
+
+Before publishing or updating claims, inspect the code path or target deployment evidence that supports the claim. Do not copy older status blocks forward just because they are present in historical docs.


### PR DESCRIPTION
Docs refresh.

Superseded by #751.

Reason:
- This PR was based on an older `main` and is now stale/diverged.
- Review found a real claim-readiness route/schema alignment issue that should be documented.
- #751 is rebuilt from current `main` with conservative wording and updated review notes.

No runtime code changes were intended in this PR.