### PR TITLE
feat(mcp): Z.AI Vision + Web Reader MCP servers, plus repo-wide build repair

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,15 @@ RESEND_API_KEY=
 # ============ OpenRouter (Multi-Model) ============
 OPENROUTER_API_KEY=
 
+# ============ Z.AI MCP Servers (Vision + Web Reader) ============
+# GLM Coding Plan key from https://z.ai/manage-apikey/apikey-list
+# Shared by the local Vision MCP server (@z_ai/mcp-server) and the remote
+# Web Reader MCP server (https://api.z.ai/api/mcp/web_reader/mcp).
+# Referenced as ${Z_AI_API_KEY} in .claude/settings.json — never commit the value.
+Z_AI_API_KEY=
+# Service platform selector for the Vision MCP server. Only ZAI is supported.
+Z_AI_MODE=ZAI
+
 # ============ Auth ============
 NEXTAUTH_SECRET=
 DSG_FINANCE_GOVERNANCE_ENABLED=true

--- a/app/dashboard/billing/page.tsx
+++ b/app/dashboard/billing/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import UsageBar from '../../../components/billing/UsageBar';
 
@@ -123,6 +123,14 @@ function formatDate(value?: string | null) {
 }
 
 export default function BillingPage() {
+  return (
+    <Suspense>
+      <BillingInner />
+    </Suspense>
+  );
+}
+
+function BillingInner() {
   const [usage, setUsage]         = useState<Usage | null>(null);
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [loading, setLoading]     = useState(true);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -190,7 +190,7 @@ export default function DashboardPage() {
     { label: "สร้างองค์กร", done: true, href: "/dashboard/settings/go-live", ring: "white" },
     { label: "เชือมต่อตัวแทน", done: Boolean(onboarding?.has_agent), href: "/dashboard/agents", ring: "blue" },
     { label: "รันการดำเนินการครั้งแรก", done: Boolean(onboarding?.first_run_complete), href: "/delivery-proof", ring: "purple" },
-    { label: "เปิดใช้งาน Ring Hermes", done: systemHealth.allGood, href: "/dashboard/hermes" ring: "green" },
+    { label: "เปิดใช้งาน Ring Hermes", done: systemHealth.allGood, href: "/dashboard/hermes", ring: "green" },
   ];
   const doneCount = onboardingSteps.filter((s) => s.done).length;
 

--- a/app/dashboard/stripe-app/connect/page.tsx
+++ b/app/dashboard/stripe-app/connect/page.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 type ConnectionStatus = 'idle' | 'connecting' | 'success' | 'error';
 
 export default function StripeConnectPage() {
+  return (
+    <Suspense>
+      <StripeConnectInner />
+    </Suspense>
+  );
+}
+
+function StripeConnectInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get('code');

--- a/app/design/page.tsx
+++ b/app/design/page.tsx
@@ -1,5 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import React from 'react';
+import Link from 'next/link';
 import Markdoc from '@markdoc/markdoc';
 import { markdocConfig } from '../../markdoc/config';
 
@@ -28,9 +30,10 @@ export default async function DesignPage() {
     );
   }
 
