### PR TITLE
fix(ci): make verify-deploy pass — drop broken CLI deploy, add z3-gate-verify

### DIFF
--- a/.github/workflows/dsg-deploy.yml
+++ b/.github/workflows/dsg-deploy.yml
@@ -98,9 +98,13 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=high
 
-  # 6. Build & Deploy to Vercel
-  deploy-vercel:
-    name: Deploy to Vercel
+  # 6. Post-Deploy Verification
+  # Production deploy is performed by the Vercel Git integration on push to main,
+  # so this workflow no longer shells out to the Vercel CLI. This job verifies the
+  # live production deploy once the gates pass. z3-gate-verify.ts retries the
+  # health/status probes so a just-finished deploy has time to become reachable.
+  verify-deploy:
+    name: Verify Production Deploy
     runs-on: ubuntu-latest
     needs: [typecheck, test-unit, test-integration, test-agent-os, z3-gate, security]
     if: github.ref == 'refs/heads/main'
@@ -109,31 +113,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install Vercel CLI
-        run: npm install -g vercel
-      - name: Deploy to Vercel
-        run: |
-          vercel deploy \
-            --token ${{ secrets.VERCEL_TOKEN }} \
-            --org-id ${{ secrets.VERCEL_ORG_ID }} \
-            --project-id ${{ secrets.VERCEL_PROJECT_ID }} \
-            --prod
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-  # 7. Post-Deploy Verification
-  verify-deploy:
-    name: Verify Production Deploy
-    runs-on: ubuntu-latest
-    needs: deploy-vercel
-    steps:
-      - uses: actions/checkout@v4
-      - name: Wait for deploy
-        run: sleep 30
-      - name: Health check
-        run: |
-          curl -f https://tdealer01-crypto-dsg-control-plane.vercel.app/api/health || exit 1
-      - name: Run Z3 Gate on production
+          cache: 'npm'
+      - run: npm ci
+      - name: Verify production deploy (health + status + deterministic gate)
         run: |
           npx tsx scripts/z3-gate-verify.ts --env=production
         env:

