### PR TITLE
feat: self-hosted Ising solver endpoint + live E2E solve evidence (+ QUBO penalty fix)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,3 +216,8 @@ NVIDIA_ISING_API_URL=
 NVIDIA_ISING_API_KEY=
 # Set to "live" to let optimizeWithIsing use the endpoint when useMock is unset
 NVIDIA_ISING_MODE=
+# Bearer key required by the self-hosted solver route /api/dsg-one/ising/solve
+# (route fails closed with 503 when unset). To make a deployment solve for
+# itself, set NVIDIA_ISING_API_URL to <deployment>/api/dsg-one/ising/solve
+# and NVIDIA_ISING_API_KEY to the same value as this key.
+DSG_ISING_SOLVER_KEY=

--- a/app/api/dsg-one/ising/solve/route.ts
+++ b/app/api/dsg-one/ising/solve/route.ts
@@ -1,0 +1,120 @@
+/**
+ * Self-hosted Ising/QUBO solver endpoint.
+ *
+ * POST /api/dsg-one/ising/solve
+ * Implements the request/response contract expected by
+ * lib/dsg-one/ising-optimizer.ts live mode, so a deployment of this app can
+ * serve as its own NVIDIA_ISING_API_URL target (or as a solver for another
+ * deployment) with no extra infrastructure.
+ *
+ * Auth (fail closed): requires Bearer DSG_ISING_SOLVER_KEY. When the env var
+ * is not configured the route returns 503 — never anonymous compute.
+ *
+ * GET /api/dsg-one/ising/solve
+ * Lightweight health/config probe (no solve, no secrets).
+ */
+
+import { NextResponse } from 'next/server';
+import { readJsonBody } from '@/lib/security/request-json';
+import { solveQubo, ISING_SOLVER_VERSION } from '@/lib/dsg-one/ising-solver-core';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_VARIABLES = 256;
+const MAX_BODY_BYTES = 2_000_000; // QUBO matrix upload: 256² numbers fits well below this
+
+type SolveRequestBody = {
+  problemId?: unknown;
+  Q?: unknown;
+  linear?: unknown;
+  numVariables?: unknown;
+  seed?: unknown;
+};
+
+function isFiniteNumberArray(value: unknown, length: number): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length === length &&
+    value.every((v) => typeof v === 'number' && Number.isFinite(v))
+  );
+}
+
+export async function POST(request: Request) {
+  const configuredKey = process.env.DSG_ISING_SOLVER_KEY;
+  if (!configuredKey) {
+    return NextResponse.json(
+      { error: 'solver_not_configured' },
+      { status: 503 },
+    );
+  }
+
+  const authHeader = request.headers.get('authorization') ?? '';
+  if (authHeader !== `Bearer ${configuredKey}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const parsed = await readJsonBody<SolveRequestBody>(request, {
+    maxBytes: MAX_BODY_BYTES,
+  });
+  if (!parsed.ok || parsed.value === null) {
+    return NextResponse.json(
+      { error: parsed.error ?? 'invalid_body' },
+      { status: parsed.status },
+    );
+  }
+
+  const body = parsed.value;
+
+  const n = body.numVariables;
+  if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > MAX_VARIABLES) {
+    return NextResponse.json(
+      { error: `numVariables must be an integer between 1 and ${MAX_VARIABLES}` },
+      { status: 400 },
+    );
+  }
+
+  const Q = body.Q;
+  if (!Array.isArray(Q) || Q.length !== n || !Q.every((row) => isFiniteNumberArray(row, n))) {
+    return NextResponse.json(
+      { error: 'Q must be an n×n matrix of finite numbers' },
+      { status: 400 },
+    );
+  }
+
+  if (!isFiniteNumberArray(body.linear, n)) {
+    return NextResponse.json(
+      { error: 'linear must be a length-n array of finite numbers' },
+      { status: 400 },
+    );
+  }
+
+  const seed =
+    typeof body.seed === 'number' && Number.isFinite(body.seed) ? body.seed : 0;
+
+  const startedAt = Date.now();
+  const result = solveQubo({
+    Q: Q as number[][],
+    linear: body.linear,
+    numVariables: n,
+    seed,
+  });
+
+  return NextResponse.json({
+    solution: result.solution,
+    energy: result.energy,
+    confidence: 0.9,
+    version: result.version,
+    evaluations: result.evaluations,
+    solveTimeMs: Date.now() - startedAt,
+    problemId: typeof body.problemId === 'string' ? body.problemId : undefined,
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    service: 'dsg-ising-solver',
+    version: ISING_SOLVER_VERSION,
+    status: process.env.DSG_ISING_SOLVER_KEY ? 'ready' : 'misconfigured',
+    maxVariables: MAX_VARIABLES,
+  });
+}

--- a/lib/dsg-one/ising-optimizer.ts
+++ b/lib/dsg-one/ising-optimizer.ts
@@ -27,6 +27,7 @@
 
 import type { QUBOMatrix } from './qubo-builder';
 import { calculateQUBOEnergy } from './qubo-builder';
+import { solveQubo } from './ising-solver-core';
 import { sha256Json } from '@/lib/dsg/hermes-e2e/hash';
 
 export interface IsingOptimizationRequest {
@@ -148,8 +149,10 @@ export async function optimizeWithIsing(
 }
 
 /**
- * Mock Ising optimizer for Day 1 validation.
- * Uses greedy assignment: assign each variable to the value that minimizes energy.
+ * Mock Ising optimizer: deterministic local solve, no network.
+ * Delegates to the same solver core the self-hosted endpoint uses
+ * (lib/dsg-one/ising-solver-core), so mock and live results share one
+ * deterministic algorithm and differ only in transport.
  */
 function generateMockIsingResult(
   qubo: QUBOMatrix,
@@ -157,43 +160,20 @@ function generateMockIsingResult(
 ): IsingOptimizationResult {
   const startTime = Date.now();
 
-  // Greedy algorithm: flip each variable to its best value
-  const solution: Record<string, number> = {};
-  const x: number[] = Array(qubo.numVariables).fill(0); // Start with all 0s
-
-  // Variable indices to process (sorted for determinism)
-  const varIndices = Array.from({ length: qubo.numVariables }, (_, i) => i).sort();
-
-  // Simple greedy: for each variable, keep 1 if it reduces energy, else 0
-  for (const idx of varIndices) {
-    // Calculate energy delta if we flip this variable
-    let energyWith1 = 0;
-    let energyWith0 = 0;
-
-    // Energy contribution from this variable with x[idx]=1
-    x[idx] = 1;
-    for (let j = 0; j < qubo.numVariables; j++) {
-      energyWith1 += qubo.Q[idx][j] * x[j];
-      energyWith1 += qubo.Q[j][idx] * x[j];
-      if (j === idx) energyWith1 -= qubo.Q[idx][j]; // Avoid double-counting diagonal
-    }
-    energyWith1 += qubo.linear[idx];
-
-    // Energy contribution with x[idx]=0
-    x[idx] = 0;
-    energyWith0 = 0; // No contribution if 0
-
-    // Keep 1 if it reduces energy, else keep 0
-    x[idx] = energyWith1 <= energyWith0 ? 1 : 0;
-  }
+  const solved = solveQubo({
+    Q: qubo.Q,
+    linear: qubo.linear,
+    numVariables: qubo.numVariables,
+    seed,
+  });
 
   // Build solution dictionary
+  const solution: Record<string, number> = {};
   for (let i = 0; i < qubo.variables.length; i++) {
-    const varName = qubo.variables[i].id;
-    solution[varName] = x[i];
+    solution[qubo.variables[i].id] = solved.solution[i];
   }
 
-  // Calculate actual energy
+  // Calculate actual energy (includes the QUBO constant term)
   const energy = calculateQUBOEnergy(qubo, solution);
 
   // Solution quality is estimated as 0.85 for mock (high but not perfect)

--- a/lib/dsg-one/ising-solver-core.ts
+++ b/lib/dsg-one/ising-solver-core.ts
@@ -1,0 +1,159 @@
+/**
+ * Deterministic QUBO solver core (self-hosted "live" Ising solver).
+ *
+ * Greedy construction + seeded simulated-annealing sweeps + steepest-descent
+ * polish. Minimizes E(x) = x^T Q x + c^T x over binary x.
+ *
+ * Determinism contract: the result is a pure function of (Q, linear, seed).
+ * The iteration budget is derived from problem size only — never from wall
+ * clock — so the same input always yields the same solution and energy.
+ * This is what lets the DSG audit trail replay a live solve bit-for-bit.
+ */
+
+export interface QuboSolveInput {
+  /** Symmetric QUBO matrix (n × n) */
+  Q: number[][];
+  /** Linear coefficients (length n) */
+  linear: number[];
+  /** Number of binary variables */
+  numVariables: number;
+  /** Seed for the annealing PRNG (default 0) */
+  seed?: number;
+}
+
+export interface QuboSolveOutput {
+  /** Binary solution vector (length n, values 0|1) */
+  solution: number[];
+  /** Energy of the solution: x^T Q x + c^T x (no constant term) */
+  energy: number;
+  /** Total variable-flip evaluations performed */
+  evaluations: number;
+  /** Solver identifier */
+  version: string;
+}
+
+export const ISING_SOLVER_VERSION = 'dsg-anneal-v1';
+
+/** mulberry32 — small deterministic PRNG, same stream for the same seed. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Contribution of variable i if set to 1, given the rest of x:
+ * A_i = Q[i][i] + c_i + Σ_{j≠i} (Q[i][j] + Q[j][i]) x_j
+ * Flipping i changes energy by +A_i (0→1) or -A_i (1→0).
+ */
+function contribution(Q: number[][], linear: number[], x: number[], i: number): number {
+  let a = Q[i][i] + linear[i];
+  for (let j = 0; j < x.length; j++) {
+    if (j !== i && x[j] === 1) {
+      a += Q[i][j] + Q[j][i];
+    }
+  }
+  return a;
+}
+
+function totalEnergy(Q: number[][], linear: number[], x: number[]): number {
+  let e = 0;
+  for (let i = 0; i < x.length; i++) {
+    if (x[i] !== 1) continue;
+    e += linear[i];
+    for (let j = 0; j < x.length; j++) {
+      if (x[j] === 1) e += Q[i][j];
+    }
+  }
+  return e;
+}
+
+export function solveQubo(input: QuboSolveInput): QuboSolveOutput {
+  const n = input.numVariables;
+  const { Q, linear } = input;
+  const rand = mulberry32(input.seed ?? 0);
+  let evaluations = 0;
+
+  // 1) Greedy construction: sequential pass, set x_i = 1 when it lowers energy.
+  const x: number[] = Array(n).fill(0);
+  for (let i = 0; i < n; i++) {
+    evaluations++;
+    if (contribution(Q, linear, x, i) < 0) x[i] = 1;
+  }
+
+  let energy = totalEnergy(Q, linear, x);
+  let best = x.slice();
+  let bestEnergy = energy;
+
+  // 2) Seeded annealing sweeps. Budget depends on n only (determinism).
+  const sweeps = Math.min(60, Math.max(12, Math.floor(2400 / Math.max(1, n))));
+  // Initial temperature scaled to the largest absolute coefficient.
+  let maxCoef = 1;
+  for (let i = 0; i < n; i++) {
+    maxCoef = Math.max(maxCoef, Math.abs(linear[i]));
+    for (let j = 0; j < n; j++) maxCoef = Math.max(maxCoef, Math.abs(Q[i][j]));
+  }
+  let temperature = maxCoef;
+  const cooling = 0.85;
+
+  const order = Array.from({ length: n }, (_, i) => i);
+
+  for (let sweep = 0; sweep < sweeps; sweep++) {
+    // Deterministic Fisher–Yates shuffle from the seeded PRNG.
+    for (let i = n - 1; i > 0; i--) {
+      const j = Math.floor(rand() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+
+    for (const i of order) {
+      evaluations++;
+      const a = contribution(Q, linear, x, i);
+      const delta = x[i] === 0 ? a : -a;
+      if (delta < 0 || rand() < Math.exp(-delta / Math.max(temperature, 1e-9))) {
+        x[i] = 1 - x[i];
+        energy += delta;
+        if (energy < bestEnergy) {
+          bestEnergy = energy;
+          best = x.slice();
+        }
+      }
+    }
+
+    temperature *= cooling;
+  }
+
+  // 3) Steepest-descent polish on the best solution until a local optimum.
+  const polished = best.slice();
+  let improved = true;
+  while (improved) {
+    improved = false;
+    let bestDelta = 0;
+    let bestIdx = -1;
+    for (let i = 0; i < n; i++) {
+      evaluations++;
+      const a = contribution(Q, linear, polished, i);
+      const delta = polished[i] === 0 ? a : -a;
+      if (delta < bestDelta) {
+        bestDelta = delta;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx >= 0) {
+      polished[bestIdx] = 1 - polished[bestIdx];
+      bestEnergy += bestDelta;
+      improved = true;
+    }
+  }
+
+  return {
+    solution: polished,
+    energy: totalEnergy(Q, linear, polished),
+    evaluations,
+    version: ISING_SOLVER_VERSION,
+  };
+}

--- a/lib/dsg-one/qubo-builder.ts
+++ b/lib/dsg-one/qubo-builder.ts
@@ -130,12 +130,14 @@ export async function buildQUBOMatrix(req: QUBOBuildRequest): Promise<QUBOBuildR
   // So: (sum_a x[i,a])^2 = sum_a x[i,a] + sum_{a<a'} 2*x[i,a]*x[i,a']
 
   for (let i = 0; i < numTasks; i++) {
-    // Quadratic terms: 2*x[i,a]*x[i,a'] for all pairs a < a'
+    // Quadratic terms: 2λ*x[i,a]*x[i,a'] for all pairs a < a'.
+    // Store λ per off-diagonal cell: the matrix is symmetrized below and
+    // x^T Q x sums both Q[i][j] and Q[j][i], yielding the intended 2λ.
     for (let a = 0; a < numAgents; a++) {
       for (let ap = a + 1; ap < numAgents; ap++) {
         const idx1 = i * numAgents + a;
         const idx2 = i * numAgents + ap;
-        Q[idx1][idx2] += 2 * ASSIGNMENT_PENALTY;
+        Q[idx1][idx2] += ASSIGNMENT_PENALTY;
       }
     }
 
@@ -160,12 +162,14 @@ export async function buildQUBOMatrix(req: QUBOBuildRequest): Promise<QUBOBuildR
   for (let a = 0; a < numAgents; a++) {
     const capacity = agents[a].maxTotalTasks;
 
-    // Quadratic terms: x[i,a]*x[j,a] for i < j
+    // Quadratic terms: 2μ*x[i,a]*x[j,a] for i < j.
+    // Store μ per off-diagonal cell: symmetrization + x^T Q x doubles it
+    // to the intended 2μ (storing 2μ here would silently double penalties).
     for (let i = 0; i < numTasks; i++) {
       for (let j = i + 1; j < numTasks; j++) {
         const idx1 = i * numAgents + a;
         const idx2 = j * numAgents + a;
-        Q[idx1][idx2] += 2 * CAPACITY_PENALTY;
+        Q[idx1][idx2] += CAPACITY_PENALTY;
       }
     }
 

--- a/tests/dsg-one-ising-live-endpoint.test.ts
+++ b/tests/dsg-one-ising-live-endpoint.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Live end-to-end Ising solve over real HTTP (no mocked fetch).
+ *
+ * A real node:http server bridges incoming requests to the actual
+ * /api/dsg-one/ising/solve route handler, and optimizeWithIsing (live mode)
+ * calls it through the network stack. This exercises the full path:
+ *
+ *   optimizeWithIsing → fetch → HTTP → route auth/validation → solveQubo
+ *
+ * plus Z3 verification of the live result. Hermetic: 127.0.0.1 only.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { buildQUBOMatrix, calculateQUBOEnergy, extractAssignmentFromQUBO } from '@/lib/dsg-one/qubo-builder';
+import { optimizeWithIsing } from '@/lib/dsg-one/ising-optimizer';
+import { verifyIsingWithZ3 } from '@/lib/dsg-one/ising-to-z3-verifier';
+import { solveQubo } from '@/lib/dsg-one/ising-solver-core';
+import { POST, GET } from '@/app/api/dsg-one/ising/solve/route';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+
+const SOLVER_KEY = 'test-solver-key-not-a-real-secret';
+
+const tasks: Task[] = [
+  {
+    id: 'task-1',
+    name: 'Payment',
+    domain: 'financial',
+    operation: 'transfer',
+    target: 'acct-1',
+    dataSensitivity: 'high',
+    externalEffect: true,
+    reversibility: 'reversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: true,
+  },
+  {
+    id: 'task-2',
+    name: 'Audit',
+    domain: 'compliance',
+    operation: 'write',
+    target: 'log',
+    dataSensitivity: 'medium',
+    externalEffect: false,
+    reversibility: 'irreversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: false,
+  },
+  {
+    id: 'task-3',
+    name: 'Policy',
+    domain: 'policy',
+    operation: 'update',
+    target: 'policy-engine',
+    dataSensitivity: 'high',
+    externalEffect: true,
+    reversibility: 'reversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: true,
+  },
+];
+
+// Capacities sum to exactly the task count (2 + 1 = 3 tasks) so the fully
+// feasible assignment is the unique QUBO optimum (total penalty 0). With
+// slack capacity the capacity term μ(Σ−cap)² makes some infeasible states
+// tie with feasible ones — that degeneracy is what the Z3 verification
+// layer exists to catch, but for this happy-path E2E we want a problem the
+// solver can provably win.
+const agents: AgentCapacity[] = [
+  { agentId: 1, maxConcurrentTasks: 2, maxTotalTasks: 2, resourceAvailable: { cpu: 4, memory: 8 } },
+  { agentId: 2, maxConcurrentTasks: 2, maxTotalTasks: 1, resourceAvailable: { cpu: 2, memory: 4 } },
+];
+
+/** Bridge a node:http request to the actual Next.js route handler. */
+function startSolverServer(): Promise<{ server: Server; url: string }> {
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', async () => {
+      const body = Buffer.concat(chunks);
+      const request = new Request(`http://127.0.0.1${req.url ?? '/'}`, {
+        method: req.method ?? 'GET',
+        headers: Object.entries(req.headers).flatMap(([k, v]) =>
+          typeof v === 'string' ? [[k, v] as [string, string]] : [],
+        ),
+        body: req.method === 'POST' ? body : undefined,
+      });
+      const response = req.method === 'POST' ? await POST(request) : await GET();
+      res.statusCode = response.status;
+      response.headers.forEach((value, key) => res.setHeader(key, value));
+      res.end(Buffer.from(await response.arrayBuffer()));
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/api/dsg-one/ising/solve` });
+    });
+  });
+}
+
+describe('Live Ising solve over real HTTP', () => {
+  let server: Server;
+  let solverUrl: string;
+
+  beforeAll(async () => {
+    ({ server, url: solverUrl } = await startSolverServer());
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function stubLiveEnv() {
+    vi.stubEnv('DSG_ISING_SOLVER_KEY', SOLVER_KEY);
+    vi.stubEnv('NVIDIA_ISING_API_URL', solverUrl);
+    vi.stubEnv('NVIDIA_ISING_API_KEY', SOLVER_KEY);
+  }
+
+  it('completes a real live solve end-to-end and passes Z3 verification', async () => {
+    stubLiveEnv();
+    const { qubo } = await buildQUBOMatrix({ tasks, agentCapacities: agents });
+
+    const result = await optimizeWithIsing({
+      problemId: 'live-e2e-1',
+      quboMatrix: qubo,
+      useMock: false,
+      fallbackToMock: false, // a real failure must fail the test, not hide in fallback
+      seed: 7,
+    });
+
+    expect(result.mode).toBe('live');
+    expect(result.solverVersion).toBe('ising-live-dsg-anneal-v1');
+    expect(result.proofData.quboHash).toBe(qubo.problemHash);
+    expect(result.proofData.solutionHash).toMatch(/^[a-f0-9]{64}$/);
+
+    // Solution must be a feasible task assignment (each task → exactly 1 agent).
+    const assignment = extractAssignmentFromQUBO(qubo, result.solution);
+    expect(Object.keys(assignment).sort()).toEqual(tasks.map((t) => t.id).sort());
+
+    // Z3-verify the live result, same as the governed pipeline would.
+    const verification = await verifyIsingWithZ3({
+      isingAssignment: result.solution,
+      quboMatrix: qubo,
+      tasks,
+      agentCapacities: agents,
+    });
+    expect(verification.isValid).toBe(true);
+    expect(verification.isSAT).toBe('sat');
+  });
+
+  it('live solve is deterministic: same QUBO + seed → same solution hash', async () => {
+    stubLiveEnv();
+    const { qubo } = await buildQUBOMatrix({ tasks, agentCapacities: agents });
+
+    const r1 = await optimizeWithIsing({
+      problemId: 'live-det',
+      quboMatrix: qubo,
+      useMock: false,
+      fallbackToMock: false,
+      seed: 42,
+    });
+    const r2 = await optimizeWithIsing({
+      problemId: 'live-det',
+      quboMatrix: qubo,
+      useMock: false,
+      fallbackToMock: false,
+      seed: 42,
+    });
+
+    expect(r1.solution).toEqual(r2.solution);
+    expect(r1.energy).toBe(r2.energy);
+    expect(r1.proofData.solutionHash).toBe(r2.proofData.solutionHash);
+  });
+
+  it('live solve energy is never worse than the greedy mock', async () => {
+    stubLiveEnv();
+    const { qubo } = await buildQUBOMatrix({ tasks, agentCapacities: agents });
+
+    const live = await optimizeWithIsing({
+      problemId: 'live-vs-mock',
+      quboMatrix: qubo,
+      useMock: false,
+      fallbackToMock: false,
+      seed: 1,
+    });
+    const mock = await optimizeWithIsing({
+      problemId: 'live-vs-mock',
+      quboMatrix: qubo,
+      useMock: true,
+    });
+
+    expect(live.energy).toBeLessThanOrEqual(mock.energy);
+  });
+
+  it('wrong bearer key falls back to mock (fail-safe) and flags the fallback', async () => {
+    vi.stubEnv('DSG_ISING_SOLVER_KEY', SOLVER_KEY);
+    vi.stubEnv('NVIDIA_ISING_API_URL', solverUrl);
+    vi.stubEnv('NVIDIA_ISING_API_KEY', 'wrong-key');
+    const { qubo } = await buildQUBOMatrix({ tasks, agentCapacities: agents });
+
+    const result = await optimizeWithIsing({
+      problemId: 'live-auth-fail',
+      quboMatrix: qubo,
+      useMock: false,
+    });
+
+    expect(result.mode).toBe('live-fallback-mock');
+    expect(result.fallbackReason).toContain('401');
+  });
+});
+
+describe('/api/dsg-one/ising/solve route handler', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function solveRequest(body: unknown, key?: string): Request {
+    return new Request('http://localhost/api/dsg-one/ising/solve', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(key ? { authorization: `Bearer ${key}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('fails closed with 503 when DSG_ISING_SOLVER_KEY is not configured', async () => {
+    const res = await POST(solveRequest({}, 'any'));
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects missing/wrong bearer token with 401', async () => {
+    vi.stubEnv('DSG_ISING_SOLVER_KEY', SOLVER_KEY);
+    expect((await POST(solveRequest({ numVariables: 1 }))).status).toBe(401);
+    expect((await POST(solveRequest({ numVariables: 1 }, 'wrong'))).status).toBe(401);
+  });
+
+  it('validates numVariables bounds and matrix shape', async () => {
+    vi.stubEnv('DSG_ISING_SOLVER_KEY', SOLVER_KEY);
+
+    expect((await POST(solveRequest({ numVariables: 0 }, SOLVER_KEY))).status).toBe(400);
+    expect((await POST(solveRequest({ numVariables: 257 }, SOLVER_KEY))).status).toBe(400);
+    expect(
+      (
+        await POST(
+          solveRequest({ numVariables: 2, Q: [[0, 0]], linear: [0, 0] }, SOLVER_KEY),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await POST(
+          solveRequest(
+            { numVariables: 2, Q: [[0, 0], [0, 0]], linear: [0, 'x'] },
+            SOLVER_KEY,
+          ),
+        )
+      ).status,
+    ).toBe(400);
+  });
+
+  it('solves a trivial QUBO correctly', async () => {
+    vi.stubEnv('DSG_ISING_SOLVER_KEY', SOLVER_KEY);
+    // E = -2·x0 + 1·x1 → optimum x = [1, 0], energy -2
+    const res = await POST(
+      solveRequest(
+        { numVariables: 2, Q: [[0, 0], [0, 0]], linear: [-2, 1], seed: 3 },
+        SOLVER_KEY,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.solution).toEqual([1, 0]);
+    expect(body.energy).toBe(-2);
+    expect(body.version).toBe('dsg-anneal-v1');
+  });
+
+  it('GET health probe reports ready/misconfigured without secrets', async () => {
+    let res = await GET();
+    let body = await res.json();
+    expect(body.service).toBe('dsg-ising-solver');
+    expect(body.status).toBe('misconfigured');
+
+    vi.stubEnv('DSG_ISING_SOLVER_KEY', SOLVER_KEY);
+    res = await GET();
+    body = await res.json();
+    expect(body.status).toBe('ready');
+    expect(JSON.stringify(body)).not.toContain(SOLVER_KEY);
+  });
+});
+
+describe('ising-solver-core determinism and quality', () => {
+  it('is a pure function of (Q, linear, seed)', () => {
+    const input = {
+      Q: [
+        [2, -1, 0],
+        [-1, 2, -1],
+        [0, -1, 2],
+      ],
+      linear: [-1, -1, -1],
+      numVariables: 3,
+      seed: 99,
+    };
+    const a = solveQubo(input);
+    const b = solveQubo(input);
+    expect(a.solution).toEqual(b.solution);
+    expect(a.energy).toBe(b.energy);
+    expect(a.evaluations).toBe(b.evaluations);
+  });
+
+  it('reaches the optimum on a QUBO the greedy mock solves suboptimally', async () => {
+    // Greedy sequential sets x0=1 first (linear -1), blocking the better
+    // pair {x1, x2}: E(x0)= -1, E(x1,x2) = -3 -3 + 2·2 = -2 with coupling +2·2?
+    // Construct: linear = [-1, -3, -3], Q[1][2]=Q[2][1]=1, Q[0][1]=Q[1][0]=5,
+    // Q[0][2]=Q[2][0]=5 → optimum is x=[0,1,1] with E=-3-3+2=-4.
+    const input = {
+      Q: [
+        [0, 5, 5],
+        [5, 0, 1],
+        [5, 1, 0],
+      ],
+      linear: [-1, -3, -3],
+      numVariables: 3,
+      seed: 0,
+    };
+    const result = solveQubo(input);
+    expect(result.solution).toEqual([0, 1, 1]);
+    expect(result.energy).toBe(-4);
+  });
+
+  it('produces feasible assignments verified against local energy recomputation', async () => {
+    const { qubo } = await buildQUBOMatrix({ tasks, agentCapacities: agents });
+    const result = solveQubo({
+      Q: qubo.Q,
+      linear: qubo.linear,
+      numVariables: qubo.numVariables,
+      seed: 5,
+    });
+
+    const solution: Record<string, number> = {};
+    qubo.variables.forEach((v, i) => {
+      solution[v.id] = result.solution[i];
+    });
+
+    // Core reports energy without the constant term; add it for comparison.
+    expect(result.energy + qubo.constant).toBeCloseTo(
+      calculateQUBOEnergy(qubo, solution),
+      8,
+    );
+  });
+});


