### PR TITLE
fix: Hermes chat textarea text invisible when typing

### DIFF
--- a/app/components/dashboard/HermesAgentChat.tsx
+++ b/app/components/dashboard/HermesAgentChat.tsx
@@ -294,7 +294,7 @@ export function HermesAgentChat() {
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="ถามเอเจนต์ หรือพิมพ์คำสั่ง... (Shift+Enter สำหรับขึ้นบรรทัด)"
-            className="flex-1 px-4 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none text-sm"
+            className="flex-1 px-4 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none text-sm text-slate-900 placeholder:text-slate-400 bg-white"
             rows={1}
             disabled={isLoading || isStreaming}
           />


### PR DESCRIPTION
## Goal

Fix Hermes chat textarea where typed text is invisible — the input field inherits `text-slate-100` (near-white) from the page's dark wrapper (`bg-slate-950 text-slate-100`), making it invisible against the white `bg-white` input background.

## Files changed

- `app/components/dashboard/HermesAgentChat.tsx` — add `text-slate-900 placeholder:text-slate-400 bg-white` to the textarea className

## Verification

- [ ] Inspected `HermesAgentChat.tsx` — textarea had no explicit text color
- [ ] Page wrapper in `app/dashboard/hermes/page.tsx` sets `text-slate-100` which cascades into the white textarea
- [ ] Fix adds `text-slate-900` to pin the input text to dark, `bg-white` to pin background, `placeholder:text-slate-400` for consistent placeholder color
- [ ] Runtime test: Not run in CI — single-line CSS class addition; visual change confirmed by code inspection

## Known limits

- Vercel preview not triggered (branch-level config); change visible after deploy to main

## User-visible benefit

Typed text in the Hermes chat input box is now visible (dark text on white background).

## Next step

Merge → Vercel auto-deploys → user can type and see text in `/dashboard/hermes` chat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfkxeQfLcX6h5qDbYq76Qj)_