### PR TITLE
fix: handle null systemHealth in dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -190,7 +190,7 @@ export default function DashboardPage() {
     { label: "สร้างองค์กร", done: true, href: "/dashboard/settings/go-live", ring: "white" },
     { label: "เชือมต่อตัวแทน", done: Boolean(onboarding?.has_agent), href: "/dashboard/agents", ring: "blue" },
     { label: "รันการดำเนินการครั้งแรก", done: Boolean(onboarding?.first_run_complete), href: "/delivery-proof", ring: "purple" },
-    { label: "เปิดใช้งาน Ring Hermes", done: systemHealth.allGood, href: "/dashboard/hermes", ring: "green" },
+    { label: "เปิดใช้งาน Ring Hermes", done: systemHealth?.allGood ?? false, href: "/dashboard/hermes", ring: "green" },
   ];
   const doneCount = onboardingSteps.filter((s) => s.done).length;
 


### PR DESCRIPTION
### Problem
Dashboard crashes on load due to null reference error.

When the dashboard component first renders while `loading = true`, the `systemHealth` state is `null`. However, line 193 tries to access `systemHealth.allGood` directly without null checking:

```typescript
// Before (crashes):
{ label: "เปิดใช้งาน Ring Hermes", done: systemHealth.allGood, ... }
// systemHealth = null → TypeError: Cannot read property 'allGood' of null
```

### Solution
Use optional chaining with nullish coalescing to safely handle null state:

```typescript
// After (safe):
{ label: "เปิดใช้งาน Ring Hermes", done: systemHealth?.allGood ?? false, ... }
```

### Changes
- Fixed null reference in onboarding steps array
- Dashboard now renders successfully during loading state

### Testing
Dashboard at `/dashboard` now loads without crashes during initial data fetch.

---
🤖 Generated with Claude Code
https://claude.ai/code/session_01N71HxHVSMME7c2bkUR4HhS

---
_Generated by [Claude Code](https://claude.ai/code/session_01N71HxHVSMME7c2bkUR4HhS)_