### PR TITLE
feat: Runpod MCP integration + unlock dashboard E2E, real ReviewGatePanel, dashboard smoke suite

### DIFF
--- a/.claude/skills/runpod-agent/SKILL.md
+++ b/.claude/skills/runpod-agent/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: runpod-agent
+description: จัดการ GPU workloads บน Runpod ผ่าน MCP server และ Runpod CLI — สร้าง/หยุด/ลบ Pods, deploy Serverless endpoints, ตรวจสอบ GPU availability, จัดการ templates และ network volumes ใช้เมื่อผู้ใช้พูดถึง Runpod, GPU pod, Serverless GPU endpoint, runpodctl หรือการ deploy โมเดล ML บน GPU cloud
+---
+
+# Runpod Agent Skill
+
+Skill นี้สอนวิธีจัดการทรัพยากร GPU บน Runpod สำหรับโปรเจกต์ DSG ONE / ProofGate Control Plane
+
+## Prerequisites (ตรวจสอบก่อนเริ่ม)
+
+1. **API key**: ต้องมี `RUNPOD_API_KEY` ในสภาพแวดล้อม
+   - Production: ตั้งค่าใน Vercel project environment variables แล้ว (ตรวจสอบด้วยชื่อ ไม่พิมพ์ค่า)
+   - Local: export ใน shell หรือใส่ใน `.env` (ห้าม commit ค่าเด็ดขาด)
+   - ตรวจสอบว่า deployment มี key: `GET /api/runpod/status` คืน `{ "configured": true }`
+2. **MCP server**: `.mcp.json` ของ repo นี้กำหนด server `runpod` (stdio ผ่าน `npx @runpod/mcp-server@latest`) และ `runpod-docs` (HTTP ที่ `https://docs.runpod.io/mcp`) ไว้แล้ว
+   - ถ้าเครื่องมือ `mcp__runpod__*` ไม่ปรากฏ ให้ผู้ใช้ตรวจสอบ `/mcp` และการตั้งค่า `RUNPOD_API_KEY`
+3. **CLI (ทางเลือก)**: `runpodctl` — ติดตั้งด้วย `curl -sSL https://cli.runpod.net | bash` แล้วยืนยันด้วย `runpodctl doctor`
+
+## เลือกเครื่องมือให้ถูก
+
+| งาน | เครื่องมือ |
+| --- | --- |
+| สร้าง/ลิสต์/หยุด/ลบ Pods, endpoints, templates, volumes | Runpod MCP tools (`mcp__runpod__*`) |
+| ถามความรู้/วิธีใช้ฟีเจอร์ Runpod | Runpod docs MCP (`mcp__runpod-docs__*`) หรือ https://docs.runpod.io/llms.txt |
+| โอนไฟล์, SSH, model caching, Hub deployments | `runpodctl` ผ่าน Bash |
+| ตรวจว่า key ถูกตั้งใน deployment | `GET /api/runpod/status` (คืนแค่ configured boolean) |
+
+## ตัวอย่างงานที่ทำได้
+
+- "List my Runpod endpoints" / "แสดง Pods ทั้งหมดของฉัน"
+- "Create a Pod with an RTX 4090" — ระบุ name, image, GPU type, GPU count, cloud type (SECURE/COMMUNITY)
+- "Deploy a Serverless endpoint using template X" — ระบุ min/max workers
+- "Stop the Pod named ml-training-pod"
+- "What GPUs are available?" / "Show my account balance"
+
+## กฎความปลอดภัยของ repo นี้ (บังคับ)
+
+1. **ห้ามพิมพ์หรือ commit ค่า `RUNPOD_API_KEY`** — อ้างอิงด้วยชื่อ env var เท่านั้น (ตาม CLAUDE.md §9)
+2. **การกระทำที่มีค่าใช้จ่าย** (สร้าง Pod, เพิ่ม workers, ซื้อ storage) — แจ้ง GPU type/ราคาโดยประมาณและขอยืนยันจากผู้ใช้ก่อน เว้นแต่ผู้ใช้สั่ง spec ชัดเจนแล้ว
+3. **การกระทำทำลายล้าง** (terminate/delete Pod, ลบ volume, ลบ endpoint) — ยืนยันชื่อ/ID ที่แน่นอนกับผู้ใช้ก่อนเสมอ
+4. **Claim boundary**: อย่าอ้างว่า endpoint/Pod "พร้อม production" จากการสร้างสำเร็จอย่างเดียว — ต้องมีหลักฐานสถานะจริง (เช่น ผลจาก list/get ที่แสดง status RUNNING/READY) ตามนโยบาย evidence-first ของ repo
+5. หลักฐานทุกอย่างรายงานตามจริง: ถ้าคำสั่งล้มเหลวหรือไม่ได้รัน ให้บอกว่า `Not run` พร้อมเหตุผล
+
+## Quick reference
+
+```bash
+# ตรวจสอบ CLI + auth
+runpodctl doctor
+
+# ลิสต์ pods ผ่าน CLI
+runpodctl get pod
+
+# ตรวจว่า deployment บน Vercel มี key แล้ว (ไม่เปิดเผยค่า)
+curl -fsSL "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/runpod/status"
+```
+
+เอกสารเต็ม: `docs/RUNPOD_INTEGRATION.md` และ https://docs.runpod.io/llms.txt

--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,13 @@ SUPERTEAM_API_KEY=
 # Optional: Override Superteam API base URL (default: https://earn.superteam.fun/api)
 SUPERTEAM_BASE_URL=
 
+# ============ Runpod (GPU Infrastructure + MCP) ============
+# Runpod API key — used by the Runpod API MCP server (.mcp.json) and any
+# server-side Runpod REST calls. Get from: https://console.runpod.io/user/settings
+# Referenced as ${RUNPOD_API_KEY} in .mcp.json — never commit the value.
+# Production: set in Vercel project environment variables (name only here).
+RUNPOD_API_KEY=
+
 # ============ Z.AI MCP Servers (Vision + Web Reader) ============
 # GLM Coding Plan key from https://z.ai/manage-apikey/apikey-list
 # Shared by the local Vision MCP server (@z_ai/mcp-server) and the remote

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,18 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=zeyguilldygozufpgxms&read_only=true"
+    },
+    "runpod": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@runpod/mcp-server@latest"],
+      "env": {
+        "RUNPOD_API_KEY": "${RUNPOD_API_KEY}"
+      }
+    },
+    "runpod-docs": {
+      "type": "http",
+      "url": "https://docs.runpod.io/mcp"
     }
   }
 }

