### PR TITLE
fix(paid): bootstrap workspace for checkout

### DIFF
--- a/app/api/auth/bootstrap/route.ts
+++ b/app/api/auth/bootstrap/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { ensureUserWorkspace } from '../../../../lib/auth/ensure-user-workspace';
+
+export const dynamic = 'force-dynamic';
+
+async function bootstrap() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const ensured = await ensureUserWorkspace(getSupabaseAdmin(), {
+    authUserId: user.id,
+    email: user.email || null,
+  });
+
+  if (!ensured.ok) {
+    return NextResponse.json(
+      { ok: false, error: ensured.error },
+      { status: ensured.status }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    org_id: ensured.profile.org_id,
+    is_active: ensured.profile.is_active,
+    bootstrapped: ensured.bootstrapped,
+  });
+}
+
+export async function GET() {
+  return bootstrap();
+}
+
+export async function POST() {
+  return bootstrap();
+}

--- a/app/api/auth/bootstrap/route.ts
+++ b/app/api/auth/bootstrap/route.ts
@@ -2,38 +2,43 @@ import { NextResponse } from 'next/server';
 import { createClient } from '../../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { ensureUserWorkspace } from '../../../../lib/auth/ensure-user-workspace';
+import { handleApiError } from '../../../../lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
 
 async function bootstrap() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
 
-  if (error || !user) {
-    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+    if (error || !user) {
+      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const ensured = await ensureUserWorkspace(getSupabaseAdmin(), {
+      authUserId: user.id,
+      email: user.email || null,
+    });
+
+    if (!ensured.ok) {
+      return NextResponse.json(
+        { ok: false, error: ensured.error },
+        { status: ensured.status }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      org_id: ensured.profile.org_id,
+      is_active: ensured.profile.is_active,
+      bootstrapped: ensured.bootstrapped,
+    });
+  } catch (error) {
+    return handleApiError('api/auth/bootstrap', error);
   }
-
-  const ensured = await ensureUserWorkspace(getSupabaseAdmin(), {
-    authUserId: user.id,
-    email: user.email || null,
-  });
-
-  if (!ensured.ok) {
-    return NextResponse.json(
-      { ok: false, error: ensured.error },
-      { status: ensured.status }
-    );
-  }
-
-  return NextResponse.json({
-    ok: true,
-    org_id: ensured.profile.org_id,
-    is_active: ensured.profile.is_active,
-    bootstrapped: ensured.bootstrapped,
-  });
 }
 
 export async function GET() {

--- a/app/api/auth/bootstrap/route.ts
+++ b/app/api/auth/bootstrap/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '../../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
-import { ensureUserWorkspace } from '../../../../lib/auth/ensure-user-workspace';
+import { ensureUserWorkspace, isWorkspaceFailure } from '../../../../lib/auth/ensure-user-workspace';
 import { handleApiError } from '../../../../lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
@@ -23,7 +23,7 @@ async function bootstrap() {
       email: user.email || null,
     });
 
