### PR TITLE
fix(deploy): cap voice stream maxDuration; fix GitHub Marketplace webhook ping

### DIFF
--- a/app/api/voice/stream/route.ts
+++ b/app/api/voice/stream/route.ts
@@ -10,7 +10,7 @@ import { createClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 600; // 10 minutes max for streaming
+export const maxDuration = 300; // Vercel hobby plan caps serverless maxDuration at 300s
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/webhooks/marketplace/route.ts
+++ b/app/api/webhooks/marketplace/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createHmac } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
@@ -49,16 +49,21 @@ function verifyWebhookSignature(payload: string, signature: string): boolean {
   const secret = process.env.GITHUB_MARKETPLACE_WEBHOOK_SECRET;
 
   if (!secret) {
-    console.warn('Missing GITHUB_MARKETPLACE_WEBHOOK_SECRET - webhook verification disabled');
-    return true; // Allow in development/testing
+    console.warn('Missing GITHUB_MARKETPLACE_WEBHOOK_SECRET - rejecting webhook (fail closed)');
+    return false;
   }
 
   const hash = createHmac('sha256', secret)
     .update(payload)
     .digest('hex');
 
-  const expectedSignature = `sha256=${hash}`;
-  return signature === expectedSignature;
+  const expectedSignature = Buffer.from(`sha256=${hash}`);
+  const receivedSignature = Buffer.from(signature);
+
+  if (expectedSignature.length !== receivedSignature.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedSignature, receivedSignature);
 }
 
 /**
@@ -141,6 +146,13 @@ export async function POST(request: Request) {
         { error: 'Invalid signature' },
         { status: 401 }
       );
+    }
+
+    // GitHub sends a `ping` event when the webhook is created/tested.
+    // Its payload has no action/marketplace_purchase, so answer before validation.
+    const githubEvent = request.headers.get('x-github-event');
+    if (githubEvent === 'ping') {
+      return NextResponse.json({ success: true, event: 'ping' }, { status: 200 });
     }
 
     // Parse payload


### PR DESCRIPTION
Goal:

Two production fixes:

1. **Unblock production deployments.** Every production deploy since PR #841 merged fails at the `patchBuild` step with:

```
errorCode: invalid_max_duration
Builder returned invalid maxDuration value for Serverless Function "api/voice/stream".
Serverless Functions must have a maxDuration between 1 and 300 for plan hobby.
```

Production is stuck serving commit `77a85fa` (PR #840); builds for `1f600ad` (#841) and `d9cecb5` (#842) compile successfully but error during deploy. Verified from Vercel deployment metadata (`dpl_i1iBo6quWrAYiRc9rDzowUsh6MBR`, `dpl_GAfrXUTKWhguzXDxJUaaiyYq27Dt`, and 4 more ERROR deployments).

2. **Fix failing GitHub Marketplace webhook deliveries.** The Manage-webhook UI shows all `ping` deliveries failing. GitHub's `ping` event has no `action`/`marketplace_purchase` fields, so `/api/webhooks/marketplace` returned 400 and GitHub marked every delivery failed.

Files changed:

- `app/api/voice/stream/route.ts` — `maxDuration` 600 → 300 (plan maximum)
- `app/api/webhooks/marketplace/route.ts` — respond 200 to `x-github-event: ping` after signature verification; fail closed when `GITHUB_MARKETPLACE_WEBHOOK_SECRET` is absent (was fail-open); use `crypto.timingSafeEqual` for signature comparison

Verification:
- [x] `npm run typecheck` — pass (after each change)
- [x] Grep of all `maxDuration` exports under `app/api` — only voice/stream exceeded 300 (all others are 60)
- [x] Vercel error evidence inspected: `errorStep: patchBuild`, `errorCode: invalid_max_duration`
- [x] Live probe: unsigned POST to `/api/webhooks/marketplace` returns 401 — confirms the webhook secret IS configured in production
- [x] Applied `20260701030000_github_marketplace_events.sql` to live DB (table was missing; migration file existed but was never applied) — `information_schema` query confirms `marketplace_events` now exists
- [ ] Production deployment Ready — pending merge; the next `main` deploy is the real test
- [ ] GitHub Marketplace ping redelivery succeeds — requires the deploy above, then "Redeliver" in the Manage-webhook UI

Known limits:

- SSE voice streaming sessions hard-cap at 300s instead of the intended 600s; clients must reconnect for longer sessions (the client hooks already auto-reconnect).
- The webhook ping fix only reaches production after this PR merges AND the deployment succeeds (which requires the maxDuration fix in the same PR).
- Marketplace purchase events delivered before the `marketplace_events` table existed were acknowledged with 200 but not persisted; they can be redelivered from the GitHub UI if needed.

User-visible benefit:

Production deployments unblocked — fixes and features merged in #841/#842 actually reach the live site. GitHub Marketplace webhook stops failing deliveries, and purchase events are now actually persisted to the database.

Next step:

Merge, confirm the `main` deployment reaches `Ready`, verify `/api/agent/status` advances past `77a85fa`, then redeliver the failed `ping` from the GitHub Marketplace webhook UI and confirm it returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqCycFjStsHrTkykLKLjKk