### PR TITLE
feat: JWT Bearer token authentication for authenticated API routes

### DIFF
--- a/lib/authz-runtime.ts
+++ b/lib/authz-runtime.ts
@@ -39,7 +39,7 @@ export async function requireRuntimeAccess(
     };
   }
 
-  const session = await requireOrgRole(RuntimeRouteRoles[routeKey]);
+  const session = await requireOrgRole(RuntimeRouteRoles[routeKey], req);
   if (!session.ok) {
     return { ok: false, status: session.status, error: session.error };
   }

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -20,15 +20,35 @@ function isMissingRuntimeRolesError(error: { message?: string; code?: string | n
   );
 }
 
-export async function requireOrgRole(requiredRoles: RuntimeRole[]){
+export async function requireOrgRole(requiredRoles: RuntimeRole[], req?: Request){
  try {
-  const supabase = await createClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
+  let userId: string | null = null;
 
-  if (authError || !user?.id) {
+  // First, check if middleware set JWT user info in headers
+  if (req) {
+    userId = (req as any).headers?.get?.('x-user-id') || null;
+  }
+
+  // Fall back to session-based auth if no JWT
+  if (!userId) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user?.id) {
+      return {
+        ok: false as const,
+        status: 401,
+        error: 'Unauthorized',
+      };
+    }
+
+    userId = user.id;
+  }
+
+  if (!userId) {
     return {
       ok: false as const,
       status: 401,
@@ -49,7 +69,7 @@ export async function requireOrgRole(requiredRoles: RuntimeRole[]){
   const profile = await admin
     .from('users')
     .select('id, org_id, is_active, role')
-    .eq('auth_user_id', user.id)
+    .eq('auth_user_id', userId)
     .maybeSingle();
 
   if (profile.error) {
@@ -113,7 +133,7 @@ export async function requireOrgRole(requiredRoles: RuntimeRole[]){
         ok: true as const,
         orgId,
         userId: appUserId,
-        authUserId: String(user.id),
+        authUserId: String(userId),
         grantedRoles: fallbackList,
       };
     }
@@ -161,7 +181,7 @@ export async function requireOrgRole(requiredRoles: RuntimeRole[]){
     ok: true as const,
     orgId,
     userId: appUserId,
-    authUserId: String(user.id),
+    authUserId: String(userId),
     grantedRoles: effectiveRolesList as RuntimeRole[],
   };
  } catch (error) {

--- a/lib/authz.ts
+++ b/lib/authz.ts
@@ -25,8 +25,8 @@ export async function requireOrgRole(requiredRoles: RuntimeRole[], req?: Request
   let userId: string | null = null;
 
   // First, check if middleware set JWT user info in headers
-  if (req) {
-    userId = (req as any).headers?.get?.('x-user-id') || null;
+  if (req && req.headers) {
+    userId = req.headers.get('x-user-id') || null;
   }
 
   // Fall back to session-based auth if no JWT

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,16 +31,19 @@ export async function middleware(request: NextRequest) {
 
   const requestStart = Date.now();
 
-  // Clone the request with the correlation ID injected
+  // Clone the request with the correlation ID injected, stripping auth-related headers
+  // to prevent header spoofing. These headers are only set after JWT verification.
+  const safeHeaders = new Headers(request.headers);
+  safeHeaders.delete('x-user-id');
+  safeHeaders.delete('x-user-email');
+
   const requestWithId = new NextRequest(request.url, {
     method: request.method,
-    headers: new Headers(request.headers),
+    headers: safeHeaders,
     body: request.body,
     duplex: 'half',
   } as RequestInit & { duplex: 'half' });
   requestWithId.headers.set('x-request-id', requestId);
-
-requestWithId.headers.set('x-request-id', requestId);
 
   // Allow public access to pricing page
   if (request.nextUrl.pathname === '/pricing') {
@@ -95,10 +98,14 @@ requestWithId.headers.set('x-request-id', requestId);
           // Verify token with Supabase
           const { data, error } = await supabase.auth.getUser(token);
           if (data?.user && !error) {
-            // Token is valid - add user to request headers
+            // Token is valid - add verified user to request headers
+            const authHeaders = new Headers(request.headers);
+            authHeaders.delete('x-user-id');
+            authHeaders.delete('x-user-email');
+
             const requestWithAuth = new NextRequest(request.url, {
               method: request.method,
-              headers: new Headers(request.headers),
+              headers: authHeaders,
               body: request.body,
               duplex: 'half',
             } as RequestInit & { duplex: 'half' });

--- a/middleware.ts
+++ b/middleware.ts
@@ -56,7 +56,7 @@ requestWithId.headers.set('x-request-id', requestId);
     return res;
   }
 
-  // ── API routes: body-size enforcement only ─────────────────────────────────
+  // ── API routes: body-size enforcement + JWT Bearer token support ──────────
   if (request.nextUrl.pathname.startsWith('/api/')) {
     if (['POST', 'PUT', 'PATCH'].includes(request.method)) {
       const cl = request.headers.get('content-length');
@@ -66,6 +66,56 @@ requestWithId.headers.set('x-request-id', requestId);
         );
       }
     }
+
+    // Extract and validate JWT Bearer token if present
+    const authHeader = request.headers.get('authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.slice(7);
+      const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const anonKey =
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+      if (url && anonKey) {
+        try {
+          const supabase = createServerClient(url, anonKey, {
+            cookies: {
+              getAll() {
+                return request.cookies.getAll();
+              },
+              setAll(cookiesToSet) {
+                cookiesToSet.forEach(({ name, value, options }) => {
+                  request.cookies.set(name, value);
+                  response.cookies.set(name, value, options);
+                });
+              },
+            },
+          });
+
+          // Verify token with Supabase
+          const { data, error } = await supabase.auth.getUser(token);
+          if (data?.user && !error) {
+            // Token is valid - add user to request headers
+            const requestWithAuth = new NextRequest(request.url, {
+              method: request.method,
+              headers: new Headers(request.headers),
+              body: request.body,
+              duplex: 'half',
+            } as RequestInit & { duplex: 'half' });
+
+            requestWithAuth.headers.set('x-user-id', data.user.id);
+            requestWithAuth.headers.set('x-user-email', data.user.email || '');
+            requestWithAuth.headers.set('x-request-id', requestId);
+
+            const authResponse = NextResponse.next({ request: requestWithAuth });
+            return stamp(authResponse);
+          }
+        } catch (err) {
+          // Invalid token - continue to route handler which will reject if needed
+        }
+      }
+    }
+
     return stamp(response);
   }
 

--- a/tests/unit/authz-runtime.test.ts
+++ b/tests/unit/authz-runtime.test.ts
@@ -123,8 +123,9 @@ describe('requireRuntimeAccess', () => {
     requireOrgRoleMock.mockResolvedValue({ ok: false, status: 403, error: 'Forbidden' });
 
     const { requireRuntimeAccess } = await import('../../lib/authz-runtime');
-    await requireRuntimeAccess(makeRequest(), 'checkpoint');
+    const req = makeRequest();
+    await requireRuntimeAccess(req, 'checkpoint');
 
-    expect(requireOrgRoleMock).toHaveBeenCalledWith(['runtime_auditor', 'org_admin']);
+    expect(requireOrgRoleMock).toHaveBeenCalledWith(['runtime_auditor', 'org_admin'], req);
   });
 });


### PR DESCRIPTION
## Goal

Enable JWT Bearer token authentication for API routes, allowing clients to authenticate using tokens from `/api/auth/login` endpoint.

## Changes

### middleware.ts
- Extract `Authorization: Bearer <token>` header from incoming requests
- Validate JWT tokens with Supabase auth
- Set `x-user-id` and `x-user-email` headers when token is valid
- Maintain backward compatibility with session-based auth (cookies)

### lib/authz.ts
- Updated `requireOrgRole()` to accept optional `Request` parameter
- Check for `x-user-id` header first (JWT auth via middleware)
- Fallback to Supabase session-based auth if no JWT header
- Both auth paths resolve to same org/role/user lookup

### lib/authz-runtime.ts
- Pass `request` to `requireOrgRole()` for JWT header access

## How It Works

**Authentication Flow:**
1. Client calls `POST /api/auth/login` with credentials
2. Server validates and returns JWT token
3. Client includes token: `Authorization: Bearer <jwt>`
4. Middleware validates JWT with Supabase
5. Route handler can access user via `x-user-id` header
6. `requireOrgRole()` validates user's org/role permissions

**Example Usage:**
```bash
# Get JWT token
TOKEN=$(curl -X POST https://app/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"user@example.com","password":"password"}' \
  | jq -r '.token')

# Use token with authenticated API
curl -H "Authorization: Bearer $TOKEN" \
  https://app/api/executions
```

## Verification

- [x] TypeScript typecheck: PASS
- [x] Next.js build: PASS (90.1 kB middleware)
- [x] Auth endpoint tested: JWT tokens generated successfully
- [x] Backward compatibility: Session-based auth still works

## Testing

To test JWT authentication in production:
```bash
# Real Supabase user test
curl -X POST https://tdealer01-crypto-dsg-control-plane.vercel.app/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"t.dealer01@dsg.pics","password":"your-password"}'

# Use returned token with authenticated endpoint
curl -H "Authorization: Bearer eyJhbGc..." \
  https://tdealer01-crypto-dsg-control-plane.vercel.app/api/executions
```

## Known Limits

- JWT tokens are validated but not cached in middleware
- Token expiry depends on Supabase session timeout
- User profile lookup still requires database access

## Impact

✅ Enables Trinity Dashboard and CLI/SDK clients to use JWT tokens
✅ Supports both password and session-based auth
✅ Maintains backward compatibility with existing auth

---

🤖 Generated with Claude Code (claude-haiku-4-5-20251001)
https://claude.ai/code/session_01V32UAxgGWEqcts7q4Zdtfm

---
_Generated by [Claude Code](https://claude.ai/code/session_01V32UAxgGWEqcts7q4Zdtfm)_