-    if (!ensured.ok) {
+    if (isWorkspaceFailure(ensured)) {
       return NextResponse.json(
         { ok: false, error: ensured.error },
         { status: ensured.status }

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -68,6 +68,49 @@ function getPriceId(plan: PlanKey, interval: BillingInterval) {
   return '';
 }
 
+type CheckoutProfileResult =
+  | {
+      ok: true;
+      profile: {
+        auth_user_id: string;
+        email: string | null;
+        org_id: string;
+        is_active: boolean;
+      };
+      bootstrapped: boolean;
+    }
+  | { ok: false; status: number; error: string };
+
+async function resolveCheckoutProfile(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  user: { id: string; email?: string | null },
+  email?: string | null
+): Promise<CheckoutProfileResult> {
+  const { data: existingProfile } = await supabase
+    .from('users')
+    .select('org_id, is_active, email')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (existingProfile?.org_id) {
+    return {
+      ok: true,
+      bootstrapped: existingProfile.is_active !== true,
+      profile: {
+        auth_user_id: user.id,
+        email: existingProfile.email || email || user.email || null,
+        org_id: String(existingProfile.org_id),
+        is_active: existingProfile.is_active === true,
+      },
+    };
+  }
+
+  return ensureUserWorkspace(getSupabaseAdmin(), {
+    authUserId: user.id,
+    email: email || user.email || null,
+  });
+}
+
 // GET handler: used by skills marketplace Link hrefs
 // GET /api/billing/checkout?plan=finance_skills&interval=monthly
 export async function GET(request: Request) {
@@ -87,10 +130,7 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${appUrl}/login?next=/marketplace/skills`);
     }
 
-    const workspace = await ensureUserWorkspace(getSupabaseAdmin(), {
-      authUserId: user.id,
-      email: user.email || null,
-    });
+    const workspace = await resolveCheckoutProfile(supabase, user, user.email || null);
 
     if (!workspace.ok) {
       return NextResponse.redirect(`${appUrl}/marketplace/skills?checkout=setup_failed`);
@@ -167,10 +207,7 @@ export async function POST(request: Request) {
     const customerEmail = body?.email ? String(body.email) : undefined;
     const orgId = body?.org_id ? String(body.org_id) : undefined;
 
-    const workspace = await ensureUserWorkspace(getSupabaseAdmin(), {
-      authUserId: user.id,
-      email: customerEmail || user.email || null,
-    });
+    const workspace = await resolveCheckoutProfile(supabase, user, customerEmail || user.email || null);
 
     if (!workspace.ok) {
       return NextResponse.json(

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { createClient } from '../../../../lib/supabase/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import { ensureUserWorkspace } from '../../../../lib/auth/ensure-user-workspace';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
 import { handleApiError } from '../../../../lib/security/api-error';
 
@@ -85,20 +87,26 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${appUrl}/login?next=/marketplace/skills`);
     }
 
-    const { data: profile } = await supabase
-      .from('users')
-      .select('org_id, is_active, email')
-      .eq('auth_user_id', user.id)
-      .maybeSingle();
+    const workspace = await ensureUserWorkspace(getSupabaseAdmin(), {
+      authUserId: user.id,
+      email: user.email || null,
+    });
 
-    // Allow trial/inactive profiles to start Stripe checkout; still require an organization.
-    if (!profile?.org_id) {
-      return NextResponse.redirect(`${appUrl}/login?next=/marketplace/skills`);
+    if (!workspace.ok) {
+      return NextResponse.redirect(`${appUrl}/marketplace/skills?checkout=setup_failed`);
     }
 
+    const profile = workspace.profile;
     const bundle = SKILLS_BUNDLE_CONFIG[plan];
     const unitAmount = interval === 'yearly' ? bundle.amountYearly : bundle.amountMonthly;
     const stripe = getStripeClient();
+    const metadata: Record<string, string> = {
+      plan_key: plan,
+      billing_interval: interval,
+      source: 'skills-marketplace',
+      org_id: profile.org_id,
+      auth_user_id: user.id,
+    };
 
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
@@ -114,10 +122,10 @@ export async function GET(request: Request) {
       success_url: `${appUrl}/dashboard/billing?checkout=success&plan=${plan}&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${appUrl}/marketplace/skills?checkout=cancelled`,
       customer_email: profile.email ?? undefined,
-      client_reference_id: String(profile.org_id),
+      client_reference_id: profile.org_id,
       allow_promotion_codes: true,
-      metadata: { plan_key: plan, billing_interval: interval, source: 'skills-marketplace', org_id: String(profile.org_id) },
-      subscription_data: { metadata: { plan_key: plan, billing_interval: interval, org_id: String(profile.org_id) } },
+      metadata,
+      subscription_data: { metadata },
     });
 
     return NextResponse.redirect(session.url ?? `${appUrl}/marketplace/skills`);
@@ -159,16 +167,19 @@ export async function POST(request: Request) {
     const customerEmail = body?.email ? String(body.email) : undefined;
     const orgId = body?.org_id ? String(body.org_id) : undefined;
 
-    const { data: profile } = await supabase
-      .from('users')
-      .select('org_id, is_active, email')
-      .eq('auth_user_id', user.id)
-      .maybeSingle();
+    const workspace = await ensureUserWorkspace(getSupabaseAdmin(), {
+      authUserId: user.id,
+      email: customerEmail || user.email || null,
+    });
 
-    // Allow trial/inactive profiles to start Stripe checkout; still require an organization.
-    if (!profile?.org_id) {
-      return NextResponse.json({ error: 'Missing organization' }, { status: 403, headers: buildRateLimitHeaders(rateLimit, 20) });
+    if (!workspace.ok) {
+      return NextResponse.json(
+        { error: workspace.error },
+        { status: workspace.status, headers: buildRateLimitHeaders(rateLimit, 20) }
+      );
     }
+
+    const profile = workspace.profile;
 
     if (orgId && orgId !== profile.org_id) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: buildRateLimitHeaders(rateLimit, 20) });
@@ -183,9 +194,14 @@ export async function POST(request: Request) {
     }
 
     const stripe = getStripeClient();
-    const resolvedOrgId = orgId || String(profile.org_id);
-    const resolvedEmail = customerEmail || profile.email || undefined;
-    const metadata: Record<string, string> = { billing_interval: interval, source: 'dsg-control-plane', org_id: resolvedOrgId };
+    const resolvedOrgId = profile.org_id;
+    const resolvedEmail = customerEmail || profile.email || user.email || undefined;
+    const metadata: Record<string, string> = {
+      billing_interval: interval,
+      source: 'dsg-control-plane',
+      org_id: resolvedOrgId,
+      auth_user_id: user.id,
+    };
     if (resolvedEmail) metadata.customer_email = resolvedEmail;
 
     let lineItems: Stripe.Checkout.SessionCreateParams['line_items'];

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { createClient } from '../../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
-import { ensureUserWorkspace } from '../../../../lib/auth/ensure-user-workspace';
+import { ensureUserWorkspace, isWorkspaceFailure } from '../../../../lib/auth/ensure-user-workspace';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
 import { handleApiError } from '../../../../lib/security/api-error';
 
@@ -132,7 +132,7 @@ export async function GET(request: Request) {
 
     const workspace = await resolveCheckoutProfile(supabase, user, user.email || null);
 
-    if (!workspace.ok) {
+    if (isWorkspaceFailure(workspace)) {
       return NextResponse.redirect(`${appUrl}/marketplace/skills?checkout=setup_failed`);
     }
 
@@ -209,7 +209,7 @@ export async function POST(request: Request) {
 
     const workspace = await resolveCheckoutProfile(supabase, user, customerEmail || user.email || null);
 
-    if (!workspace.ok) {
+    if (isWorkspaceFailure(workspace)) {
       return NextResponse.json(
         { error: workspace.error },
         { status: workspace.status, headers: buildRateLimitHeaders(rateLimit, 20) }

--- a/components/AutoSetupTrigger.tsx
+++ b/components/AutoSetupTrigger.tsx
@@ -7,6 +7,14 @@ export default function AutoSetupTrigger() {
     let cancelled = false;
 
     async function runAutoSetupIfNeeded() {
+      await fetch("/api/auth/bootstrap", {
+        method: "POST",
+        cache: "no-store",
+        credentials: "include",
+      }).catch(() => null);
+
+      if (cancelled) return;
+
       const stateResponse = await fetch("/api/onboarding/state", {
         cache: "no-store",
       });
@@ -16,7 +24,7 @@ export default function AutoSetupTrigger() {
       if (cancelled || state.is_empty !== true) return;
 
       const setupResponse = await fetch("/api/setup/auto", { method: "POST" });
-      const data = await setupResponse.json().catch(() => null);
+      await setupResponse.json().catch(() => null);
       // Auto-setup completed; persistent onboarding source-of-truth is the org-scoped API/DB state.
       // api_key and agent_id are available via authenticated API routes — not stored in browser storage.
     }

--- a/lib/auth/ensure-user-workspace.ts
+++ b/lib/auth/ensure-user-workspace.ts
@@ -1,0 +1,76 @@
+type SupabaseAdminLike = {
+  rpc: (fn: string, args?: Record<string, unknown>) => Promise<{ data: unknown; error: { message?: string } | null }>;
+  from: (table: string) => any;
+};
+
+export type EnsuredWorkspaceProfile = {
+  id?: string | null;
+  auth_user_id: string;
+  email: string | null;
+  org_id: string;
+  is_active: boolean;
+};
+
+export type EnsureUserWorkspaceResult =
+  | { ok: true; profile: EnsuredWorkspaceProfile; bootstrapped: boolean }
+  | { ok: false; status: number; error: string };
+
+function errorMessage(error: unknown) {
+  return String((error as { message?: string } | null)?.message || 'unknown error');
+}
+
+export async function ensureUserWorkspace(
+  admin: SupabaseAdminLike,
+  input: { authUserId: string; email?: string | null }
+): Promise<EnsureUserWorkspaceResult> {
+  if (!input.authUserId) {
+    return { ok: false, status: 401, error: 'missing_auth_user' };
+  }
+
+  const { data: ensuredOrgId, error: rpcError } = await admin.rpc(
+    'dsg_ensure_workspace_for_auth_user',
+    {
+      p_auth_user_id: input.authUserId,
+      p_email: input.email || null,
+    }
+  );
+
+  if (rpcError || !ensuredOrgId) {
+    return {
+      ok: false,
+      status: 500,
+      error: `workspace_bootstrap_failed: ${errorMessage(rpcError)}`,
+    };
+  }
+
+  const { data: profile, error: profileError } = await admin
+    .from('users')
+    .select('id, auth_user_id, email, org_id, is_active')
+    .eq('auth_user_id', input.authUserId)
+    .maybeSingle();
+
+  if (profileError) {
+    return {
+      ok: false,
+      status: 500,
+      error: `workspace_profile_lookup_failed: ${errorMessage(profileError)}`,
+    };
+  }
+
+  const orgId = String(profile?.org_id || ensuredOrgId || '');
+  if (!orgId) {
+    return { ok: false, status: 500, error: 'workspace_bootstrap_missing_org_id' };
+  }
+
+  return {
+    ok: true,
+    bootstrapped: !profile?.org_id || profile?.is_active !== true,
+    profile: {
+      id: profile?.id || null,
+      auth_user_id: String(profile?.auth_user_id || input.authUserId),
+      email: (profile?.email || input.email || null) as string | null,
+      org_id: orgId,
+      is_active: true,
+    },
+  };
+}

--- a/lib/auth/ensure-user-workspace.ts
+++ b/lib/auth/ensure-user-workspace.ts
@@ -20,6 +20,15 @@ export type EnsureUserWorkspaceResult =
   | { ok: true; profile: EnsuredWorkspaceProfile; bootstrapped: boolean }
   | { ok: false; status: number; error: string };
 
+export type EnsureUserWorkspaceSuccess = Extract<EnsureUserWorkspaceResult, { ok: true }>;
+export type EnsureUserWorkspaceFailure = Extract<EnsureUserWorkspaceResult, { ok: false }>;
+
+export function isWorkspaceFailure(
+  result: EnsureUserWorkspaceResult
+): result is EnsureUserWorkspaceFailure {
+  return result.ok === false;
+}
+
 function errorMessage(error: unknown) {
   return String((error as { message?: string } | null)?.message || 'unknown error');
 }

--- a/lib/auth/ensure-user-workspace.ts
+++ b/lib/auth/ensure-user-workspace.ts
@@ -1,5 +1,10 @@
-type SupabaseAdminLike = {
-  rpc: (fn: string, args?: Record<string, unknown>) => Promise<{ data: unknown; error: { message?: string } | null }>;
+type RpcResult = {
+  data: unknown;
+  error: { message?: string } | null;
+};
+
+type SupabaseAdminLoose = {
+  rpc: (fn: string, args?: Record<string, unknown>) => Promise<RpcResult>;
   from: (table: string) => any;
 };
 
@@ -20,14 +25,16 @@ function errorMessage(error: unknown) {
 }
 
 export async function ensureUserWorkspace(
-  admin: SupabaseAdminLike,
+  admin: unknown,
   input: { authUserId: string; email?: string | null }
 ): Promise<EnsureUserWorkspaceResult> {
   if (!input.authUserId) {
     return { ok: false, status: 401, error: 'missing_auth_user' };
   }
 
-  const { data: ensuredOrgId, error: rpcError } = await admin.rpc(
+  const client = admin as SupabaseAdminLoose;
+
+  const { data: ensuredOrgId, error: rpcError } = await client.rpc(
     'dsg_ensure_workspace_for_auth_user',
     {
       p_auth_user_id: input.authUserId,
@@ -43,7 +50,7 @@ export async function ensureUserWorkspace(
     };
   }
 
-  const { data: profile, error: profileError } = await admin
+  const { data: profile, error: profileError } = await client
     .from('users')
     .select('id, auth_user_id, email, org_id, is_active')
     .eq('auth_user_id', input.authUserId)

--- a/supabase/migrations/20260620090000_workspace_bootstrap_paid_flow.sql
+++ b/supabase/migrations/20260620090000_workspace_bootstrap_paid_flow.sql
@@ -1,0 +1,180 @@
+-- DSG ONE paid-flow workspace bootstrap
+-- Creates a race-safe auth_user_id -> org_id mapping and a server-side RPC.
+-- The application must call this RPC only after verifying the Supabase Auth session server-side.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.dsg_user_workspace_bootstrap (
+  auth_user_id uuid PRIMARY KEY,
+  org_id uuid UNIQUE NOT NULL,
+  email text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION public.dsg_try_insert_workspace_org(
+  p_table regclass,
+  p_org_id uuid,
+  p_name text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  cols text[] := ARRAY['id'];
+  vals text[] := ARRAY['$1'];
+BEGIN
+  IF p_table IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = split_part(p_table::text, '.', 1)
+      AND table_name = split_part(p_table::text, '.', 2)
+      AND column_name = 'id'
+  ) THEN
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = split_part(p_table::text, '.', 1)
+      AND table_name = split_part(p_table::text, '.', 2)
+      AND column_name = 'name'
+  ) THEN
+    cols := cols || 'name';
+    vals := vals || '$2';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = split_part(p_table::text, '.', 1)
+      AND table_name = split_part(p_table::text, '.', 2)
+      AND column_name = 'plan'
+  ) THEN
+    cols := cols || 'plan';
+    vals := vals || '$3';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = split_part(p_table::text, '.', 1)
+      AND table_name = split_part(p_table::text, '.', 2)
+      AND column_name = 'created_at'
+  ) THEN
+    cols := cols || 'created_at';
+    vals := vals || '$4';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = split_part(p_table::text, '.', 1)
+      AND table_name = split_part(p_table::text, '.', 2)
+      AND column_name = 'updated_at'
+  ) THEN
+    cols := cols || 'updated_at';
+    vals := vals || '$5';
+  END IF;
+
+  EXECUTE format(
+    'INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (id) DO NOTHING',
+    p_table,
+    array_to_string(cols, ', '),
+    array_to_string(vals, ', ')
+  ) USING p_org_id, p_name, 'trial', now(), now();
+EXCEPTION WHEN others THEN
+  RAISE NOTICE 'workspace org insert skipped for %: %', p_table, SQLERRM;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.dsg_ensure_workspace_for_auth_user(
+  p_auth_user_id uuid,
+  p_email text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user record;
+  v_org_id uuid;
+  v_email text := nullif(trim(coalesce(p_email, '')), '');
+BEGIN
+  IF p_auth_user_id IS NULL THEN
+    RAISE EXCEPTION 'auth_user_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext(p_auth_user_id::text));
+
+  SELECT id, auth_user_id, email, org_id, is_active
+    INTO v_user
+  FROM public.users
+  WHERE auth_user_id = p_auth_user_id
+  LIMIT 1;
+
+  v_email := coalesce(nullif(trim(coalesce(v_user.email, '')), ''), v_email);
+
+  IF v_user.org_id IS NOT NULL THEN
+    v_org_id := v_user.org_id;
+  ELSE
+    SELECT org_id
+      INTO v_org_id
+    FROM public.dsg_user_workspace_bootstrap
+    WHERE auth_user_id = p_auth_user_id;
+
+    IF v_org_id IS NULL THEN
+      v_org_id := gen_random_uuid();
+      INSERT INTO public.dsg_user_workspace_bootstrap (auth_user_id, org_id, email)
+      VALUES (p_auth_user_id, v_org_id, v_email)
+      ON CONFLICT (auth_user_id) DO UPDATE
+        SET updated_at = now()
+      RETURNING org_id INTO v_org_id;
+    END IF;
+  END IF;
+
+  PERFORM public.dsg_try_insert_workspace_org(
+    to_regclass('public.organizations'),
+    v_org_id,
+    coalesce(v_email, 'DSG Workspace')
+  );
+
+  PERFORM public.dsg_try_insert_workspace_org(
+    to_regclass('public.orgs'),
+    v_org_id,
+    coalesce(v_email, 'DSG Workspace')
+  );
+
+  UPDATE public.dsg_user_workspace_bootstrap
+     SET org_id = v_org_id,
+         email = coalesce(email, v_email),
+         updated_at = now()
+   WHERE auth_user_id = p_auth_user_id;
+
+  UPDATE public.users
+     SET org_id = v_org_id,
+         is_active = true,
+         email = coalesce(email, v_email)
+   WHERE auth_user_id = p_auth_user_id;
+
+  IF NOT FOUND THEN
+    INSERT INTO public.users (auth_user_id, email, org_id, is_active)
+    VALUES (p_auth_user_id, v_email, v_org_id, true);
+  END IF;
+
+  RETURN v_org_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.dsg_try_insert_workspace_org(regclass, uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.dsg_ensure_workspace_for_auth_user(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dsg_ensure_workspace_for_auth_user(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.dsg_ensure_workspace_for_auth_user(uuid, text) TO service_role;
+
+COMMIT;

--- a/tests/unit/auth/workspace-bootstrap-static.test.ts
+++ b/tests/unit/auth/workspace-bootstrap-static.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('paid workspace bootstrap wiring', () => {
+  it('adds the auth bootstrap endpoint', () => {
+    const route = readFileSync(join(process.cwd(), 'app/api/auth/bootstrap/route.ts'), 'utf8');
+    expect(route).toContain('ensureUserWorkspace');
+    expect(route).toContain('supabase.auth.getUser');
+    expect(route).not.toContain('request.json');
+  });
+
+  it('billing checkout bootstraps workspace before Stripe checkout', () => {
+    const route = readFileSync(join(process.cwd(), 'app/api/billing/checkout/route.ts'), 'utf8');
+    expect(route).toContain('ensureUserWorkspace');
+    expect(route).toContain('client_reference_id: resolvedOrgId');
+    expect(route).toContain('auth_user_id: user.id');
+    expect(route).not.toContain("return NextResponse.json({ error: 'Missing organization' }");
+    expect(route).not.toContain('!profile?.is_active || !profile?.org_id');
+  });
+
+  it('dashboard startup calls bootstrap before org-scoped setup', () => {
+    const component = readFileSync(join(process.cwd(), 'components/AutoSetupTrigger.tsx'), 'utf8');
+    expect(component).toContain('/api/auth/bootstrap');
+    expect(component.indexOf('/api/auth/bootstrap')).toBeLessThan(component.indexOf('/api/onboarding/state'));
+  });
+});


### PR DESCRIPTION
Fix paid checkout flow for authenticated users whose profile has no org_id yet.

Changes:
- Add workspace bootstrap DB migration and RPC.
- Add server helper for workspace bootstrap.
- Add /api/auth/bootstrap.
- Update billing checkout to run bootstrap before Stripe Checkout.
- Update dashboard startup to call bootstrap.
- Add regression test for paid checkout path.

Validation:
- npm run typecheck
- npm test -- tests/unit/auth/workspace-bootstrap-static.test.ts
- Smoke test /dashboard/billing Upgrade and /marketplace/skills Activate Pack.