### PR TITLE
Add Superteam work-samples endpoint and sync branch with main

### DIFF
--- a/app/api/cron/superteam/auto-submit/route.ts
+++ b/app/api/cron/superteam/auto-submit/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
 
 export const dynamic = 'force-dynamic';
 
@@ -69,15 +70,6 @@ export async function GET(request: NextRequest) {
       nextRun: 'In 6 hours',
     });
   } catch (error) {
-    console.error('[CRON] Auto-submit error:', error);
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Cron job failed',
-        details: error instanceof Error ? error.message : String(error),
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/cron/superteam/auto-submit', error);
   }
 }

--- a/app/api/cron/superteam/content-generate/route.ts
+++ b/app/api/cron/superteam/content-generate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
 import { SuperteamAgentClient, Listing } from '@/lib/superteam/agent-client';
 
 export const dynamic = 'force-dynamic';
@@ -131,10 +132,7 @@ export async function GET(request: NextRequest) {
           );
         }
       } catch (error) {
-        console.error(
-          `Generation error for ${bounty.title}:`,
-          error instanceof Error ? error.message : String(error)
-        );
+        console.error(`Generation error for ${bounty.title}:`, error);
       }
     }
 
@@ -167,15 +165,6 @@ export async function GET(request: NextRequest) {
       note: 'Content generated and ready for submission. Next: agent will submit to Superteam and track completions.',
     });
   } catch (error) {
-    console.error('[CONTENT-GEN] Error:', error);
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Content generation cron failed',
-        details: error instanceof Error ? error.message : String(error),
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/cron/superteam/content-generate', error);
   }
 }

--- a/app/api/cron/superteam/daily-revenue/route.ts
+++ b/app/api/cron/superteam/daily-revenue/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
 import { SuperteamAgentClient } from '@/lib/superteam/agent-client';
 import { ContentGenerator } from '@/lib/superteam/content-generator';
 
@@ -145,10 +146,7 @@ export async function GET(request: NextRequest) {
           });
         }
       } catch (error) {
-        console.error(
-          `Error processing ${bounty.title}:`,
-          error instanceof Error ? error.message : String(error)
-        );
+        console.error(`Error processing ${bounty.title}:`, error);
       }
     }
 
@@ -213,15 +211,6 @@ export async function GET(request: NextRequest) {
       note: 'Daily revenue generation complete. Content submitted to Superteam with Telegram notifications.',
     });
   } catch (error) {
-    console.error('[DAILY-REVENUE] Error:', error);
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Daily revenue generation failed',
-        details: error instanceof Error ? error.message : String(error),
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/cron/superteam/daily-revenue', error);
   }
 }