--- a/app/api/runpod/status/route.ts
+++ b/app/api/runpod/status/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { handleApiError } from '../../../../lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+// Public configuration probe (same spirit as /api/health): reports only whether
+// RUNPOD_API_KEY is present in this deployment. Never returns the value and
+// never calls the Runpod API.
+export async function GET() {
+  try {
+    const configured = Boolean(process.env.RUNPOD_API_KEY);
+    return NextResponse.json({
+      service: 'runpod',
+      configured,
+      checkedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    return handleApiError('api/runpod/status', error);
+  }
+}

--- a/app/components/dashboard/HermesAgentChat.tsx
+++ b/app/components/dashboard/HermesAgentChat.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { MessageCircle, Send, Loader, AlertCircle, StopCircle } from 'lucide-react';
+import { ReviewGatePanel, type ReviewGateDecision } from '@/components/ui/ReviewGatePanel';
+import type { ReviewGate } from '@/lib/types/hermes';
 
 interface Message {
   id: string;
@@ -13,7 +15,16 @@ interface Message {
     steps: number;
     completed: boolean;
   };
+  preflight?: {
+    risk?: 'LOW' | 'MEDIUM' | 'HIGH';
+    affectedCount?: number;
+    rollbackAvailable?: boolean;
+    reason?: string;
+  };
+  reviewGate?: ReviewGate;
 }
+
+const REVIEW_GATE_TTL_MS = 5 * 60 * 1000;
 
 export function HermesAgentChat() {
   const [messages, setMessages] = useState<Message[]>([
@@ -151,6 +162,14 @@ export function HermesAgentChat() {
           const lastMsg = newMessages[newMessages.length - 1];
           if (lastMsg && lastMsg.role === 'agent' && executionSummary) {
             lastMsg.executionSummary = executionSummary;
+            if (executionSummary.decision === 'REVIEW') {
+              const now = Date.now();
+              lastMsg.reviewGate = {
+                status: 'PENDING',
+                createdAt: new Date(now).toISOString(),
+                expiresAt: new Date(now + REVIEW_GATE_TTL_MS).toISOString(),
+              };
+            }
           }
           return newMessages;
         });
@@ -180,6 +199,27 @@ export function HermesAgentChat() {
       e.preventDefault();
       handleSendMessage();
     }
+  };
+
+  const handleReviewDecision = (messageId: string, decision: ReviewGateDecision) => {
+    setMessages((prev) => {
+      const next = prev.map((msg) =>
+        msg.id === messageId && msg.reviewGate
+          ? { ...msg, reviewGate: { ...msg.reviewGate, status: decision } }
+          : msg
+      );
+      const label =
+        decision === 'APPROVED' ? '✅ Operator confirmed the REVIEW-gated action'
+        : decision === 'BLOCKED' ? '❌ Operator blocked the REVIEW-gated action'
+        : '🤔 Operator delegated the REVIEW-gated action';
+      next.push({
+        id: `msg-${Date.now()}-gate`,
+        role: 'system',
+        content: `${label} (message ${messageId}). This updates the chat session only — no runtime commit is issued from this panel.`,
+        timestamp: new Date(),
+      });
+      return next;
+    });
   };
 
   const handleStop = async () => {
@@ -249,6 +289,17 @@ export function HermesAgentChat() {
                     <p className="text-xs opacity-75">✓ Execution complete</p>
                   )}
                 </div>
+              )}
+
+              {msg.reviewGate && (
+                <ReviewGatePanel
+                  reviewGate={msg.reviewGate}
+                  risk={msg.preflight?.risk ?? 'HIGH'}
+                  affectedCount={msg.preflight?.affectedCount}
+                  rollbackAvailable={msg.preflight?.rollbackAvailable}
+                  reason={msg.preflight?.reason}
+                  onDecision={(decision) => handleReviewDecision(msg.id, decision)}
+                />
               )}
 
               <p className="text-xs opacity-60 mt-2">

--- a/app/dashboard/hermes/layout.tsx
+++ b/app/dashboard/hermes/layout.tsx
@@ -9,10 +9,21 @@ export const metadata = {
 };
 
 export default async function HermesLayout({ children }: { children: React.ReactNode }) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  // When Supabase public env vars are absent (local inspection), createClient()
+  // throws before any session check is possible. Middleware fails closed for
+  // non-localhost hosts, so rendering here only affects local dev. With env
+  // present, the redirect-on-no-session behavior is unchanged.
+  let hasSession = false;
+  let authConfigured = true;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    hasSession = Boolean(user);
+  } catch {
+    authConfigured = false;
+  }
 
