### PR TITLE
feat: Add NVIDIA API streaming integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,12 @@ RESEND_API_KEY=
 # ============ OpenRouter (Multi-Model) ============
 OPENROUTER_API_KEY=
 
+# ============ NVIDIA API (Direct Integration) ============
+NVIDIA_API_KEY=
+# Optional model override for Hermes NVIDIA fallback (default: nvidia/llama2-70b)
+# Popular options: nvidia/nemotron-3-8b, nvidia/llama2-70b, nvidia/mistral-large, etc.
+NVIDIA_MODEL_CHAT=
+
 # ============ Z.AI MCP Servers (Vision + Web Reader) ============
 # GLM Coding Plan key from https://z.ai/manage-apikey/apikey-list
 # Shared by the local Vision MCP server (@z_ai/mcp-server) and the remote

--- a/app/api/dashboard/hermes/chat/route.ts
+++ b/app/api/dashboard/hermes/chat/route.ts
@@ -133,7 +133,7 @@ Always be respectful and helpful.`;
   // Fallback to NVIDIA API if available
   const nvidiaKey = process.env.NVIDIA_API_KEY;
   if (nvidiaKey) {
-    const nvidiaModel = process.env.NVIDIA_MODEL_CHAT || 'nvidia/llama2-70b';
+    const nvidiaModel = process.env.NVIDIA_MODEL_CHAT || 'z-ai/glm-5.2';
 
     try {
       const response = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {

--- a/app/api/dashboard/hermes/chat/route.ts
+++ b/app/api/dashboard/hermes/chat/route.ts
@@ -49,42 +49,101 @@ function limitedModeReply(reason: string): string {
     '⚠️ Hermes is running in limited mode — the conversational LLM backend is not available right now.',
     `(${reason})`,
     '',
-    'To enable full conversational replies, configure OPENROUTER_API_KEY for this deployment.',
+    'To enable full conversational replies, configure OPENROUTER_API_KEY or NVIDIA_API_KEY for this deployment.',
   ].join('\n');
 }
 
 async function generateAgentResponse(message: string): Promise<string> {
-  const apiKey = process.env.OPENROUTER_API_KEY;
-
-  if (!apiKey) {
-    return limitedModeReply('LLM not configured');
-  }
-
   const systemPrompt = `You are Hermes, a helpful AI governance agent that helps users understand policies and make decisions.
 You support Thai language responses.
 Keep responses concise but informative.
 Always be respectful and helpful.`;
 
-  // Primary model overridable via env; fallback chain handles upstream 429s.
-  // Note: 'meta-llama/llama-4-maverick:free' was removed — OpenRouter now
-  // 404s it ("this model is unavailable for free"); its own error response
-  // points to the paid slug, which we don't want to silently switch to.
-  const models = [
-    process.env.OPENROUTER_MODEL_CHAT || 'openai/gpt-oss-120b:free',
-    'google/gemma-3-27b-it:free',
-    'deepseek/deepseek-chat-v3-0324:free',
-  ];
+  // Try OpenRouter first if available
+  const openrouterKey = process.env.OPENROUTER_API_KEY;
+  if (openrouterKey) {
+    // Primary model overridable via env; fallback chain handles upstream 429s.
+    // Note: 'meta-llama/llama-4-maverick:free' was removed — OpenRouter now
+    // 404s it ("this model is unavailable for free"); its own error response
+    // points to the paid slug, which we don't want to silently switch to.
+    const models = [
+      process.env.OPENROUTER_MODEL_CHAT || 'openai/gpt-oss-120b:free',
+      'google/gemma-3-27b-it:free',
+      'deepseek/deepseek-chat-v3-0324:free',
+    ];
 
-  for (const model of models) {
+    for (const model of models) {
+      try {
+        const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${openrouterKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              {
+                role: 'system',
+                content: systemPrompt,
+              },
+              {
+                role: 'user',
+                content: message,
+              },
+            ],
+            max_tokens: 500,
+            temperature: 0.7,
+          }),
+        });
+
+        if (response.status === 429) {
+          const detail = await response.text().catch(() => '');
+          console.error(
+            `[api/dashboard/hermes/chat] OpenRouter 429 for model "${model}", trying next: ${detail.slice(0, 200)}`,
+          );
+          continue;
+        }
+
+        if (!response.ok) {
+          const detail = await response.text().catch(() => '');
+          console.error(
+            `[api/dashboard/hermes/chat] OpenRouter ${response.status} for model "${model}": ${detail.slice(0, 300)}`,
+          );
+          // Continue to next model or fallback
+          continue;
+        }
+
+        const data = (await response.json()) as {
+          choices?: Array<{ message?: { content?: string } }>;
+        };
+
+        const content = data.choices?.[0]?.message?.content;
+        if (content) return content;
+      } catch (error) {
+        console.error(
+          `[api/dashboard/hermes/chat] OpenRouter error for model "${model}":`,
+          error,
+        );
+        // Continue to next model or fallback
+      }
+    }
+  }
+
+  // Fallback to NVIDIA API if available
+  const nvidiaKey = process.env.NVIDIA_API_KEY;
+  if (nvidiaKey) {
+    const nvidiaModel = process.env.NVIDIA_MODEL_CHAT || 'nvidia/llama2-70b';
+
     try {
-      const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      const response = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${apiKey}`,
+          'Authorization': `Bearer ${nvidiaKey}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          model,
+          model: nvidiaModel,
           messages: [
             {
               role: 'system',
@@ -97,38 +156,33 @@ Always be respectful and helpful.`;
           ],
           max_tokens: 500,
           temperature: 0.7,
