### PR TITLE
Fix Design System link contrast in mobile navigation

### DIFF
--- a/components/GlobalNav.tsx
+++ b/components/GlobalNav.tsx
@@ -256,7 +256,9 @@ export default function GlobalNav() {
                 onClick={closeMobileMenu}
                 className={[
                   'block rounded-xl border px-4 py-3 text-sm font-semibold',
-                  match(pathname)
+                  href === '/design-system-tool.html'
+                    ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
+                    : match(pathname)
                     ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
                     : 'border-white/10 bg-white/[0.03] text-slate-100',
                 ].join(' ')}


### PR DESCRIPTION
## Goal

Fix text/background color contrast issue in the Design System link within mobile navigation menu, making text and background colors clearly different/contrasting.

## Files changed

- `components/GlobalNav.tsx` — Updated mobile nav styling for Design System link to use amber/gold colors (matching highlighted/active state)

## Verification

- [x] Inspected GlobalNav.tsx mobile navigation section
- [x] Applied amber/gold styling to Design System link for better contrast
- [x] Text color (text-amber-100) and background (bg-amber-300/10) now have clear visual distinction

## Known limits

This is a styling fix only; no functional changes to navigation behavior.

## User-visible benefit

The Design System link now has proper contrast in mobile menu, making it clearly visible against the dark background, matching user request: "สีตัวหนังสือกับพื้นหลัง ให้มันคนละสี" (text and background colors should be different).

## Next step

Ready for review and merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4dYesk7QzaU6WfNzacNAi)_