-  const { createReactComponents } = Markdoc.createReactComponents(markdocConfig);
-  const transformed = Markdoc.transform(content, markdocConfig);
-  const rendered = Markdoc.renderReact(transformed, createReactComponents());
+  const transformed = Markdoc.transform(Markdoc.parse(content), markdocConfig);
+  const rendered = Markdoc.renderers.react(transformed, React, {
+    components: createComponents(),
+  });
 
   return (
     <div className="min-h-screen bg-[#07080b] text-white">
@@ -43,8 +46,8 @@ export default async function DesignPage() {
             <span className="text-lg font-semibold text-white">Design System</span>
           </div>
           <div className="flex gap-2">
-            <a href="/docs/th" className="rounded-lg px-3 py-1.5 text-sm text-slate-400 hover:bg-white/5 hover:text-white">เอกสาร</a>
-            <a href="/dashboard" className="rounded-lg px-3 py-1.5 text-sm text-slate-400 hover:bg-white/5 hover:text-white">Dashboard</a>
+            <Link href="/docs/th" className="rounded-lg px-3 py-1.5 text-sm text-slate-400 hover:bg-white/5 hover:text-white">เอกสาร</Link>
+            <Link href="/dashboard" className="rounded-lg px-3 py-1.5 text-sm text-slate-400 hover:bg-white/5 hover:text-white">Dashboard</Link>
           </div>
         </div>
       </header>

--- a/app/docs/[lang]/page.tsx
+++ b/app/docs/[lang]/page.tsx
@@ -1,5 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import React from 'react';
+import Link from 'next/link';
 import Markdoc from '@markdoc/markdoc';
 import { markdocConfig } from '../../../markdoc/config';
 
@@ -7,8 +9,9 @@ const DOCS_DIR = path.join(process.cwd(), 'markdoc', 'docs');
 
 export const dynamic = 'force-dynamic';
 
-export default async function DocsPage({ params }: { params: { lang: string } }) {
-  const lang = params.lang || 'en';
+export default async function DocsPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang: langParam } = await params;
+  const lang = langParam || 'en';
   const filePath = path.join(DOCS_DIR, lang, 'index.md');
 
   let content: string;
@@ -17,14 +20,13 @@ export default async function DocsPage({ params }: { params: { lang: string } })
   } catch {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#07080b]">
-        <p className="text-slate-400">Document not found. Try <a href="/docs/en" className="text-emerald-400">English</a> or <a href="/docs/th" className="text-emerald-400">ไทย</a></p>
+        <p className="text-slate-400">Document not found. Try <Link href="/docs/en" className="text-emerald-400">English</Link> or <Link href="/docs/th" className="text-emerald-400">ไทย</Link></p>
       </div>
     );
   }
 
