### PR TITLE
feat: live Ising solver mode (env-configured endpoint, verified fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,3 +206,13 @@ SOLANA_MAX_RETRIES=3
 
 # Optional: Enable Solana integration debugging
 SOLANA_DEBUG=false
+
+# --- DSG ONE Ising live solver (optional) ---
+# Endpoint for a QUBO/Ising solver you run or subscribe to (no public NVIDIA
+# QUBO endpoint exists; cuOpt covers LP/MILP/QP/VRP). Leave unset to use the
+# deterministic mock solver.
+NVIDIA_ISING_API_URL=
+# Optional bearer token for the solver endpoint
+NVIDIA_ISING_API_KEY=
+# Set to "live" to let optimizeWithIsing use the endpoint when useMock is unset
+NVIDIA_ISING_MODE=

--- a/lib/dsg-one/ising-optimizer.ts
+++ b/lib/dsg-one/ising-optimizer.ts
@@ -1,11 +1,28 @@
 /**
- * Ising Optimizer (with Mock Mode for Day 1)
+ * Ising Optimizer (mock mode + live HTTP solver mode)
  *
- * Solves QUBO problems using NVIDIA Ising solver.
- * Day 1: Uses deterministic mock for architecture validation.
- * Phase 2+: Calls real NVIDIA Ising API.
+ * Solves QUBO problems with an Ising-style solver.
  *
- * Determinism: Same QUBO + seed → same solution (greedy mock or NVIDIA both deterministic with seed)
+ * Modes:
+ * - mock (default): deterministic greedy assignment, no network. Used by all
+ *   existing callers and CI.
+ * - live: POSTs the QUBO to an external solver endpoint configured via
+ *   NVIDIA_ISING_API_URL (+ optional NVIDIA_ISING_API_KEY bearer auth).
+ *   There is no hardcoded vendor URL: NVIDIA does not publish a public
+ *   QUBO/Ising REST endpoint (cuOpt covers LP/MILP/QP/VRP), so the endpoint
+ *   must point at a self-hosted or managed solver you actually run.
+ *
+ * Mode selection:
+ * - useMock: true  → mock, always.
+ * - useMock: false → live; throws IsingConfigError when the endpoint is not
+ *   configured, and falls back to the deterministic mock on transient solver
+ *   failures unless fallbackToMock is false.
+ * - useMock unset  → live only when NVIDIA_ISING_MODE=live AND the endpoint
+ *   is configured; otherwise mock (preserves existing default behavior).
+ *
+ * Determinism: energy is always recomputed locally from the QUBO (the remote
+ * solver's reported energy is never trusted for the audit trail), and
+ * proofData hashes are real SHA-256 over the sorted solution entries.
  */
 
 import type { QUBOMatrix } from './qubo-builder';
@@ -22,11 +39,18 @@ export interface IsingOptimizationRequest {
   /** Maximum solve time in milliseconds */
   timeout?: number;
 
-  /** Use mock instead of real NVIDIA API */
+  /** Use mock instead of the live solver endpoint */
   useMock?: boolean;
 
   /** Random seed for reproducible solver behavior (for stochastic solvers) */
   seed?: number;
+
+  /**
+   * When a live solve fails transiently (network/HTTP/shape errors), fall
+   * back to the deterministic mock instead of throwing. Defaults to true.
+   * Configuration errors (missing endpoint) always throw.
+   */
+  fallbackToMock?: boolean;
 }
 
 export interface IsingOptimizationResult {
@@ -45,6 +69,12 @@ export interface IsingOptimizationResult {
   /** Solver version identifier */
   solverVersion: string;
 
+  /** Which path produced this result */
+  mode: 'mock' | 'live' | 'live-fallback-mock';
+
+  /** Present only when mode is 'live-fallback-mock' */
+  fallbackReason?: string;
+
   /** Proof metadata for determinism */
   proofData: {
     quboHash: string;
@@ -53,24 +83,68 @@ export interface IsingOptimizationResult {
   };
 }
 
+/** Thrown when live mode is requested but the endpoint is not configured. */
+export class IsingConfigError extends Error {}
+
+/** Thrown when the live solver call fails and fallback is disabled. */
+export class IsingSolverError extends Error {}
+
+export interface IsingLiveConfig {
+  url: string;
+  apiKey?: string;
+}
+
+/**
+ * Read live-solver configuration from the environment.
+ * Returns null when no endpoint is configured.
+ */
+export function resolveIsingLiveConfig(): IsingLiveConfig | null {
+  const url = process.env.NVIDIA_ISING_API_URL?.trim();
+  if (!url) return null;
+  const apiKey = process.env.NVIDIA_ISING_API_KEY?.trim() || undefined;
+  return { url, apiKey };
+}
+
+function liveModeRequested(req: IsingOptimizationRequest): boolean {
+  if (req.useMock === true) return false;
+  if (req.useMock === false) return true;
+  // Unset: opt-in via env, and only when an endpoint is actually configured.
+  return (
+    process.env.NVIDIA_ISING_MODE === 'live' && resolveIsingLiveConfig() !== null
+  );
+}
+
 /**
  * Solve QUBO problem with Ising optimizer.
- *
- * Day 1: useMock=true returns deterministic greedy assignment
- * Phase 2: Real NVIDIA Ising API call with service credentials
  */
 export async function optimizeWithIsing(
   req: IsingOptimizationRequest,
 ): Promise<IsingOptimizationResult> {
-  const startTime = Date.now();
-
-  if (req.useMock ?? true) {
-    // Day 1: Deterministic mock (no API call)
+  if (!liveModeRequested(req)) {
     return generateMockIsingResult(req.quboMatrix, req.seed);
   }
 
-  // Phase 2+: Real NVIDIA Ising API
-  return callNvidiaIsingAPI(req);
+  const config = resolveIsingLiveConfig();
+  if (!config) {
+    throw new IsingConfigError(
+      'Live Ising solve requested but NVIDIA_ISING_API_URL is not set',
+    );
+  }
+
+  try {
+    return await callLiveIsingSolver(req, config);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    if (req.fallbackToMock === false) {
+      throw new IsingSolverError(`Live Ising solve failed: ${reason}`);
+    }
+    const mockResult = generateMockIsingResult(req.quboMatrix, req.seed);
+    return {
+      ...mockResult,
+      mode: 'live-fallback-mock',
+      fallbackReason: reason,
+    };
+  }
 }
 
 /**
@@ -126,7 +200,7 @@ function generateMockIsingResult(
   const confidence = 0.85;
 
   // Hash for determinism verification
-  const solutionHash = sha256Hash(JSON.stringify(Object.entries(solution).sort()));
+  const solutionHash = hashSolution(solution);
 
   const solveTimeMs = Date.now() - startTime;
 
@@ -136,6 +210,7 @@ function generateMockIsingResult(
     confidence,
     solveTimeMs,
     solverVersion: 'ising-mock-v1',
+    mode: 'mock',
     proofData: {
       quboHash: qubo.problemHash,
       solutionHash,
@@ -145,103 +220,136 @@ function generateMockIsingResult(
 }
 
 /**
- * Real NVIDIA Ising API call (Phase 2+).
- * Not implemented yet; placeholder for integration.
+ * POST the QUBO to the configured live solver endpoint.
+ *
+ * Request body (JSON):
+ *   { problemId, Q, linear, numVariables, timeoutMs, seed }
+ * Expected response body (JSON):
+ *   { solution: number[] | Record<string, 0|1|boolean>, version?, confidence? }
+ *
+ * Energy is always recomputed locally from the QUBO; the remote value is
+ * ignored so the audit trail cannot be skewed by a misbehaving solver.
  */
-async function callNvidiaIsingAPI(
+async function callLiveIsingSolver(
   req: IsingOptimizationRequest,
+  config: IsingLiveConfig,
 ): Promise<IsingOptimizationResult> {
   const startTime = Date.now();
+  const timeoutMs = Math.min(req.timeout ?? 5000, 30000);
 
-  const apiKey = process.env.NVIDIA_ISING_API_KEY;
-  if (!apiKey) {
-    throw new Error('NVIDIA_ISING_API_KEY environment variable not set');
-  }
-
-  // Prepare QUBO payload for NVIDIA API
   const payload = {
+    problemId: req.problemId,
     Q: req.quboMatrix.Q,
     linear: req.quboMatrix.linear,
-    timeout: Math.min(req.timeout ?? 5000, 30000), // Cap at 30s
+    numVariables: req.quboMatrix.numVariables,
+    timeoutMs,
     seed: req.seed,
   };
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
   try {
-    const response = await fetch('https://api.nvidia.com/ising/solve', {
+    response = await fetch(config.url, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
+        ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
       },
       body: JSON.stringify(payload),
+      signal: controller.signal,
     });
-
-    if (!response.ok) {
-      throw new Error(`NVIDIA API error: ${response.statusText}`);
-    }
-
-    const result = await response.json();
-
-    // Parse NVIDIA response and extract solution
-    const solution = normalizeSolution(result.solution, req.quboMatrix);
-    const energy = result.energy ?? calculateQUBOEnergy(req.quboMatrix, solution);
-    const confidence = result.confidence ?? 0.90;
-
-    const solutionHash = sha256Hash(JSON.stringify(Object.entries(solution).sort()));
-
-    return {
-      solution,
-      energy,
-      confidence,
-      solveTimeMs: Date.now() - startTime,
-      solverVersion: `nvidia-ising-${result.version ?? 'unknown'}`,
-      proofData: {
-        quboHash: req.quboMatrix.problemHash,
-        solutionHash,
-        seed: req.seed,
-      },
-    };
   } catch (error) {
-    throw new Error(`Failed to call NVIDIA Ising API: ${error instanceof Error ? error.message : String(error)}`);
+    const reason =
+      controller.signal.aborted
+        ? `solver timed out after ${timeoutMs}ms`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    throw new Error(reason);
+  } finally {
+    clearTimeout(timer);
   }
+
+  if (!response.ok) {
+    throw new Error(`solver HTTP ${response.status}`);
+  }
+
+  const result = (await response.json()) as {
+    solution?: unknown;
+    version?: unknown;
+    confidence?: unknown;
+  };
+
+  const solution = normalizeSolution(result.solution, req.quboMatrix);
+
+  // Determinism boundary: recompute energy locally, never trust remote energy.
+  const energy = calculateQUBOEnergy(req.quboMatrix, solution);
+  const confidence =
+    typeof result.confidence === 'number' &&
+    result.confidence >= 0 &&
+    result.confidence <= 1
+      ? result.confidence
+      : 0.9;
+
+  return {
+    solution,
+    energy,
+    confidence,
+    solveTimeMs: Date.now() - startTime,
+    solverVersion: `ising-live-${typeof result.version === 'string' ? result.version : 'unversioned'}`,
+    mode: 'live',
+    proofData: {
+      quboHash: req.quboMatrix.problemHash,
+      solutionHash: hashSolution(solution),
+      seed: req.seed,
+    },
+  };
 }
 
 /**
- * Normalize solution from NVIDIA API response to our format.
+ * Normalize and validate a solver response solution.
+ * Every QUBO variable must be assigned a binary value; anything else is a
+ * solver contract violation and throws (triggering fallback upstream).
  */
 function normalizeSolution(
-  apiSolution: any,
+  apiSolution: unknown,
   qubo: QUBOMatrix,
-): Record<string, number | boolean> {
-  const solution: Record<string, number | boolean> = {};
+): Record<string, number> {
+  const raw: Record<string, unknown> = {};
 
   if (Array.isArray(apiSolution)) {
-    // Solution as array of binary values
-    for (let i = 0; i < Math.min(apiSolution.length, qubo.variables.length); i++) {
-      solution[qubo.variables[i].id] = apiSolution[i];
+    if (apiSolution.length !== qubo.variables.length) {
+      throw new Error(
+        `solver returned ${apiSolution.length} values for ${qubo.variables.length} variables`,
+      );
     }
-  } else if (typeof apiSolution === 'object') {
-    // Solution as dictionary
-    for (const [key, value] of Object.entries(apiSolution)) {
-      solution[key] = value as number | boolean;
+    for (let i = 0; i < qubo.variables.length; i++) {
+      raw[qubo.variables[i].id] = apiSolution[i];
+    }
+  } else if (apiSolution !== null && typeof apiSolution === 'object') {
+    Object.assign(raw, apiSolution as Record<string, unknown>);
+  } else {
+    throw new Error('solver response has no solution field');
+  }
+
+  const solution: Record<string, number> = {};
+  for (const variable of qubo.variables) {
+    const value = raw[variable.id];
+    if (value === 0 || value === false) {
+      solution[variable.id] = 0;
+    } else if (value === 1 || value === true) {
+      solution[variable.id] = 1;
+    } else {
+      throw new Error(`solver returned non-binary value for variable ${variable.id}`);
     }
   }
 
   return solution;
 }
 
-/**
- * Simple SHA-256 hash implementation fallback.
- * In production, use crypto.subtle.digest or a library.
- */
-function sha256Hash(data: string): string {
-  // Placeholder: return deterministic hash based on content
-  // In production, use: crypto.subtle.digest('SHA-256', new TextEncoder().encode(data))
-  let hash = 0;
-  for (let i = 0; i < data.length; i++) {
-    const char = data.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32-bit integer
-  }
-  return `sha256:${Math.abs(hash).toString(16).padStart(8, '0')}`;
+/** Real SHA-256 over sorted solution entries (hex, same format as problemHash). */
+function hashSolution(solution: Record<string, number | boolean>): string {
+  return sha256Json(Object.entries(solution).sort());
 }

--- a/tests/dsg-one-ising-live.test.ts
+++ b/tests/dsg-one-ising-live.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Live Ising solver mode tests (mocked fetch — no real network).
+ *
+ * Verifies:
+ * 1. Mode selection: mock default, env opt-in, explicit useMock=false
+ * 2. Live call contract: URL, auth header, payload shape
+ * 3. Response normalization + validation (array and object forms)
+ * 4. Local energy recomputation (remote energy is never trusted)
+ * 5. Fallback to deterministic mock on transient failures
+ * 6. IsingConfigError / IsingSolverError behavior
+ * 7. Real SHA-256 proof hashes
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { buildQUBOMatrix, calculateQUBOEnergy } from '@/lib/dsg-one/qubo-builder';
+import {
+  optimizeWithIsing,
+  resolveIsingLiveConfig,
+  IsingConfigError,
+  IsingSolverError,
+} from '@/lib/dsg-one/ising-optimizer';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+
+const tasks: Task[] = [
+  {
+    id: 'task-1',
+    name: 'Payment',
+    domain: 'financial',
+    operation: 'transfer',
+    target: 'acct-1',
+    dataSensitivity: 'high',
+    externalEffect: true,
+    reversibility: 'reversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: true,
+  },
+  {
+    id: 'task-2',
+    name: 'Audit',
+    domain: 'compliance',
+    operation: 'write',
+    target: 'log',
+    dataSensitivity: 'medium',
+    externalEffect: false,
+    reversibility: 'irreversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: false,
+  },
+];
+
+const agents: AgentCapacity[] = [
+  { agentId: 1, maxConcurrentTasks: 2, maxTotalTasks: 2, resourceAvailable: { cpu: 4, memory: 8 } },
+];
+
+async function buildQubo() {
+  const result = await buildQUBOMatrix({ tasks, agentCapacities: agents });
+  return result.qubo;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('Live Ising solver mode', () => {
+  describe('mode selection', () => {
+    it('defaults to mock when useMock is unset and no env opt-in', async () => {
+      const qubo = await buildQubo();
+      const result = await optimizeWithIsing({ problemId: 'p1', quboMatrix: qubo });
+
+      expect(result.mode).toBe('mock');
+      expect(result.solverVersion).toBe('ising-mock-v1');
+    });
+
+    it('stays mock when NVIDIA_ISING_MODE=live but endpoint is not configured', async () => {
+      vi.stubEnv('NVIDIA_ISING_MODE', 'live');
+      const qubo = await buildQubo();
+      const result = await optimizeWithIsing({ problemId: 'p1', quboMatrix: qubo });
+
+      expect(result.mode).toBe('mock');
+    });
+
+    it('uses live solver when NVIDIA_ISING_MODE=live and endpoint configured', async () => {
+      vi.stubEnv('NVIDIA_ISING_MODE', 'live');
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ solution: Array(qubo.numVariables).fill(0), version: 'v9' }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await optimizeWithIsing({ problemId: 'p1', quboMatrix: qubo });
+
+      expect(result.mode).toBe('live');
+      expect(result.solverVersion).toBe('ising-live-v9');
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('useMock=true always wins over env opt-in', async () => {
+      vi.stubEnv('NVIDIA_ISING_MODE', 'live');
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      const qubo = await buildQubo();
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: true,
+      });
+
+      expect(result.mode).toBe('mock');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws IsingConfigError when useMock=false without endpoint', async () => {
+      const qubo = await buildQubo();
+      await expect(
+        optimizeWithIsing({ problemId: 'p1', quboMatrix: qubo, useMock: false }),
+      ).rejects.toBeInstanceOf(IsingConfigError);
+    });
+  });
+
+  describe('live call contract', () => {
+    it('POSTs QUBO payload with bearer auth to the configured URL', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      vi.stubEnv('NVIDIA_ISING_API_KEY', 'test-key-not-real');
+      const qubo = await buildQubo();
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ solution: Array(qubo.numVariables).fill(1) }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await optimizeWithIsing({
+        problemId: 'p-contract',
+        quboMatrix: qubo,
+        useMock: false,
+        seed: 42,
+        timeout: 1234,
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://solver.example.test/solve');
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Bearer test-key-not-real');
+      const body = JSON.parse(init.body);
+      expect(body.problemId).toBe('p-contract');
+      expect(body.numVariables).toBe(qubo.numVariables);
+      expect(body.seed).toBe(42);
+      expect(body.timeoutMs).toBe(1234);
+      expect(body.Q).toEqual(qubo.Q);
+      expect(body.linear).toEqual(qubo.linear);
+    });
+
+    it('omits Authorization header when no API key is set', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ solution: Array(qubo.numVariables).fill(0) }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await optimizeWithIsing({ problemId: 'p1', quboMatrix: qubo, useMock: false });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('response normalization', () => {
+    it('accepts object-form solutions and coerces booleans to 0/1', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      const objectSolution: Record<string, boolean> = {};
+      for (const v of qubo.variables) objectSolution[v.id] = true;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ solution: objectSolution })),
+      );
+
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+
+      for (const v of qubo.variables) {
+        expect(result.solution[v.id]).toBe(1);
+      }
+    });
+
+    it('recomputes energy locally and ignores remote energy', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            solution: Array(qubo.numVariables).fill(0),
+            energy: -999999, // hostile/misreported value must be ignored
+          }),
+        ),
+      );
+
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+
+      const expected = calculateQUBOEnergy(qubo, result.solution);
+      expect(result.energy).toBe(expected);
+      expect(result.energy).not.toBe(-999999);
+    });
+
+    it('produces a real sha256 solution hash (64 hex chars)', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          jsonResponse({ solution: Array(qubo.numVariables).fill(0) }),
+        ),
+      );
+
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+
+      expect(result.proofData.solutionHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  describe('failure handling', () => {
+    it('falls back to deterministic mock on HTTP error by default', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ error: 'boom' }, 503)),
+      );
+
+      const live = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+      const mock = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: true,
+      });
+
+      expect(live.mode).toBe('live-fallback-mock');
+      expect(live.fallbackReason).toContain('503');
+      expect(live.solution).toEqual(mock.solution);
+      expect(live.proofData.solutionHash).toBe(mock.proofData.solutionHash);
+    });
+
+    it('falls back when solver returns wrong variable count', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ solution: [0] })),
+      );
+
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+
+      expect(result.mode).toBe('live-fallback-mock');
+      expect(result.fallbackReason).toContain('variables');
+    });
+
+    it('falls back when solver returns non-binary values', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          jsonResponse({ solution: Array(qubo.numVariables).fill(0.5) }),
+        ),
+      );
+
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+
+      expect(result.mode).toBe('live-fallback-mock');
+      expect(result.fallbackReason).toContain('non-binary');
+    });
+
+    it('throws IsingSolverError when fallbackToMock=false', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ error: 'boom' }, 500)),
+      );
+
+      await expect(
+        optimizeWithIsing({
+          problemId: 'p1',
+          quboMatrix: qubo,
+          useMock: false,
+          fallbackToMock: false,
+        }),
+      ).rejects.toBeInstanceOf(IsingSolverError);
+    });
+
+    it('falls back on network failure', async () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      const qubo = await buildQubo();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockRejectedValue(new TypeError('fetch failed')),
+      );
+
+      const result = await optimizeWithIsing({
+        problemId: 'p1',
+        quboMatrix: qubo,
+        useMock: false,
+      });
+
+      expect(result.mode).toBe('live-fallback-mock');
+      expect(result.fallbackReason).toContain('fetch failed');
+    });
+  });
+
+  describe('config resolution', () => {
+    it('returns null when NVIDIA_ISING_API_URL is unset or blank', () => {
+      expect(resolveIsingLiveConfig()).toBeNull();
+      vi.stubEnv('NVIDIA_ISING_API_URL', '   ');
+      expect(resolveIsingLiveConfig()).toBeNull();
+    });
+
+    it('returns url and optional key when configured', () => {
+      vi.stubEnv('NVIDIA_ISING_API_URL', 'https://solver.example.test/solve');
+      expect(resolveIsingLiveConfig()).toEqual({
+        url: 'https://solver.example.test/solve',
+        apiKey: undefined,
+      });
+
+      vi.stubEnv('NVIDIA_ISING_API_KEY', 'k');
+      expect(resolveIsingLiveConfig()).toEqual({
+        url: 'https://solver.example.test/solve',
+        apiKey: 'k',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Goal:

Implement the Phase 2 "real Ising API" path that PR #865 left as a placeholder. `lib/dsg-one/ising-optimizer.ts` previously had a non-functional live branch: a hardcoded `https://api.nvidia.com/ising/solve` URL (no such public endpoint exists — NVIDIA cuOpt covers LP/MILP/QP/VRP, not QUBO/Ising REST) and a fake 32-bit hash labelled `sha256:`.

Files changed:

- `lib/dsg-one/ising-optimizer.ts` — working live solver path:
  - Endpoint via `NVIDIA_ISING_API_URL` (+ optional `NVIDIA_ISING_API_KEY` bearer auth); no hardcoded vendor URL.
  - Mode selection: `useMock: true` → mock; `useMock: false` → live (throws `IsingConfigError` when unconfigured); unset → live only with `NVIDIA_ISING_MODE=live` AND a configured endpoint, otherwise mock. Existing callers and CI keep current behavior.
  - Hardening: AbortController timeout (capped 30s), response validation (all variables present, binary values only), fallback to the deterministic mock on transient failures with `mode: 'live-fallback-mock'` + `fallbackReason`, or `IsingSolverError` when `fallbackToMock: false`.
  - Determinism boundary: energy always recomputed locally from the QUBO; remote-reported energy is ignored for the audit trail.
  - Real SHA-256 solution hashes (`sha256Json`), replacing the fake hash.
- `tests/dsg-one-ising-live.test.ts` — 17 tests with mocked `fetch` (no real network): mode selection, request contract, normalization (array/object/boolean forms), local energy recomputation, HTTP/network/shape failures, config resolution.
- `.env.example` — documents `NVIDIA_ISING_API_URL`, `NVIDIA_ISING_API_KEY`, `NVIDIA_ISING_MODE` (names only).

Verification:
- [x] `npx vitest run tests/dsg-one-ising-live.test.ts` — 17 passed
- [x] `npx vitest run tests/dsg-one-ising-*.test.ts tests/dsg-one-phase*.test.ts` — 81 passed (existing Ising suites unaffected)
- [x] `npm test` — 3061 passed, 0 failed
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass

Known limits:
- Live mode is proven against a mocked `fetch` only; no real solver endpoint was invoked in this change. Claim boundary: this is "setup-ready" live integration — not "production Ising solver connected" until a real endpoint is configured and a live solve is evidenced.
- The env-configured endpoint must implement the documented request/response contract (`{ solution: number[] | Record<string, 0|1|boolean>, version?, confidence? }`).

User-visible benefit:

Operators can point the DSG Determinism Engine at a real QUBO/Ising solver (self-hosted or managed) with two env vars — with a verified fail-safe: malformed or failing solver responses never corrupt results, they fall back to the deterministic mock and are flagged in the proof metadata.

Next step:

Stand up an actual solver endpoint (e.g. a GPU instance running a QUBO solver), set the env vars in a preview environment, and record a live solve as L2 evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoZpJmEXKkmjzEmaVi8AqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoZpJmEXKkmjzEmaVi8AqW)_