+          top_p: 1,
         }),
       });
 
-      if (response.status === 429) {
+      if (response.ok) {
+        const data = (await response.json()) as {
+          choices?: Array<{ message?: { content?: string } }>;
+        };
+
+        const content = data.choices?.[0]?.message?.content;
+        if (content) return content;
+      } else {
         const detail = await response.text().catch(() => '');
         console.error(
-          `[api/dashboard/hermes/chat] OpenRouter 429 for model "${model}", trying next: ${detail.slice(0, 200)}`,
+          `[api/dashboard/hermes/chat] NVIDIA ${response.status}: ${detail.slice(0, 300)}`,
         );
-        continue;
       }
-
-      if (!response.ok) {
-        const detail = await response.text().catch(() => '');
-        console.error(
-          `[api/dashboard/hermes/chat] OpenRouter ${response.status} for model "${model}": ${detail.slice(0, 300)}`,
-        );
-        return limitedModeReply('LLM upstream error');
-      }
-
-      const data = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
-      };
-
-      const content = data.choices?.[0]?.message?.content;
-      if (content) return content;
-      return limitedModeReply('LLM returned no content');
-    } catch {
-      return limitedModeReply('LLM request failed');
+    } catch (error) {
+      console.error('[api/dashboard/hermes/chat] NVIDIA error:', error);
     }
   }
 
-  return limitedModeReply('LLM upstream error');
+  if (!openrouterKey && !nvidiaKey) {
+    return limitedModeReply('No LLM configured');
+  }
+
+  return limitedModeReply('All LLM backends unavailable');
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/models/nvidia/chat/route.ts
+++ b/app/api/models/nvidia/chat/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+interface NvidiaMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface NvidiaChatRequest {
+  model?: string;
+  messages: NvidiaMessage[];
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  seed?: number;
+  stream?: boolean;
+}
+
+async function callNvidiaAPI(
+  apiKey: string,
+  payload: NvidiaChatRequest,
+  stream: boolean = true,
+): Promise<Response> {
+  const model = payload.model || 'nvidia/llama2-70b';
+
+  const response = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages: payload.messages,
+      temperature: payload.temperature ?? 1,
+      top_p: payload.top_p ?? 1,
+      max_tokens: payload.max_tokens ?? 1024,
+      seed: payload.seed,
+      stream,
+    }),
+  });
+
+  return response;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const apiKey = process.env.NVIDIA_API_KEY;
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'NVIDIA_API_KEY not configured' },
+        { status: 500 },
+      );
+    }
+
+    const body = await request.json() as NvidiaChatRequest;
+    const { messages, model, temperature, top_p, max_tokens, seed, stream = true } = body;
+
+    if (!messages || !Array.isArray(messages)) {
+      return NextResponse.json(
+        { error: 'messages array is required' },
+        { status: 400 },
+      );
+    }
+
+    const response = await callNvidiaAPI(
+      apiKey,
+      {
+        model,
+        messages,
+        temperature,
+        top_p,
+        max_tokens,
+        seed,
+      },
+      stream,
+    );
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error(
+        `[api/models/nvidia/chat] NVIDIA API error ${response.status}:`,
+        errorData.slice(0, 500),
+      );
+      return handleApiError(
+        new Error(`NVIDIA API error: ${response.status}`),
+        response.status,
+      );
+    }
+
+    if (stream && response.body) {
+      return new Response(response.body, {
+        status: response.status,
+        headers: {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache, no-transform',
+          'connection': 'keep-alive',
+        },
+      });
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: {
+        'content-type': response.headers.get('content-type') ?? 'application/json',
+      },
+    });
+  } catch (error) {
+    console.error('[api/models/nvidia/chat] error:', error);
+    return handleApiError(error);
+  }
+}

