### PR TITLE
Fix documentation claims to match actual code state

### DIFF
--- a/docs/8WEEK_PROGRESS_SUMMARY.md
+++ b/docs/8WEEK_PROGRESS_SUMMARY.md
@@ -472,7 +472,7 @@ ALTER TABLE organizations ADD COLUMN IF NOT EXISTS current_tier TEXT DEFAULT 'fr
 - ⏳ Supabase migrations (3 new tables + 2 alters) not yet applied
 - ⏳ RLS policies not yet enforced (auth context not implemented)
 - ⏳ Free tier quotas tracked in code, not persisted to DB
-- ⏳ Email notifications (Resend integration) scaffolded but not wired
+- ⏳ Email notifications (Resend integration code exists in `lib/resend.ts`; requires `RESEND_API_KEY` and `RESEND_FROM_EMAIL` env vars to activate)
 - ⏳ Billing (Stripe) configured in code, webhooks not tested
 - ⏳ Demo videos not yet recorded (placeholder scripts ready)
 

--- a/docs/one-pager-dev-team.md
+++ b/docs/one-pager-dev-team.md
@@ -132,9 +132,9 @@ console.log(result.audit_id, result.proof.proof_hash);
 ---
 
 ## Truth Boundary
-| ✅ Verified | ❌ Not Yet |
-|-------------|------------|
-| SDK builds, types work | **Not yet on npm** (ready to publish) |
+| ✅ Verified | ⏳ Pending |
+|-------------|-----------|
+| SDK builds, types work | **Ready to publish** (npm credentials required; no live npm registry entry yet) |
 | Gate returns decision + proof | Metered billing wired into execution; Stripe meter env not yet configured |
 | 2173 tests pass | GitHub App not yet live |
 | Edge gate <50ms latency | PyPI package not built |


### PR DESCRIPTION
## Goal

Align documentation with current implementation state per CLAUDE.md truth policy — no overclaiming, distinguish between code-ready and live-active states.

## Changes

**`docs/one-pager-dev-team.md` (Truth Boundary section)**
- OLD: `**Not yet on npm** (ready to publish)`
- NEW: `**Ready to publish** (npm credentials required; no live npm registry entry yet)`
- Reason: PR #919 merged with complete SDK packaging (`@dsg-one/sdk`), build passes, npm publish ready. Acknowledges founder action (npm token) required for actual publication.

**`docs/8WEEK_PROGRESS_SUMMARY.md` (MVP Limitations section)**
- OLD: `Email notifications (Resend integration) scaffolded but not wired`
- NEW: `Email notifications (Resend integration code exists in lib/resend.ts; requires RESEND_API_KEY and RESEND_FROM_EMAIL env vars to activate)`
- Reason: Actual Resend integration code present in codebase (`lib/resend.ts`, `lib/finance-governance/notify.ts`). Refines claim to reflect implementation exists but requires env configuration.

## Verification

- ✅ No longer any "Not yet on npm" claims remaining in docs/
- ✅ Removed misleading "scaffolded but not wired" claim
- ✅ Claims maintain distinction between code-ready and live-active per CLAUDE.md
- ✅ Documentation-only changes (no .ts/.tsx files modified)
- ✅ All metered billing statements already correct (code wired + env required)

## Known Limits

- SDK is **prepared for publishing** (tarball clean, build passes) but **not yet on npm registry**
  - Actual publication requires founder to run `npm publish` with valid npm credentials
  - This is a credential-level action outside agent scope
- Email notifications code exists but **not active** without RESEND_API_KEY
  - Reflects MVP pre-production state: implementation scaffolded + environment-gated

---

🤖 Documentation-only fix per Truth Boundary policy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX43jPKRga4pWGAMUry4RQ)_