--- a/scripts/z3-gate-verify.ts
+++ b/scripts/z3-gate-verify.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/z3-gate-verify.ts — post-deploy production verification.
+ *
+ * Referenced by .github/workflows/dsg-deploy.yml (job "Verify Production Deploy").
+ * Runs after the production deploy (performed by the Vercel Git integration) and
+ * confirms the live control plane is healthy AND that the deterministic gate
+ * invariants still hold on the deployed code.
+ *
+ * Two layers:
+ *   1. Live production probes — GET /api/health and /api/agent/status on the
+ *      target base URL, with retries so a just-finished deploy has time to
+ *      become reachable. Asserts health 200, ok=true, and (for --env=production)
+ *      env === "production".
+ *   2. Deterministic gate invariants — exercises lib/dsg/deterministic to assert
+ *      the PASS/BLOCK/REVIEW mapping, UNSUPPORTED-is-never-PASS, and determinism.
+ *
+ * Usage:
+ *   npx tsx scripts/z3-gate-verify.ts --env=production
+ *   npx tsx scripts/z3-gate-verify.ts --url=https://example.vercel.app
+ *
+ * Claim boundary (CLAUDE.md §12): no external production Z3 solver is assumed.
+ * Exits non-zero on any failed check and writes artifacts/z3-gate/verify-result.json.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { evaluateDeterministicGate, proofToGateStatus } from '../lib/dsg/deterministic/gate-engine';
+import { proveDeterministicPlan } from '../lib/dsg/deterministic/proof-engine';
+import { getDeterministicPolicyManifest } from '../lib/dsg/deterministic/policy-manifest';
+import type { DeterministicProofRequest } from '../lib/dsg/deterministic/types';
+
+type CheckResult = { name: string; ok: boolean; detail: string };
+
+const results: CheckResult[] = [];
+const record = (name: string, ok: boolean, detail: string) => results.push({ name, ok, detail });
+
+const DEFAULT_PRODUCTION_URL = 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
+
+function parseArgs(argv: string[]): { env: string; baseUrl: string } {
+  let env = 'production';
+  let url = '';
+  for (const arg of argv) {
+    if (arg.startsWith('--env=')) env = arg.slice('--env='.length);
+    else if (arg.startsWith('--url=')) url = arg.slice('--url='.length);
+  }
+  const baseUrl = (url || process.env.DSG_CONTROL_PLANE_BASE_URL || DEFAULT_PRODUCTION_URL).replace(/\/+$/, '');
+  return { env, baseUrl };
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Fetch with a few retries so a just-completed deploy has time to become reachable. */
+async function fetchWithRetry(url: string, attempts = 5, delayMs = 6000): Promise<Response | null> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, { headers: { 'user-agent': 'dsg-z3-gate-verify' } });
+      if (res.ok) return res;
+      if (i < attempts - 1) await sleep(delayMs);
+    } catch {
+      if (i < attempts - 1) await sleep(delayMs);
+    }
+  }
+  return null;
+}
+
+const manifest = getDeterministicPolicyManifest();
+
+function requestWith(overrides: { false?: string[]; nonceSuffix?: string; riskLevel?: DeterministicProofRequest['riskLevel'] }): DeterministicProofRequest {
+  const falseKeys = new Set(overrides.false ?? []);
+  const context: Record<string, unknown> = {};
+  for (const constraint of manifest.constraints) context[constraint.evidenceKey] = !falseKeys.has(constraint.evidenceKey);
+  const suffix = overrides.nonceSuffix ?? 'base';
+  return {
+    planId: `z3-gate-verify-${suffix}`,
+    riskLevel: overrides.riskLevel ?? 'high',
+    nonce: `z3-gate-verify-nonce-${suffix}`,
+    idempotencyKey: `z3-gate-verify-idem-${suffix}`,
+    context,
+  };
+}
+
+async function verifyLiveProduction(env: string, baseUrl: string): Promise<void> {
+  // Health probe.
+  const healthUrl = `${baseUrl}/api/health`;
+  const health = await fetchWithRetry(healthUrl);
+  record('production /api/health reachable (200)', Boolean(health), health ? `HTTP ${health.status} ${healthUrl}` : `unreachable ${healthUrl}`);
+
+  // Identity / status probe.
+  const statusUrl = `${baseUrl}/api/agent/status`;
+  const statusRes = await fetchWithRetry(statusUrl);
+  if (!statusRes) {
+    record('production /api/agent/status reachable', false, `unreachable ${statusUrl}`);
+    return;
+  }
+  let status: { ok?: boolean; env?: string; commit?: string; checks?: { db?: boolean } } = {};
+  try {
+    status = (await statusRes.json()) as typeof status;
+  } catch {
+    record('production /api/agent/status JSON', false, 'invalid JSON');
+    return;
+  }
+  record('production status ok=true', status.ok === true, `ok=${status.ok} commit=${(status.commit ?? '').slice(0, 8)}`);
+  if (env === 'production') {
+    record('production env === "production"', status.env === 'production', `env=${status.env}`);
+  }
+}
+
+async function verifyDeterministicInvariants(): Promise<void> {
+  const passGate = await evaluateDeterministicGate(requestWith({ nonceSuffix: 'pass' }));
+  record('deterministic full-context PASS', passGate.gateStatus === 'PASS' && passGate.ok, `gateStatus=${passGate.gateStatus}`);
+
+  const blockGate = await evaluateDeterministicGate(requestWith({ false: ['permission_granted'], nonceSuffix: 'block' }));
+  record('deterministic missing-critical BLOCK', !blockGate.ok && blockGate.gateStatus === 'BLOCK', `gateStatus=${blockGate.gateStatus}`);
+
+  const low = proofToGateStatus('UNSUPPORTED', 'low');
+  const high = proofToGateStatus('UNSUPPORTED', 'high');
+  record('deterministic UNSUPPORTED never PASS', low === 'REVIEW' && high === 'BLOCK', `low=${low} high=${high}`);
+
+  const a = await proveDeterministicPlan(requestWith({ nonceSuffix: 'det' }));
+  const b = await proveDeterministicPlan(requestWith({ nonceSuffix: 'det' }));
+  record('deterministic proofHash stable', a.proofHash === b.proofHash, a.proofHash === b.proofHash ? 'stable' : 'DIVERGED');
+}
+
+async function run(): Promise<void> {
+  const { env, baseUrl } = parseArgs(process.argv.slice(2));
+  await verifyLiveProduction(env, baseUrl);
+  await verifyDeterministicInvariants();
+
+  const failures = results.filter((r) => !r.ok);
+  const summary = {
+    schema: 'dsg-z3-gate-verify-v1',
+    ok: failures.length === 0,
+    env,
+    baseUrl,
+    checkedAt: new Date().toISOString(),
+    policyVersion: manifest.policyVersion,
+    constraintSetHash: manifest.constraintSetHash,
+    externalZ3ProductionSolverClaim: false,
+    totalChecks: results.length,
+    failedChecks: failures.length,
+    checks: results,
+    userOutcome:
+      failures.length === 0
+        ? `Production deploy verified: live ${baseUrl} healthy and deterministic gate invariants hold.`
+        : 'Production deploy verification failed. Inspect failing checks.',
+  };
+
+  const outDir = path.join('artifacts', 'z3-gate');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'verify-result.json'), `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (!summary.ok) process.exit(1);
+}
+
+run().catch((error) => {
+  console.error('[z3-gate-verify] Unexpected error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Goal:

Make the `dsg-deploy.yml` "Verify Production Deploy" (verify-deploy) job actually run and pass on push to main. It never has: the pipeline died at the deploy step and verify-deploy was always skipped.

Root cause (both pre-existing infra bugs):
1. The `deploy-vercel` job ran `vercel deploy --token ${{ secrets.VERCEL_TOKEN }}` with an **empty** `VERCEL_TOKEN` secret → `ArgError: option requires argument: --token` → job failure on every main push. It also duplicated the **Vercel Git integration**, which already deploys production on push to main.
2. `verify-deploy` had `needs: deploy-vercel`, so it was **skipped** whenever deploy-vercel failed. It also called `scripts/z3-gate-verify.ts`, which **did not exist** in the repo (same class of missing-file bug as the earlier z3-gate.ts).

Files changed:

- `.github/workflows/dsg-deploy.yml`
  - Remove the redundant, broken `deploy-vercel` job (production deploy is handled by the Vercel Git integration).
  - Rewire `verify-deploy` to run on push to main (`if: github.ref == 'refs/heads/main'`, `needs: [typecheck, test-unit, test-integration, test-agent-os, z3-gate, security]`) instead of depending on the CLI deploy. It now checks out, `npm ci`, and runs the verify script (which retries the health/status probes so a just-finished Git-integration deploy has time to become reachable).
- `scripts/z3-gate-verify.ts` (new) — post-deploy verification:
  - Live probes: `GET /api/health` (expect 200) and `GET /api/agent/status` (expect `ok=true`, and `env="production"` for `--env=production`), with retries.
  - Deterministic gate invariants: PASS/BLOCK/REVIEW mapping, UNSUPPORTED-is-never-PASS, and determinism.
  - Exits non-zero on any failure; writes `artifacts/z3-gate/verify-result.json`. Accepts `--env=` and `--url=`.

Verification:
- [x] `npx tsx scripts/z3-gate-verify.ts --env=production` against **live production** (commit f491bb5) → 7/7 checks pass, exit 0 (health HTTP 200; status ok=true, env=production; deterministic invariants hold)
- [x] Workflow YAML parses (`yaml.safe_load`); jobs are now `typecheck, test-unit, test-integration, test-agent-os, z3-gate, security, verify-deploy, notify`
- [x] No remaining references to `deploy-vercel`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, or `VERCEL_PROJECT_ID` in the workflow
- [ ] verify-deploy green on main — only observable after merge, since the job is gated on `github.ref == 'refs/heads/main'` and does not run on the PR event. The script it runs is verified above against live production.

Known limits:

- Production deployment now relies solely on the Vercel Git integration (as it already did in practice). This workflow no longer performs a CLI deploy; it only verifies the result.
- The verify script does not assume an external production Z3 solver (per CLAUDE.md); it runs the deterministic gate invariants plus live health/identity probes.

User-visible benefit:

- The `dsg-deploy.yml` pipeline can reach a green terminal state on main: `verify-deploy` runs and confirms production health + gate invariants instead of being permanently skipped behind a broken, redundant deploy job.

Next step:

- Merge to main and confirm `verify-deploy` runs green on the resulting push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmfocALtqmw6guXhwMRn2j

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmfocALtqmw6guXhwMRn2j)_