### PR TITLE
fix(openrouter): Improve HTTP 401 authentication error handling

### DIFF
--- a/app/api/dsg-bridge/codex/route.ts
+++ b/app/api/dsg-bridge/codex/route.ts
@@ -87,10 +87,26 @@ export async function POST(request: Request) {
 
           if (!res.ok) {
             const detail = await res.text().catch(() => '');
-            console.error(
-              `[dsg-bridge/codex] OpenRouter ${res.status} for "${model}": ${detail.slice(0, 300)}`,
-            );
-            enqueue({ type: 'error', error: `LLM error ${res.status}` });
+
+            // Handle auth errors specifically
+            if (res.status === 401) {
+              console.error('[dsg-bridge/codex] OpenRouter 401: Invalid API key or account not found');
+              enqueue({
+                type: 'error',
+                error: 'OpenRouter authentication failed. Check your OPENROUTER_API_KEY configuration.',
+              });
+            } else if (res.status === 403) {
+              console.error('[dsg-bridge/codex] OpenRouter 403: Access forbidden');
+              enqueue({
+                type: 'error',
+                error: 'OpenRouter access denied. Your API key may lack required permissions.',
+              });
+            } else {
+              console.error(
+                `[dsg-bridge/codex] OpenRouter ${res.status} for "${model}": ${detail.slice(0, 300)}`,
+              );
+              enqueue({ type: 'error', error: `LLM error ${res.status}` });
+            }
             controller.close();
             return;
           }

--- a/app/api/setup/test-openrouter/route.ts
+++ b/app/api/setup/test-openrouter/route.ts
@@ -75,10 +75,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         logApiError('api/setup/test-openrouter', new Error('Invalid API key'), { status: 401 });
         return NextResponse.json(
           {
-            error: 'Unauthorized',
+            error: 'Authentication failed: Invalid OpenRouter API key or account not found. Verify your API key at https://openrouter.ai/settings/keys',
             statusCode: 401,
+            details: 'HTTP 401 Unauthorized - Check that your API key is valid and the account is active',
           },
           { status: 401 }
+        );
+      }
+
+      if (testResponse.status === 403) {
+        logApiError('api/setup/test-openrouter', new Error('Access forbidden'), { status: 403 });
+        return NextResponse.json(
+          {
+            error: 'Access forbidden: Your API key may lack the required permissions',
+            statusCode: 403,
+            details: 'HTTP 403 Forbidden - Check your account permissions at https://openrouter.ai/settings',
+          },
+          { status: 403 }
         );
       }
 
@@ -86,8 +99,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         logApiError('api/setup/test-openrouter', new Error('Model not found'), { status: 404, model });
         return NextResponse.json(
           {
-            error: 'Not found',
+            error: 'Model not found',
             statusCode: 404,
+            details: `The model "${model}" is not available on OpenRouter. Check available models at https://openrouter.ai/models`,
           },
           { status: 404 }
         );
@@ -98,6 +112,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         {
           error: 'API request failed',
           statusCode: testResponse.status,
+          details: await testResponse.text().catch(() => 'See OpenRouter status at https://status.openrouter.ai'),
         },
         { status: testResponse.status }
       );

--- a/app/api/setup/test-openrouter/route.ts
+++ b/app/api/setup/test-openrouter/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         {
           error: 'API request failed',
           statusCode: testResponse.status,
-          details: await testResponse.text().catch(() => 'See OpenRouter status at https://status.openrouter.ai'),
+          details: 'Check OpenRouter status at https://status.openrouter.ai',
         },
         { status: testResponse.status }
       );

--- a/lib/dsg/brain/hermes-api-resilient.ts
+++ b/lib/dsg/brain/hermes-api-resilient.ts
@@ -106,9 +106,21 @@ async function makeApiCall(
 
   if (!response.ok) {
     const errText = await response.text().catch(() => response.statusText);
-    const error = new Error(`API error ${response.status}: ${errText}`);
+
+    // Provide helpful error message for auth failures
+    let errorMessage = `API error ${response.status}`;
+    if (response.status === 401) {
+      errorMessage = 'OpenRouter authentication failed (HTTP 401). Check that OPENROUTER_API_KEY is valid and the account exists.';
+    } else if (response.status === 403) {
+      errorMessage = 'OpenRouter access forbidden (HTTP 403). The API key may lack required permissions.';
+    } else {
+      errorMessage += ': ' + errText;
+    }
+
+    const error = new Error(errorMessage);
     (error as any).statusCode = response.status;
     (error as any).errorText = errText;
+    (error as any).isAuthError = response.status === 401 || response.status === 403;
     throw error;
   }
 
@@ -237,6 +249,15 @@ export async function callHermesAPIResilient(
     totalAttempts: errors.length,
     errors: errors.map((e) => ({ model: e.model, statusCode: e.statusCode, attempt: e.attempt })),
   });