### PR DESCRIPTION
Goal:

Make the live Ising path (merged in #866) actually solve end-to-end with zero external infrastructure, and prove it with a real HTTP solve verified by Z3.

Files changed:

- `lib/dsg-one/ising-solver-core.ts` (new) — deterministic QUBO solver: greedy construction + seeded simulated-annealing sweeps + steepest-descent polish. Pure function of `(Q, linear, seed)`: iteration budget derives from problem size only (never wall clock), so live solves replay bit-for-bit for the audit trail.
- `app/api/dsg-one/ising/solve/route.ts` (new) — solver endpoint implementing the ising-optimizer live-mode contract, so a deployment can be its own `NVIDIA_ISING_API_URL` target. Fail-closed auth (503 without `DSG_ISING_SOLVER_KEY`, 401 on wrong bearer, matching the CRON_SECRET convention), `readJsonBody` 2 MB cap, `numVariables ≤ 256`, full matrix shape validation. GET is a secret-free health probe.
- `lib/dsg-one/qubo-builder.ts` (**bug fix**) — off-diagonal penalty cells stored `2λ`/`2μ`, but the matrix is symmetrized and `x^T Q x` sums both triangles, so penalties were silently doubled (4λ effective). Consequence: a fully feasible assignment scored energy 2000 instead of 0 and **tied with infeasible states that drop a task**. Now stores `λ`/`μ` per cell; feasible assignments are the true optimum (energy 0, verified in tests).
- `lib/dsg-one/ising-optimizer.ts` — mock mode now delegates to the same solver core (still local/deterministic/no network) instead of the weaker one-pass greedy; mock and live differ only in transport.
- `tests/dsg-one-ising-live-endpoint.test.ts` (new, 12 tests) — live E2E over a **real node:http server** bridged to the actual route handler (real `fetch`, no mocked transport): `optimizeWithIsing(useMock:false, fallbackToMock:false)` → HTTP → bearer auth → `solveQubo` → response; result passes Z3 verification (`sat`), produces a complete feasible assignment, and yields identical solution hashes across runs. Also: 401 fail-safe fallback flagged in proof metadata, route validation cases, and a solver-core case that finds the optimum the old greedy provably misses.
- `.env.example` — adds `DSG_ISING_SOLVER_KEY` (name only) with self-solve wiring notes.

Verification:
- [x] `npx vitest run` all 8 dsg-one suites — 124 passed (includes live E2E + Z3 SAT verification of the live result)
- [x] `npm test` — 3074 passed, 0 failed
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass, `/api/dsg-one/ising/solve` present in route manifest

Known limits:
- The live E2E uses an in-process HTTP server (real network stack, real handler) — it is not a claim that any production deployment is currently solving live. Production activation requires setting `DSG_ISING_SOLVER_KEY`, `NVIDIA_ISING_API_URL`, `NVIDIA_ISING_API_KEY` (and optionally `NVIDIA_ISING_MODE=live`) in the deployment environment — env changes need explicit approval per repo policy, so they are not part of this PR.
- The capacity penalty remains the documented loose approximation; with slack capacity some infeasible states can still tie with feasible ones — the Z3 verification layer (REVIEW/BLOCK, never PASS) remains the guard.

User-visible benefit:

Live Ising solving now works end-to-end with two env vars and no new infrastructure — the deployed app is its own solver — and the QUBO penalty fix means the optimizer genuinely prefers complete task assignments instead of tying with solutions that silently drop tasks.

Next step:

After merge: set the three env vars in the Vercel deployment (needs your approval), then run a live solve against the production URL and record it as L2 evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoZpJmEXKkmjzEmaVi8AqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoZpJmEXKkmjzEmaVi8AqW)_