### PR TITLE
Fix /dashboard/hermes blank/stuck screen (Supabase auth gate loop)

### DIFF
--- a/app/api/dashboard/hermes/chat/route.ts
+++ b/app/api/dashboard/hermes/chat/route.ts
@@ -42,12 +42,22 @@ async function evaluateGovernancePolicy(
   return decisions[Math.floor(Math.random() * decisions.length)];
 }
 
+// Honest limited-mode reply used when the LLM backend is unavailable, so the
+// dashboard remains usable instead of surfacing a hard error.
+function limitedModeReply(reason: string): string {
+  return [
+    '⚠️ Hermes is running in limited mode — the conversational LLM backend is not available right now.',
+    `(${reason})`,
+    '',
+    'To enable full conversational replies, configure OPENROUTER_API_KEY for this deployment.',
+  ].join('\n');
+}
+
 async function generateAgentResponse(message: string): Promise<string> {
   const apiKey = process.env.OPENROUTER_API_KEY;
 
   if (!apiKey) {
-    const err = new Error('OpenRouter API key not configured');
-    throw err;
+    return limitedModeReply('LLM not configured');
   }
 
   const systemPrompt = `You are Hermes, a helpful AI governance agent that helps users understand policies and make decisions.
@@ -55,43 +65,47 @@ You support Thai language responses.
 Keep responses concise but informative.
 Always be respectful and helpful.`;
 
-  const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: 'qwen/qwen-3-coder:free',
-      messages: [
-        {
-          role: 'system',
-          content: systemPrompt,
-        },
-        {
-          role: 'user',
-          content: message,
-        },
-      ],
-      max_tokens: 500,
-      temperature: 0.7,
-    }),
-  });
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'qwen/qwen-3-coder:free',
+        messages: [
+          {
+            role: 'system',
+            content: systemPrompt,
+          },
+          {
+            role: 'user',
+            content: message,
+          },
+        ],
+        max_tokens: 500,
+        temperature: 0.7,
+      }),
+    });
 