--- a/app/api/models/nvidia/chat/route.ts
+++ b/app/api/models/nvidia/chat/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { handleApiError } from '@/lib/security/api-error';
+import { readJsonBody } from '@/lib/security/request-json';
 
 export const dynamic = 'force-dynamic';
 
@@ -56,7 +57,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json() as NvidiaChatRequest;
+    const bodyResult = await readJsonBody<NvidiaChatRequest>(request, { maxBytes: 512_000 });
+    if (!bodyResult.ok) {
+      return NextResponse.json(
+        { error: bodyResult.error },
+        { status: bodyResult.status },
+      );
+    }
+
+    const body = bodyResult.value;
+    if (!body) {
+      return NextResponse.json(
+        { error: 'Invalid request body' },
+        { status: 400 },
+      );
+    }
+
     const { messages, model, temperature, top_p, max_tokens, seed, stream = true } = body;
 
     if (!messages || !Array.isArray(messages)) {

--- a/app/api/models/nvidia/chat/route.ts
+++ b/app/api/models/nvidia/chat/route.ts
@@ -23,7 +23,7 @@ async function callNvidiaAPI(
   payload: NvidiaChatRequest,
   stream: boolean = true,
 ): Promise<Response> {
-  const model = payload.model || 'nvidia/llama2-70b';
+  const model = payload.model || 'z-ai/glm-5.2';
 
   const response = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {
     method: 'POST',

--- a/app/api/nvidia/stream/route.ts
+++ b/app/api/nvidia/stream/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const upstreamUrl = new URL('/api/models/nvidia/chat', req.url);
+  const body = await req.text();
+
+  const upstream = await fetch(upstreamUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': req.headers.get('content-type') ?? 'application/json',
+    },
+    body,
+    cache: 'no-store',
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'content-type':
+        upstream.headers.get('content-type') ?? 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Added NVIDIA API streaming support to the control plane with intelligent fallback to OpenRouter providers.

- **POST /api/models/nvidia/chat** — dedicated NVIDIA streaming endpoint
- **POST /api/nvidia/stream** — proxy route for simplified access
- **Hermes fallback** — automatically tries NVIDIA when OpenRouter fails
- Supports OpenAI-compatible chat completion format
- Server-Sent Events (SSE) streaming support

## Files Changed

- `.env.example` — Added NVIDIA_API_KEY and NVIDIA_MODEL_CHAT configuration
- `app/api/models/nvidia/chat/route.ts` — New NVIDIA API streaming route
- `app/api/nvidia/stream/route.ts` — New proxy route
- `app/api/dashboard/hermes/chat/route.ts` — Enhanced with NVIDIA fallback logic

## Verification

- [x] TypeScript compilation passes
- [x] Environment variables documented in `.env.example`
- [x] Request parsing uses `readJsonBody()` for safety per CLAUDE.md section 8
- [x] Fallback chain maintains existing OpenRouter priority
- [x] Streaming response headers properly configured
- [x] Security checks passed (no vulnerabilities, no secrets)

## Test Plan

1. Set `NVIDIA_API_KEY` in environment
2. Try `POST /api/nvidia/stream` with chat messages:
   ```json
   {
     "model": "z-ai/glm-5.2",
     "messages": [{"role": "user", "content": "Hello"}],
     "stream": true
   }
   ```
3. Verify streaming responses work (test not run — requires live NVIDIA API)
4. Test Hermes fallback when OpenRouter is unavailable

## Known Limits

- Direct NVIDIA endpoint used (not through OpenRouter)
- Model selection can be overridden via environment variable
- No built-in rate limiting at this layer (use upstream limits)
- Streaming endpoint not yet live-tested (requires NVIDIA_API_KEY)

## Implementation Notes

- Added to existing Hermes chat route as secondary fallback after OpenRouter
- Proxy route at `/api/nvidia/stream` forwards to `/api/models/nvidia/chat`
- Default model: `z-ai/glm-5.2` (can be overridden via `NVIDIA_MODEL_CHAT` env var)
- Request payload limited to 512KB for safety

🤖 Generated with Claude Code