### PR TITLE
docs: Fix metered billing claim — code-wired, not live-active

### DIFF
--- a/docs/AI_MARKET_ANALYSIS_2026.md
+++ b/docs/AI_MARKET_ANALYSIS_2026.md
@@ -89,7 +89,7 @@ Auth = Bearer token + SHA256 hash ของ agent key (resolve ใน `lib/agent
 3. **Expand:** skill pack upsell ตาม persona
 
 ### ข้อต้องระวัง (truth boundary ในการส่งมอบ)
-- **Stripe metered billing มี infra แต่ยังไม่ wired เข้า execution** (`lib/billing/metered.ts`) — ปัจจุบันใช้ quota รายเดือนแบบ flat tier → **อย่าขาย "usage-based billing" ว่าพร้อมใช้**
+- **Stripe metered billing wired into execution path** (`meterExecution` called in `/api/spine/execute` line 347); requires Stripe meter env (`STRIPE_METER_EVENT_NAME`/meter id) to emit live meter events — ปัจจุบันใช้ quota รายเดือนแบบ flat tier → **อย่าขาย "usage-based billing active" ว่าส่ง meter events ถ้า env ยังไม่ตั้ง**
 - หลักฐานทุกชิ้นติด `certificationClaim=false` / `independentAuditClaim=false` → ส่งมอบเป็น **"audit-ready / pre-audit evidence" ไม่ใช่ "certified"**
 - "WORM" = DB hash chain ที่ตรวจสอบได้ ไม่ใช่ tamper-proof storage จริง (ไม่มี HSM/blockchain)
 
@@ -187,7 +187,7 @@ Skill packs (upsell): Finance $199 · Dev Automation $99 · Compliance $249 · O
 - **Retention hook:** audit export + evidence history สร้าง lock-in (ลูกค้าไม่อยากเสียประวัติหลักฐาน)
 
 ### 8.3 ลำดับงานก่อนขาย pricing ขั้นสูง
-- **wire Stripe metered billing เข้า execution** ก่อนพูดเรื่อง usage-based overage จริง (ตอนนี้ flat tier)
+- **configure Stripe meter env** (`STRIPE_METER_EVENT_NAME`, meter id) ก่อนโฆษณา usage-based overage live (ตอนนี้ flat tier; code wired แต่ยังต้อง env + meter คอนฟิก)
 - ตรวจสอบ entitlement (`lib/billing/entitlements.ts`) ให้ map ตรงกับหน้า pricing ที่โฆษณา ก่อน launch แคมเปญ
 
 ---
@@ -198,14 +198,14 @@ Skill packs (upsell): Finance $199 · Dev Automation $99 · Compliance $249 · O
 2. **ล่า quick-win:** เจาะ Finance Ops ($199–999/เดือน รอบสั้น) เพื่อ revenue + case study แรก
 3. **ขยาย growth loop:** ทำ Delivery Proof report ให้แชร์ลื่นที่สุด = การตลาดทบต้น
 4. **รักษาเส้น claim:** ทุก asset ใช้ `production-connected / audit-ready / pre-audit` ไม่ใช่ `certified / production-ready`
-5. **wire metered billing** ก่อนขาย usage-based pricing
+5. **configure Stripe meter env + test meter events** ก่อนโฆษณา usage-based billing live
 
 ---
 
 ## 10. หมายเหตุความถูกต้อง (Verification Note)
 
-- **Verified จากโค้ด:** routes (`/api/agents`, `/api/spine/execute`, `/api/gateway/tools/execute`, `/api/dsg/v1/gates/evaluate`, `/api/delivery-proof/scan`, `/api/compliance-evidence-pack*`, `/api/ccvs/*`), Bearer auth + SHA256 (`lib/agent-auth.ts`), quota (`lib/usage/quota.ts`), pricing tiers (`lib/stripe-products.ts` / หน้า pricing), evidence surfaces (`lib/ccvs/*`, `lib/gateway/evidence-bundle.ts`)
+- **Verified จากโค้ด:** routes (`/api/agents`, `/api/spine/execute`, `/api/gateway/tools/execute`, `/api/dsg/v1/gates/evaluate`, `/api/delivery-proof/scan`, `/api/compliance-evidence-pack*`, `/api/ccvs/*`), Bearer auth + SHA256 (`lib/agent-auth.ts`), quota (`lib/usage/quota.ts`), pricing tiers (`lib/stripe-products.ts` / หน้า pricing), evidence surfaces (`lib/ccvs/*`, `lib/gateway/evidence-bundle.ts`), metering call (`meterExecution` in `/api/spine/execute` line 347)
 - **Projection / สมมติฐาน:** TAM, MRR/ARR, CAC, churn, conversion, เป้าหมายลูกค้า, ICP score thresholds — ยังไม่มี traction จริงรองรับ
-- **ยังไม่ verified / ยังไม่พร้อม:** SDK บน npm/PyPI (ยังไม่ published), Stripe metered billing wired เข้า execution (ยังไม่ wired), pilot ลูกค้าจริง (ยังไม่มี), third-party certification/audit (ไม่มี)
+- **ยังไม่ verified / ยังไม่พร้อม:** SDK บน npm/PyPI (ยังไม่ published), Stripe meter env + live meter emission (code wired, env not yet configured), pilot ลูกค้าจริง (ยังไม่มี), third-party certification/audit (ไม่มี)
 
 > เอกสารนี้เป็น strategy artifact เพื่อช่วยตัดสินใจ ไม่เปลี่ยนสถานะ production readiness และไม่ใช่หลักฐาน compliance

--- a/docs/one-pager-dev-team.md
+++ b/docs/one-pager-dev-team.md
@@ -135,7 +135,7 @@ console.log(result.audit_id, result.proof.proof_hash);
 | ✅ Verified | ❌ Not Yet |
 |-------------|------------|
 | SDK builds, types work | **Not yet on npm** (ready to publish) |
-| Gate returns decision + proof | Metered billing not wired to execution |
+| Gate returns decision + proof | Metered billing wired into execution; Stripe meter env not yet configured |
 | 2173 tests pass | GitHub App not yet live |
 | Edge gate <50ms latency | PyPI package not built |
 

--- a/docs/pitch-deck.md
+++ b/docs/pitch-deck.md
@@ -61,7 +61,7 @@ AI Agent → [DSG Gate: policy + replay + quota + evidence] → Execute / Block 
 | "Production-ready" | "Production-connected" |
 | "Certified / Third-party audited" | "Audit-ready / Pre-audit evidence mapping" |
 | "WORM-certified storage" | "SHA-256 hash chain, tamper-evident by construction" |
-| "Usage-based metered billing" | "Flat-tier quota; metered infra exists but not wired" |
+| "Usage-based metered billing active" | "Flat-tier quota; metering code wired into execution but Stripe meter env not yet configured" |
 | "SDK one-liner connect" | "SDK ready, not yet published to npm" |
 | "SLA 99.9%" | "No SLA claimed" |
 
@@ -128,7 +128,7 @@ Each viewer sees: Decision Explainer + Audit Trail + Compliance Mapping
 | # | Action | Timeline | Blocked By |
 |---|--------|----------|------------|
 | 1 | **Publish SDK to npm + GitHub App** | Week 1 | — |
-| 2 | **Wire Stripe metered billing → execution** | Week 2 | SDK |
+| 2 | **Configure Stripe meter env + test meter emission** | Week 2 | SDK |
 | 3 | **3 Finance Ops pilots → case studies** | Weeks 2–6 | — |
 | 4 | **Optimize Delivery Proof sharing** | Week 2 | — |
 | 5 | **CISO/Enterprise pipeline** | Weeks 4–12 | Case studies |


### PR DESCRIPTION
## Goal

Fix outdated documentation claims that stated "metered billing not wired to execution" — this is inaccurate since `meterExecution` is already called in the execution path. Update docs to reflect actual code status: **wired into execution, requires Stripe meter env configuration**.

## Summary

- `meterExecution` is called in `/api/spine/execute` (line 347) during governed execution
- Code is production-connected to metering infrastructure
- **But** Stripe meter events won't emit to live billing until `STRIPE_METER_EVENT_NAME` env var is configured
- Distinction: code-wired ≠ live-active billing

## Files Changed

| File | Changes |
|------|---------|
| `docs/AI_MARKET_ANALYSIS_2026.md` | 4 refs: updated delivery truth boundary, roadmap steps 8.3 + 9.5, verification notes |
| `docs/one-pager-dev-team.md` | 1 ref: Truth Boundary table (line 138) |
| `docs/pitch-deck.md` | 2 refs: Slide 5 claim + Slide 10 roadmap |

## Verification

```bash
# Before: grep found "not wired / ยังไม่ wired" in metering context
# After: grep finds only correct status in updated docs
grep -rn "Metered billing\|metered billing" docs/ | grep "wired"
# → shows: "wired into execution path" + "code wired... env not yet configured"
# ✅ No overclaims of "active" or "live" remain
```

## Truth Boundary

**✅ Verified from code:**
- `meterExecution` function exists and is called
- Call is in execution path after decision
- Metering infrastructure scaffolding is in place

**❌ Not yet verified:**
- Stripe meter env (`STRIPE_METER_EVENT_NAME`) configured
- Live meter events emitted to Stripe
- End-to-end meter → billing flow working

## Known Limits

- This is docs-only; no code changes
- Metering infrastructure remains untested in production
- Next step: configure Stripe meter env + test meter event emission

---

🤖 Generated with [Claude Code](https://claude.ai/code)  
https://claude.ai/code/session_01JgSqVKmRDFv1XoDkRHtwGX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgSqVKmRDFv1XoDkRHtwGX)_