### PR TITLE
Add payment failed dunning notifications

### DIFF
--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -3,7 +3,7 @@ import Stripe from 'stripe';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
 import type { Database, Json } from '../../../../lib/database.types';
-import { sendTrialWelcome, sendUpgradeSuccess } from '../../../../lib/email/sales';
+import { sendTrialWelcome, sendUpgradeSuccess, sendPaymentFailed } from '../../../../lib/email/sales';
 import { fulfillSubscription, revokeSubscription } from '../../../../lib/billing/fulfillment';
 import { REVOKED_STATUSES } from '../../../../lib/billing/entitlements';
 import { captureEvent } from '../../../../lib/telemetry/capture-event';
@@ -311,7 +311,37 @@ async function handleInvoiceEvent(
         attemptCount: invoice.attempt_count,
         nextPaymentAttempt: invoice.next_payment_attempt,
       });
-      // Could trigger dunning webhook or alert here
+
+      // Capture dunning event for analytics
+      if (orgId) {
+        await captureEvent('payment_failed', {
+          userId: orgId,
+          organizationId: orgId,
+        }, {
+          organization_id: orgId,
+          stripe_invoice_id: invoice.id,
+          stripe_customer_id: stripeCustomerId,
+          amount_due: invoice.amount_due,
+          attempt_count: invoice.attempt_count,
+          next_payment_attempt: invoice.next_payment_attempt,
+        });
+      }
+
+      // Send dunning email to customer
+      const billingCustomer = await getBillingCustomer(supabase, stripeCustomerId);
+
+      if (billingCustomer?.email) {
+        // Fire-and-forget email send (fail-open)
+        // Plan key defaults to 'pro' since invoice dunning is relevant to paid plans
+        void sendPaymentFailed({
+          email: billingCustomer.email,
+          planKey: 'pro',
+          amountDue: invoice.amount_due,
+          attemptCount: invoice.attempt_count,
+          nextPaymentAttempt: invoice.next_payment_attempt,
+        }).catch(() => null);
+      }
+
       break;
     }
     case 'invoice.finalized': {

--- a/lib/email/sales.ts
+++ b/lib/email/sales.ts
@@ -395,3 +395,40 @@ export async function sendGitHubLeadFollowup(opts: {
     </div>`,
   );
 }
+
+// ─── Payment Failed (Dunning) ─────────────────────────────────────────────────
+// Triggered on invoice.payment_failed webhook event
+export async function sendPaymentFailed(opts: {
+  email: string;
+  planKey: string;
+  amountDue: number;
+  attemptCount: number;
+  nextPaymentAttempt: number | null;
+}): Promise<void> {
+  const amountStr = (opts.amountDue / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+  const nextAttemptDate = opts.nextPaymentAttempt
+    ? new Date(opts.nextPaymentAttempt * 1000).toLocaleDateString('en-US')
+    : 'soon';
+
+  await sendEmail(
+    opts.email,
+    `⚠️ Payment failed — update your billing method now`,
+    `<div style="font-family:sans-serif;max-width:560px;margin:auto">
+      <h2 style="color:#ef4444">⚠️ Payment could not be processed</h2>
+      <p>We tried to charge ${amountStr} for your <strong>${opts.planKey.toUpperCase()}</strong> plan (attempt ${opts.attemptCount}).</p>
+      <p>The charge was declined. This can happen if:</p>
+      <ul>
+        <li>Your card has expired or been replaced</li>
+        <li>Your bank blocked the charge</li>
+        <li>Insufficient funds</li>
+      </ul>
+      <p><strong>Next retry:</strong> ${nextAttemptDate}</p>
+      <p>To avoid service suspension, update your billing method now:</p>
+      <a href="${BASE_URL}/dashboard/billing"
+         style="background:#ef4444;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;display:inline-block;font-weight:bold;margin-top:16px">
+        Update Payment Method →
+      </a>
+      <p style="color:#64748b;font-size:12px;margin-top:32px">If this charge was denied by mistake, contact your bank or <a href="mailto:support@dsg.pics" style="color:#64748b">reach out to support</a>.</p>
+    </div>`,
+  );
+}

--- a/tests/unit/billing/stripe-webhook.test.ts
+++ b/tests/unit/billing/stripe-webhook.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../../lib/supabase-server', () => ({
 vi.mock('../../../lib/email/sales', () => ({
   sendTrialWelcome: vi.fn(),
   sendUpgradeSuccess: vi.fn(),
+  sendPaymentFailed: vi.fn(),
 }));
 vi.mock('../../../lib/security/api-error', () => ({
   internalErrorMessage: vi.fn(() => 'Internal server error'),
@@ -28,14 +29,18 @@ vi.mock('../../../lib/billing/entitlements', () => ({
     ['canceled', 'unpaid', 'past_due', 'incomplete_expired'].includes(status) ? 'free' : planKey
   ),
 }));
+vi.mock('../../../lib/telemetry/capture-event', () => ({
+  captureEvent: vi.fn().mockResolvedValue({}),
+}));
 
 import { POST } from '../../../app/api/billing/webhook/route';
 import { getSupabaseAdmin } from '../../../lib/supabase-server';
-import { sendUpgradeSuccess } from '../../../lib/email/sales';
+import { sendUpgradeSuccess, sendPaymentFailed } from '../../../lib/email/sales';
 import { fulfillSubscription, revokeSubscription } from '../../../lib/billing/fulfillment';
 
 const mockGetAdmin = vi.mocked(getSupabaseAdmin);
 const mockSendUpgradeSuccess = vi.mocked(sendUpgradeSuccess);
+const mockSendPaymentFailed = vi.mocked(sendPaymentFailed);
 const mockFulfill = vi.mocked(fulfillSubscription);
 const mockRevoke = vi.mocked(revokeSubscription);
 
@@ -378,5 +383,28 @@ describe('POST /api/billing/webhook', () => {
     const res = await POST(makeRequest('{}'));
     expect(res.status).toBe(200);
     expect(mockRevoke).toHaveBeenCalledWith('org-1');
+  });
+
+  it('handles invoice.payment_failed without crashing', async () => {
+    const invoice = {
+      id: 'in_1',
+      customer: 'cus_1',
+      amount_due: 9999,
+      attempt_count: 2,
+      next_payment_attempt: 1704067200,
+      subscription: null,
+    };
+    const event = {
+      id: 'evt_payment_failed',
+      type: 'invoice.payment_failed',
+      data: { object: invoice },
+    };
+    mockStripeInstance.webhooks.constructEvent.mockReturnValue(event as any);
+
+    const res = await POST(makeRequest('{}'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.received).toBe(true);
+    expect(body.type).toBe('invoice.payment_failed');
   });
 });


### PR DESCRIPTION
## Goal

Replace the stub console.warn for `invoice.payment_failed` webhook events with real dunning notification flow: send email to customer, capture event for analytics.

## Files changed

- `lib/email/sales.ts`: Added `sendPaymentFailed()` email helper with HTML template
- `app/api/billing/webhook/route.ts`: 
  - Import sendPaymentFailed
  - Call captureEvent('payment_failed', ...) for analytics
  - Send dunning email via sendPaymentFailed() with fail-open pattern
- `tests/unit/billing/stripe-webhook.test.ts`: Added test for invoice.payment_failed handler

## Verification

- [x] npm run typecheck — passed
- [x] npm run test -- tests/unit/billing/stripe-webhook.test.ts — 10/10 tests pass
- [x] npm run build — succeeded

## Known limits

- Email only sends if RESEND_API_KEY env var is set (silent no-op otherwise, per pattern in lib/email/sales.ts)
- Plan key defaults to 'pro' in email (dunning is relevant to paid plans)
- "Live dunning" claim status: pending env configuration and evidence of actual sends to production environment

## User-visible benefit

Customers whose payments fail now receive email notification to update their billing method, with link to `/dashboard/billing` and next retry date. Dunning events are captured for analytics via captureEvent().

## Next step

Verify payment failed emails in staging/production environment with configured RESEND_API_KEY.

---
_Generated by [Claude Code](https://claude.ai/code/session_011xTvSUkX1u3nXHqa7UuqMY)_