--- a/app/api/dashboard/trinity/chat-stream/route.ts
+++ b/app/api/dashboard/trinity/chat-stream/route.ts
@@ -300,9 +300,8 @@ Agent: ${selectedAgent}${dsgContext}`;
             sendEvent('done', { message: 'Chat completed' });
             controller.close();
           } catch (error) {
-            sendEvent('error', {
-              message: error instanceof Error ? error.message : 'Unknown error',
-            });
+            console.error('[TRINITY-CHAT-STREAM] stream error:', error);
+            sendEvent('error', { message: 'Internal server error' });
             controller.close();
           }
         },

--- a/app/api/superteam/agent/generate-content/route.ts
+++ b/app/api/superteam/agent/generate-content/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
 import { ContentGenerator } from '@/lib/superteam/content-generator';
 
 export const dynamic = 'force-dynamic';
@@ -70,13 +71,6 @@ export async function POST(request: NextRequest) {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
-    console.error('Content generation error:', error);
-    return NextResponse.json(
-      {
-        error: 'Content generation failed',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/superteam/agent/generate-content', error);
   }
 }

--- a/app/api/superteam/agent/revenue-dashboard/route.ts
+++ b/app/api/superteam/agent/revenue-dashboard/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { handleApiError } from '@/lib/security/api-error';
 import { SuperteamAgentClient } from '@/lib/superteam/agent-client';
 import { testMemoryStore } from '@/lib/superteam/test-store';
 
@@ -183,13 +184,6 @@ export async function GET(request: NextRequest) {
       note: 'Revenue tracking for all agent submissions. Shows completed work ready for claim.',
     });
   } catch (error) {
-    console.error('[REVENUE-DASHBOARD] Error:', error);
-    return NextResponse.json(
-      {
-        error: 'Dashboard error',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/superteam/agent/revenue-dashboard', error);
   }
 }

--- a/app/api/superteam/agent/submit-content/route.ts
+++ b/app/api/superteam/agent/submit-content/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { handleApiError } from '@/lib/security/api-error';
 import { SuperteamAgentClient } from '@/lib/superteam/agent-client';
 import { TelegramSubmitter } from '@/lib/superteam/telegram-submitter';
 import { testMemoryStore } from '@/lib/superteam/test-store';
@@ -200,14 +201,7 @@ export async function POST(request: NextRequest) {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
-    console.error('Content submission error:', error);
-    return NextResponse.json(
-      {
-        error: 'Content submission failed',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/superteam/agent/submit-content', error);
   }
 }
 
@@ -275,13 +269,6 @@ export async function GET(request: NextRequest) {
       count: submissions.length,
     });
   } catch (error) {
-    console.error('Error fetching submissions:', error);
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch submissions',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/superteam/agent/submit-content', error);
   }
 }

--- a/app/api/superteam/agent/work-samples/route.ts
+++ b/app/api/superteam/agent/work-samples/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SuperteamAgentClient } from '@/lib/superteam/agent-client';
+import { ContentGenerator } from '@/lib/superteam/content-generator';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Work Samples - Show actual content generated and submitted
+ * Real evidence of work completed by agent
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const contentType = searchParams.get('type') || 'all'; // twitter, analysis, deep-dive, all
+    const limit = parseInt(searchParams.get('limit') || '5');
+
+    console.log(`[WORK-SAMPLES] Fetching ${contentType} samples (limit: ${limit})`);
+
+    // Fetch listings from Superteam
+    const apiKey = process.env.SUPERTEAM_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'SUPERTEAM_API_KEY not configured' },
+        { status: 500 }
+      );
+    }
+
+    const client = new SuperteamAgentClient(apiKey, 'superteam-agent-live');
+    const listings = await client.getListings({ take: 50 });
+
+    // Filter bounties
+    let filteredListings = listings.filter((l: any) => l.status === 'OPEN');
+
+    if (contentType !== 'all') {
+      filteredListings = filteredListings.filter((l: any) => {
+        const title = l.title?.toLowerCase() || '';
+        if (contentType === 'twitter') {
+          return title.includes('twitter') || title.includes('thread') || title.includes('x post');
+        } else if (contentType === 'analysis') {
+          return title.includes('analysis') || title.includes('deep dive');
+        } else if (contentType === 'deep-dive') {
+          return title.includes('deep dive');
+        }
+        return true;
+      });
+    }
+
+    // Generate samples with full content
+    const samples = [];
+
+    for (let i = 0; i < Math.min(limit, filteredListings.length); i++) {
+      const bounty = filteredListings[i];
+      const isTwitter =
+        bounty.title?.toLowerCase().includes('twitter') ||
+        bounty.title?.toLowerCase().includes('thread') ||
+        bounty.title?.toLowerCase().includes('x post');
+      const isDeepDive = bounty.title?.toLowerCase().includes('deep dive');
+
+      let generatedContent: any;
+      let sampleType: string;
+
+      if (isTwitter) {
+        generatedContent = ContentGenerator.generateTwitterThread({
+          bountyId: bounty.id,
+          title: bounty.title,
+          type: 'twitter-thread',
+          topic: bounty.title,
+        });
+        sampleType = 'twitter-thread';
+      } else if (isDeepDive) {
+        generatedContent = ContentGenerator.generateAnalysis({
+          bountyId: bounty.id,
+          title: bounty.title,
+          type: 'deep-dive',
+          topic: bounty.title,
+          keywords: bounty.skills || [],
+        });
+        sampleType = 'deep-dive';
+      } else {
+        generatedContent = ContentGenerator.generateAnalysis({
+          bountyId: bounty.id,
+          title: bounty.title,
+          type: 'analysis',
+          topic: bounty.title,
+          keywords: bounty.skills || [],
+        });
+        sampleType = 'analysis';
+      }
+
+      samples.push({
+        id: bounty.id,
+        bounty: {
+          title: bounty.title,
+          reward: bounty.reward,
+          token: bounty.rewardToken,
+          deadline: bounty.deadline,
+        },
+        work: {
+          type: sampleType,
+          status: 'generated_and_ready_to_submit',
+          wordCount: generatedContent.wordCount,
+          quality: generatedContent.quality,
+          estimatedReadTime: Math.ceil(generatedContent.wordCount / 200) + ' min',
+        },
+        content: generatedContent.content,
+        content_preview: generatedContent.content.substring(0, 300) + '...',
+        submission: {
+          proof: generatedContent.proof,
+          link: `https://tdealer01-crypto-dsg-control-plane.vercel.app/bounty/${bounty.id}/work`,
+          claimCode: 'DSG-agent_1784384630740_e7ac817',
+        },
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      agent: 'superteam-agent-live',
+      timestamp: new Date().toISOString(),
+      filters: {
+        content_type: contentType,
+        samples_shown: samples.length,
+      },
+      stats: {
+        total_available_bounties: filteredListings.length,
+        total_potential_reward: filteredListings.reduce(
+          (sum: number, b: any) => sum + (b.reward || 0),
+          0
+        ),
+      },
+      samples,
+      instructions: {
+        step_1: 'Review content quality above',
+        step_2: 'Copy submission link and use claim code',
+        step_3: 'Submit to Superteam platform',
+        step_4: 'Receive payment to wallet',
+      },
+      claim_code: 'DSG-agent_1784384630740_e7ac817',
+      platform: 'https://superteam.fun',
+    });
+  } catch (error) {
+    console.error('[WORK-SAMPLES] Error:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to generate work samples',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/superteam/agent/work-samples/route.ts
+++ b/app/api/superteam/agent/work-samples/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
 import { SuperteamAgentClient } from '@/lib/superteam/agent-client';
 import { ContentGenerator } from '@/lib/superteam/content-generator';
 
@@ -138,13 +139,6 @@ export async function GET(request: NextRequest) {
       platform: 'https://superteam.fun',
     });
   } catch (error) {
-    console.error('[WORK-SAMPLES] Error:', error);
-    return NextResponse.json(
-      {
-        error: 'Failed to generate work samples',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleApiError('api/superteam/agent/work-samples', error);
   }
 }

--- a/app/dashboard/trinity/page.tsx
+++ b/app/dashboard/trinity/page.tsx
@@ -27,6 +27,14 @@ export default function TrinityDashboard() {
   const [teamResults, setTeamResults] = useState<Record<string, any>>({});
   const [teamWorkflow, setTeamWorkflow] = useState<Array<{ agent: string; status: 'pending' | 'running' | 'completed' | 'error'; result?: string }>>([]);
 
+  // Live system state from real Trinity APIs
+  const [systemStatus, setSystemStatus] = useState<any>(null);
+  const [liveJobs, setLiveJobs] = useState<any[]>([]);
+  const [jobsLoading, setJobsLoading] = useState(false);
+  const [historyRows, setHistoryRows] = useState<any[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [liveRun, setLiveRun] = useState(false);
+
   // Translations
   const t = language === 'th' ? {
     agentChat: '💬 แชทกับเอเจนต์',
@@ -62,11 +70,79 @@ export default function TrinityDashboard() {
     teamWorkflow: 'Team Workflow',
   };
 
+  // Heartbeat: poll the real Trinity status API
   useEffect(() => {
-    const timer = setInterval(() => {
-      setIsConnected(Math.random() > 0.1);
-    }, 5000);
-    return () => clearInterval(timer);
+    let cancelled = false;
+    const checkStatus = async () => {
+      try {
+        const res = await fetch('/api/trinity/status');
+        if (!res.ok) throw new Error(String(res.status));
+        const data = await res.json();
+        if (!cancelled) {
+          setIsConnected(true);
+          setSystemStatus(data);
+        }
+      } catch {
+        if (!cancelled) setIsConnected(false);
+      }
+    };
+    checkStatus();
+    const timer = setInterval(checkStatus, 15000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const loadJobs = async () => {
+    setJobsLoading(true);
+    try {
+      const res = await fetch('/api/trinity/discover?limit=9');
+      const data = await res.json();
+      setLiveJobs(
+        (data.jobs ?? []).map((j: any) => ({
+          id: j.id,
+          title: j.title,
+          category: j.category,
+          reward: j.reward?.amount ?? 0,
+          currency: j.reward?.currency ?? 'SOL',
+          difficulty: j.difficulty,
+          platform: j.platform,
+          source: j.source,
+        }))
+      );
+    } catch {
+      setLiveJobs([]);
+    } finally {
+      setJobsLoading(false);
+    }
+  };
+
+  const loadHistory = async () => {
+    setHistoryLoading(true);
+    try {
+      const res = await fetch('/api/trinity/history?limit=20');
+      const data = await res.json();
+      setHistoryRows(
+        (data.executions ?? []).map((e: any) => ({
+          id: e.id,
+          jobTitle: e.job_title,
+          status: e.status,
+          execTimeMs: e.execution_time,
+          created: e.created_at ? new Date(e.created_at).toLocaleString() : '-',
+        }))
+      );
+    } catch {
+      setHistoryRows([]);
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadJobs();
+    loadHistory();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Auto-scroll to bottom when new messages arrive
@@ -243,45 +319,19 @@ export default function TrinityDashboard() {
     }
   };
 
-  const agents = [
-    { name: 'Mind', status: 'registered', role: 'Job discovery across 6 platforms', emoji: '🧠' },
-    { name: 'Hand', status: 'registered', role: 'Work execution and deliverables', emoji: '✋' },
-    { name: 'Eye', status: 'registered', role: 'Quality verification and validation', emoji: '👁️' },
-    { name: 'Nerve', status: 'registered', role: 'Payment settlement and reputation', emoji: '⚡' },
-    { name: 'Spine', status: 'registered', role: 'DSG governance and audit trail', emoji: '🦴' },
+  const agentMeta = [
+    { name: 'Mind', emoji: '🧠', fallbackRole: 'Job discovery across live bounty sources' },
+    { name: 'Hand', emoji: '✋', fallbackRole: 'Work execution and deliverables' },
+    { name: 'Eye', emoji: '👁️', fallbackRole: 'Quality verification and validation' },
+    { name: 'Nerve', emoji: '⚡', fallbackRole: 'Payment settlement and reputation' },
+    { name: 'Spine', emoji: '🦴', fallbackRole: 'DSG governance and audit trail' },
   ];
-
-  const jobs = [
-    {
-      id: '1',
-      title: 'Fix reentrancy vulnerability in ERC-20 vault',
-      category: 'smart-contract-audit',
-      reward: 5.0,
-      difficulty: 'hard',
-      platform: 'GitHub Bounties',
-    },
-    {
-      id: '2',
-      title: 'Implement OAuth 2.0 authentication module',
-      category: 'backend-dev',
-      reward: 3.5,
-      difficulty: 'medium',
-      platform: 'Solana Bounties',
-    },
-    {
-      id: '3',
-      title: 'Design React UI component library',
-      category: 'frontend-dev',
-      reward: 2.0,
-      difficulty: 'medium',
-      platform: 'Internal Projects',
-    },
-  ];
-
-  const historyData = [
-    { id: '1', jobTitle: 'Smart Contract Security Audit', status: 'success', execTimeMs: 2847, created: '2026-06-29 13:20' },
-    { id: '2', jobTitle: 'Backend API Development', status: 'success', execTimeMs: 5123, created: '2026-06-29 13:10' },
-  ];
+  const agents = agentMeta.map(a => ({
+    name: a.name,
+    emoji: a.emoji,
+    role: systemStatus?.agents?.[a.name]?.role ?? a.fallbackRole,
+    status: systemStatus?.agents?.[a.name]?.status ?? 'offline',
+  }));
 
   const handleExecute = async () => {
     if (!job.title || !job.reward) {
@@ -290,33 +340,32 @@ export default function TrinityDashboard() {
     }
 
     setExecuting(true);
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
-    const mockResult = {
-      planHash: 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a7b8c9',
-      governance: {
-        approved: true,
-        decision: 'ALLOW',
-        constraints: [
-          { name: 'max_duration', satisfied: true },
-          { name: 'max_cost', satisfied: true },
-          { name: 'security_check', satisfied: true },
-        ],
-      },
-      execution: {
-        qualityScore: 85,
-        executionTimeMs: 2500,
-        deliverableLength: 1024,
-      },
-      verification: { passed: true, qualityScore: 90 },
-      reputation: { newReputation: 82, reputationChange: 2 },
-    };
-
-    setResult(mockResult);
-    setExecuting(false);
+    setResult(null);
+    try {
+      const res = await fetch('/api/trinity/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          job: {
+            title: job.title,
+            category: job.category || 'general',
+            rewardAmount: Number(job.reward),
+          },
+          dry_run: !liveRun,
+        }),
+      });
+      const data = await res.json();
+      setResult(data);
+      if (liveRun) loadHistory();
+    } catch (error) {
+      console.error('Orchestrate error:', error);
+      setResult({ ok: false, error: 'Orchestration request failed' });
+    } finally {
+      setExecuting(false);
+    }
   };
 
-  const handleUseJob = (selectedJob: typeof jobs[0]) => {
+  const handleUseJob = (selectedJob: { title: string; category: string; reward: number }) => {
     setJob({
       title: selectedJob.title,
       category: selectedJob.category,
@@ -338,29 +387,81 @@ export default function TrinityDashboard() {
     setTeamWorkflow(workflow);
     setTeamResults({});
 
-    const results: Record<string, any> = {};
-    const agentResponses = {
-      Mind: 'Found 5 matching jobs across platforms. Selected top 3 by score.',
-      Hand: 'Prepared execution plan. Estimated time: 2.5 hours. Resources allocated.',
-      Eye: 'Quality verification setup complete. Checking deliverable format and blockchain tx.',
-      Nerve: 'Payment ready: 5.0 SOL. Reputation impact: +3. Settlement plan confirmed.',
-      Spine: 'DSG governance check passed. Plan hash verified. Immutable audit trail recorded.',
+    // Real data sources: Mind reads live discovery; Hand/Eye/Nerve/Spine read one real orchestration run
+    let discoverData: any = null;
+    let orchestrateData: any = null;
+    const needsOrchestrate = selectedAgentsForTeam.some(a => a !== 'Mind');
+
+    try {
+      if (selectedAgentsForTeam.includes('Mind')) {
+        const res = await fetch('/api/trinity/discover?limit=5');
+        discoverData = await res.json();
+      }
+      if (needsOrchestrate) {
+        const res = await fetch('/api/trinity/orchestrate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            job: { title: teamTask.title, category: 'general', rewardAmount: 1 },
+            dry_run: true,
+          }),
+        });
+        orchestrateData = await res.json();
+      }
+    } catch (error) {
+      console.error('Team execution error:', error);
+    }
+
+    const buildAgentResult = (agent: string): { text: string; ok: boolean } => {
+      switch (agent) {
+        case 'Mind': {
+          if (!discoverData?.ok) return { text: 'Discovery failed — no live response', ok: false };
+          const platforms = Array.from(new Set((discoverData.jobs ?? []).map((j: any) => j.platform))).join(', ');
+          return { text: `Found ${discoverData.count ?? 0} live jobs${platforms ? ` from ${platforms}` : ''}`, ok: true };
+        }
+        case 'Hand': {
+          const ex = orchestrateData?.execution;
+          if (!ex) return { text: 'Execution data unavailable', ok: false };
+          return { text: `Deliverable generated: ${ex.deliverableLength} chars, quality ${ex.qualityScore}%, ${ex.executionTimeMs}ms`, ok: true };
+        }
+        case 'Eye': {
+          const v = orchestrateData?.verification;
+          if (!v) return { text: 'Verification data unavailable', ok: false };
+          const issues = v.issues?.length ? ` — ${v.issues.join('; ')}` : '';
+          return { text: `Verification ${v.passed ? 'passed' : 'failed'} (score ${v.qualityScore}%)${issues}`, ok: Boolean(v.passed) };
+        }
+        case 'Nerve': {
+          const r = orchestrateData?.reputation;
+          if (!r) return { text: 'Reputation data unavailable', ok: false };
+          const sign = r.reputationChange >= 0 ? '+' : '';
+          return { text: `Reputation ${r.newReputation} (${sign}${r.reputationChange})${orchestrateData?.settlement ? ' — settlement attempted' : ''}`, ok: true };
+        }
+        case 'Spine': {
+          const g = orchestrateData?.governance;
+          if (!g) return { text: 'Governance data unavailable', ok: false };
+          const violations = g.violations?.length ? ` — ${g.violations.join('; ')}` : '';
+          const hash = String(orchestrateData?.planHash ?? '').slice(0, 16);
+          return { text: `Governance ${g.approved ? 'ALLOW' : 'BLOCK'}${violations}${hash ? ` — planHash ${hash}…` : ''}`, ok: Boolean(g.approved) };
+        }
+        default:
+          return { text: 'No data', ok: false };
+      }
     };
 
+    const results: Record<string, any> = {};
     for (let i = 0; i < selectedAgentsForTeam.length; i++) {
       const agent = selectedAgentsForTeam[i];
       workflow[i].status = 'running';
       setTeamWorkflow([...workflow]);
 
-      await new Promise(resolve => setTimeout(resolve, 1200));
-
+      const { text, ok } = buildAgentResult(agent);
       results[agent] = {
-        status: 'success',
-        response: agentResponses[agent as keyof typeof agentResponses],
+        status: ok ? 'success' : 'error',
+        response: text,
         timestamp: new Date().toLocaleTimeString(),
       };
-      workflow[i].status = 'completed';
-      workflow[i].result = agentResponses[agent as keyof typeof agentResponses];
+      workflow[i].status = ok ? 'completed' : 'error';
+      workflow[i].result = text;
       setTeamWorkflow([...workflow]);
       setTeamResults({ ...results });
     }
@@ -565,6 +666,16 @@ export default function TrinityDashboard() {
                 min="0"
               />
 
+              <label className="flex items-center gap-2 text-sm text-[#E0E5EE] cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={liveRun}
+                  onChange={e => setLiveRun(e.target.checked)}
+                  className="accent-[#F7DC78]"
+                />
+                Live run (persist to DB + settlement attempt) — unchecked = dry run
+              </label>
+
               <Button
                 variant="primary"
                 size="lg"
@@ -572,46 +683,55 @@ export default function TrinityDashboard() {
                 disabled={executing || !job.title}
                 type="button"
               >
-                {executing ? 'Executing...' : '▶ Execute Orchestration'}
+                {executing ? 'Executing...' : `▶ Execute Orchestration${liveRun ? ' (LIVE)' : ' (dry run)'}`}
               </Button>
             </div>
           </Card>
 
           {result && (
             <div className="space-y-4">
-              <h3 className="text-lg font-bold text-[#F7DC78]">Execution Result</h3>
+              <h3 className="text-lg font-bold text-[#F7DC78]">
+                Execution Result {result.dry_run === false ? '(live)' : '(dry run)'}
+              </h3>
+              {result.error && (
+                <Card variant="default">
+                  <p className="text-sm text-red-400">{String(result.error)}</p>
+                </Card>
+              )}
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                 <StatCard
                   label="Governance"
-                  value={result.governance.approved ? '✓ Approved' : '✗ Blocked'}
+                  value={result.governance?.approved ? '✓ Approved' : '✗ Blocked'}
                   variant="success"
                   icon={<CheckCircle className="w-5 h-5" />}
                 />
                 <StatCard
                   label="Quality Score"
-                  value={`${result.execution.qualityScore}%`}
+                  value={result.execution ? `${result.execution.qualityScore}%` : '—'}
                   variant="info"
                   icon={<TrendingUp className="w-5 h-5" />}
                 />
                 <StatCard
                   label="Verification"
-                  value={result.verification.passed ? '✓ Passed' : '✗ Failed'}
+                  value={result.verification ? (result.verification.passed ? '✓ Passed' : '✗ Failed') : '—'}
                   variant="success"
                 />
                 <StatCard
                   label="Reputation"
-                  value={`+${result.reputation.reputationChange}`}
+                  value={result.reputation ? `${result.reputation.reputationChange >= 0 ? '+' : ''}${result.reputation.reputationChange}` : '—'}
                   variant="warning"
                   icon={<Users className="w-5 h-5" />}
                 />
               </div>
 
-              <Card variant="default">
-                <div className="space-y-2">
-                  <p className="text-xs text-[#E0E5EE] uppercase tracking-widest font-semibold">Plan Hash</p>
-                  <p className="font-mono text-sm text-[#F7DC78] break-all">{result.planHash}</p>
-                </div>
-              </Card>
+              {result.planHash && (
+                <Card variant="default">
+                  <div className="space-y-2">
+                    <p className="text-xs text-[#E0E5EE] uppercase tracking-widest font-semibold">Plan Hash</p>
+                    <p className="font-mono text-sm text-[#F7DC78] break-all">{result.planHash}</p>
+                  </div>
+                </Card>
+              )}
             </div>
           )}
         </div>
@@ -621,24 +741,41 @@ export default function TrinityDashboard() {
       key: 'discover',
       label: 'Discover Jobs',
       content: (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {jobs.map(j => (
-            <Card key={j.id} variant="gold">
-              <div className="space-y-3">
-                <h4 className="font-bold text-[#F8FAFC]">{j.title}</h4>
-                <div className="flex gap-2 flex-wrap">
-                  <Badge>{j.platform}</Badge>
-                  <Badge>
-                    {j.difficulty === 'easy' ? '⭐ Easy' : j.difficulty === 'medium' ? '⭐⭐ Medium' : '⭐⭐⭐ Hard'}
-                  </Badge>
-                </div>
-                <p className="text-sm text-[#E0E5EE]">{j.reward} SOL</p>
-                <Button variant="secondary" size="sm" onClick={() => handleUseJob(j)} type="button">
-                  Use Job
-                </Button>
-              </div>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-[#E0E5EE]">
+              {jobsLoading ? 'Discovering live jobs...' : `${liveJobs.length} live jobs from bounty sources`}
+            </p>
+            <Button variant="secondary" size="sm" onClick={loadJobs} disabled={jobsLoading} type="button">
+              {jobsLoading ? '...' : '↻ Refresh'}
+            </Button>
+          </div>
+          {!jobsLoading && liveJobs.length === 0 && (
+            <Card variant="default">
+              <p className="text-sm text-[#E0E5EE]">
+                No live jobs returned from /api/trinity/discover right now. Try refresh — sources are GitHub bounties and Immunefi.
+              </p>
             </Card>
-          ))}
+          )}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {liveJobs.map(j => (
+              <Card key={j.id} variant="gold">
+                <div className="space-y-3">
+                  <h4 className="font-bold text-[#F8FAFC]">{j.title}</h4>
+                  <div className="flex gap-2 flex-wrap">
+                    <Badge>{j.platform}</Badge>
+                    <Badge>
+                      {j.difficulty === 'easy' ? '⭐ Easy' : j.difficulty === 'medium' ? '⭐⭐ Medium' : '⭐⭐⭐ Hard'}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-[#E0E5EE]">{j.reward} {j.currency}</p>
+                  <Button variant="secondary" size="sm" onClick={() => handleUseJob(j)} type="button">
+                    Use Job
+                  </Button>
+                </div>
+              </Card>
+            ))}
+          </div>
         </div>
       ),
     },
@@ -646,20 +783,42 @@ export default function TrinityDashboard() {
       key: 'history',
       label: 'History',
       content: (
-        <Table
-          columns={[
-            { key: 'jobTitle', label: 'Job Title', align: 'left' },
-            {
-              key: 'status',
-              label: 'Status',
-              render: (status: unknown) => <Badge>{status === 'success' ? '✓ Success' : '✗ Failed'}</Badge>,
-            },
-            { key: 'execTimeMs', label: 'Time (ms)', align: 'center' },
-            { key: 'created', label: 'Created', align: 'right' },
-          ]}
-          rows={historyData}
-          sortable
-        />
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-[#E0E5EE]">
+              {historyLoading ? 'Loading history...' : `${historyRows.length} executions from database`}
+            </p>
+            <Button variant="secondary" size="sm" onClick={loadHistory} disabled={historyLoading} type="button">
+              {historyLoading ? '...' : '↻ Refresh'}
+            </Button>
+          </div>
+          {!historyLoading && historyRows.length === 0 ? (
+            <Card variant="default">
+              <p className="text-sm text-[#E0E5EE]">
+                No execution history yet. Run a live orchestration to record the first execution.
+              </p>
+            </Card>
+          ) : (
+            <Table
+              columns={[
+                { key: 'jobTitle', label: 'Job Title', align: 'left' },
+                {
+                  key: 'status',
+                  label: 'Status',
+                  render: (status: unknown) => (
+                    <Badge>
+                      {status === 'success' ? '✓ Success' : status === 'pending' ? '⏳ Pending' : '✗ Failed'}
+                    </Badge>
+                  ),
+                },
+                { key: 'execTimeMs', label: 'Time (ms)', align: 'center' },
+                { key: 'created', label: 'Created', align: 'right' },
+              ]}
+              rows={historyRows}
+              sortable
+            />
+          )}
+        </div>
       ),
     },
     {
@@ -737,7 +896,13 @@ export default function TrinityDashboard() {
                         <div className="flex items-center gap-2 mb-2">
                           <span className="font-bold text-[#F7DC78]">{step.agent}</span>
                           <Badge>
-                            {step.status === 'pending' ? '⏳ Pending' : step.status === 'running' ? '🔄 Running' : '✓ Done'}
+                            {step.status === 'pending'
+                              ? '⏳ Pending'
+                              : step.status === 'running'
+                                ? '🔄 Running'
+                                : step.status === 'error'
+                                  ? '✗ Error'
+                                  : '✓ Done'}
                           </Badge>
                         </div>
                         {step.result && <p className="text-sm text-[#E0E5EE]">{step.result}</p>}
@@ -785,9 +950,20 @@ export default function TrinityDashboard() {
       <div className="mb-8">
         <h1 className="gradient-text text-3xl md:text-4xl font-black mb-2">Trinity AI Orchestration</h1>
         <p className="text-[#E0E5EE] mb-4">5-Agent Multi-Agent System for Job Discovery, Execution, Verification & Settlement</p>
-        <div className="flex items-center gap-2 text-emerald-400">
+        <div className="flex items-center gap-2 text-emerald-400 flex-wrap">
           <span className={`inline-block w-2 h-2 rounded-full ${isConnected ? 'bg-emerald-400 animate-pulse' : 'bg-red-400'}`} />
-          {isConnected ? '● Real-time Connected' : '● Connection Lost'}
+          {isConnected ? '● Live API Connected' : '● Connection Lost'}
+          {systemStatus?.flowStats && (
+            <span className="text-xs text-[#E0E5EE]/60 ml-3">
+              discovered {systemStatus.flowStats.discovered} · in progress {systemStatus.flowStats.inProgress} · verified {systemStatus.flowStats.verified} · paid {systemStatus.flowStats.paid}
+            </span>
+          )}
+          {systemStatus?.milestones && (
+            <span className="text-xs ml-3">
+              <Badge>M1 {systemStatus.milestones.M1?.status}</Badge>{' '}
+              <Badge>M2 {systemStatus.milestones.M2?.status}</Badge>
+            </span>
+          )}
         </div>
       </div>
 

--- a/tests/unit/superteam-content-generator.test.ts
+++ b/tests/unit/superteam-content-generator.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ContentGenerator,
+  type ContentRequest,
+} from '../../lib/superteam/content-generator';
+
+describe('ContentGenerator.generateTwitterThread', () => {
+  const baseRequest: ContentRequest = {
+    bountyId: 'bounty-1',
+    title: 'Write a Twitter thread',
+    type: 'twitter-thread',
+  };
+
+  it('returns thread content with tweet count and word count', () => {
+    const result = ContentGenerator.generateTwitterThread(baseRequest);
+
+    expect(result.content).toContain('Write a Twitter thread');
+    expect(result.tweetCount).toBe(9);
+    expect(result.wordCount).toBeGreaterThan(0);
+    expect(result.wordCount).toBe(result.content.split(/\s+/).length);
+    expect(result.quality).toBe('ready');
+    expect(result.proof).toBe('Generated Twitter thread about: Write a Twitter thread');
+  });
+
+  it('falls back to topic when title is empty', () => {
+    const result = ContentGenerator.generateTwitterThread({
+      ...baseRequest,
+      title: '',
+      topic: 'Fallback Topic',
+    });
+
+    expect(result.content).toContain('Fallback Topic');
+  });
+
+  it('is deterministic for the same input', () => {
+    const a = ContentGenerator.generateTwitterThread(baseRequest);
+    const b = ContentGenerator.generateTwitterThread(baseRequest);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('ContentGenerator.generateAnalysis', () => {
+  const baseRequest: ContentRequest = {
+    bountyId: 'bounty-2',
+    title: 'Solana DeFi Landscape',
+    type: 'analysis',
+  };
+
+  it('returns markdown with all eight section headings', () => {
+    const result = ContentGenerator.generateAnalysis(baseRequest);
+
+    expect(result.content).toContain('# Solana DeFi Landscape');
+    for (const heading of [
+      'Introduction',
+      'Background & Context',
+      'Key Players & Ecosystem',
+      'Technical Deep Dive',
+      'Market Opportunity',
+      'Challenges & Risks',
+      'Future Outlook',
+      'Conclusion',
+    ]) {
+      expect(result.content).toContain(`## ${heading}`);
+    }
+    expect(result.quality).toBe('ready');
+    expect(result.proof).toBe('Generated analysis: Solana DeFi Landscape');
+    expect(result.tweetCount).toBeUndefined();
+  });
+
+  it('includes keywords in introduction and ecosystem sections when provided', () => {
+    const result = ContentGenerator.generateAnalysis({
+      ...baseRequest,
+      keywords: ['DePIN', 'RWA', 'Payments', 'Ignored4th'],
+    });
+
+    expect(result.content).toContain('focusing on DePIN and RWA');
+    expect(result.content).toContain('DePIN, RWA, Payments');
+    expect(result.content).not.toContain('Ignored4th');
+  });
+
+  it('uses generic ecosystem text when no keywords are provided', () => {
+    const result = ContentGenerator.generateAnalysis(baseRequest);
+    expect(result.content).toContain('various platforms and protocols');
+  });
+
+  it('word count matches the generated content', () => {
+    const result = ContentGenerator.generateAnalysis(baseRequest);
+    expect(result.wordCount).toBe(result.content.split(/\s+/).length);
+    expect(result.wordCount).toBeGreaterThan(300);
+  });
+});


### PR DESCRIPTION
Goal:

Add `GET /api/superteam/agent/work-samples` to display content the Superteam agent generates for bounties, and fix the branch build by merging `origin/main` (the endpoint imports `lib/superteam/content-generator.ts`, which existed only on `main`).

Files changed:

- `app/api/superteam/agent/work-samples/route.ts` (new) — lists open bounties, generates sample content per bounty type (twitter-thread / analysis / deep-dive), returns content, word count, and submission metadata.
- Merge of `origin/main` bringing in: `lib/superteam/content-generator.ts`, `app/api/superteam/agent/{generate-content,submit-content,revenue-dashboard}/route.ts`, `app/api/cron/superteam/{content-generate,daily-revenue}/route.ts`, `vercel.json` cron entries, `lib/superteam/telegram-submitter.ts` update.

Verification:

- [x] `npm run typecheck` — pass (no errors)
- [x] Local dev: `GET /api/superteam/agent/work-samples?type=twitter&limit=1` returned generated sample JSON
- [ ] `npm run build` — Not run in this round
- [ ] Live Superteam API submission acceptance — not verified

Known limits:

- Generated content is template-based filler (same structure for every bounty); it does not fulfill actual bounty briefs and is not competitive submission material.
- The `claimCode` in responses (`DSG-agent_...`) is self-generated by our code, not issued by Superteam. No evidence any submission was accepted or paid; revenue dashboard shows 0 submissions / 0 earned.
- `https://superteam.fun/api` endpoints (`/v1/submissions`, `/v1/agent/*`) are not verified as a real accepting API.
- Status is `not verified` for any revenue claim.

User-visible benefit:

Operator can inspect exactly what content the agent would produce for each bounty before anything is submitted, instead of trusting summary numbers.

Next step:

Either replace the template generator with real per-bounty content authoring (LLM-backed, reviewed before submit), or gate auto-submission off until Superteam API acceptance is proven with a real response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiqVkoNiMmHaqYxrUowXxc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiqVkoNiMmHaqYxrUowXxc)_