### PR TITLE
NVIDIA LLM Advisory Verifier + DSG Policy Gate (Option B architecture)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -221,3 +221,15 @@ NVIDIA_ISING_MODE=
 # itself, set NVIDIA_ISING_API_URL to <deployment>/api/dsg-one/ising/solve
 # and NVIDIA_ISING_API_KEY to the same value as this key.
 DSG_ISING_SOLVER_KEY=
+
+# --- DSG ONE LLM advisory verifier (optional) ---
+# NVIDIA ising-calibration LLM as a SECONDARY analysis layer. The LLM only
+# analyzes/explains deterministic solver results — it never decides validity.
+# Set to "advisory" to enable; leave unset to disable (deterministic-only).
+NVIDIA_LLM_VERIFIER_MODE=
+# API key from build.nvidia.com (falls back to NVIDIA_ISING_API_KEY if unset)
+NVIDIA_API_KEY=
+# Override chat completions endpoint (default: https://integrate.api.nvidia.com/v1/chat/completions)
+NVIDIA_LLM_VERIFIER_URL=
+# Override model id (default: nvidia/ising-calibration-1-35b-a3b)
+NVIDIA_LLM_VERIFIER_MODEL=

--- a/lib/dsg-one/ising-llm-verifier.ts
+++ b/lib/dsg-one/ising-llm-verifier.ts
@@ -1,0 +1,394 @@
+/**
+ * Ising LLM Advisory Verifier (NVIDIA ising-calibration-1-35b-a3b)
+ *
+ * SECONDARY analysis layer for the DSG determinism pipeline. The LLM is an
+ * advisor, never a decision-maker:
+ *
+ *   Problem → Deterministic Solver (Z3/QUBO — source of truth)
+ *           → LLM Verifier (analysis & explanation, THIS module)
+ *           → DSG Policy Gate (compares both; disagreement = flag, not override)
+ *
+ * Hard guarantees:
+ * - The LLM NEVER modifies the solution. Its output is advisory metadata only.
+ * - The deterministic verdict always wins. If the LLM disagrees, the result is
+ *   flagged for human review — never auto-changed.
+ * - This module never throws: any transport/parse failure degrades to verdict
+ *   'unavailable' so the deterministic pipeline is unaffected.
+ * - Prompt and response are SHA-256 hashed into the audit trail so every
+ *   advisory opinion is reconstructible years later.
+ *
+ * Configuration (all optional — module is inert without them):
+ * - NVIDIA_API_KEY (or legacy NVIDIA_ISING_API_KEY): bearer token
+ * - NVIDIA_LLM_VERIFIER_MODE=advisory: explicit opt-in switch
+ * - NVIDIA_LLM_VERIFIER_URL: override endpoint
+ *   (default https://integrate.api.nvidia.com/v1/chat/completions)
+ * - NVIDIA_LLM_VERIFIER_MODEL: override model id
+ *   (default nvidia/ising-calibration-1-35b-a3b)
+ */
+
+import type { QUBOMatrix } from './qubo-builder';
+import type { Z3VerificationResult } from './ising-to-z3-verifier';
+import { sha256Json } from '@/lib/dsg/hermes-e2e/hash';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+
+export const DEFAULT_LLM_VERIFIER_URL =
+  'https://integrate.api.nvidia.com/v1/chat/completions';
+export const DEFAULT_LLM_VERIFIER_MODEL = 'nvidia/ising-calibration-1-35b-a3b';
+
+export interface LLMVerifierConfig {
+  url: string;
+  model: string;
+  apiKey: string;
+}
+
+export interface LLMAnalysisRequest {
+  /** Binary assignment produced by the deterministic solver */
+  solution: Record<string, number | boolean>;
+
+  /** QUBO matrix the solution was solved from */
+  quboMatrix: QUBOMatrix;
+
+  /** Task list (constraint context) */
+  tasks: Task[];
+
+  /** Agent capacities (constraint context) */
+  agentCapacities: AgentCapacity[];
+
+  /** Timeout in milliseconds (default 15000, capped at 30000) */
+  timeout?: number;
+}
+
+export type LLMVerdict =
+  | 'agrees' // LLM found no constraint violations
+  | 'flags_violations' // LLM believes constraints are violated
+  | 'uncertain' // LLM responded but output could not be parsed reliably
+  | 'unavailable'; // Not configured, or transport/HTTP failure
+
+export interface LLMAnalysisResult {
+  verdict: LLMVerdict;
+
+  /** Constraint violations the LLM claims to have found (advisory only) */
+  claimedViolations: string[];
+
+  /** LLM's natural-language explanation of the solution */
+  explanation: string;
+
+  /** Optional improvement suggestions (advisory only, never applied) */
+  suggestions: string[];
+
+  /** Wall-clock analysis time in milliseconds */
+  analysisTimeMs: number;
+
+  /** Model identifier that produced the analysis */
+  model: string;
+
+  /** Audit trail: SHA-256 of the exact prompt sent */
+  promptHash: string;
+
+  /** Audit trail: SHA-256 of the raw response (empty string when unavailable) */
+  responseHash: string;
+
+  /** Present when verdict is 'unavailable' or 'uncertain' */
+  failureReason?: string;
+}
+
+/** DSG gate outcome comparing deterministic verdict with LLM advisory. */
+export interface DSGGateResult {
+  /**
+   * - confirmed: deterministic solver and LLM agree the solution is valid
+   * - flagged_for_review: they disagree — deterministic verdict STANDS, but a
+   *   human should look at it
+   * - deterministic_only: LLM advisory unavailable/uncertain; deterministic
+   *   verdict stands alone
+   * - rejected: the deterministic solver itself said the solution is invalid
+   *   (LLM opinion is irrelevant — invalid is invalid)
+   */
+  status: 'confirmed' | 'flagged_for_review' | 'deterministic_only' | 'rejected';
+
+  /** The verdict that decides the outcome — always the deterministic one */
+  deterministicValid: boolean;
+
+  llmVerdict: LLMVerdict;
+
+  /** Human-readable rationale for the gate decision */
+  rationale: string;
+
+  /** Combined audit hash: deterministic proofHash + LLM promptHash/responseHash */
+  gateProofHash: string;
+}
+
+/** Read verifier configuration from the environment. Null = advisory disabled. */
+export function resolveLLMVerifierConfig(): LLMVerifierConfig | null {
+  if (process.env.NVIDIA_LLM_VERIFIER_MODE !== 'advisory') return null;
+  const apiKey =
+    process.env.NVIDIA_API_KEY?.trim() ||
+    process.env.NVIDIA_ISING_API_KEY?.trim() ||
+    '';
+  if (!apiKey) return null;
+  return {
+    url: process.env.NVIDIA_LLM_VERIFIER_URL?.trim() || DEFAULT_LLM_VERIFIER_URL,
+    model:
+      process.env.NVIDIA_LLM_VERIFIER_MODEL?.trim() || DEFAULT_LLM_VERIFIER_MODEL,
+    apiKey,
+  };
+}
+
+/**
+ * Ask the NVIDIA LLM to analyze a deterministic solver's solution.
+ *
+ * Never throws. Never modifies the solution. Returns advisory metadata only.
+ */
+export async function analyzeSolutionWithLLM(
+  req: LLMAnalysisRequest,
+): Promise<LLMAnalysisResult> {
+  const startTime = Date.now();
+  const config = resolveLLMVerifierConfig();
+
+  const prompt = buildAnalysisPrompt(req);
+  const promptHash = sha256Json(prompt);
+
+  if (!config) {
+    return {
+      verdict: 'unavailable',
+      claimedViolations: [],
+      explanation: '',
+      suggestions: [],
+      analysisTimeMs: Date.now() - startTime,
+      model: 'none',
+      promptHash,
+      responseHash: '',
+      failureReason:
+        'LLM advisory not configured (set NVIDIA_LLM_VERIFIER_MODE=advisory and NVIDIA_API_KEY)',
+    };
+  }
+
+  const timeoutMs = Math.min(req.timeout ?? 15000, 30000);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let rawContent: string;
+  try {
+    const response = await fetch(config.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.apiKey}`,
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        model: config.model,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 4096,
+        // Low temperature: we want stable, analytical output, not creativity.
+        temperature: 0.2,
+        top_p: 1.0,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`LLM HTTP ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      choices?: { message?: { content?: unknown } }[];
+    };
+    const content = body.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || content.length === 0) {
+      throw new Error('LLM response has no message content');
+    }
+    rawContent = content;
+  } catch (error) {
+    const reason = controller.signal.aborted
+      ? `LLM timed out after ${timeoutMs}ms`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    return {
+      verdict: 'unavailable',
+      claimedViolations: [],
+      explanation: '',
+      suggestions: [],
+      analysisTimeMs: Date.now() - startTime,
+      model: config.model,
+      promptHash,
+      responseHash: '',
+      failureReason: reason,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const responseHash = sha256Json(rawContent);
+  const parsed = parseAnalysisResponse(rawContent);
+
+  return {
+    ...parsed,
+    analysisTimeMs: Date.now() - startTime,
+    model: config.model,
+    promptHash,
+    responseHash,
+  };
+}
+
+/**
+ * DSG Policy Gate: combine the deterministic verdict with the LLM advisory.
+ *
+ * The deterministic result ALWAYS decides validity. The LLM can only cause a
+ * review flag — it can never flip an invalid solution to valid or vice versa.
+ */
+export function gateWithDSG(
+  deterministic: Z3VerificationResult,
+  llm: LLMAnalysisResult,
+): DSGGateResult {
+  const gateProofHash = sha256Json({
+    deterministicProofHash: deterministic.proofHash,
+    llmPromptHash: llm.promptHash,
+    llmResponseHash: llm.responseHash,
+    llmVerdict: llm.verdict,
+  });
+
+  if (!deterministic.isValid) {
+    return {
+      status: 'rejected',
+      deterministicValid: false,
+      llmVerdict: llm.verdict,
+      rationale:
+        'Deterministic solver rejected the solution (UNSAT). LLM advisory cannot override a formal rejection.',
+      gateProofHash,
+    };
+  }
+
+  if (llm.verdict === 'agrees') {
+    return {
+      status: 'confirmed',
+      deterministicValid: true,
+      llmVerdict: llm.verdict,
+      rationale:
+        'Deterministic solver verified the solution and LLM advisory found no violations.',
+      gateProofHash,
+    };
+  }
+
+  if (llm.verdict === 'flags_violations') {
+    return {
+      status: 'flagged_for_review',
+      deterministicValid: true,
+      llmVerdict: llm.verdict,
+      rationale:
+        `Deterministic solver verified the solution but LLM advisory claims violations: ` +
+        `${llm.claimedViolations.join('; ') || '(unspecified)'}. ` +
+        'Deterministic verdict stands; human review recommended.',
+      gateProofHash,
+    };
+  }
+
+  return {
+    status: 'deterministic_only',
+    deterministicValid: true,
+    llmVerdict: llm.verdict,
+    rationale:
+      llm.verdict === 'unavailable'
+        ? `LLM advisory unavailable (${llm.failureReason ?? 'not configured'}); deterministic verdict stands alone.`
+        : 'LLM advisory response could not be parsed reliably; deterministic verdict stands alone.',
+    gateProofHash,
+  };
+}
+
+/** Build the analysis prompt. Kept deterministic: sorted keys, no timestamps. */
+export function buildAnalysisPrompt(req: LLMAnalysisRequest): string {
+  const assignments = Object.entries(req.solution)
+    .map(([k, v]) => [k, Number(v)] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  const taskLines = req.tasks
+    .map((t) => `- ${t.id}`)
+    .sort()
+    .join('\n');
+  const agentLines = req.agentCapacities
+    .map((a) => `- agent ${a.agentId}: maxTotalTasks=${a.maxTotalTasks}`)
+    .sort()
+    .join('\n');
+  const assignmentLines = assignments
+    .map(([k, v]) => `- ${k} = ${v}`)
+    .join('\n');
+
+  return [
+    'You are a constraint-verification analyst. A deterministic solver produced a',
+    'binary assignment for a task-assignment QUBO problem. Analyze it. Do NOT',
+    'propose a different assignment — only verify and explain this one.',
+    '',
+    'Constraints:',
+    '1. Every task must be assigned to exactly one agent.',
+    '2. No agent may exceed its maxTotalTasks capacity.',
+    '',
+    'Tasks:',
+    taskLines,
+    '',
+    'Agents:',
+    agentLines,
+    '',
+    'Assignment variables (1 = assigned, 0 = not assigned):',
+    assignmentLines,
+    '',
+    'Respond with ONLY a JSON object, no other text:',
+    '{',
+    '  "violations": ["<constraint violated and why>", ...] (empty array if none),',
+    '  "explanation": "<2-3 sentence analysis of the assignment>",',
+    '  "suggestions": ["<optional improvement>", ...] (empty array if none)',
+    '}',
+  ].join('\n');
+}
+
+/** Parse the LLM's JSON reply; malformed output degrades to 'uncertain'. */
+function parseAnalysisResponse(
+  raw: string,
+): Pick<
+  LLMAnalysisResult,
+  'verdict' | 'claimedViolations' | 'explanation' | 'suggestions' | 'failureReason'
+> {
+  // Models often wrap JSON in prose or code fences; extract the first object.
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    return {
+      verdict: 'uncertain',
+      claimedViolations: [],
+      explanation: raw.slice(0, 500),
+      suggestions: [],
+      failureReason: 'no JSON object found in LLM response',
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(jsonMatch[0]) as {
+      violations?: unknown;
+      explanation?: unknown;
+      suggestions?: unknown;
+    };
+
+    const violations = Array.isArray(parsed.violations)
+      ? parsed.violations.filter((v): v is string => typeof v === 'string')
+      : [];
+    const suggestions = Array.isArray(parsed.suggestions)
+      ? parsed.suggestions.filter((s): s is string => typeof s === 'string')
+      : [];
+    const explanation =
+      typeof parsed.explanation === 'string' ? parsed.explanation : '';
+
+    return {
+      verdict: violations.length > 0 ? 'flags_violations' : 'agrees',
+      claimedViolations: violations,
+      explanation,
+      suggestions,
+    };
+  } catch {
+    return {
+      verdict: 'uncertain',
+      claimedViolations: [],
+      explanation: raw.slice(0, 500),
+      suggestions: [],
+      failureReason: 'LLM response JSON failed to parse',
+    };
+  }
+}

--- a/tests/dsg-one-ising-llm-verifier.test.ts
+++ b/tests/dsg-one-ising-llm-verifier.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests: Ising LLM Advisory Verifier + DSG Policy Gate
+ *
+ * Verifies the Option-B architecture invariants:
+ * - LLM is advisory only: it never changes the solution or the verdict
+ * - Deterministic solver verdict always decides validity
+ * - Disagreement produces a review flag, never an auto-override
+ * - Transport/parse failures degrade gracefully (never throw)
+ * - All network calls are mocked — no real API usage in CI
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  analyzeSolutionWithLLM,
+  buildAnalysisPrompt,
+  gateWithDSG,
+  resolveLLMVerifierConfig,
+  DEFAULT_LLM_VERIFIER_MODEL,
+  type LLMAnalysisRequest,
+  type LLMAnalysisResult,
+} from '../lib/dsg-one/ising-llm-verifier';
+import type { Z3VerificationResult } from '../lib/dsg-one/ising-to-z3-verifier';
+import { buildQUBOMatrix } from '../lib/dsg-one/qubo-builder';
+import type { Task, AgentCapacity } from '../lib/dsg/multi-agent/types';
+
+const tasks: Task[] = [
+  {
+    id: 'task-1',
+    name: 'Payment',
+    domain: 'financial',
+    operation: 'transfer',
+    target: 'acct-1',
+    dataSensitivity: 'high',
+    externalEffect: true,
+    reversibility: 'reversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: true,
+  },
+  {
+    id: 'task-2',
+    name: 'Audit',
+    domain: 'compliance',
+    operation: 'write',
+    target: 'log',
+    dataSensitivity: 'medium',
+    externalEffect: false,
+    reversibility: 'irreversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: false,
+  },
+] as Task[];
+
+const agents: AgentCapacity[] = [
+  { agentId: 1, maxConcurrentTasks: 2, maxTotalTasks: 2, resourceAvailable: { cpu: 4, memory: 8 } },
+  { agentId: 2, maxConcurrentTasks: 2, maxTotalTasks: 1, resourceAvailable: { cpu: 2, memory: 4 } },
+] as AgentCapacity[];
+
+async function makeRequest(): Promise<LLMAnalysisRequest> {
+  const { qubo: quboMatrix } = await buildQUBOMatrix({
+    tasks,
+    agentCapacities: agents,
+  });
+  const solution: Record<string, number> = {};
+  for (const v of quboMatrix.variables) solution[v.id] = 0;
+  // Assign task-1 → agent 1, task-2 → agent 2
+  const v1 = quboMatrix.variables.find(
+    (v) => v.taskId === 'task-1' && v.agentId === 1,
+  );
+  const v2 = quboMatrix.variables.find(
+    (v) => v.taskId === 'task-2' && v.agentId === 2,
+  );
+  if (v1) solution[v1.id] = 1;
+  if (v2) solution[v2.id] = 1;
+  return { solution, quboMatrix, tasks, agentCapacities: agents };
+}
+
+function llmChatResponse(content: string) {
+  return {
+    ok: true,
+    json: async () => ({ choices: [{ message: { content } }] }),
+  } as Response;
+}
+
+const validDeterministic: Z3VerificationResult = {
+  isSAT: 'sat',
+  isValid: true,
+  verifyTimeMs: 5,
+  proof: 'SAT: verified',
+  proofHash: 'proof-hash-sat',
+  z3Version: 'z3-solver-wasm',
+};
+
+const invalidDeterministic: Z3VerificationResult = {
+  isSAT: 'unsat',
+  isValid: false,
+  verifyTimeMs: 5,
+  proof: 'UNSAT: violated',
+  proofHash: 'proof-hash-unsat',
+  violatedConstraints: ['task_task-1_count == 1 (got 0)'],
+  z3Version: 'z3-solver-wasm',
+};
+
+describe('resolveLLMVerifierConfig', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns null when advisory mode is not enabled', () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', '');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    expect(resolveLLMVerifierConfig()).toBeNull();
+  });
+
+  it('returns null when no API key is present', () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', '');
+    vi.stubEnv('NVIDIA_ISING_API_KEY', '');
+    expect(resolveLLMVerifierConfig()).toBeNull();
+  });
+
+  it('resolves defaults when enabled with a key', () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    const config = resolveLLMVerifierConfig();
+    expect(config?.model).toBe(DEFAULT_LLM_VERIFIER_MODEL);
+    expect(config?.url).toContain('integrate.api.nvidia.com');
+  });
+
+  it('falls back to legacy NVIDIA_ISING_API_KEY', () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', '');
+    vi.stubEnv('NVIDIA_ISING_API_KEY', 'nvapi-legacy');
+    expect(resolveLLMVerifierConfig()?.apiKey).toBe('nvapi-legacy');
+  });
+});
+
+describe('analyzeSolutionWithLLM', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns unavailable (and does not call fetch) when not configured', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await analyzeSolutionWithLLM(await makeRequest());
+
+    expect(result.verdict).toBe('unavailable');
+    expect(result.failureReason).toContain('not configured');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.promptHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.responseHash).toBe('');
+  });
+
+  it('returns agrees when LLM reports no violations', async () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        llmChatResponse(
+          JSON.stringify({
+            violations: [],
+            explanation: 'Each task is assigned to exactly one agent within capacity.',
+            suggestions: [],
+          }),
+        ),
+      ),
+    );
+
+    const result = await analyzeSolutionWithLLM(await makeRequest());
+
+    expect(result.verdict).toBe('agrees');
+    expect(result.claimedViolations).toEqual([]);
+    expect(result.explanation).toContain('exactly one agent');
+    expect(result.model).toBe(DEFAULT_LLM_VERIFIER_MODEL);
+    expect(result.responseHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns flags_violations when LLM claims violations', async () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        llmChatResponse(
+          'Analysis follows:\n' +
+            JSON.stringify({
+              violations: ['agent 2 exceeds maxTotalTasks'],
+              explanation: 'Capacity issue detected.',
+              suggestions: ['reassign task-2 to agent 1'],
+            }),
+        ),
+      ),
+    );
+
+    const result = await analyzeSolutionWithLLM(await makeRequest());
+
+    expect(result.verdict).toBe('flags_violations');
+    expect(result.claimedViolations).toEqual(['agent 2 exceeds maxTotalTasks']);
+    expect(result.suggestions).toEqual(['reassign task-2 to agent 1']);
+  });
+
+  it('degrades to uncertain on unparseable LLM output', async () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(llmChatResponse('The assignment looks fine to me!')),
+    );
+
+    const result = await analyzeSolutionWithLLM(await makeRequest());
+
+    expect(result.verdict).toBe('uncertain');
+    expect(result.failureReason).toContain('no JSON object');
+  });
+
+  it('degrades to unavailable on HTTP error without throwing', async () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 429 } as Response),
+    );
+
+    const result = await analyzeSolutionWithLLM(await makeRequest());
+
+    expect(result.verdict).toBe('unavailable');
+    expect(result.failureReason).toContain('429');
+  });
+
+  it('degrades to unavailable on network failure without throwing', async () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const result = await analyzeSolutionWithLLM(await makeRequest());
+
+    expect(result.verdict).toBe('unavailable');
+    expect(result.failureReason).toContain('ECONNREFUSED');
+  });
+
+  it('never mutates the input solution', async () => {
+    vi.stubEnv('NVIDIA_LLM_VERIFIER_MODE', 'advisory');
+    vi.stubEnv('NVIDIA_API_KEY', 'nvapi-test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        llmChatResponse(
+          JSON.stringify({
+            violations: ['bogus claim'],
+            explanation: 'x',
+            suggestions: ['flip variable v0 to 1'],
+          }),
+        ),
+      ),
+    );
+
+    const req = await makeRequest();
+    const snapshot = JSON.stringify(req.solution);
+    await analyzeSolutionWithLLM(req);
+
+    expect(JSON.stringify(req.solution)).toBe(snapshot);
+  });
+
+  it('produces a deterministic prompt for identical input', async () => {
+    const p1 = buildAnalysisPrompt(await makeRequest());
+    const p2 = buildAnalysisPrompt(await makeRequest());
+    expect(p1).toBe(p2);
+    expect(p1).toContain('Do NOT');
+  });
+});
+
+describe('gateWithDSG (DSG Policy Gate)', () => {
+  const llmAgrees: LLMAnalysisResult = {
+    verdict: 'agrees',
+    claimedViolations: [],
+    explanation: 'ok',
+    suggestions: [],
+    analysisTimeMs: 10,
+    model: DEFAULT_LLM_VERIFIER_MODEL,
+    promptHash: 'p'.repeat(64),
+    responseHash: 'r'.repeat(64),
+  };
+
+  it('confirms when deterministic solver and LLM both approve', () => {
+    const gate = gateWithDSG(validDeterministic, llmAgrees);
+    expect(gate.status).toBe('confirmed');
+    expect(gate.deterministicValid).toBe(true);
+    expect(gate.gateProofHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('flags for review on disagreement — deterministic verdict stands', () => {
+    const gate = gateWithDSG(validDeterministic, {
+      ...llmAgrees,
+      verdict: 'flags_violations',
+      claimedViolations: ['claimed capacity violation'],
+    });
+    expect(gate.status).toBe('flagged_for_review');
+    // The LLM does NOT flip validity:
+    expect(gate.deterministicValid).toBe(true);
+    expect(gate.rationale).toContain('Deterministic verdict stands');
+  });
+
+  it('rejects when deterministic solver says UNSAT, regardless of LLM opinion', () => {
+    const gate = gateWithDSG(invalidDeterministic, llmAgrees);
+    expect(gate.status).toBe('rejected');
+    expect(gate.deterministicValid).toBe(false);
+    expect(gate.rationale).toContain('cannot override');
+  });
+
+  it('falls back to deterministic_only when LLM is unavailable', () => {
+    const gate = gateWithDSG(validDeterministic, {
+      ...llmAgrees,
+      verdict: 'unavailable',
+      responseHash: '',
+      failureReason: 'not configured',
+    });
+    expect(gate.status).toBe('deterministic_only');
+    expect(gate.deterministicValid).toBe(true);
+  });
+
+  it('falls back to deterministic_only when LLM output is uncertain', () => {
+    const gate = gateWithDSG(validDeterministic, {
+      ...llmAgrees,
+      verdict: 'uncertain',
+      failureReason: 'parse error',
+    });
+    expect(gate.status).toBe('deterministic_only');
+  });
+
+  it('produces a stable gate proof hash for identical inputs', () => {
+    const g1 = gateWithDSG(validDeterministic, llmAgrees);
+    const g2 = gateWithDSG(validDeterministic, llmAgrees);
+    expect(g1.gateProofHash).toBe(g2.gateProofHash);
+  });
+});


### PR DESCRIPTION
## Summary

Integrates NVIDIA `ising-calibration-1-35b-a3b` (via `integrate.api.nvidia.com` chat completions) as a **SECONDARY advisory analysis layer** for the DSG determinism pipeline — Option B architecture: the LLM analyzes and explains, the deterministic solver decides.

```
Problem
   │
   ▼
Deterministic Solver (Z3 / QUBO)  ← source of truth
   │
   ▼
LLM Verifier (analysis & explanation only)   ← NEW: lib/dsg-one/ising-llm-verifier.ts
   │
   ▼
DSG Policy Gate (compare; disagreement = review flag, never override)
   │
   ▼
Final Approved Result
```

## What's new

**`lib/dsg-one/ising-llm-verifier.ts`** (~380 LOC)
- `analyzeSolutionWithLLM()`: sends the deterministic solver's solution + constraints to the NVIDIA LLM, parses a structured JSON verdict (`agrees` / `flags_violations` / `uncertain` / `unavailable`)
- `gateWithDSG()`: DSG policy gate combining the deterministic verdict with the LLM advisory → `confirmed` / `flagged_for_review` / `deterministic_only` / `rejected`
- `resolveLLMVerifierConfig()`: opt-in config from env; module is completely inert when unset

## Hard invariants (enforced by tests)

- The LLM **never modifies the solution** and **never flips the verdict**
- Deterministic verdict always decides validity; LLM disagreement only raises `flagged_for_review`
- A deterministic UNSAT is `rejected` regardless of LLM opinion ("cannot override a formal rejection")
- Any transport/parse failure degrades gracefully (`unavailable`/`uncertain`) — never throws, never blocks the pipeline
- Prompt + response SHA-256 hashed into `gateProofHash` for multi-year audit reconstruction
- Prompt is deterministic (sorted keys, no timestamps) → same input, same promptHash

## Configuration (all optional)

| Variable | Purpose |
|---|---|
| `NVIDIA_LLM_VERIFIER_MODE=advisory` | Explicit opt-in switch |
| `NVIDIA_API_KEY` | Bearer token from build.nvidia.com (falls back to `NVIDIA_ISING_API_KEY`) |
| `NVIDIA_LLM_VERIFIER_URL` | Endpoint override (default: integrate.api.nvidia.com chat completions) |
| `NVIDIA_LLM_VERIFIER_MODEL` | Model override (default: `nvidia/ising-calibration-1-35b-a3b`) |

Unset = advisory disabled = deterministic-only pipeline, zero network calls. CI needs no credentials.

## Validation

- 18 new tests in `tests/dsg-one-ising-llm-verifier.test.ts` — all network mocked, CI-safe
- Full suite: **3092 passed, 0 failed** (79 skipped = opt-in live suites)
- Typecheck: ✅ pass

## Future path (Option C hybrid)

This module is the middle piece of the long-term hybrid: LLM generates/refines constraints → deterministic solver solves → LLM verifies/explains (this PR) → DSG gates. Constraint-generation is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mqMSGUHW8NGhmDWPVRAei

---
_Generated by [Claude Code](https://claude.ai/code/session_016mqMSGUHW8NGhmDWPVRAei)_