### PR TITLE
fix(db): grant is_org_member/is_org_admin EXECUTE to authenticated

### DIFF
--- a/supabase/migrations/20260703043000_grant_org_membership_helpers_to_authenticated.sql
+++ b/supabase/migrations/20260703043000_grant_org_membership_helpers_to_authenticated.sql
@@ -1,0 +1,20 @@
+-- Fix: dashboard/API-key pages fail with "permission denied for function is_org_member"
+--
+-- Root cause: public.is_org_member(uuid) and public.is_org_admin(uuid) are
+-- SECURITY DEFINER helper functions referenced by 16 RLS policies (on agents,
+-- audit_logs, executions, organizations, policies, subscriptions,
+-- usage_counters, usage_events, users) that target the `authenticated` role,
+-- but EXECUTE was only granted to `postgres` and `service_role`. Any org-scoped
+-- query from a logged-in user therefore errored with permission denied —
+-- including the api_keys policy, whose USING subquery reads `users` and
+-- triggers users_select_same_org -> is_org_member.
+--
+-- The functions are safe to expose to `authenticated`: they only check
+-- membership/role for auth.uid() and take no caller-controlled identity.
+--
+-- Applied to live project zeyguilldygozufpgxms via Supabase MCP on 2026-07-03
+-- (migration name: grant_org_membership_helpers_to_authenticated).
+-- GRANT is idempotent; safe to re-run.
+
+GRANT EXECUTE ON FUNCTION public.is_org_member(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_org_admin(uuid) TO authenticated;


### PR DESCRIPTION
Goal:

Fix the production bug reported via screenshots: the API Key Management page fails with `permission denied for function is_org_member` (create key) and `Internal server error` (list keys) for logged-in users.

Files changed:

- `supabase/migrations/20260703043000_grant_org_membership_helpers_to_authenticated.sql` — grants `EXECUTE` on `public.is_org_member(uuid)` and `public.is_org_admin(uuid)` to the `authenticated` role.

Root cause (verified against the live database):

- Both helpers are `SECURITY DEFINER` functions referenced by **16 RLS policies** across 9 tables (`agents`, `audit_logs`, `executions`, `organizations`, `policies`, `subscriptions`, `usage_counters`, `usage_events`, `users`) that target the `authenticated` role — but `EXECUTE` was only granted to `postgres` and `service_role`.
- The `api_keys` policy's `USING` subquery reads `users`, which triggers `users_select_same_org` → `is_org_member(...)` → permission denied. Every org-scoped dashboard query from a logged-in user failed the same way.
- The functions are safe to expose: they only check membership for `auth.uid()` and take no caller-controlled identity.

Verification:
- [x] Live DB inspected: `routine_privileges` showed only `EXECUTE:postgres`, `EXECUTE:service_role` before the fix
- [x] Grant applied to live project `zeyguilldygozufpgxms` via Supabase migration tooling (2026-07-03)
- [x] `routine_privileges` now includes `EXECUTE:authenticated` on both functions
- [x] `BEGIN; SET LOCAL ROLE authenticated; SELECT public.is_org_member('0000…'::uuid); ROLLBACK;` → returns `false` (no more permission denied)
- [ ] UI re-test (create/list API key as a signed-in user) — pending user confirmation

Known limits:

- The live DB already has the grant; this migration file records it for reproducibility (GRANT is idempotent, safe to re-run)
- The `is_org_member`/`is_org_admin` function definitions themselves are still not in repo migrations (created outside the repo history) — follow-up candidate

User-visible benefit:

Logged-in users can create and list API keys again, and all org-scoped dashboard pages (agents, audit logs, executions, policies, usage, subscriptions) stop failing with permission-denied errors.

Next step:

Reload the API Key Management page and confirm key creation works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqCycFjStsHrTkykLKLjKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqCycFjStsHrTkykLKLjKk)_