### PR TITLE
feat: Migrate ai-firstify handlers to Supabase persistence

### DIFF
--- a/packages/ai-firstify-plugin/src/handlers/audit-handler.ts
+++ b/packages/ai-firstify-plugin/src/handlers/audit-handler.ts
@@ -1,12 +1,23 @@
 import type { Context } from 'hono';
+import { getSupabaseClient } from '../lib/supabase-client';
 import type { AuditLog } from '../lib/types';
-
-// In-memory storage for demo purposes
-const auditLogs: AuditLog[] = [];
 
 export async function logAuditEvent(c: Context) {
   try {
-    const body = (await c.req.json()) as Partial<AuditLog>;
+    const supabase = getSupabaseClient();
+    const body = (await c.req.json()) as Partial<AuditLog> & {
+      orgId?: string;
+      decision?: string;
+      decisionReason?: string;
+      proofReference?: string;
+      policyId?: string;
+      complianceTags?: string[];
+    };
+
+    const orgId = body.orgId || c.req.header('x-org-id');
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
+    }
 
     if (!body.eventType || !body.resourceType || !body.action) {
       return c.json(
@@ -17,19 +28,45 @@ export async function logAuditEvent(c: Context) {
       );
     }
 
-    const log: AuditLog = {
-      id: `audit-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      eventType: body.eventType,
-      resourceType: body.resourceType,
-      resourceId: body.resourceId || '',
-      action: body.action,
-      userId: body.userId || 'system',
-      details: body.details || {},
-      timestamp: new Date(),
-      ipAddress: body.ipAddress,
-    };
+    const { data, error } = await supabase
+      .from('ai_audit_logs')
+      .insert({
+        org_id: orgId,
+        event_type: body.eventType,
+        resource_type: body.resourceType,
+        resource_id: body.resourceId || '',
+        action: body.action,
+        user_id: body.userId,
+        actor_type: 'user',
+        actor_id: body.userId,
+        decision: body.decision,
+        decision_reason: body.decisionReason,
+        proof_reference: body.proofReference,
+        policy_id: body.policyId,
+        request_metadata: JSON.stringify(body.details || {}),
+        execution_details: JSON.stringify(body.details || {}),
+        ip_address: body.ipAddress,
+        compliance_tags: body.complianceTags || [],
+      })
+      .select()
+      .single();
 
-    auditLogs.push(log);
+    if (error) {
+      console.error('Supabase error:', error);
+      return c.json({ error: 'Failed to log audit event', details: error.message }, 500);
+    }
+
+    const log: AuditLog = {
+      id: data.id,
+      eventType: data.event_type,
+      resourceType: data.resource_type,
+      resourceId: data.resource_id,
+      action: data.action,
+      userId: data.user_id || 'system',
+      details: JSON.parse(data.execution_details as string),
+      timestamp: new Date(data.created_at),
+      ipAddress: data.ip_address || undefined,
+    };
 
     return c.json(log, 201);
   } catch (error) {
@@ -46,26 +83,60 @@ export async function logAuditEvent(c: Context) {
 
 export async function listAuditLogs(c: Context) {
   try {
+    const supabase = getSupabaseClient();
+    const orgId = c.req.header('x-org-id');
+
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
+    }
+
     const limit = c.req.query('limit') ? parseInt(c.req.query('limit')!) : 50;
     const offset = c.req.query('offset') ? parseInt(c.req.query('offset')!) : 0;
     const eventType = c.req.query('eventType');
     const resourceType = c.req.query('resourceType');
+    const resourceId = c.req.query('resourceId');
 
-    let filtered = auditLogs;
+    let query = supabase
+      .from('ai_audit_logs')
+      .select('*', { count: 'exact' })
+      .eq('org_id', orgId);
 
     if (eventType) {
-      filtered = filtered.filter((log) => log.eventType === eventType);
+      query = query.eq('event_type', eventType);
     }
 
     if (resourceType) {
-      filtered = filtered.filter((log) => log.resourceType === resourceType);
+      query = query.eq('resource_type', resourceType);
     }
 
-    const paginated = filtered.slice(offset, offset + limit);
+    if (resourceId) {
+      query = query.eq('resource_id', resourceId);
+    }
+
+    const { data, error, count } = await query
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      console.error('Supabase error:', error);
+      return c.json({ error: 'Failed to list audit logs', details: error.message }, 500);
+    }
+
+    const logs: AuditLog[] = (data || []).map((row) => ({
+      id: row.id,
+      eventType: row.event_type,
+      resourceType: row.resource_type,
+      resourceId: row.resource_id,
+      action: row.action,
+      userId: row.user_id || 'system',
+      details: JSON.parse(row.execution_details as string),
+      timestamp: new Date(row.created_at),
+      ipAddress: row.ip_address || undefined,
+    }));
 
     return c.json({
-      logs: paginated,
-      total: filtered.length,
+      logs,
+      total: count || 0,
       limit,
       offset,
     });
@@ -83,12 +154,41 @@ export async function listAuditLogs(c: Context) {
 
 export async function getAuditLog(c: Context) {
   try {
+    const supabase = getSupabaseClient();
     const id = c.req.param('id');
-    const log = auditLogs.find((l) => l.id === id);
+    const orgId = c.req.header('x-org-id');
 
-    if (!log) {
+    if (!id) {
+      return c.json({ error: 'Audit log ID is required' }, 400);
+    }
+
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from('ai_audit_logs')
+      .select('*')
+      .eq('id', id)
+      .eq('org_id', orgId)
+      .single();
+
+    if (error || !data) {
+      console.error('Supabase error:', error);
       return c.json({ error: 'Audit log not found' }, 404);
     }
+
+    const log: AuditLog = {
+      id: data.id,
+      eventType: data.event_type,
+      resourceType: data.resource_type,
+      resourceId: data.resource_id,
+      action: data.action,
+      userId: data.user_id || 'system',
+      details: JSON.parse(data.execution_details as string),
+      timestamp: new Date(data.created_at),
+      ipAddress: data.ip_address || undefined,
+    };
 
     return c.json(log);
   } catch (error) {

--- a/packages/ai-firstify-plugin/src/handlers/policy-handler.ts
+++ b/packages/ai-firstify-plugin/src/handlers/policy-handler.ts
@@ -1,12 +1,19 @@
 import type { Context } from 'hono';
-import type { GovernancePolicy } from '../lib/types';
-
-// In-memory storage for demo purposes
-const policies: Map<string, GovernancePolicy> = new Map();
+import { getSupabaseClient } from '../lib/supabase-client';
+import type { GovernancePolicy, PolicyRule } from '../lib/types';
 
 export async function createPolicy(c: Context) {
   try {
-    const body = (await c.req.json()) as Partial<GovernancePolicy>;
+    const supabase = getSupabaseClient();
+    const body = (await c.req.json()) as Partial<GovernancePolicy> & {
+      orgId?: string;
+      createdBy?: string;
+    };
+
+    const orgId = body.orgId || c.req.header('x-org-id');
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
+    }
 
     if (!body.name || !body.rules || body.rules.length === 0) {
       return c.json(
@@ -17,20 +24,37 @@ export async function createPolicy(c: Context) {
       );
     }
 
-    const policy: GovernancePolicy = {
-      id: `policy-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      name: body.name,
-      description: body.description || '',
-      rules: body.rules,
-      riskLevel: body.riskLevel || 'medium',
-      enabled: body.enabled !== false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+    const { data, error } = await supabase
+      .from('ai_policies')
+      .insert({
+        org_id: orgId,
+        name: body.name,
+        description: body.description || null,
+        policy_type: 'governance',
+        rules: JSON.stringify(body.rules),
+        risk_level: body.riskLevel || 'medium',
+        enabled: body.enabled !== false,
+        version: 1,
+        created_by: body.createdBy,
+      })
+      .select()
+      .single();
 
-    policies.set(policy.id, policy);
+    if (error) {
+      console.error('Supabase error:', error);
+      return c.json({ error: 'Failed to create policy', details: error.message }, 500);
+    }
 
-    return c.json(policy, 201);
+    return c.json({
+      id: data.id,
+      name: data.name,
+      description: data.description,
+      rules: JSON.parse(data.rules as string),
+      riskLevel: data.risk_level,
+      enabled: data.enabled,
+      createdAt: new Date(data.created_at),
+      updatedAt: new Date(data.updated_at),
+    }, 201);
   } catch (error) {
     console.error('Policy creation error:', error);
     return c.json(
@@ -45,8 +69,36 @@ export async function createPolicy(c: Context) {
 
 export async function listPolicies(c: Context) {
   try {
-    const policyList = Array.from(policies.values());
-    return c.json({ policies: policyList });
+    const supabase = getSupabaseClient();
+    const orgId = c.req.header('x-org-id');
+
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from('ai_policies')
+      .select('*')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Supabase error:', error);
+      return c.json({ error: 'Failed to list policies', details: error.message }, 500);
+    }
+
+    const policies = data.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      rules: JSON.parse(row.rules as string) as PolicyRule[],
+      riskLevel: row.risk_level as GovernancePolicy['riskLevel'],
+      enabled: row.enabled,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+    }));
+
+    return c.json({ policies });
   } catch (error) {
     console.error('Policy listing error:', error);
     return c.json(
@@ -61,16 +113,40 @@ export async function listPolicies(c: Context) {
 
 export async function getPolicy(c: Context) {
   try {
+    const supabase = getSupabaseClient();
     const id = c.req.param('id');
+    const orgId = c.req.header('x-org-id');
+
     if (!id) {
       return c.json({ error: 'Policy ID is required' }, 400);
     }
 
-    const policy = policies.get(id);
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
+    }
 
-    if (!policy) {
+    const { data, error } = await supabase
+      .from('ai_policies')
+      .select('*')
+      .eq('id', id)
+      .eq('org_id', orgId)
+      .single();
+
+    if (error || !data) {
+      console.error('Supabase error:', error);
       return c.json({ error: 'Policy not found' }, 404);
     }
+
+    const policy: GovernancePolicy = {
+      id: data.id,
+      name: data.name,
+      description: data.description || '',
+      rules: JSON.parse(data.rules as string) as PolicyRule[],
+      riskLevel: data.risk_level as GovernancePolicy['riskLevel'],
+      enabled: data.enabled,
+      createdAt: new Date(data.created_at),
+      updatedAt: new Date(data.updated_at),
+    };
 
     return c.json(policy);
   } catch (error) {
@@ -87,28 +163,50 @@ export async function getPolicy(c: Context) {
 
 export async function updatePolicy(c: Context) {
   try {
+    const supabase = getSupabaseClient();
     const id = c.req.param('id');
+    const orgId = c.req.header('x-org-id');
+
     if (!id) {
       return c.json({ error: 'Policy ID is required' }, 400);
     }
 
-    const existingPolicy = policies.get(id);
-
-    if (!existingPolicy) {
-      return c.json({ error: 'Policy not found' }, 404);
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
     }
 
     const body = (await c.req.json()) as Partial<GovernancePolicy>;
 
-    const updatedPolicy: GovernancePolicy = {
-      ...existingPolicy,
-      ...body,
-      id: existingPolicy.id,
-      createdAt: existingPolicy.createdAt,
-      updatedAt: new Date(),
-    };
+    const { data, error } = await supabase
+      .from('ai_policies')
+      .update({
+        name: body.name,
+        description: body.description,
+        rules: body.rules ? JSON.stringify(body.rules) : undefined,
+        risk_level: body.riskLevel,
+        enabled: body.enabled,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .eq('org_id', orgId)
+      .select()
+      .single();
 
-    policies.set(id, updatedPolicy);
+    if (error || !data) {
+      console.error('Supabase error:', error);
+      return c.json({ error: 'Policy not found' }, 404);
+    }
+
+    const updatedPolicy: GovernancePolicy = {
+      id: data.id,
+      name: data.name,
+      description: data.description || '',
+      rules: JSON.parse(data.rules as string) as PolicyRule[],
+      riskLevel: data.risk_level as GovernancePolicy['riskLevel'],
+      enabled: data.enabled,
+      createdAt: new Date(data.created_at),
+      updatedAt: new Date(data.updated_at),
+    };
 
     return c.json(updatedPolicy);
   } catch (error) {
@@ -125,16 +223,28 @@ export async function updatePolicy(c: Context) {
 
 export async function deletePolicy(c: Context) {
   try {
+    const supabase = getSupabaseClient();
     const id = c.req.param('id');
+    const orgId = c.req.header('x-org-id');
+
     if (!id) {
       return c.json({ error: 'Policy ID is required' }, 400);
     }
 
-    if (!policies.has(id)) {
-      return c.json({ error: 'Policy not found' }, 404);
+    if (!orgId) {
+      return c.json({ error: 'Organization ID is required' }, 400);
     }
 
-    policies.delete(id);
+    const { error } = await supabase
+      .from('ai_policies')
+      .delete()
+      .eq('id', id)
+      .eq('org_id', orgId);
+
+    if (error) {
+      console.error('Supabase error:', error);
+      return c.json({ error: 'Failed to delete policy', details: error.message }, 500);
+    }
 
     return c.json({ success: true });
   } catch (error) {

--- a/packages/ai-firstify-plugin/src/lib/dsg-client.ts
+++ b/packages/ai-firstify-plugin/src/lib/dsg-client.ts
@@ -1,4 +1,5 @@
-import type { GovernanceRequest, GovernanceResponse } from './types';
+import { getSupabaseClient } from './supabase-client';
+import type { AIModel, GovernanceRequest, GovernanceResponse } from './types';
 
 export class DSGClient {
   private apiBase: string;
@@ -79,6 +80,99 @@ export class DSGClient {
     }
 
     return response.json();
+  }
+
+  async getAIModel(modelId: string, orgId: string): Promise<AIModel | null> {
+    const supabase = getSupabaseClient();
+
+    const { data, error } = await supabase
+      .from('ai_models')
+      .select('*')
+      .eq('id', modelId)
+      .eq('org_id', orgId)
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return {
+      id: data.id,
+      name: data.name,
+      version: data.version,
+      provider: data.provider,
+      tags: data.tags || [],
+      createdAt: new Date(data.created_at),
+      updatedAt: new Date(data.updated_at),
+    };
+  }
+
+  async listAIModels(orgId: string): Promise<AIModel[]> {
+    const supabase = getSupabaseClient();
+
+    const { data, error } = await supabase
+      .from('ai_models')
+      .select('*')
+      .eq('org_id', orgId)
+      .eq('status', 'active')
+      .order('created_at', { ascending: false });
+
+    if (error || !data) {
+      return [];
+    }
+
+    return data.map((row) => ({
+      id: row.id,
+      name: row.name,
+      version: row.version,
+      provider: row.provider,
+      tags: row.tags || [],
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+    }));
+  }
+
+  async createAIModel(
+    orgId: string,
+    model: Omit<AIModel, 'createdAt' | 'updatedAt'> & {
+      description?: string;
+      modelType?: string;
+      endpoint?: string;
+      createdBy?: string;
+    }
+  ): Promise<AIModel | null> {
+    const supabase = getSupabaseClient();
+
+    const { data, error } = await supabase
+      .from('ai_models')
+      .insert({
+        org_id: orgId,
+        name: model.name,
+        version: model.version,
+        provider: model.provider,
+        tags: model.tags || [],
+        description: model.description,
+        model_type: model.modelType,
+        endpoint_url: model.endpoint,
+        created_by: model.createdBy,
+        status: 'active',
+      })
+      .select()
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return {
+      id: data.id,
+      name: data.name,
+      version: data.version,
+      provider: data.provider,
+      tags: data.tags || [],
+      createdAt: new Date(data.created_at),
+      updatedAt: new Date(data.updated_at),
+    };
   }
 }
 

--- a/packages/ai-firstify-plugin/src/lib/supabase-client.ts
+++ b/packages/ai-firstify-plugin/src/lib/supabase-client.ts
@@ -1,0 +1,38 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '../types/database';
+
+let supabaseClient: ReturnType<typeof createClient<Database>> | null = null;
+
+export function initializeSupabaseClient() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      'Missing required Supabase environment variables: SUPABASE_URL and SUPABASE_ANON_KEY'
+    );
+  }
+
+  supabaseClient = createClient<Database>(supabaseUrl, supabaseKey);
+  return supabaseClient;
+}
+
+export function getSupabaseClient() {
+  if (!supabaseClient) {
+    return initializeSupabaseClient();
+  }
+  return supabaseClient;
+}
+
+export function getSupabaseAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    throw new Error(
+      'Missing required Supabase admin environment variables: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY'
+    );
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseServiceKey);
+}

--- a/packages/ai-firstify-plugin/src/types/database.ts
+++ b/packages/ai-firstify-plugin/src/types/database.ts
@@ -1,0 +1,243 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      ai_models: {
+        Row: {
+          id: string
+          org_id: string
+          name: string
+          description: string | null
+          version: string
+          provider: string
+          model_type: string | null
+          tags: string[]
+          endpoint_url: string | null
+          api_key_id: string | null
+          status: string
+          metadata: Json
+          created_at: string
+          updated_at: string
+          created_by: string | null
+        }
+        Insert: {
+          id?: string
+          org_id: string
+          name: string
+          description?: string | null
+          version: string
+          provider: string
+          model_type?: string | null
+          tags?: string[]
+          endpoint_url?: string | null
+          api_key_id?: string | null
+          status?: string
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+          created_by?: string | null
+        }
+        Update: {
+          id?: string
+          org_id?: string
+          name?: string
+          description?: string | null
+          version?: string
+          provider?: string
+          model_type?: string | null
+          tags?: string[]
+          endpoint_url?: string | null
+          api_key_id?: string | null
+          status?: string
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+          created_by?: string | null
+        }
+        Relationships: []
+      }
+      ai_policies: {
+        Row: {
+          id: string
+          org_id: string
+          name: string
+          description: string | null
+          policy_type: string
+          rules: Json
+          risk_level: string
+          enabled: boolean
+          version: number
+          policy_hash: string | null
+          applies_to_models: string[]
+          applies_to_actions: string[]
+          created_at: string
+          updated_at: string
+          created_by: string | null
+        }
+        Insert: {
+          id?: string
+          org_id: string
+          name: string
+          description?: string | null
+          policy_type: string
+          rules: Json
+          risk_level?: string
+          enabled?: boolean
+          version?: number
+          policy_hash?: string | null
+          applies_to_models?: string[]
+          applies_to_actions?: string[]
+          created_at?: string
+          updated_at?: string
+          created_by?: string | null
+        }
+        Update: {
+          id?: string
+          org_id?: string
+          name?: string
+          description?: string | null
+          policy_type?: string
+          rules?: Json
+          risk_level?: string
+          enabled?: boolean
+          version?: number
+          policy_hash?: string | null
+          applies_to_models?: string[]
+          applies_to_actions?: string[]
+          created_at?: string
+          updated_at?: string
+          created_by?: string | null
+        }
+        Relationships: []
+      }
+      ai_policy_versions: {
+        Row: {
+          id: string
+          policy_id: string
+          org_id: string
+          version: number
+          rules: Json
+          risk_level: string
+          change_summary: string | null
+          created_at: string
+          created_by: string | null
+        }
+        Insert: {
+          id?: string
+          policy_id: string
+          org_id: string
+          version: number
+          rules: Json
+          risk_level: string
+          change_summary?: string | null
+          created_at?: string
+          created_by?: string | null
+        }
+        Update: {
+          id?: string
+          policy_id?: string
+          org_id?: string
+          version?: number
+          rules?: Json
+          risk_level?: string
+          change_summary?: string | null
+          created_at?: string
+          created_by?: string | null
+        }
+        Relationships: []
+      }
+      ai_audit_logs: {
+        Row: {
+          id: string
+          org_id: string
+          event_type: string
+          resource_type: string
+          resource_id: string
+          action: string
+          decision: string | null
+          decision_reason: string | null
+          user_id: string | null
+          actor_type: string
+          actor_id: string | null
+          request_id: string | null
+          request_metadata: Json
+          policy_id: string | null
+          policy_version: number | null
+          proof_reference: string | null
+          execution_details: Json
+          error_message: string | null
+          execution_time_ms: number | null
+          ip_address: string | null
+          user_agent: string | null
+          compliance_tags: string[]
+          retention_until: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          org_id: string
+          event_type: string
+          resource_type: string
+          resource_id: string
+          action: string
+          decision?: string | null
+          decision_reason?: string | null
+          user_id?: string | null
+          actor_type?: string
+          actor_id?: string | null
+          request_id?: string | null
+          request_metadata?: Json
+          policy_id?: string | null
+          policy_version?: number | null
+          proof_reference?: string | null
+          execution_details?: Json
+          error_message?: string | null
+          execution_time_ms?: number | null
+          ip_address?: string | null
+          user_agent?: string | null
+          compliance_tags?: string[]
+          retention_until?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          org_id?: string
+          event_type?: string
+          resource_type?: string
+          resource_id?: string
+          action?: string
+          decision?: string | null
+          decision_reason?: string | null
+          user_id?: string | null
+          actor_type?: string
+          actor_id?: string | null
+          request_id?: string | null
+          request_metadata?: Json
+          policy_id?: string | null
+          policy_version?: number | null
+          proof_reference?: string | null
+          execution_details?: Json
+          error_message?: string | null
+          execution_time_ms?: number | null
+          ip_address?: string | null
+          user_agent?: string | null
+          compliance_tags?: string[]
+          retention_until?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {}
+    Functions: {}
+    Enums: {}
+    CompositeTypes: {}
+  }
+}


### PR DESCRIPTION
## Summary

Migrates the AI-Firstify plugin handlers from in-memory storage to Supabase persistent storage. Implements org-scoped data isolation with proper RLS query patterns.

## Files changed

- `packages/ai-firstify-plugin/src/lib/supabase-client.ts` — Supabase client initialization with env-based config
- `packages/ai-firstify-plugin/src/types/database.ts` — TypeScript types for AI-Firstify schema (ai_models, ai_policies, ai_policy_versions, ai_audit_logs)
- `packages/ai-firstify-plugin/src/handlers/policy-handler.ts` — Migrated to Supabase queries for ai_policies CRUD with org scoping
- `packages/ai-firstify-plugin/src/handlers/audit-handler.ts` — Migrated to ai_audit_logs for immutable append-only audit logging
- `packages/ai-firstify-plugin/src/lib/dsg-client.ts` — Added AI model registry methods (getAIModel, listAIModels, createAIModel)

## Key changes

- **Supabase client**: Env-based initialization supporting both anon and service-role access
- **Database types**: Manual TypeScript types matching the schema from merged PR #900
- **Org scoping**: All handlers validate `x-org-id` header and filter queries by org_id
- **Policy handler**: Complete CRUD operations on ai_policies table with version tracking
- **Audit handler**: Immutable append-only logging to ai_audit_logs with decision tracking
- **Model registry**: DSGClient now queries ai_models table for active models by org

## Verification

- [x] npm run build passed
- [x] TypeScript strict mode check passed
- [ ] Integration tests with live Supabase (pending: requires env setup)
- [ ] RLS enforcement verification (pending: requires deployed schema)

## Known limits

- Requires SUPABASE_URL and SUPABASE_ANON_KEY env vars in plugin environment
- Database types are manually defined (not generated from live schema) — should regenerate with `npm run db:types` once Supabase is configured
- Policy versioning is tracked at DB level but version increment logic not yet implemented in handlers
- Policy hashing not yet implemented in createPolicy handler

## Next steps

1. Apply migrations to Supabase staging/production (if not already done)
2. Configure plugin env vars: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
3. Generate types from live schema: `npm run db:types`
4. Add integration tests with RLS verification
5. Implement policy version increment and hashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NGbh5spXG64Vfcjy3JdAi

---
_Generated by [Claude Code](https://claude.ai/code/session_015NGbh5spXG64Vfcjy3JdAi)_