-  if (!user) {
+  if (authConfigured && !hasSession) {
     redirect('/login?next=/dashboard/hermes');
   }
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import type { User } from '@supabase/supabase-js';
 import { createClient } from '../../lib/supabase/server';
 import Link from 'next/link';
 import AgentChatWidget from '../../components/AgentChatWidget';
@@ -10,10 +11,18 @@ import NudgeBanner from '../../components/billing/NudgeBanner';
 export const dynamic = 'force-dynamic';
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // Local/dev inspection: when Supabase public env vars are absent, createClient()
+  // throws. Middleware already fails closed (503/redirect) for protected paths on
+  // non-localhost hosts, so falling back to a signed-out shell here only affects
+  // local inspection — production auth behavior is unchanged.
+  let user: User | null = null;
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase.auth.getUser();
+    user = data.user;
+  } catch {
+    user = null;
+  }
 
   return (
     <div className="min-h-screen bg-slate-950 text-white">

--- a/app/design/page.tsx
+++ b/app/design/page.tsx
@@ -4,47 +4,11 @@ import React from 'react';
 import Link from 'next/link';
 import Markdoc from '@markdoc/markdoc';
 import { markdocConfig } from '../../markdoc/config';
+import { createMarkdocComponents } from '../../markdoc/components';
 
 const DESIGN_PATH = path.join(process.cwd(), 'DESIGN.md');
 
 export const dynamic = 'force-dynamic';
-
-function createComponents() {
-  return {
-    // Design-system-specific tags (already implemented as stubs).
-    DesignButton: ({ color, variant, children }: any) => null,
-    ColorSwatch: ({ color, name, usage }: any) => null,
-    SpacingTable: () => null,
-    ComponentSpec: ({ name, bg, border, rounded, padding, text }: any) => null,
-
-    // Base markdown nodes. markdocConfig.nodes maps every standard markdown
-    // construct (heading, paragraph, list, table, link, ...) to one of these
-    // component names via `render: 'X'`. Without an entry here, Markdoc's
-    // react renderer looks up an undefined component and React throws
-    // "Element type is invalid ... but got: undefined" on any normal
-    // markdown content (the actual cause of the /design crash).
-    Document: ({ children }: any) => React.createElement(React.Fragment, null, children),
-    Heading: ({ id, level, children }: any) =>
-      React.createElement(`h${level ?? 2}`, { id }, children),
-    Paragraph: ({ children }: any) => React.createElement('p', null, children),
-    BlockQuote: ({ children }: any) => React.createElement('blockquote', null, children),
-    CodeBlock: ({ content, language }: any) =>
-      React.createElement('pre', null, React.createElement('code', { className: language ? `language-${language}` : undefined }, content)),
-    HR: () => React.createElement('hr'),
-    List: ({ ordered, children }: any) => React.createElement(ordered ? 'ol' : 'ul', null, children),
-    ListItem: ({ children }: any) => React.createElement('li', null, children),
-    Table: ({ children }: any) => React.createElement('table', null, children),
-    THead: ({ children }: any) => React.createElement('thead', null, children),
-    TBody: ({ children }: any) => React.createElement('tbody', null, children),
-    TR: ({ children }: any) => React.createElement('tr', null, children),
-    TH: ({ align, children }: any) => React.createElement('th', { style: align ? { textAlign: align } : undefined }, children),
-    TD: ({ align, children }: any) => React.createElement('td', { style: align ? { textAlign: align } : undefined }, children),
-    Link: ({ href, children }: any) => React.createElement('a', { href, target: href?.startsWith('http') ? '_blank' : undefined, rel: href?.startsWith('http') ? 'noopener noreferrer' : undefined }, children),
-    Image: ({ src, alt }: any) => React.createElement('img', { src, alt }),
-    Strong: ({ children }: any) => React.createElement('strong', null, children),
-    Em: ({ children }: any) => React.createElement('em', null, children),
-  };
-}
 
 export default async function DesignPage() {
   let content: string;
@@ -60,7 +24,7 @@ export default async function DesignPage() {
 
   const transformed = Markdoc.transform(Markdoc.parse(content), markdocConfig);
   const rendered = Markdoc.renderers.react(transformed, React, {
-    components: createComponents(),
+    components: createMarkdocComponents(),
   });
 
   return (

--- a/app/docs/[lang]/page.tsx
+++ b/app/docs/[lang]/page.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import Markdoc from '@markdoc/markdoc';
 import { markdocConfig } from '../../../markdoc/config';
+import { createMarkdocComponents } from '../../../markdoc/components';
 
 const DOCS_DIR = path.join(process.cwd(), 'markdoc', 'docs');
 
@@ -26,7 +27,9 @@ export default async function DocsPage({ params }: { params: Promise<{ lang: str
   }
 
   const transformed = Markdoc.transform(Markdoc.parse(content), markdocConfig);
-  const rendered = Markdoc.renderers.react(transformed, React, { components: {} });
+  const rendered = Markdoc.renderers.react(transformed, React, {
+    components: createMarkdocComponents(),
+  });
 
   const availableLangs = [
     { code: 'en', label: '🇬🇧 English' },

--- a/components/ui/ReviewGatePanel.tsx
+++ b/components/ui/ReviewGatePanel.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import type { ReviewGate, ReviewGateStatus } from '../../lib/types/hermes';
+
+type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export type ReviewGateDecision = Extract<ReviewGateStatus, 'APPROVED' | 'BLOCKED' | 'DELEGATED'>;
+
+type ReviewGatePanelProps = {
+  reviewGate: ReviewGate;
+  risk?: RiskLevel;
+  affectedCount?: number;
+  rollbackAvailable?: boolean;
+  reason?: string;
+  /** Called when the operator resolves the gate. Omit to render read-only. */
+  onDecision?: (decision: ReviewGateDecision) => void;
+};
+
+const riskBadgeClasses: Record<RiskLevel, string> = {
+  HIGH: 'border-red-400/30 bg-red-400/10 text-red-300',
+  MEDIUM: 'border-amber-400/30 bg-amber-400/10 text-amber-300',
+  LOW: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300',
+};
+
+const resolvedLabels: Record<Exclude<ReviewGateStatus, 'PENDING'>, string> = {
+  APPROVED: '✅ Approved',
+  BLOCKED: '❌ Blocked',
+  DELEGATED: '🤔 Delegated',
+};
+
+/**
+ * Gatekeeper review gate rendered under an agent message whose preflight
+ * decision is REVIEW. Presents the risk summary and the operator actions
+ * (Confirm / Block / Delegate). Purely presentational: persistence of the
+ * decision is the caller's responsibility via onDecision.
+ */
+export function ReviewGatePanel({
+  reviewGate,
+  risk = 'HIGH',
+  affectedCount,
+  rollbackAvailable,
+  reason,
+  onDecision,
+}: ReviewGatePanelProps) {
+  const pending = reviewGate.status === 'PENDING';
+
+  return (
+    <div className="mt-3 rounded-xl border border-amber-400/30 bg-amber-400/10 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-sm font-bold text-amber-200">
+          {pending ? '⏳ Pending Review' : resolvedLabels[reviewGate.status as Exclude<ReviewGateStatus, 'PENDING'>]}
+        </span>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-bold ${riskBadgeClasses[risk]}`}
+        >
+          {risk} Risk
+        </span>
+      </div>
+
+      <div className="mb-4 space-y-2 text-xs text-slate-300">
+        {reason && (
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-slate-500">Reason:</span>
+            <span className="truncate font-semibold" title={reason}>{reason}</span>
+          </div>
+        )}
+        {typeof affectedCount === 'number' && (
+          <div className="flex items-center justify-between">
+            <span className="text-slate-500">Affected:</span>
+            <span className="font-semibold">{affectedCount} users</span>
+          </div>
+        )}
+        {typeof rollbackAvailable === 'boolean' && (
+          <div className="flex items-center justify-between">
+            <span className="text-slate-500">Rollback:</span>
+            <span className={`font-semibold ${rollbackAvailable ? 'text-emerald-300' : 'text-red-300'}`}>
+              {rollbackAvailable ? 'Available' : 'Unavailable'}
+            </span>
+          </div>
+        )}
+        {reviewGate.expiresAt && (
+          <div className="flex items-center justify-between">
+            <span className="text-slate-500">Expires:</span>
+            <span className="font-semibold">
+              {new Date(reviewGate.expiresAt).toLocaleTimeString('th-TH')}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {pending && onDecision && (
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => onDecision('APPROVED')}
+            className="flex items-center gap-1.5 rounded-lg border border-emerald-400/30 bg-emerald-400/10 px-3 py-2 text-xs font-bold text-emerald-300 transition hover:bg-emerald-400/20"
+          >
+            ✅ Confirm
+          </button>
+          <button
+            type="button"
+            onClick={() => onDecision('BLOCKED')}
+            className="flex items-center gap-1.5 rounded-lg border border-red-400/30 bg-red-400/10 px-3 py-2 text-xs font-bold text-red-300 transition hover:bg-red-400/20"
+          >
+            ❌ Block
+          </button>
+          <button
+            type="button"
+            onClick={() => onDecision('DELEGATED')}
+            className="flex items-center gap-1.5 rounded-lg border border-violet-400/30 bg-violet-400/10 px-3 py-2 text-xs font-bold text-violet-300 transition hover:bg-violet-400/20"
+          >
+            🤔 Delegate
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/RUNPOD_INTEGRATION.md
+++ b/docs/RUNPOD_INTEGRATION.md
@@ -1,0 +1,95 @@
+# Runpod Integration — DSG ONE / ProofGate Control Plane
+
+เอกสารนี้อธิบายการเชื่อมต่อ Runpod (GPU cloud) เข้ากับโปรเจกต์นี้: MCP servers, agent skill, การตั้งค่า API key และขอบเขตการอ้างสถานะ (claim boundary)
+
+สถานะปัจจุบัน: **setup-ready** — มีการกำหนดค่า MCP + skill + env var name แล้ว การใช้งานจริงต้องมี `RUNPOD_API_KEY` ที่ใช้งานได้ในสภาพแวดล้อมนั้น ๆ
+
+---
+
+## 1. ส่วนประกอบ
+
+| ส่วนประกอบ | ตำแหน่ง | หน้าที่ |
+| --- | --- | --- |
+| Runpod API MCP server | `.mcp.json` → `runpod` | จัดการ Pods, Serverless endpoints, templates, network volumes, registries ผ่าน Runpod REST API |
+| Runpod docs MCP server | `.mcp.json` → `runpod-docs` | ค้นหาเอกสาร Runpod (ไม่ต้องการ API key) |
+| Agent skill | `.claude/skills/runpod-agent/SKILL.md` | สอน AI agent ให้ใช้เครื่องมือ Runpod อย่างถูกต้องและปลอดภัย |
+| Env var | `.env.example` → `RUNPOD_API_KEY` | ชื่อ env var สำหรับ API key (ชื่อเท่านั้น ห้าม commit ค่า) |
+| Status probe | `GET /api/runpod/status` | ตรวจว่า deployment มี `RUNPOD_API_KEY` แล้วหรือไม่ (คืน boolean เท่านั้น ไม่แตะ Runpod API และไม่เปิดเผยค่า) |
+
+## 2. การตั้งค่า API key
+
+สร้าง key ได้ที่ https://console.runpod.io/user/settings
+
+- **Vercel (production)**: ตั้งค่า `RUNPOD_API_KEY` ใน Project → Settings → Environment Variables แล้ว redeploy เพื่อให้ route อ่านค่าใหม่ได้
+- **Local development**:
+
+```bash
+export RUNPOD_API_KEY=<key>       # ชั่วคราวใน shell
+# หรือใส่ใน .env (git-ignored) — ห้าม commit ค่าเด็ดขาด
+```
+
+ตรวจสอบว่า deployment เห็น key แล้ว (ไม่เปิดเผยค่า):
+
+```bash
+curl -fsSL "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/runpod/status"
+# คาดหวัง: {"service":"runpod","configured":true,...}
+```
+
+`configured: true` แปลว่า env var ถูกตั้งค่าแล้วเท่านั้น — ไม่ได้พิสูจน์ว่า key ใช้งานได้กับ Runpod API การพิสูจน์ว่า key ใช้งานได้ต้องเรียก Runpod API จริง (เช่น list pods ผ่าน MCP หรือ `runpodctl get pod`)
+
+## 3. MCP servers ใน `.mcp.json`
+
+```json
+"runpod": {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@runpod/mcp-server@latest"],
+  "env": { "RUNPOD_API_KEY": "${RUNPOD_API_KEY}" }
+},
+"runpod-docs": {
+  "type": "http",
+  "url": "https://docs.runpod.io/mcp"
+}
+```
+
+- `runpod` รันเป็น local stdio process และอ่าน key จาก env ของเครื่องที่รัน Claude Code — ต้อง export `RUNPOD_API_KEY` ก่อนเปิด session
+- `runpod-docs` เป็น hosted HTTP server ไม่ต้องการการยืนยันตัวตน
+- ตรวจสอบการเชื่อมต่อใน Claude Code ด้วยคำสั่ง `/mcp`
+
+## 4. Runpod CLI (ทางเลือก)
+
+```bash
+curl -sSL https://cli.runpod.net | bash   # หรือ: brew install runpod/runpodctl/runpodctl
+runpodctl doctor                          # ตรวจการติดตั้ง + บันทึก key ลง ~/.runpod/config.toml
+runpodctl get pod                         # ลิสต์ pods
+```
+
+CLI ใช้ `RUNPOD_API_KEY` ตัวเดียวกับ MCP server
+
+## 5. Claim boundaries (ตามนโยบาย evidence-first)
+
+อนุญาต:
+
+- `setup-ready` — ไฟล์ config/skill/docs อยู่ใน repo (ตรวจได้จากไฟล์)
+- `configured` — `GET /api/runpod/status` คืน `configured: true` จาก deployment จริง
+- `key ใช้งานได้` — เมื่อมีผลลัพธ์จริงจากการเรียก Runpod API (list pods/endpoints สำเร็จ)
+
+ห้ามอ้างโดยไม่มีหลักฐานสด:
+
+- "Runpod production workload live" — ต้องมีสถานะ Pod/endpoint จริงจาก API
+- "GPU endpoint พร้อมให้บริการ" — ต้องมีผล health/status ของ endpoint นั้น
+- ค่าใช้จ่าย/ยอดคงเหลือ — ต้องมาจาก account API จริงเท่านั้น
+
+## 6. ความปลอดภัย
+
+- ห้าม commit หรือพิมพ์ค่า `RUNPOD_API_KEY` ในโค้ด, เอกสาร, log, PR body (CLAUDE.md §9)
+- `GET /api/runpod/status` เจตนาให้เป็น public probe แบบเดียวกับ `/api/health` — คืนเฉพาะ boolean ว่าตั้งค่าแล้วหรือไม่ ไม่คืนค่า key, ไม่เรียก Runpod API, ไม่เปิดเผยข้อมูลบัญชี
+- การกระทำที่มีค่าใช้จ่ายหรือทำลายล้าง (สร้าง/ลบ Pod, ลบ volume) ต้องยืนยันกับผู้ใช้ก่อนตามกฎใน skill
+
+## 7. อ้างอิง
+
+- Documentation index: https://docs.runpod.io/llms.txt
+- MCP servers: https://docs.runpod.io/get-started/mcp-servers
+- Agent skills plugin: `npx skills add runpod/runpod-plugins-official`
+- CLI reference: https://docs.runpod.io/runpodctl/overview
+- MCP source: https://github.com/runpod/runpod-mcp

--- a/lib/types/hermes.ts
+++ b/lib/types/hermes.ts
@@ -5,6 +5,17 @@
 
 export type Decision = 'ALLOW' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED';
 
+export type ReviewGateStatus = 'PENDING' | 'APPROVED' | 'BLOCKED' | 'DELEGATED';
+
+export type ReviewGate = {
+  status: ReviewGateStatus;
+  /** Runtime decision id when the gate is backed by a persisted decision. */
+  decisionId?: string;
+  /** ISO timestamps used by UI countdown/expiry displays. */
+  createdAt?: string;
+  expiresAt?: string;
+};
+
 export type ToolStep = {
   id: string;
   toolId: string;
@@ -30,10 +41,7 @@ export type Message = {
     rollbackAvailable?: boolean;
   };
   collapsible?: boolean;
-  reviewGate?: {
-    status: 'PENDING' | 'APPROVED' | 'BLOCKED' | 'DELEGATED';
-    decisionId: string;
-  };
+  reviewGate?: ReviewGate;
 };
 
 export type SystemStatus = {

--- a/markdoc/components.ts
+++ b/markdoc/components.ts
@@ -1,0 +1,67 @@
+import React from 'react';
+
+/**
+ * React components for every `render: 'X'` name declared in markdocConfig
+ * (markdoc/config.ts). Markdoc's react renderer resolves each rendered node
+ * against this map; a missing entry makes React throw "Element type is
+ * invalid ... but got: undefined" on ordinary markdown content, which is how
+ * both /design and /docs/[lang] previously crashed with a 500.
+ */
+export function createMarkdocComponents() {
+  return {
+    // Design-system-specific tags (stub implementations).
+    DesignButton: (_props: { color?: string; variant?: string; children?: React.ReactNode }) => null,
+    ColorSwatch: (_props: { color?: string; name?: string; usage?: string }) => null,
+    SpacingTable: () => null,
+    ComponentSpec: (_props: Record<string, unknown>) => null,
+
+    // Base markdown nodes.
+    Document: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    Heading: ({ id, level, children }: { id?: string; level?: number; children?: React.ReactNode }) =>
+      React.createElement(`h${level ?? 2}`, { id }, children),
+    Paragraph: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('p', null, children),
+    BlockQuote: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('blockquote', null, children),
+    CodeBlock: ({ content, language }: { content?: string; language?: string }) =>
+      React.createElement(
+        'pre',
+        null,
+        React.createElement('code', { className: language ? `language-${language}` : undefined }, content),
+      ),
+    HR: () => React.createElement('hr'),
+    List: ({ ordered, children }: { ordered?: boolean; children?: React.ReactNode }) =>
+      React.createElement(ordered ? 'ol' : 'ul', null, children),
+    ListItem: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('li', null, children),
+    Table: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('table', null, children),
+    THead: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('thead', null, children),
+    TBody: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('tbody', null, children),
+    TR: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('tr', null, children),
+    TH: ({ align, children }: { align?: string; children?: React.ReactNode }) =>
+      React.createElement('th', { style: align ? { textAlign: align as 'left' | 'center' | 'right' } : undefined }, children),
+    TD: ({ align, children }: { align?: string; children?: React.ReactNode }) =>
+      React.createElement('td', { style: align ? { textAlign: align as 'left' | 'center' | 'right' } : undefined }, children),
+    Link: ({ href, children }: { href?: string; children?: React.ReactNode }) =>
+      React.createElement(
+        'a',
+        {
+          href,
+          target: href?.startsWith('http') ? '_blank' : undefined,
+          rel: href?.startsWith('http') ? 'noopener noreferrer' : undefined,
+        },
+        children,
+      ),
+    Image: ({ src, alt }: { src?: string; alt?: string }) =>
+      React.createElement('img', { src, alt }),
+    Strong: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('strong', null, children),
+    Em: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('em', null, children),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,9 +1238,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1302,9 +1302,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5542,9 +5542,9 @@
       "license": "MIT"
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6211,9 +6211,9 @@
       "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8705,9 +8705,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8789,9 +8789,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8873,9 +8873,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8964,9 +8964,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13388,9 +13388,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13694,9 +13694,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15088,9 +15088,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16638,17 +16638,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/tests/e2e/dashboard-smoke.spec.ts
+++ b/tests/e2e/dashboard-smoke.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Dashboard route smoke test.
+ *
+ * Opens every page under app/dashboard/ and asserts the route actually renders:
+ * - HTTP status is not 503 (auth-not-configured fail-close) and not a 5xx
+ * - the page body has visible content
+ * - no uncaught page error (crash) occurred
+ * - the Supabase missing-env error page is not shown
+ *
+ * Relies on the middleware localhost bypass plus the dashboard/hermes layout
+ * signed-out fallback, so no Supabase env vars are required. Client pages may
+ * still log console errors from failed data fetches when no backend env is
+ * configured; those are reported but do not fail the smoke check.
+ *
+ * Keep this list in sync with `find app/dashboard -name page.tsx`.
+ */
+
+const STATIC_DASHBOARD_ROUTES = [
+  '/dashboard',
+  '/dashboard/agents',
+  '/dashboard/agents/connect',
+  '/dashboard/agi',
+  '/dashboard/api-keys',
+  '/dashboard/approvals',
+  '/dashboard/audit',
+  '/dashboard/audit-trail',
+  '/dashboard/audit/matrix',
+  '/dashboard/billing',
+  '/dashboard/breach-signal',
+  '/dashboard/capacity',
+  '/dashboard/command-center',
+  '/dashboard/core-compat',
+  '/dashboard/dsg-brain',
+  '/dashboard/executions',
+  '/dashboard/governance',
+  '/dashboard/governance/controls',
+  '/dashboard/governance/evidence',
+  '/dashboard/governance/incidents',
+  '/dashboard/hermes',
+  '/dashboard/hermes/agents',
+  '/dashboard/hermes/skills',
+  '/dashboard/integration',
+  '/dashboard/integrations',
+  '/dashboard/integrations/webhooks',
+  '/dashboard/ledger',
+  '/dashboard/live-control',
+  '/dashboard/markdoc-policies',
+  '/dashboard/markdoc-policies/new',
+  '/dashboard/mission',
+  '/dashboard/monitoring',
+  '/dashboard/notifications',
+  '/dashboard/omniaagent-command-center',
+  '/dashboard/operations',
+  '/dashboard/payout-safety',
+  '/dashboard/policies',
+  '/dashboard/proofs',
+  '/dashboard/readiness-config',
+  '/dashboard/referrals',
+  '/dashboard/revenue',
+  '/dashboard/settings/access',
+  '/dashboard/settings/configuration',
+  '/dashboard/settings/defi',
+  '/dashboard/settings/domains',
+  '/dashboard/settings/go-live',
+  '/dashboard/settings/security',
+  '/dashboard/setup',
+  '/dashboard/setup/audit',
+  '/dashboard/setup/executions',
+  '/dashboard/setup/test-results',
+  '/dashboard/skills',
+  '/dashboard/stripe-app',
+  '/dashboard/stripe-app/approvals',
+  '/dashboard/stripe-app/audit',
+  '/dashboard/stripe-app/connect',
+  '/dashboard/stripe-app/policies',
+  '/dashboard/support/faq',
+  '/dashboard/support/tickets',
+  '/dashboard/support/tickets/create',
+  '/dashboard/tasks',
+  '/dashboard/team',
+  '/dashboard/trinity',
+  '/dashboard/usage',
+  '/dashboard/verification',
+  '/dashboard/webhooks',
+  '/dashboard/welcome',
+  '/dashboard/work-queue',
+];
+
+// Dynamic-segment routes visited with a placeholder id. The page must still
+// render its shell (empty/error state is fine); only a server crash fails.
+const DYNAMIC_DASHBOARD_ROUTES = [
+  '/dashboard/agents/e2e-placeholder/permissions',
+  '/dashboard/governance/question/e2e-placeholder',
+  '/dashboard/markdoc-policies/e2e-placeholder',
+  '/dashboard/replay/e2e-placeholder',
+  '/dashboard/support/tickets/e2e-placeholder',
+];
+
+async function smokeCheck(page: import('@playwright/test').Page, route: string) {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  const response = await page.goto(route, { waitUntil: 'domcontentloaded' });
+
+  expect(response, `${route}: no response`).not.toBeNull();
+  const status = response!.status();
+  expect(status, `${route}: fail-closed 503 (auth not configured)`).not.toBe(503);
+  expect(status, `${route}: server error ${status}`).toBeLessThan(500);
+
+  await expect(page.locator('body')).toBeVisible();
+  await expect(
+    page.locator('text=Missing Supabase public environment variables'),
+  ).toHaveCount(0);
+
+  expect(pageErrors, `${route}: uncaught page errors: ${pageErrors.join(' | ')}`).toEqual([]);
+
+  if (consoleErrors.length > 0) {
+    // Data fetches may fail without backend env — surface but do not fail.
+    console.warn(`[smoke] ${route}: ${consoleErrors.length} console error(s):`);
+    for (const err of consoleErrors.slice(0, 5)) console.warn(`  - ${err.slice(0, 200)}`);
+  }
+}
+
+test.describe('Dashboard route smoke', () => {
+  for (const route of STATIC_DASHBOARD_ROUTES) {
+    test(`renders ${route}`, async ({ page }) => {
+      await smokeCheck(page, route);
+    });
+  }
+});
+
+test.describe('Dashboard dynamic route smoke (placeholder ids)', () => {
+  for (const route of DYNAMIC_DASHBOARD_ROUTES) {
+    test(`renders ${route}`, async ({ page }) => {
+      await smokeCheck(page, route);
+    });
+  }
+});

--- a/tests/e2e/review-gate-panel.spec.ts
+++ b/tests/e2e/review-gate-panel.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Real-UI proof for the Gatekeeper ReviewGatePanel (Phase B Feature 1).
+ *
+ * Unlike phase-b-ux-features.spec.ts (which simulates the markup on
+ * about:blank), this opens the real /dashboard/hermes page, stubs the chat
+ * API with an SSE stream whose execution decision is REVIEW, and asserts the
+ * real <ReviewGatePanel> renders and resolves through its operator buttons.
+ */
+
+const SSE_REVIEW_RESPONSE = [
+  'data: {"type":"content","content":"About to execute a HIGH-risk action affecting 50 users..."}',
+  '',
+  'data: {"type":"execution","decision":"REVIEW","steps":2,"completed":false}',
+  '',
+  '',
+].join('\n');
+
+test.describe('ReviewGatePanel (real UI)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/dashboard/hermes/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: SSE_REVIEW_RESPONSE,
+      });
+    });
+    await page.goto('/dashboard/hermes');
+  });
+
+  async function triggerReviewGate(page: import('@playwright/test').Page) {
+    const input = page.locator('textarea[placeholder*="ถามเอเจนต์"]');
+    await expect(input).toBeVisible();
+    // Retry until hydration has attached handlers and the panel appears.
+    await expect(async () => {
+      await input.fill('delete 50 user accounts');
+      await input.press('Enter');
+      await expect(page.locator('.border-amber-400\\/30').first()).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 20_000 });
+  }
+
+  test('renders pending review gate for REVIEW decision', async ({ page }) => {
+    await triggerReviewGate(page);
+
+    await expect(page.locator('text=⏳ Pending Review')).toBeVisible();
+    await expect(page.locator('text=HIGH Risk')).toBeVisible();
+    await expect(page.locator('button:has-text("✅ Confirm")')).toBeVisible();
+    await expect(page.locator('button:has-text("❌ Block")')).toBeVisible();
+    await expect(page.locator('button:has-text("🤔 Delegate")')).toBeVisible();
+  });
+
+  test('confirm resolves the gate and records an audit line', async ({ page }) => {
+    await triggerReviewGate(page);
+
+    await page.locator('button:has-text("✅ Confirm")').click();
+    await expect(page.locator('text=✅ Approved')).toBeVisible();
+    await expect(page.locator('text=Operator confirmed the REVIEW-gated action')).toBeVisible();
+    // Action buttons disappear once resolved.
+    await expect(page.locator('button:has-text("✅ Confirm")')).toHaveCount(0);
+  });
+
+  test('block resolves the gate', async ({ page }) => {
+    await triggerReviewGate(page);
+
+    await page.locator('button:has-text("❌ Block")').click();
+    await expect(page.locator('text=❌ Blocked')).toBeVisible();
+    await expect(page.locator('text=Operator blocked the REVIEW-gated action')).toBeVisible();
+  });
+});

--- a/tests/e2e/ui-pages.spec.ts
+++ b/tests/e2e/ui-pages.spec.ts
@@ -90,26 +90,22 @@ test.describe('Password Login Page UI', () => {
     await expect(page.locator('a:has-text("กลับไปหน้าเข้าสู่ระบบ")')).toBeVisible();
   });
 
-  test('should show loading state on submit', async ({ page }) => {
-    // Intercept POST to /auth/password-login to delay response and keep loading state visible
-    await page.route('**/auth/password-login', route => {
-      // Hold the request for 2 seconds to allow assertion of loading text
-      setTimeout(() => route.abort(), 2000);
+  test('should submit credentials to the auth endpoint', async ({ page }) => {
+    // Stub the auth endpoint: respond like a failed login (303 back with error
+    // param) so the test proves the form performs a real POST submission and
+    // the page renders the resulting error banner — without needing Supabase.
+    await page.route('**/auth/password-login', async (route) => {
+      await route.fulfill({
+        status: 303,
+        headers: { location: '/password-login?error=invalid-credentials' },
+      });
     });
 
     await page.locator('input#email').fill('test@example.com');
     await page.locator('input#password').fill('password123');
-<<<<<<< HEAD
-    const submitBtn = page.locator('button:has-text("เข้าสู่ระบบ")');
-    await expect(submitBtn).toBeEnabled();
-    // Don't actually submit since it requires backend
-=======
-    const submitBtn = page.locator('button[type="submit"]');
-    // Click submit and verify form exists (form will attempt submission)
-    await submitBtn.click();
-    // Button should exist and form should be attempting submission
-    await expect(submitBtn).toBeVisible();
->>>>>>> c9832a8 (Fix E2E UI tests for Login and Dashboard pages)
+    await page.locator('button[type="submit"]').click();
+    await expect(page).toHaveURL(/error=invalid-credentials/);
+    await expect(page.locator('text=อีเมลหรือรหัสผ่านไม่ถูกต้อง')).toBeVisible();
   });
 });
 
@@ -119,7 +115,7 @@ test.describe('Signup Page UI', () => {
   });
 
   test('should display signup form with all fields', async ({ page }) => {
-    await expect(page.locator('text=สร้าง workspace แรกของคุณ')).toBeVisible();
+    await expect(page.locator('text=สร้าง workspace แรกของคุณ').first()).toBeVisible();
     await expect(page.locator('input[name="full_name"]')).toBeVisible();
     await expect(page.locator('input[name="email"]')).toBeVisible();
     await expect(page.locator('input[name="workspace_name"]')).toBeVisible();
@@ -139,66 +135,46 @@ test.describe('Signup Page UI', () => {
   });
 
   test('should show link back to login', async ({ page }) => {
-    await expect(page.locator('a:has-text("เข้าสู่ระบบ")')).toBeVisible();
+    await expect(page.locator('a:has-text("เข้าสู่ระบบ")').first()).toBeVisible();
   });
 });
 
-// Dashboard, Hermes, and Chat Widget tests require Supabase environment variables to be configured.
-// These tests are skipped in the current E2E test suite.
-// To enable them, configure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.
+// Dashboard and Hermes pages render on localhost without Supabase env vars:
+// middleware skips auth for localhost hosts and the dashboard/hermes layouts
+// fall back to a signed-out shell when Supabase public env vars are absent.
 
 test.describe('Dashboard Page UI', () => {
-  test.skip('should display dashboard header', async ({ page }) => {
-    // Skipped: Requires Supabase env vars NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY
-    await expect(page.locator('h1')).toContainText('ศูนย์ควบคุม');
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/dashboard');
   });
 
-<<<<<<< HEAD
-  test.skip('should show 4 KPI cards', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await expect(page.locator('text=Agents')).toBeVisible();
-    await expect(page.locator('text=Executions')).toBeVisible();
-    await expect(page.locator('text=Core Status')).toBeVisible();
-    await expect(page.locator('text=DB Status')).toBeVisible();
-=======
+  test('should display dashboard header', async ({ page }) => {
+    await expect(page.locator('h1').first()).toContainText('ศูนย์ควบคุม');
+  });
+
   test('should show 4 KPI cards', async ({ page }) => {
     await expect(page.locator('text=ตัวแทนที่ใช้งาน').first()).toBeVisible();
-    await expect(page.locator('text=การดำเนินการทั้งหมด')).toBeVisible();
-    await expect(page.locator('text=สถานะ Core')).toBeVisible();
-    await expect(page.locator('text=สถานะฐานข้อมูล')).toBeVisible();
->>>>>>> c9832a8 (Fix E2E UI tests for Login and Dashboard pages)
+    await expect(page.locator('text=การดำเนินการทั้งหมด').first()).toBeVisible();
+    await expect(page.locator('text=สถานะ Core').first()).toBeVisible();
+    await expect(page.locator('text=สถานะฐานข้อมูล').first()).toBeVisible();
   });
 
-  test.skip('should show system health indicator', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await expect(page.locator('text=สถานะระบบ')).toBeVisible();
+  test('should show system health indicator', async ({ page }) => {
+    await expect(page.locator('text=สถานะระบบ').first()).toBeVisible();
   });
 
-<<<<<<< HEAD
-  test.skip('should show refresh button', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await expect(page.locator('button:has-text("รีเฟรช")')).toBeVisible();
-=======
   test('should show refresh button', async ({ page }) => {
     // Button contains "รีเฟรช" or "กำลังโหลด"
     const refreshBtn = page.locator('button').filter({ hasText: /รีเฟรช|กำลังโหลด/ });
-    await expect(refreshBtn).toBeVisible();
->>>>>>> c9832a8 (Fix E2E UI tests for Login and Dashboard pages)
+    await expect(refreshBtn.first()).toBeVisible();
   });
 
-  test.skip('should show command center link', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await expect(page.locator('a:has-text("ศูนย์บัญชาการ")')).toBeVisible();
+  test('should show command center link', async ({ page }) => {
+    await expect(page.locator('a:has-text("ศูนย์บัญชาการ")').first()).toBeVisible();
   });
 
-<<<<<<< HEAD
-  test.skip('should show products grid', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await expect(page.locator('text=Products')).toBeVisible();
-=======
   test('should show products grid', async ({ page }) => {
-    await expect(page.locator('text=ผลิตภัณฑ์')).toBeVisible();
->>>>>>> c9832a8 (Fix E2E UI tests for Login and Dashboard pages)
+    await expect(page.locator('text=ผลิตภัณฑ์').first()).toBeVisible();
   });
 });
 
@@ -207,26 +183,29 @@ test.describe('Hermes Dashboard UI', () => {
     await page.goto('/dashboard/hermes');
   });
 
-  test.skip('should display tabs', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await expect(page.locator('button:has-text("overview")')).toBeVisible();
-    await expect(page.locator('button:has-text("agents")')).toBeVisible();
-    await expect(page.locator('button:has-text("executions")')).toBeVisible();
-    await expect(page.locator('button:has-text("governance")')).toBeVisible();
+  test('should display tabs', async ({ page }) => {
+    await expect(page.locator('button:has-text("overview")').first()).toBeVisible();
+    await expect(page.locator('button:has-text("agents")').first()).toBeVisible();
+    await expect(page.locator('button:has-text("executions")').first()).toBeVisible();
+    await expect(page.locator('button:has-text("governance")').first()).toBeVisible();
   });
 
-  test.skip('should switch between tabs', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await page.locator('button:has-text("agents")').click();
-    await expect(page.locator('text=Agents tab content')).toBeVisible();
+  test('should switch between tabs', async ({ page }) => {
+    // Retry the click until the tab content appears — the first click can land
+    // before React hydration attaches the tab onClick handlers.
+    await expect(async () => {
+      await page.locator('button:has-text("agents")').first().click();
+      await expect(page.locator('text=Agents tab content')).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20_000 });
 
-    await page.locator('button:has-text("executions")').click();
-    await expect(page.locator('text=Executions tab content')).toBeVisible();
+    await expect(async () => {
+      await page.locator('button:has-text("executions")').first().click();
+      await expect(page.locator('text=Executions tab content')).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20_000 });
   });
 
-  test.skip('should show Hermes Agent chat on overview tab', async ({ page }) => {
-    // Skipped: Requires Supabase env vars
-    await page.locator('button:has-text("overview")').click();
+  test('should show Hermes Agent chat on overview tab', async ({ page }) => {
+    await page.locator('button:has-text("overview")').first().click();
     await expect(page.locator('h1:has-text("Hermes Agent")')).toBeVisible();
     await expect(page.locator('text=Policy governance · Execution control · Audit trail')).toBeVisible();
     await expect(page.locator('textarea[placeholder*="ถามเอเจนต์"]')).toBeVisible();
@@ -238,40 +217,45 @@ test.describe('Chat Widget UI', () => {
     await page.goto('/dashboard');
   });
 
+  // Skipped: the dashboard layout renders AgentChatWidget only for a signed-in
+  // user ({user && <AgentChatWidget />} in app/dashboard/layout.tsx), so these
+  // require an authenticated Supabase session (E2E_TEST_EMAIL/E2E_TEST_PASSWORD
+  // + Supabase env), not just a rendering dashboard.
+
   test.skip('should show floating chat button', async ({ page }) => {
-    // Skipped: Requires Supabase env vars to load dashboard
+    // Skipped: requires authenticated session — widget renders only when signed in
     await expect(page.locator('button[aria-label="เปิดแชท AI"]')).toBeVisible();
   });
 
   test.skip('should open chat on click', async ({ page }) => {
-    // Skipped: Requires Supabase env vars to load dashboard
+    // Skipped: requires authenticated session — widget renders only when signed in
     await page.locator('button[aria-label="เปิดแชท AI"]').click();
     await expect(page.locator('text=DSG AI')).toBeVisible();
     await expect(page.locator('text=พร้อมช่วยเหลือ')).toBeVisible();
   });
 
   test.skip('should show QA buttons in chat', async ({ page }) => {
-    // Skipped: Requires Supabase env vars to load dashboard
+    // Skipped: requires authenticated session — widget renders only when signed in
     await page.locator('button[aria-label="เปิดแชท AI"]').click();
     await expect(page.locator('text=ตรวจหน้านี้')).toBeVisible();
     await expect(page.locator('text=ตรวจทั้งหมด')).toBeVisible();
   });
 
   test.skip('should show suggestion chips', async ({ page }) => {
-    // Skipped: Requires Supabase env vars to load dashboard
+    // Skipped: requires authenticated session — widget renders only when signed in
     await page.locator('button[aria-label="เปิดแชท AI"]').click();
     await expect(page.locator('text=ตรวจสอบระบบ')).toBeVisible();
   });
 
   test.skip('should have text input and send button', async ({ page }) => {
-    // Skipped: Requires Supabase env vars to load dashboard
+    // Skipped: requires authenticated session — widget renders only when signed in
     await page.locator('button[aria-label="เปิดแชท AI"]').click();
     await expect(page.locator('input[placeholder="พิมพ์คำถามหรือคำสั่ง..."]')).toBeVisible();
     await expect(page.locator('button:has-text("ส่ง")')).toBeVisible();
   });
 
   test.skip('should close chat on X click', async ({ page }) => {
-    // Skipped: Requires Supabase env vars to load dashboard
+    // Skipped: requires authenticated session — widget renders only when signed in
     await page.locator('button[aria-label="เปิดแชท AI"]').click();
     await expect(page.locator('text=DSG AI')).toBeVisible();
     await page.locator('button[aria-label="ปิดแชท"]').click();
@@ -282,14 +266,14 @@ test.describe('Chat Widget UI', () => {
 test.describe('Docs Page UI', () => {
   test('should display English docs at /docs/en', async ({ page }) => {
     await page.goto('/docs/en');
-    await expect(page.locator('text=DSG ONE')).toBeVisible();
-    await expect(page.locator('text=User Guide')).toBeVisible();
+    await expect(page.locator('text=DSG ONE').first()).toBeVisible();
+    await expect(page.locator('text=User Guide').first()).toBeVisible();
   });
 
   test('should display Thai docs at /docs/th', async ({ page }) => {
     await page.goto('/docs/th');
-    await expect(page.locator('text=DSG ONE')).toBeVisible();
-    await expect(page.locator('text=คู่มือการใช้งาน')).toBeVisible();
+    await expect(page.locator('text=DSG ONE').first()).toBeVisible();
+    await expect(page.locator('text=คู่มือการใช้งาน').first()).toBeVisible();
   });
 
   test('should have language switcher', async ({ page }) => {
@@ -300,9 +284,12 @@ test.describe('Docs Page UI', () => {
 
   test('should switch language', async ({ page }) => {
     await page.goto('/docs/en');
-    await page.locator('a[href="/docs/th"]').click();
-    await expect(page).toHaveURL(/\/docs\/th/);
-    await expect(page.locator('text=คู่มือการใช้งาน')).toBeVisible();
+    // Retry the click — it can land before Next.js Link hydration completes.
+    await expect(async () => {
+      await page.locator('a[href="/docs/th"]').first().click();
+      await expect(page).toHaveURL(/\/docs\/th/, { timeout: 3000 });
+    }).toPass({ timeout: 20_000 });
+    await expect(page.locator('text=คู่มือการใช้งาน').first()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
Goal:

1. เพิ่มการเชื่อมต่อ Runpod: MCP servers, agent skill, เอกสาร setup และการเตรียม `RUNPOD_API_KEY` (ค่า key อยู่ใน Vercel env — ไม่อยู่ใน repo)
2. แก้ merge conflict ที่ถูก commit ค้างใน `tests/e2e/ui-pages.spec.ts` และปลดล็อกเทส Dashboard/Hermes ให้รันได้จริง
3. สร้าง `ReviewGatePanel` component จริงตามสเปกเทส Phase B พร้อมเชื่อมเข้า Hermes chat
4. สร้าง smoke test ครอบคลุมทุก route ใต้ `app/dashboard/`

Files changed:

**Runpod (commit 6e86305, 47e9b86):**
- `.mcp.json` — เพิ่ม `runpod` (stdio) + `runpod-docs` (HTTP) MCP servers
- `.claude/skills/runpod-agent/SKILL.md` — agent skill พร้อมกฎความปลอดภัย/claim boundary
- `docs/RUNPOD_INTEGRATION.md`, `.env.example` — เอกสาร + ชื่อ env var
- `app/api/runpod/status/route.ts` — probe คืน `{ configured: boolean }` เท่านั้น
- `package-lock.json` — แก้ brace-expansion high CVE + zod lockfile drift (CI แดง 2 ตัวก่อนหน้า → เขียวแล้ว)

**E2E + UI (commit 5cebabd):**
- `tests/e2e/ui-pages.spec.ts` — แก้ conflict 4 บล็อก (เลือกฝั่ง c9832a8), เพิ่ม `beforeEach`, unskip Dashboard/Hermes, แก้ strict-mode violations, เขียนเทส submit ของ password-login ใหม่ให้ stub auth endpoint, แก้เหตุผล skip ของ Chat Widget ให้ตรงจริง (widget เรนเดอร์เฉพาะ user ที่ล็อกอิน)
- `app/dashboard/layout.tsx`, `app/dashboard/hermes/layout.tsx` — fallback เป็น signed-out shell เมื่อไม่มี Supabase env แทนการ throw 500 (middleware ยัง fail closed บน non-localhost — พฤติกรรม production ไม่เปลี่ยน)
- `app/docs/[lang]/page.tsx`, `markdoc/components.ts`, `app/design/page.tsx` — แก้บักจริง `/docs/en|th` คืน 500 (ส่ง `components: {}` ว่างให้ Markdoc) โดย extract component map จากหน้า design เป็น module กลาง
- `lib/types/hermes.ts` — แยก `ReviewGate`/`ReviewGateStatus`, เพิ่ม `createdAt`/`expiresAt`, `decisionId` เป็น optional
- `components/ui/ReviewGatePanel.tsx` — component จริงตาม markup เทส Phase B (Confirm/Block/Delegate)
- `app/components/dashboard/HermesAgentChat.tsx` — ติด review gate PENDING เมื่อ decision เป็น REVIEW, เรนเดอร์ panel, ปุ่มตัดสินใจอัปเดตสถานะ + audit line ในแชท
- `tests/e2e/review-gate-panel.spec.ts` — พิสูจน์ component จริงบนหน้า `/dashboard/hermes` จริง (stub SSE)
- `tests/e2e/dashboard-smoke.spec.ts` — เปิด 68 static + 5 dynamic routes ตรวจไม่มี 503/5xx/page crash

Verification:

- [x] `npx playwright test tests/e2e/ui-pages.spec.ts tests/e2e/phase-b-ux-features.spec.ts` → **37 passed, 0 failed**, 6 skipped (Chat Widget ต้องมี session จริง)
- [x] `npx playwright test tests/e2e/dashboard-smoke.spec.ts` → **73 passed**
- [x] `npx playwright test tests/e2e/review-gate-panel.spec.ts` → **3 passed**
- [x] `npm run typecheck` → ไม่มี error ใหม่ (TS5101 config deprecation 2 ตัวมีอยู่บน main แล้ว)
- [x] `npm audit --audit-level=high` → ผ่าน (exit 0)
- [x] `curl /docs/en` local → เรนเดอร์แล้ว (เดิม 500)
- [ ] `npm run build` — Not run ใน sandbox (dev server รันจริงทุกหน้าผ่าน smoke แล้ว; CI build จะยืนยัน)
- [ ] Live probe `/api/runpod/status` — Not run (ต้อง merge + deploy ก่อน)

Known limits:

- ปุ่ม Confirm/Block/Delegate ของ ReviewGatePanel อัปเดตสถานะฝั่ง client + บันทึก audit line ในแชทเท่านั้น — **ยังไม่ยิง runtime commit/approvals API** (ยังไม่มี endpoint approvals ใน repo); ระบุไว้ในข้อความ audit ของ UI ชัดเจน
- ปุ่ม Approve/Reject ที่ disabled ในหน้า command-center ยังไม่ถูกต่อ workflow — ต้องออกแบบ approvals API ก่อน (สถาปัตยกรรมใหญ่เกิน PR นี้)
- เทส Chat Widget 6 ตัวยัง skip เพราะ widget เรนเดอร์เฉพาะ user ล็อกอิน (`{user && <AgentChatWidget />}`) — ต้องใช้ `E2E_TEST_EMAIL`/`E2E_TEST_PASSWORD` + Supabase env
- `configured: true` จาก `/api/runpod/status` พิสูจน์แค่ env ถูกตั้ง ไม่พิสูจน์ว่า key ใช้งานได้กับ Runpod API
- หมายเหตุจากการตรวจจริง: middleware localhost bypass อย่างเดียว **ไม่พอ** ให้ dashboard เรนเดอร์ (layout เรียก `createClient()` ที่ throw) — จึงต้องมี layout fallback ใน PR นี้

User-visible benefit:

- `/docs/en` และ `/docs/th` กลับมาใช้งานได้ (เดิม 500 ทุกครั้ง)
- นักพัฒนารัน E2E dashboard ทั้งชุดบนเครื่อง/CI ได้โดยไม่ต้องตั้ง Supabase credentials
- Operator เห็น review gate จริงใน Hermes chat เมื่อ action เป็น HIGH-risk REVIEW พร้อมปุ่มตัดสินใจ
- สั่งงาน GPU บน Runpod ผ่าน Claude Code ได้ด้วยภาษาธรรมชาติ

Next step:

1. รอ CI รอบ commit `5cebabd` เขียว แล้ว review + merge
2. หลัง deploy: `curl .../api/runpod/status` คาดหวัง `configured: true` และทดสอบ "List my Runpod endpoints" ผ่าน MCP
3. งานต่อ (แยก PR): ออกแบบ approvals API + ต่อปุ่ม command-center และ ReviewGatePanel เข้า runtime commit จริง

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BRDx27HZucRTRAtHvXSmX