-  if (!response.ok) {
-    const error = new Error('OpenRouter API request failed');
-    throw error;
+    if (!response.ok) {
+      return limitedModeReply('LLM upstream error');
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const content = data.choices?.[0]?.message?.content;
+    if (content) {
+      return content;
+    }
+
+    return limitedModeReply('LLM returned no content');
+  } catch {
+    return limitedModeReply('LLM request failed');
   }
-
-  const data = (await response.json()) as {
-    choices: Array<{ message: { content: string } }>;
-  };
-
-  if (data.choices && data.choices[0] && data.choices[0].message) {
-    return data.choices[0].message.content;
-  }
-
-  throw new Error('Invalid response from OpenRouter API');
 }
 
 export async function POST(request: NextRequest) {

--- a/app/components/dashboard/HermesAgentChat.tsx
+++ b/app/components/dashboard/HermesAgentChat.tsx
@@ -195,7 +195,7 @@ export function HermesAgentChat() {
   };
 
   return (
-    <div className="flex flex-col h-screen bg-gradient-to-b from-slate-50 to-white">
+    <div className="flex flex-col h-full min-h-[600px] bg-gradient-to-b from-slate-50 to-white rounded-lg overflow-hidden border border-slate-200">
       <div className="flex items-center gap-3 px-6 py-4 border-b border-slate-200 bg-white">
         <MessageCircle className="w-6 h-6 text-blue-600" />
         <div>

--- a/app/dashboard/hermes/page.tsx
+++ b/app/dashboard/hermes/page.tsx
@@ -1,61 +1,18 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { createClient } from '@/lib/supabase/client';
+import { useState } from 'react';
 import { HermesAgentChat } from '@/app/components/dashboard/HermesAgentChat';
 
+// Authentication is enforced server-side by app/dashboard/hermes/layout.tsx
+// (Supabase SSR cookie session + redirect). The page must NOT re-gate auth with
+// the browser Supabase client: that client stores its session in localStorage,
+// not the SSR cookies, so getUser() returns null even for a logged-in user and
+// the page would redirect-loop to /login (blank/stuck screen).
 export default function HermesPage() {
   const [activeTab, setActiveTab] = useState('overview');
-  const [isLoading, setIsLoading] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const router = useRouter();
-
-  useEffect(() => {
-    const checkAuth = async () => {
-      try {
-        const supabase = createClient();
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-
-        if (!user) {
-          router.push('/login?next=/dashboard/hermes');
-          return;
-        }
-        setIsAuthenticated(true);
-
-        // Fetch health, agents, and executions data
-        await Promise.all([
-          fetch('/api/health').catch(() => {}),
-          fetch('/api/agents').catch(() => {}),
-          fetch('/api/executions').catch(() => {}),
-        ]);
-      } catch (error) {
-        console.error('Auth check failed:', error);
-        router.push('/login?next=/dashboard/hermes');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    checkAuth();
-  }, [router]);
-
-  if (isLoading) {
-    return (
-      <div className="w-full h-screen bg-slate-950 flex items-center justify-center">
-        <div className="text-slate-400">กำลังโหลด...</div>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return null;
-  }
 
   return (
-    <div className="w-full h-screen bg-slate-950 text-slate-100">
+    <div className="w-full h-full min-h-screen bg-slate-950 text-slate-100">
       <div className="flex h-full flex-col">
         {/* Tab Navigation */}
         <div className="border-b border-slate-800">

--- a/tests/unit/ui-pages.test.ts
+++ b/tests/unit/ui-pages.test.ts
@@ -126,21 +126,33 @@ describe('Dashboard Page UI', () => {
 });
 
 describe('Hermes Dashboard UI', () => {
-  it('should have tabs and data fetching', async () => {
+  it('should have tabs and render the chat component', async () => {
     const fs = await import('fs');
     const content = fs.readFileSync('./app/dashboard/hermes/page.tsx', 'utf8');
 
     // Client-side component
     expect(content).toContain('use client');
 
-    // Auth check (uses Supabase auth)
-    expect(content).toContain('supabase.auth.getUser');
-
     // Chat component
     expect(content).toContain('HermesAgentChat');
 
     // Dark theme
     expect(content).toContain('bg-slate-950');
+  });
+
+  it('enforces auth server-side in the layout (not via the browser client)', async () => {
+    const fs = await import('fs');
+    const page = fs.readFileSync('./app/dashboard/hermes/page.tsx', 'utf8');
+    const layout = fs.readFileSync('./app/dashboard/hermes/layout.tsx', 'utf8');
+
+    // Auth must be enforced in the server layout via the SSR (cookie) client,
+    // which redirects unauthenticated users.
+    expect(layout).toContain('supabase.auth.getUser');
+    expect(layout).toContain('redirect');
+
+    // The page must NOT re-gate auth with the browser client: that client uses
+    // localStorage, not SSR cookies, and caused a redirect loop (blank screen).
+    expect(page).not.toContain('supabase.auth.getUser');
   });
 });
 


### PR DESCRIPTION
Goal:
`/dashboard/hermes` rendered a blank / stuck "กำลังโหลด..." screen for logged-in users. Make the page load and the chat usable.

Root cause:
The client page re-checked auth with the browser Supabase client (`lib/supabase/client.ts`), which persists its session in **localStorage**. The server side (layout + API routes) uses `@supabase/ssr` **cookie** sessions. So the browser client's `getUser()` returned `null` for a user who was actually logged in (cookie session present), and the page pushed to `/login`; the server layout (cookie) saw the user and sent them back — a redirect loop that presents as a blank/stuck page.

Files changed:
- `app/dashboard/hermes/page.tsx` — remove the redundant, buggy client-side auth gate. Auth is already enforced server-side in `layout.tsx` (cookie session + redirect). Render the tabs/chat directly.
- `app/components/dashboard/HermesAgentChat.tsx` — `h-screen` → `h-full` so the chat fits inside the tab content area instead of overflowing a second full viewport below the tab bar.
- `app/api/dashboard/hermes/chat/route.ts` — degrade gracefully when the LLM backend is unavailable (missing `OPENROUTER_API_KEY` or upstream error): stream an honest limited-mode message instead of failing the whole request, so the page stays usable.

Verification:
- [x] npm run typecheck — passed
- [x] npm run lint — passed (pre-existing warnings only)
- [x] npm run build — passed
- [x] bash scripts/check-error-handlers.sh — OK
- [ ] Live authenticated load — Not run (cannot authenticate from CI); fix targets the exact localStorage/cookie mismatch that caused the loop

Known limits:
- `evaluateGovernancePolicy()` still returns a placeholder decision; wiring the real deterministic gate is out of scope for this fix.
- Full conversational replies require `OPENROUTER_API_KEY` set on the deployment; without it the chat now shows an honest limited-mode message instead of erroring.

User-visible benefit:
The Hermes dashboard loads instead of showing a blank/stuck screen, and the chat returns a response (real LLM when configured, an honest limited-mode notice otherwise) rather than failing.

Next step:
Set `OPENROUTER_API_KEY` on the Vercel deployment to enable full conversational replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfkxeQfLcX6h5qDbYq76Qj)_