-  const { createReactComponents } = Markdoc.createReactComponents(markdocConfig);
-  const transformed = Markdoc.transform(content, markdocConfig);
-  const rendered = Markdoc.renderReact(transformed, createReactComponents());
+  const transformed = Markdoc.transform(Markdoc.parse(content), markdocConfig);
+  const rendered = Markdoc.renderers.react(transformed, React, { components: {} });
 
   const availableLangs = [
     { code: 'en', label: '🇬🇧 English' },
@@ -37,17 +39,17 @@ export default async function DocsPage({ params }: { params: { lang: string } })
       <header className="sticky top-0 z-50 border-b border-white/10 bg-[#0c0e14]/90 backdrop-blur-xl">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
-            <a href="/" className="flex items-center gap-3">
+            <Link href="/" className="flex items-center gap-3">
               <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-400 to-cyan-500 text-sm font-bold text-black">
                 DSG
               </div>
               <span className="text-lg font-semibold text-white">Documentation</span>
-            </a>
+            </Link>
           </div>
           {/* Language Switcher */}
           <div className="flex gap-2">
             {availableLangs.map((l) => (
-              <a
+              <Link
                 key={l.code}
                 href={`/docs/${l.code}`}
                 className={`rounded-lg px-3 py-1.5 text-sm font-medium transition ${
@@ -57,7 +59,7 @@ export default async function DocsPage({ params }: { params: { lang: string } })
                 }`}
               >
                 {l.label}
-              </a>
+              </Link>
             ))}
           </div>
         </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -69,20 +69,13 @@ export default function LoginPage() {
 function LoginInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [notice, setNotice] = useState<{ type: string; message: string } | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     const error = searchParams.get("error") || undefined;
     const message = searchParams.get("message") || undefined;
-    if (message === "check-email") setNotice({ type: "success", message: "ส่งลิงก์กู้คืนแล้ว! กรุณาตรวจสอบอีเมลของคุณ" });
-    else if (error === "approval-required") setNotice({ type: "error", message: "Workspace นี้ต้องได้รับอนุมัติจากผู้ดูแลก่อนเข้าสู่ระบบ" });
-    else if (error === "sso-required") setNotice({ type: "error", message: "องค์กรนี้กำหนดให้เข้าสู่ระบบผ่าน SSO เท่านั้น" });
-    else if (error === "not-allowed") setNotice({ type: "error", message: "บัญชีของคุณไม่ได้รับอนุญาตให้เข้าถึง workspace นี้" });
-    else if (error === "invalid-email") setNotice({ type: "error", message: "รูปแบบอีเมลไม่ถูกต้อง กรุณาใส่อีเมลธุรกิจที่ถูกต้อง" });
-    else if (error === "too-many-attempts") setNotice({ type: "error", message: "คุณพยายามเข้าสู่ระบบบ่อยเกินไป กรุณารอ 60 วินาทีแล้วลองใหม่" });
-    else if (error) setNotice({ type: "error", message: "ไม่สามารถเข้าสู่ระบบได้ กรุณาลองใหม่อีกครั้ง" });
-    else setNotice(null);
+    setNotice(getNotice(error, message));
   }, [searchParams]);
 
   const handleSSOClick = useCallback(() => {
@@ -96,7 +89,13 @@ function LoginInner() {
     info: "ℹ️",
   };
 
-  return ($
+  const noticeStyles = {
+    error: "border-red-500/30 bg-red-500/10 text-red-200",
+    success: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+    info: "border-blue-500/30 bg-blue-500/10 text-blue-200",
+  };
+
+  return (
     <main className="flex min-h-screen items-center justify-center bg-[#07080b] px-4 py-12">
       <div className="w-full max-w-4xl">
         {/* Logo */}

--- a/app/password-login/page.tsx
+++ b/app/password-login/page.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 export default function PasswordLoginPage() {
+  return (
+    <Suspense>
+      <PasswordLoginInner />
+    </Suspense>
+  );
+}
+
+function PasswordLoginInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -90,6 +90,14 @@ function validateForm(data: FormData): FormErrors {
 }
 
 export default function SignupPage() {
+  return (
+    <Suspense>
+      <SignupInner />
+    </Suspense>
+  );
+}
+
+function SignupInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [notice, setNotice] = useState<Notice | null>(null);

--- a/docs/mcp-server/ZAI_VISION_WEB_READER.md
+++ b/docs/mcp-server/ZAI_VISION_WEB_READER.md
@@ -1,0 +1,161 @@
+# Z.AI MCP Servers — Vision + Web Reader
+
+This document describes how the **Z.AI Vision MCP Server** and **Z.AI Web Reader
+MCP Server** are wired into this repository's Claude Code configuration, the full
+tool surface each one exposes, and the choices made to keep startup fast and
+reliable.
+
+These servers give the coding agent two capabilities the base model lacks in
+this workflow:
+
+- **Vision** — read screenshots, diagrams, charts, error snapshots, and short
+  videos from the local working directory.
+- **Web Reader** — fetch and structure the full content of a public webpage
+  (title, body, metadata, links) without a local browser.
+
+> Both servers require a **GLM Coding Plan** API key. They share one key:
+> `Z_AI_API_KEY`. See `.env.example` for the variable names (values are never
+> committed).
+
+---
+
+## 1. Configuration (as designed)
+
+The repo centralizes MCP configuration in `.claude/settings.json`, using
+`${VAR}` substitution so secrets stay out of git. The two Z.AI servers follow
+the same pattern as the existing `dsg-one-v1` / `dsg-control-plane` entries.
+
+Add the following two entries to the `mcpServers` object in
+`.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "zai-vision": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@z_ai/mcp-server@latest"],
+      "env": {
+        "Z_AI_API_KEY": "${Z_AI_API_KEY}",
+        "Z_AI_MODE": "ZAI"
+      }
+    },
+    "web-reader": {
+      "type": "http",
+      "url": "https://api.z.ai/api/mcp/web_reader/mcp",
+      "headers": {
+        "Authorization": "Bearer ${Z_AI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+> Note: editing `.claude/settings.json` changes the agent's own tooling and is
+> guarded as a self-modification. Apply it yourself with the one-click commands
+> below, or paste the block above. The repo ships the documentation, the
+> `.env.example` variable names, and the `scripts/setup-zai-mcp.sh` helper; the
+> final enable step is left to the operator on purpose.
+
+### One-click install (Claude Code)
+
+```bash
+# Vision (local stdio server). @latest avoids a stale npx cache — see §3.
+claude mcp add -s user zai-vision \
+  --env Z_AI_API_KEY="$Z_AI_API_KEY" --env Z_AI_MODE=ZAI \
+  -- npx -y "@z_ai/mcp-server@latest"
+
+# Web Reader (remote HTTP server)
+claude mcp add -s user -t http web-reader \
+  https://api.z.ai/api/mcp/web_reader/mcp \
+  --header "Authorization: Bearer $Z_AI_API_KEY"
+```
+
+Use `-s user` so both servers are available across every session and project
+without re-adding them per repo.
+
+---
+
+## 2. Tool surface (complete)
+
+### Vision MCP Server (`zai-vision`)
+
+| Tool | Purpose |
+| :--- | :--- |
+| `ui_to_artifact` | Turn UI screenshots into code, prompts, specs, or descriptions. |
+| `extract_text_from_screenshot` | OCR for code, terminals, docs, general text. |
+| `diagnose_error_screenshot` | Analyze an error snapshot and propose fixes. |
+| `understand_technical_diagram` | Read architecture, flow, UML, ER, system diagrams. |
+| `analyze_data_visualization` | Read charts/dashboards and surface insights. |
+| `ui_diff_check` | Compare two UI shots to flag visual/implementation drift. |
+| `image_analysis` | General-purpose image understanding. |
+| `video_analysis` | Inspect local/remote videos ≤ 8 MB (MP4/MOV/M4V). |
+
+Place the file in the working directory and reference it by name/path in the
+prompt, e.g. `What does demo.png describe?`. (Pasting an image directly works in
+Claude Code, but the documented best practice is to reference a file on disk.)
+
+### Web Reader MCP Server (`web-reader`)
+
+| Tool | Purpose |
+| :--- | :--- |
+| `webReader` | Fetch a URL and return title, main content, metadata, and links. |
+
+---
+
+## 3. Efficiency choices
+
+| Choice | Why |
+| :--- | :--- |
+| Pin `@z_ai/mcp-server@latest` | Z.AI's own guidance: a cached older version can pin an older model (pre-GLM-4.6V) and is a common cause of the `Connection Closed` error. `@latest` forces the newest build. |
+| Pre-warm the npx cache (`scripts/setup-zai-mcp.sh`) | The first stdio launch downloads the package; pre-fetching it removes that cost from the first tool call and avoids stdio start-up timeouts. |
+| Web Reader over remote HTTP | No local install, no Node process to manage; lower local overhead and a shared, server-side fetch path. |
+| Install at user scope (`-s user`) | One install serves every session/project instead of re-adding per repo. |
+| Single shared `Z_AI_API_KEY` | Both servers authenticate with the same GLM Coding Plan key — one secret to manage and rotate. |
+
+---
+
+## 4. Prerequisites & verification
+
+| Item | Status | Evidence |
+| :--- | :--- | :--- |
+| Node.js ≥ v22.0.0 (required by Vision server) | verified | `node -v` → `v22.22.2` in this environment |
+| `@z_ai/mcp-server` published and ≥ 0.1.2 | verified | `npm view @z_ai/mcp-server version` → `0.1.4` |
+| Config is valid JSON after edit | verify with `scripts/setup-zai-mcp.sh --check` or `node -e "JSON.parse(require('fs').readFileSync('.claude/settings.json','utf8'))"` |
+| Live Vision/Web Reader tool calls succeed | **not verified** | requires a real `Z_AI_API_KEY`; not run here — no key configured in this environment |
+
+Local install smoke test (needs a key):
+
+```bash
+Z_AI_API_KEY="$Z_AI_API_KEY" npx -y @z_ai/mcp-server@latest
+```
+
+If it starts and waits on stdio, the environment is correct and any remaining
+issue is client configuration.
+
+---
+
+## 5. Quota (GLM Coding Plan)
+
+Web search + Web Reader share a monthly call budget; vision understanding draws
+from the plan's 5-hour rolling prompt resource pool.
+
+| Plan | Web search + Web Reader (total) | Vision |
+| :--- | :--- | :--- |
+| Lite | 100 | 5-hour rolling pool |
+| Pro | 1,000 | 5-hour rolling pool |
+| Max | 4,000 | 5-hour rolling pool |
+
+---
+
+## 6. Troubleshooting
+
+- **Connection Closed** — confirm Node ≥ 22 (`node -v`, `npx -v`), confirm
+  `Z_AI_API_KEY` is set, and confirm `@latest` is pinned (stale cache is the
+  usual cause).
+- **Invalid API Key** — confirm the key is copied correctly, activated, has
+  balance, and that `Z_AI_MODE=ZAI` matches the key's platform.
+- **Web fetch returned empty** — confirm the target URL is public and not behind
+  anti-scraping; try a different URL.
+
+Sources: Z.AI Vision MCP Server and Web Reader MCP Server documentation.

--- a/markdoc/config.ts
+++ b/markdoc/config.ts
@@ -9,9 +9,6 @@ export const markdocConfig: Config = {
     locales: ['th', 'en'],
     defaultLocale: 'th',
   },
-  headings: {
-    anchorPrefix: 'heading-',
-  },
   tags: {
     designButton: {
       render: 'DesignButton',
@@ -60,9 +57,8 @@ export const markdocConfig: Config = {
       attributes: { content: { type: String, required: true }, language: { type: String, required: true } },
     },
     hr: { render: 'HR' },
-    ul: { render: 'List' } as any,
-    ol: { render: 'OrderedList' } as any,
-    li: { render: 'ListItem' } as any,
+    list: { render: 'List' },
+    item: { render: 'ListItem' },
     table: { render: 'Table' },
     thead: { render: 'THead' },
     tbody: { render: 'TBody' },
@@ -73,6 +69,5 @@ export const markdocConfig: Config = {
     image: { render: 'Image', attributes: { src: { type: String, required: true }, alt: { type: String } } },
     strong: { render: 'Strong' },
     em: { render: 'Em' },
-    inlineCode: { render: 'InlineCode' },
   },
 };

--- a/scripts/setup-zai-mcp.sh
+++ b/scripts/setup-zai-mcp.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup-zai-mcp.sh
+# Verify prerequisites and (optionally) pre-warm the Z.AI Vision MCP server so
+# its first tool call does not pay the npx download cost. Web Reader is a remote
+# HTTP server and needs no local install.
+#
+# Usage:
+#   scripts/setup-zai-mcp.sh           # check prereqs + pre-warm npx cache
+#   scripts/setup-zai-mcp.sh --check   # checks only, no network pre-warm
+#
+# Docs: docs/mcp-server/ZAI_VISION_WEB_READER.md
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_ONLY=false
+[[ "${1:-}" == "--check" ]] && CHECK_ONLY=true
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+ok()   { echo "  [ok] $*"; }
+
+echo "== Z.AI MCP setup (Vision + Web Reader) =="
+
+# 1) Node >= 22 (required by @z_ai/mcp-server)
+command -v node >/dev/null 2>&1 || fail "node not found; install Node.js >= v22.0.0"
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+[[ "${NODE_MAJOR}" -ge 22 ]] || fail "Node >= 22 required (found $(node -v))"
+ok "node $(node -v)"
+
+# 2) npx available
+command -v npx >/dev/null 2>&1 || fail "npx not found"
+ok "npx $(npx -v)"
+
+# 3) .claude/settings.json is valid JSON (config the operator edits to enable)
+SETTINGS="${ROOT_DIR}/.claude/settings.json"
+if [[ -f "${SETTINGS}" ]]; then
+  node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "${SETTINGS}" \
+    || fail ".claude/settings.json is not valid JSON"
+  ok ".claude/settings.json parses"
+  if node -e "process.exit(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).mcpServers?.['zai-vision']?0:1)" "${SETTINGS}"; then
+    ok "zai-vision is configured"
+  else
+    echo "  [info] zai-vision not yet in .claude/settings.json — see docs to enable"
+  fi
+fi
+
+# 4) Key presence (name only; never printed)
+if [[ -n "${Z_AI_API_KEY:-}" ]]; then
+  ok "Z_AI_API_KEY is set"
+else
+  echo "  [info] Z_AI_API_KEY not set in this shell — live tool calls will fail until exported"
+fi
+
+if [[ "${CHECK_ONLY}" == true ]]; then
+  echo "Checks complete (no pre-warm)."
+  exit 0
+fi
+
+# 5) Pre-warm the npx cache for the Vision server (efficiency).
+echo "Pre-warming @z_ai/mcp-server@latest into the npx cache ..."
+if npx -y @z_ai/mcp-server@latest --help >/dev/null 2>&1; then
+  ok "package fetched"
+else
+  # --help may not be supported; a non-zero exit here usually still means the
+  # package downloaded. Report without failing the whole script.
+  echo "  [warn] pre-warm command returned non-zero (package likely still cached)"
+fi
+
+echo "Done. Enable the servers per docs/mcp-server/ZAI_VISION_WEB_READER.md"


### PR DESCRIPTION
Goal:
(1) Make the two Z.AI GLM Coding Plan MCP servers — **Vision** (`@z_ai/mcp-server`) and **Web Reader** (remote HTTP) — usable as documented, tuned for fast startup. (2) Per maintainer request, fold in the pre-existing build breakage fixes that were blocking ALL CI repo-wide, and get this PR green to merge.

## Part 1 — Z.AI MCP integration (original scope)
Files: `docs/mcp-server/ZAI_VISION_WEB_READER.md` (new), `scripts/setup-zai-mcp.sh` (new), `.env.example` (+`Z_AI_API_KEY`/`Z_AI_MODE`, names only).
- `zai-vision` — stdio `npx -y @z_ai/mcp-server@latest`, env `Z_AI_API_KEY`+`Z_AI_MODE=ZAI`. Tools: ui_to_artifact, extract_text_from_screenshot, diagnose_error_screenshot, understand_technical_diagram, analyze_data_visualization, ui_diff_check, image_analysis, video_analysis.
- `web-reader` — remote HTTP `https://api.z.ai/api/mcp/web_reader/mcp`, Bearer `${Z_AI_API_KEY}`. Tool: webReader.
- Efficiency: pin `@latest` (documented stale-cache fix), pre-warm helper, remote HTTP web-reader, user-scope install, one shared key.
- `.claude/settings.json` enable step is left to the operator (self-modification guard); secret stays in env.

## Part 2 — Pre-existing build repair (added per request)
All errors pre-dated this branch and blocked typecheck/build for the whole repo (main was red). Fixing the two surface typos unmasked the rest.
- `app/dashboard/page.tsx`: missing comma in onboardingSteps.
- `app/login/page.tsx`: stray `$` in return; type notice state as `Notice` (restores `action`), wire `getNotice()`, add `noticeStyles`.
- `markdoc/config.ts`: valid Markdoc node types (`list`/`item`, drop `ul`/`ol`/`li`/`inlineCode`), remove unsupported top-level `headings`.
- `app/design/page.tsx`, `app/docs/[lang]/page.tsx`: real Markdoc API (`parse`→`transform`→`renderers.react`); internal `<a>`→`<Link>`; docs awaits Promise-shaped `params` (Next 15).
- `app/password-login`, `app/signup`, `app/dashboard/stripe-app/connect`, `app/dashboard/billing`: wrap `useSearchParams` pages in `<Suspense>` (Next 15 prerender fix).

Verification (local, deps via `npm ci`, TypeScript 5.8.3):
- [x] `npm run typecheck` → 0 errors
- [x] `npm run build` → ✓ Compiled, lint clean, **Generating static pages 176/176**, exit 0
- [x] `node -v` → v22.22.2 (Vision server needs ≥ 22); `npm view @z_ai/mcp-server version` → 0.1.4
- [x] `scripts/setup-zai-mcp.sh --check` passes; config JSON snippet parses
- [ ] Live Vision/Web Reader tool calls — Not run: requires a real `Z_AI_API_KEY`, none in this environment.

Known limits:
- `.claude/settings.json` not modified here; operator enables the two servers via the documented one-click commands.
- MCP end-to-end is `not verified` without a GLM Coding Plan key.

User-visible benefit:
Repo builds green again (typecheck + 176/176 prerender), unblocking every PR. Once the operator enables the servers and exports `Z_AI_API_KEY`, the agent gains vision + structured web reading.

Next step:
Operator: export `Z_AI_API_KEY`, enable the two MCP servers per the doc, run `scripts/setup-zai-mcp.sh` to pre-warm/confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)