+
+  // Check if this is an auth error — if so, provide clearer message
+  const hasAuthError = errors.some((e) => e.statusCode === 401 || e.statusCode === 403);
+  if (hasAuthError) {
+    throw new Error(
+      'OpenRouter API authentication failed. Ensure OPENROUTER_API_KEY is set correctly and the account is active. ' +
+      `Status: ${lastError?.message || 'unknown'}`,
+    );
+  }
 
   throw new Error(
     `Hermes API exhausted all retries and fallbacks (${errors.length} attempts). ` +

--- a/lib/dsg/brain/openrouter-free-models.ts
+++ b/lib/dsg/brain/openrouter-free-models.ts
@@ -132,8 +132,18 @@ export async function getModelFallbackList(primaryModel: string): Promise<string
 
 /**
  * Parse OpenRouter error to determine if we should retry with fallback.
+ *
+ * Note: 401/403 errors are permanent authentication failures and should not
+ * trigger fallback (all models use the same API key). These should be surfaced
+ * to the user as configuration issues.
  */
 export function shouldFallbackOnError(statusCode: number, errorText: string): boolean {
+  // 401: Unauthorized / Invalid API key — permanent, don't retry
+  if (statusCode === 401) return false;
+
+  // 403: Forbidden / Insufficient permissions — permanent, don't retry
+  if (statusCode === 403) return false;
+
   // 429: Rate limited / quota exceeded
   if (statusCode === 429) return true;
 

--- a/lib/hermes-orchestrator.ts
+++ b/lib/hermes-orchestrator.ts
@@ -67,6 +67,18 @@ async function callOpenRouter(model: string, messages: Array<Record<string, unkn
 
   if (!response.ok) {
     const text = await response.text().catch(() => '');
+
+    // Provide clearer error message for auth failures
+    if (response.status === 401) {
+      throw new Error(
+        'OpenRouter authentication error (HTTP 401): Check that OPENROUTER_API_KEY is valid and the account exists.',
+      );
+    } else if (response.status === 403) {
+      throw new Error(
+        'OpenRouter access forbidden (HTTP 403): The API key may lack required permissions.',
+      );
+    }
+
     throw new Error('OpenRouter ' + response.status + ': ' + text.slice(0, 200));
   }
 


### PR DESCRIPTION
## Summary

Improves OpenRouter API authentication error handling by properly distinguishing permanent auth failures (401/403) from temporary/recoverable errors (429, 404, 503).

## Files Changed

- `lib/dsg/brain/openrouter-free-models.ts` — Updated `shouldFallbackOnError` to explicitly return false for 401/403 errors with documentation
- `lib/dsg/brain/hermes-api-resilient.ts` — Enhanced error messages for auth failures and added auth error detection
- `lib/hermes-orchestrator.ts` — Provide clearer error messages for 401/403 from OpenRouter
- `app/api/setup/test-openrouter/route.ts` — Detailed troubleshooting guidance in error responses
- `app/api/dsg-bridge/codex/route.ts` — Proper formatting for 401/403 errors

## Verification

- [x] TypeScript type checking passes
- [x] No retry attempts wasted on permanent auth failures
- [x] Users receive clear guidance on fixing auth issues
- [x] Error messages guide to https://openrouter.ai/settings/keys for API key verification

## Benefits

- Faster diagnosis of authentication issues
- No unnecessary retry attempts on permanent 401/403 errors
- Consistent error messaging across OpenRouter integration points
- Users can identify and fix auth problems quickly

## Known Limits

- 401/403 errors require user to verify their API key — no automatic recovery possible
- Error messages assume OPENROUTER_API_KEY environment variable is expected to be set

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pcoa89Lzda1UFKEjp6Ys8P)_