### PR TITLE
fix: pricing catalog alignment, committed conflict cleanup, truthful logs, trinity E2E rewrite

### DIFF
--- a/app/api/revenue/[action]/route.ts
+++ b/app/api/revenue/[action]/route.ts
@@ -8,6 +8,7 @@ import { createClient } from '@supabase/supabase-js';
 import { PostHog } from 'posthog-node';
 import { handleApiError } from '@/lib/security/api-error';
 import { requireInternalService } from '@/lib/auth/internal-service';
+import { GATE_PLANS } from '@/lib/billing/pricing-catalog';
 
 export const dynamic = 'force-dynamic';
 
@@ -350,6 +351,14 @@ export async function POST(
       const posthog = getPostHog();
       const body = await req.json();
       const { eventType, plan } = body;
+      // Simulated amounts follow the pricing catalog ('agency' is this
+      // route's legacy alias for the business tier).
+      const simulatedAmount =
+        plan === 'enterprise'
+          ? GATE_PLANS.enterprise.displayMonthlyUsd
+          : plan === 'agency'
+            ? GATE_PLANS.business.displayMonthlyUsd
+            : GATE_PLANS.pro.displayMonthlyUsd;
 
       // Get a random customer for simulation
       const { data: customers } = await supabase
@@ -374,7 +383,7 @@ export async function POST(
             {
               customer_id: customer.id,
               plan: plan || 'pro',
-              amount: plan === 'pro' ? 99 : 299,
+              amount: simulatedAmount,
               status: 'active',
               created_at: new Date().toISOString(),
             },
@@ -388,7 +397,7 @@ export async function POST(
           properties: {
             customer_id: customer.id,
             plan: plan || 'pro',
-            amount: plan === 'pro' ? 99 : 299,
+            amount: simulatedAmount,
           },
         });
 
@@ -406,7 +415,7 @@ export async function POST(
           .insert([
             {
               customer_id: customer.id,
-              amount: plan === 'pro' ? 99 : 299,
+              amount: simulatedAmount,
               status: 'paid',
               created_at: new Date().toISOString(),
             },
@@ -419,7 +428,7 @@ export async function POST(
           event: 'invoice_paid',
           properties: {
             customer_id: customer.id,
-            amount: plan === 'pro' ? 99 : 299,
+            amount: simulatedAmount,
           },
         });
 

--- a/app/dashboard/billing/page.tsx
+++ b/app/dashboard/billing/page.tsx
@@ -7,42 +7,50 @@ import { PageHeader } from '@/components/ui/PageHeader';
 import { Card } from '@/components/ui/Card';
 import { StatCard } from '@/components/ui/StatCard';
 import UsageBar from '../../../components/billing/UsageBar';
+import { GATE_PLANS, SKILLS_BUNDLES, type PlanKey } from '@/lib/billing/pricing-catalog';
 
-type PlanKey = 'pro' | 'business' | 'enterprise';
 type NudgeLevel = 'none' | 'soft' | 'hard' | 'blocked';
 type BillingInterval = 'monthly' | 'yearly';
+
+// Monthly prices come from the pricing catalog (single source of truth — the
+// same numbers /api/billing/checkout charges). Yearly display keeps this
+// page's ~20% discount convention; the Stripe yearly prices must be
+// reconciled against these per the catalog's pricing rule.
+function yearlyPerMonth(monthly: number): number {
+  return Math.round(monthly * 0.8);
+}
 
 const PLANS: { key: PlanKey; title: string; monthly: number; yearly: number; yearlyTotal: number; features: string[] }[] = [
   {
     key: 'pro',
     title: 'Pro',
-    monthly: 99,
-    yearly: 79,
-    yearlyTotal: 948,
+    monthly: GATE_PLANS.pro.displayMonthlyUsd,
+    yearly: yearlyPerMonth(GATE_PLANS.pro.displayMonthlyUsd),
+    yearlyTotal: yearlyPerMonth(GATE_PLANS.pro.displayMonthlyUsd) * 12,
     features: ['10,000 executions / mo', '60 req/min gate limit', '10 agents', 'PDF export'],
   },
   {
     key: 'business',
     title: 'Business',
-    monthly: 299,
-    yearly: 239,
-    yearlyTotal: 2868,
+    monthly: GATE_PLANS.business.displayMonthlyUsd,
+    yearly: yearlyPerMonth(GATE_PLANS.business.displayMonthlyUsd),
+    yearlyTotal: yearlyPerMonth(GATE_PLANS.business.displayMonthlyUsd) * 12,
     features: ['100,000 executions / mo', '300 req/min gate limit', '50 agents', 'Audit ledger'],
   },
   {
     key: 'enterprise',
     title: 'Enterprise',
-    monthly: 799,
-    yearly: 639,
-    yearlyTotal: 7668,
+    monthly: GATE_PLANS.enterprise.displayMonthlyUsd,
+    yearly: yearlyPerMonth(GATE_PLANS.enterprise.displayMonthlyUsd),
+    yearlyTotal: yearlyPerMonth(GATE_PLANS.enterprise.displayMonthlyUsd) * 12,
     features: ['1,000,000 executions / mo', 'Unlimited gates', 'Unlimited agents', 'SLA + support'],
   },
 ];
 
 const SKILL_BUNDLES = [
-  { id: 'finance_skills', name: 'Finance Governance', monthly: 199 },
-  { id: 'dev_skills', name: 'Dev Automation', monthly: 99 },
-  { id: 'compliance_skills', name: 'Compliance & Legal', monthly: 249 },
+  { id: 'finance_skills', name: 'Finance Governance', monthly: SKILLS_BUNDLES.finance_skills.amountMonthly / 100 },
+  { id: 'dev_skills', name: 'Dev Automation', monthly: SKILLS_BUNDLES.dev_skills.amountMonthly / 100 },
+  { id: 'compliance_skills', name: 'Compliance & Legal', monthly: SKILLS_BUNDLES.compliance_skills.amountMonthly / 100 },
 ];
 
 function UpgradeCard({

--- a/app/delivery-proof/report/[run_id]/page.tsx
+++ b/app/delivery-proof/report/[run_id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { GATE_PLANS } from '@/lib/billing/pricing-catalog';
 import { UpgradeCTA } from '../../_components/UpgradeCTA';
 import { ShareSection } from './ShareSection';
 
@@ -204,13 +205,13 @@ export default async function DeliveryProofReportPage({ params }: { params: Prom
                 href="/billing?plan=pro"
                 className="rounded-xl bg-emerald-400 px-5 py-3 text-sm font-bold text-emerald-950 hover:bg-emerald-300 transition text-center"
               >
-                Upgrade to Pro — $99/mo →
+                Upgrade to Pro — ${GATE_PLANS.pro.displayMonthlyUsd}/mo →
               </a>
               <a
                 href="/billing?plan=business"
                 className="rounded-xl border border-emerald-300/50 bg-emerald-400/10 px-5 py-3 text-sm font-bold text-emerald-200 hover:bg-emerald-400/20 transition text-center"
               >
-                Agency Plan — $299/mo →
+                Business Plan — ${GATE_PLANS.business.displayMonthlyUsd}/mo →
               </a>
             </div>
           </div>

--- a/app/finance-governance/pricing/page.tsx
+++ b/app/finance-governance/pricing/page.tsx
@@ -2,6 +2,17 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { GATE_PLANS } from '@/lib/billing/pricing-catalog';
+
+// Display prices derive from the pricing catalog — the same numbers
+// /api/billing/checkout charges for these plan keys. Yearly follows this
+// page's "2 months free" (×10) convention.
+function monthlyLabel(plan: keyof typeof GATE_PLANS): string {
+  return `US$${GATE_PLANS[plan].displayMonthlyUsd}/mo`;
+}
+function yearlyLabel(plan: keyof typeof GATE_PLANS): string {
+  return `US$${(GATE_PLANS[plan].displayMonthlyUsd * 10).toLocaleString('en-US')}/yr`;
+}
 
 type BillingInterval = 'monthly' | 'yearly';
 type PaidPlanKey = 'pro' | 'business' | 'enterprise';
@@ -37,8 +48,8 @@ const plans: PlanCard[] = [
   {
     key: 'pro',
     name: 'Growth',
-    monthlyPrice: 'US$99/mo',
-    yearlyPrice: 'US$990/yr',
+    monthlyPrice: monthlyLabel('pro'),
+    yearlyPrice: yearlyLabel('pro'),
     subtitle: 'Best for finance teams moving from spreadsheets and email into governed approvals',
     trial: '14-day free trial',
     features: [
@@ -52,18 +63,18 @@ const plans: PlanCard[] = [
   },
   {
     key: 'business',
-    name: 'Enterprise',
-    monthlyPrice: 'US$299/mo',
-    yearlyPrice: 'US$2,990/yr',
+    name: 'Business',
+    monthlyPrice: monthlyLabel('business'),
+    yearlyPrice: yearlyLabel('business'),
     subtitle: 'Best for audit-heavy deployments, identity integration, and governance-first rollout support',
-    trial: '30-day pilot',
+    trial: '14-day free trial',
     features: [
       'SSO and SCIM readiness',
       'Advanced segregation-of-duties support',
       'Evidence bundle export',
       'Governance onboarding support',
     ],
-    cta: 'Start Enterprise Pilot',
+    cta: 'Start Business Pilot',
   },
   {
     key: 'enterprise',

--- a/app/try/page.tsx
+++ b/app/try/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import TryChatWidget from '../../components/TryChatWidget';
+import { GATE_PLANS } from '@/lib/billing/pricing-catalog';
 
 const TRIAL_FEATURES = [
   {
@@ -50,24 +51,25 @@ const STEPS = [
   { num: '4', title: 'View Audit Trail', desc: 'Every action has a stamp, reason, and proof — in real time' },
 ];
 
+// Prices come from the pricing catalog — the same numbers /api/billing/checkout charges.
 const PLANS_AFTER_TRIAL = [
   {
     name: 'Pro',
-    price: '$99',
+    price: `$${GATE_PLANS.pro.displayMonthlyUsd}`,
     per: '/month',
     highlight: false,
     features: ['Unlimited gate evaluations', '90-day audit trail', '3 API keys', 'Email support'],
   },
   {
     name: 'Business',
-    price: '$299',
+    price: `$${GATE_PLANS.business.displayMonthlyUsd}`,
     per: '/month',
     highlight: true,
     features: ['Everything in Pro', 'Team management', 'Webhook & Notifications', 'PDF export', 'Priority support'],
   },
   {
     name: 'Enterprise',
-    price: '$999',
+    price: `$${GATE_PLANS.enterprise.displayMonthlyUsd}`,
     per: '/month',
     highlight: false,
     features: ['Everything in Business', 'Custom policy engine', 'SLA 99.9%', 'Dedicated onboarding', 'Custom audit report'],

--- a/browserbase-service/tsconfig.json
+++ b/browserbase-service/tsconfig.json
@@ -3,26 +3,13 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-<<<<<<< HEAD
-    "outDir": "dist",
-    "rootDir": "src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "sourceMap": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
-}
-=======
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "declaration": true,
     "sourceMap": true,
@@ -32,4 +19,3 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "examples"]
 }
->>>>>>> origin/main

--- a/lib/agents/nerve-agent.ts
+++ b/lib/agents/nerve-agent.ts
@@ -83,7 +83,9 @@ export class NerveAgent {
         //   currency: job.reward.currency,
         //   tx_signature: signature,
         // });
-        console.log(`[${this.agentName}] ✅ Earnings persisted to Supabase`);
+        console.warn(
+          `[${this.agentName}] ⚠️ Earnings NOT persisted — agentProfileManager unavailable (recordEarnings disabled); tx ${signature} settled on-chain only`,
+        );
       } catch (err) {
         console.warn(`[${this.agentName}] ⚠️ Failed to persist earnings:`, err);
       }

--- a/tests/e2e/trinity-dashboard.spec.ts
+++ b/tests/e2e/trinity-dashboard.spec.ts
@@ -1,350 +1,130 @@
 /**
- * E2E UI Tests: Trinity AI Dashboard
+ * E2E UI Tests: Trinity AI Dashboard (/dashboard/trinity)
  *
- * ทดสอบ UI flow ของ Trinity Dashboard:
- * - System status loading
- * - Form validation
- * - Orchestration execution
- * - Real-time status updates
- * - Job discovery display
- * - Execution history
+ * Rewritten against the current page: the old suite targeted a previous
+ * version of this page ("Trinity AI System" header, Agent Registry,
+ * Run Orchestration button, inline validation messages) none of which
+ * exist in today's tabbed UI, so every test failed on locators.
  *
- * ทั้งหมด in dry_run mode — ไม่มี real SOL transfers
+ * Current page structure this suite asserts:
+ * - h1 "Trinity AI Orchestration" + 5-agent subtitle
+ * - Tabs (default: Agent Chat): Agents / Orchestrate / Discover Jobs /
+ *   History / Team Coordinator
+ * - Orchestrate tab: Job Title/Category/Reward inputs, live-run checkbox,
+ *   "▶ Execute Orchestration (dry run)" button disabled until a title is set
+ * - "Trinity Capabilities" section with per-agent cards
  *
- * NOTE: These tests require a running dev server.
- * Run `npm run dev` in a separate terminal before running these tests.
- * In CI, tests are automatically skipped if server is not accessible.
+ * NOTE: Requires a running dev server (skipped in CI without
+ * PLAYWRIGHT_BASE_URL). No real SOL transfers: the execute button stays in
+ * dry-run mode unless the live-run checkbox is ticked, which this suite
+ * never does.
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const BASE = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000';
 const TRINITY_DASHBOARD = `${BASE}/dashboard/trinity`;
 
-// Skip all Trinity Dashboard tests if running in CI without a dev server
-// (CI environments typically don't have a running dev server)
+// Skip in CI without a reachable server (CI runners don't start `next dev`).
 const skipTrinityTests = process.env.CI === 'true' && !process.env.PLAYWRIGHT_BASE_URL;
-
 const suiteRunner = skipTrinityTests ? test.describe.skip : test.describe;
+
+const AGENT_NAMES = ['Mind', 'Hand', 'Eye', 'Nerve', 'Spine'];
+
+// Click a tab and wait for its content — retried because the first click can
+// land before React hydration attaches the tab handlers.
+async function openTab(page: Page, tabLabel: string, contentProbe: string) {
+  await expect(async () => {
+    await page.locator(`button:has-text("${tabLabel}")`).first().click();
+    await expect(page.locator(contentProbe).first()).toBeVisible({ timeout: 3000 });
+  }).toPass({ timeout: 20_000 });
+}
 
 suiteRunner('Trinity Dashboard UI', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to Trinity Dashboard
-    await page.goto(TRINITY_DASHBOARD, { waitUntil: 'networkidle' });
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto(TRINITY_DASHBOARD, { waitUntil: 'domcontentloaded' });
   });
 
-  // =========================================================================
-  // 1. Page Load & System Status
-  // =========================================================================
-  test('should load Trinity Dashboard with header', async ({ page }) => {
-    // Check header is visible
-    const header = page.locator('h1:has-text("Trinity AI System")');
-    await expect(header).toBeVisible();
-
-    // Check subtitle
-    const subtitle = page.locator('text=Multi-Agent Orchestration • DSG Governance');
-    await expect(subtitle).toBeVisible();
+  // ── Page load ──────────────────────────────────────────────────────────
+  test('should load header and subtitle', async ({ page }) => {
+    await expect(page.locator('h1:has-text("Trinity AI Orchestration")')).toBeVisible();
+    await expect(
+      page.locator('text=5-Agent Multi-Agent System for Job Discovery'),
+    ).toBeVisible();
   });
 
-  test('should display all 5 agent cards', async ({ page }) => {
-    // Wait for agent cards to load
-    await page.waitForSelector('text=Agent Registry');
+  test('should show API connection status line', async ({ page }) => {
+    await expect(
+      page.locator('text=/Live API Connected|Connection Lost/').first(),
+    ).toBeVisible({ timeout: 20_000 });
+  });
 
-    // Check all 5 agents are present
-    for (const agent of ['Mind', 'Hand', 'Eye', 'Nerve', 'Spine']) {
-      const agentCard = page.locator(`text="${agent}"`);
-      await expect(agentCard).toBeVisible();
+  test('should render the Trinity Capabilities section', async ({ page }) => {
+    await expect(page.locator('text=Trinity Capabilities')).toBeVisible();
+    await expect(page.locator('text=Mind Agent').first()).toBeVisible();
+    await expect(page.locator('text=Hand Agent').first()).toBeVisible();
+  });
+
+  test('should display all tab buttons', async ({ page }) => {
+    for (const label of ['Agents', 'Orchestrate', 'Discover Jobs', 'History']) {
+      await expect(page.locator(`button:has-text("${label}")`).first()).toBeVisible();
     }
   });
 
-  test('should show agent status badges', async ({ page }) => {
-    // Wait for cards
-    await page.waitForSelector('text=registered');
-
-    // Check status badges
-    const statusBadges = page.locator('text=registered');
-    const count = await statusBadges.count();
-    expect(count).toBeGreaterThanOrEqual(5);
-  });
-
-  test('should have refresh button and refresh status', async ({ page }) => {
-    const refreshBtn = page.locator('button:has-text("Refresh")');
-    await expect(refreshBtn).toBeVisible();
-
-    // Click refresh
-    await refreshBtn.click();
-
-    // Status should still be visible after refresh
-    await page.waitForSelector('text=registered', { timeout: 10000 });
-    const agentCard = page.locator('text=Mind').first();
-    await expect(agentCard).toBeVisible();
-  });
-
-  // =========================================================================
-  // 2. Form Validation
-  // =========================================================================
-  test('should show validation errors for empty form', async ({ page }) => {
-    // Clear job title
-    const jobTitleInput = page.locator('input[placeholder="e.g., Smart Contract Audit"]');
-    await jobTitleInput.clear();
-
-    // Click run button
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Should show error toast
-    await page.waitForSelector('text=Please fix validation errors', { timeout: 5000 });
-  });
-
-  test('should validate reward amount', async ({ page }) => {
-    // Set reward to 0
-    const rewardInput = page.locator('input[type="number"][value="2"]').first();
-    await rewardInput.clear();
-    await rewardInput.fill('0');
-
-    // Try to run
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Should show validation error
-    await expect(page.locator('text=Reward must be greater than 0')).toBeVisible({
-      timeout: 5000,
-    });
-  });
-
-  test('should validate reputation range (0-100)', async ({ page }) => {
-    // Set reputation to 150
-    const reputationInputs = page.locator('input[type="number"]');
-    const reputationInput = reputationInputs.nth(reputationInputs.length - 1);
-
-    await reputationInput.clear();
-    await reputationInput.fill('150');
-
-    // Try to run
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Should show validation error
-    await expect(page.locator('text=Reputation must be between 0-100')).toBeVisible({
-      timeout: 5000,
-    });
-  });
-
-  test('should clear validation error when user fixes input', async ({ page }) => {
-    const jobTitleInput = page.locator('input[placeholder="e.g., Smart Contract Audit"]');
-
-    // Clear to trigger error
-    await jobTitleInput.clear();
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Should show error
-    await expect(page.locator('text=Job title is required')).toBeVisible();
-
-    // Type in field
-    await jobTitleInput.fill('Test Job');
-
-    // Error should disappear
-    await expect(page.locator('text=Job title is required')).not.toBeVisible({
-      timeout: 5000,
-    });
-  });
-
-  // =========================================================================
-  // 3. Form Submission & Orchestration
-  // =========================================================================
-  test('should run orchestration with valid inputs', async ({ page }) => {
-    // Set valid inputs
-    const jobTitleInput = page.locator('input[placeholder="e.g., Smart Contract Audit"]');
-    await jobTitleInput.fill('Integration Test Job');
-
-    // Click run
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Should show loading state
-    await expect(page.locator('text=Running')).toBeVisible({ timeout: 5000 });
-
-    // Wait for result
-    await expect(page.locator('text=Orchestration complete|Blocked')).toBeVisible({
-      timeout: 15000,
-    });
-  });
-
-  test('should display execution result with plan hash', async ({ page }) => {
-    // Run orchestration
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Wait for result section to show plan hash
-    await page.waitForSelector('text=Plan Hash', { timeout: 15000 });
-    const planHash = page.locator('text=Plan Hash').locator('..').locator('p').last();
-    const hashText = await planHash.textContent();
-
-    expect(hashText).toMatch(/^[a-f0-9]{64}$/);
-  });
-
-  test('should show governance constraints in result', async ({ page }) => {
-    // Run orchestration
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Wait for governance section
-    await page.waitForSelector('text=Governance', { timeout: 15000 });
-
-    // Check for constraint checkmarks
-    const constraints = page.locator('text=✅, text=❌');
-    const count = await constraints.count();
-    expect(count).toBeGreaterThan(0);
-  });
-
-  test('should display agent-specific results', async ({ page }) => {
-    // Run orchestration
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Wait for Hand execution section
-    await page.waitForSelector('text=Hand', { timeout: 15000 });
-    await expect(page.locator('text=✋ Hand — Execution')).toBeVisible();
-
-    // Check for quality score
-    await expect(page.locator('text=Quality Score')).toBeVisible();
-  });
-
-  // =========================================================================
-  // 4. Execution History
-  // =========================================================================
-  test('should display execution history section', async ({ page }) => {
-    // Look for history section
-    const historySection = page.locator('text=Execution History');
-    await expect(historySection).toBeVisible();
-  });
-
-  test('should have refresh button for execution history', async ({ page }) => {
-    // Find refresh button near Execution History
-    const historySection = page.locator('text=Execution History').locator('..');
-    const refreshBtn = historySection.locator('button:has-text("Refresh")');
-
-    // Button should exist
-    await expect(refreshBtn).toBeVisible();
-  });
-
-  test('should load and display execution history entries', async ({ page }) => {
-    // Wait for history to load
-    await page.waitForTimeout(2000);
-
-    // Check if history table is visible
-    const historyTable = page.locator('table');
-
-    // If table exists, check for headers
-    if (await historyTable.isVisible()) {
-      await expect(historyTable.locator('text=Job Title')).toBeVisible();
-      await expect(historyTable.locator('text=Status')).toBeVisible();
+  // ── Agents tab ─────────────────────────────────────────────────────────
+  test('should list all 5 agents on the Agents tab', async ({ page }) => {
+    await openTab(page, 'Agents', `h3:has-text("${AGENT_NAMES[0]}")`);
+    for (const name of AGENT_NAMES) {
+      await expect(page.locator(`h3:has-text("${name}")`).first()).toBeVisible();
     }
   });
 
-  // =========================================================================
-  // 5. Job Discovery (Mind Agent)
-  // =========================================================================
-  test('should display job discovery section', async ({ page }) => {
-    const jobsSection = page.locator('text=Discovered Jobs');
-    await expect(jobsSection).toBeVisible();
+  // ── Orchestrate tab ────────────────────────────────────────────────────
+  test('should show the orchestration form', async ({ page }) => {
+    await openTab(page, 'Orchestrate', 'input[placeholder="e.g., Smart Contract Audit"]');
+    await expect(page.locator('input[placeholder="e.g., smart-contract-audit"]')).toBeVisible();
+    await expect(page.locator('input[placeholder="0.0"]')).toBeVisible();
   });
 
-  test('should load and display discovered jobs', async ({ page }) => {
-    // Wait for jobs to load
-    await page.waitForTimeout(2000);
+  test('should disable execute until a job title is set', async ({ page }) => {
+    await openTab(page, 'Orchestrate', 'input[placeholder="e.g., Smart Contract Audit"]');
+    const titleInput = page.locator('input[placeholder="e.g., Smart Contract Audit"]');
+    const executeBtn = page.locator('button:has-text("Execute Orchestration")');
 
-    // Check if any job cards are visible
-    const jobCards = page.locator('text=smart-contract-audit, text=frontend-dev');
+    await titleInput.clear();
+    await expect(executeBtn).toBeDisabled();
 
-    // At least one job category should be visible
-    const count = await jobCards.count();
-    expect(count).toBeGreaterThanOrEqual(0);
+    await titleInput.fill('E2E Test Job');
+    await expect(executeBtn).toBeEnabled();
   });
 
-  test('should show job details in cards', async ({ page }) => {
-    // Wait for jobs to load
-    await page.waitForTimeout(2000);
+  test('should default to dry run and switch label on live-run toggle', async ({ page }) => {
+    await openTab(page, 'Orchestrate', 'input[placeholder="e.g., Smart Contract Audit"]');
+    const executeBtn = page.locator('button:has-text("Execute Orchestration")');
+    await expect(executeBtn).toContainText('dry run');
 
-    // Look for SOL amounts (indicating job cards are loaded)
-    const solAmounts = page.locator('text=SOL');
+    await page.locator('input[type="checkbox"]').first().check();
+    await expect(executeBtn).toContainText('LIVE');
 
-    if (await solAmounts.first().isVisible()) {
-      // Check for job metadata
-      await expect(page.locator('text=Due:')).toBeVisible();
-    }
+    // Switch back — this suite never executes a live run.
+    await page.locator('input[type="checkbox"]').first().uncheck();
+    await expect(executeBtn).toContainText('dry run');
   });
 
-  // =========================================================================
-  // 6. Real-time Features
-  // =========================================================================
-  test('should attempt WebSocket/SSE connection on load', async ({ page }) => {
-    // Check console for connection attempts
-    let wsAttempt = false;
-    page.on('console', (msg) => {
-      if (msg.text().includes('WebSocket') || msg.text().includes('connected')) {
-        wsAttempt = true;
-      }
-    });
-
-    // Give it a moment to try
-    await page.waitForTimeout(2000);
-
-    // Note: WebSocket may not connect in Next.js, which is expected
-    // The important thing is the dashboard still functions
-    expect(page.locator('text=Trinity AI System')).toBeVisible();
+  // ── Discover Jobs / History tabs ───────────────────────────────────────
+  test('should open the Discover Jobs tab', async ({ page }) => {
+    await expect(async () => {
+      await page.locator('button:has-text("Discover Jobs")').first().click();
+      await expect(
+        page.locator('input[placeholder="e.g., Smart Contract Audit"]'),
+      ).toHaveCount(0, { timeout: 3000 });
+    }).toPass({ timeout: 20_000 });
   });
 
-  test('should show system is functional even without real-time connection', async ({
-    page,
-  }) => {
-    // All primary features should work without WebSocket
-    await expect(page.locator('text=Trinity AI System')).toBeVisible();
-    await expect(page.locator('button:has-text("Run Orchestration")')).toBeEnabled();
-    await expect(page.locator('button:has-text("Refresh")')).toBeVisible();
-  });
-
-  // =========================================================================
-  // 7. Toast Notifications
-  // =========================================================================
-  test('should show success toast on orchestration completion', async ({ page }) => {
-    // Listen for toast messages
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-    await runBtn.click();
-
-    // Wait for completion toast
-    const successToast = page.locator('text=successfully|failed|blocked');
-    await expect(successToast).toBeVisible({ timeout: 15000 });
-  });
-
-  // =========================================================================
-  // 8. Accessibility & UX
-  // =========================================================================
-  test('should have proper button states during execution', async ({ page }) => {
-    const runBtn = page.locator('button:has-text("Run Orchestration")');
-
-    // Button should be enabled initially
-    await expect(runBtn).toBeEnabled();
-
-    // Click and check disabled state
-    await runBtn.click();
-    await expect(runBtn).toBeDisabled({ timeout: 5000 });
-
-    // Should re-enable after completion
-    await expect(runBtn).toBeEnabled({ timeout: 15000 });
-  });
-
-  test('should have responsive layout', async ({ page }) => {
-    // Check for grid layout sections
-    const sections = page.locator('section');
-    const count = await sections.count();
-
-    expect(count).toBeGreaterThan(0);
-  });
-
-  test('should display footer disclaimer', async ({ page }) => {
-    const footer = page.locator('text=dry-run only');
-    await expect(footer).toBeVisible();
+  test('should open the History tab', async ({ page }) => {
+    // Without DB data the tab shows an empty-state card; with data, the table.
+    await openTab(page, 'History', 'text=/executions from database|Loading history/');
+    await expect(
+      page.locator('text=/No execution history yet|Job Title/').first(),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
Goal:

รวมการแก้บักที่ยืนยันได้จากการสแกน 3 รอบ: (1) ราคาที่ผู้ใช้เห็น ≠ ราคาที่ checkout ชาร์จจริง, (2) conflict markers ที่ถูก commit ค้าง, (3) log ที่อ้างผลสำเร็จโดยไม่ได้ทำจริง, (4) เทส E2E ที่อ้างอิง UI รุ่นเก่า

Files changed:

**ราคา (commit ff54d99, 637040e):**
- `app/dashboard/billing/page.tsx` — business $299→catalog $199, enterprise $799→$499; ดึง plan + skills bundles จาก `pricing-catalog.ts`
- `app/finance-governance/pricing/page.tsx` — การ์ด business เดิมชื่อ "Enterprise US$299/mo" (ชาร์จจริง $199) → "Business" + ราคาจาก catalog + trial 14 วัน
- `app/try/page.tsx` — Business $299/Enterprise $999 → catalog ($199/$499)
- `app/delivery-proof/report/[run_id]/page.tsx` — "Agency Plan — $299/mo" (ลิงก์ plan=business ชาร์จ $199) → "Business Plan" ราคาจาก catalog
- `app/api/revenue/[action]/route.ts` — ยอดจำลอง simulate-webhook ใช้ catalog (`agency` = alias ของ business)

**Conflict cleanup (commit 1b57c20):**
- `browserbase-service/tsconfig.json` — resolve conflict markers ที่ถูก commit ค้าง (ไฟล์เดียวที่เหลือทั้ง repo); เลือกฝั่ง origin/main + คง forceConsistentCasingInFileNames

**Truthful logging + เทส (commit 4a06cc2):**
- `lib/agents/nerve-agent.ts` — เดิม log "✅ Earnings persisted to Supabase" ทั้งที่ `recordEarnings` ถูก comment out → log ตามจริงว่า persistence ถูกข้าม (settle on-chain เท่านั้น)
- `tests/e2e/trinity-dashboard.spec.ts` — เขียนใหม่ทั้งไฟล์ให้ตรง UI ปัจจุบัน (ของเดิมอ้าง "Trinity AI System"/"Agent Registry"/"Run Orchestration"/ข้อความ validation ที่ไม่มีอยู่แล้ว — fail ทุกข้อเมื่อรันในเครื่อง; suite นี้ skip ตัวเองใน CI) → 10 เทสใหม่: header, connection status, capabilities, tabs, 5 agents, ฟอร์ม orchestrate, ปุ่ม execute gating, dry-run/LIVE toggle, Discover Jobs, History — ไม่แตะ live SOL path

Verification:

- [x] `npx playwright test tests/e2e/trinity-dashboard.spec.ts` → **10 passed**
- [x] `npm run typecheck` — ไม่มี error ใหม่ (TS5101 ×2 มีบน main อยู่แล้ว)
- [x] headless Chromium `/dashboard/billing`: $99/$199/$499 ✓, ไม่มี $299/$799
- [x] curl `/finance-governance/pricing` + `/try` (dev): ราคาตรง catalog ทุกจุด
- [x] `node JSON.parse` บน tsconfig ที่แก้: valid; สแกน conflict markers ทั้ง repo: 0 ไฟล์
- [ ] Stripe yearly amounts — Not verified (Stripe MCP เชื่อมคนละบัญชีกับ price IDs ใน catalog)

Known limits:

- ราคา yearly display ยังเป็น convention ต่อหน้า — ควร reconcile Stripe แล้วเพิ่ม `displayYearlyUsd` ใน catalog
- Nerve agent persistence ยังปิดอยู่ (TODO agentProfileManager) — PR นี้แก้เฉพาะ log ให้ตรงจริง ไม่ได้เปิด persistence
- Trinity chat-stream SSE ยังเป็น stub, Agent OS registry ยัง in-memory, แท็บ hermes agents/executions/governance ยัง placeholder — เป็นงานฟีเจอร์แยก
- `products/readiness-gate|policy-gates` มี $299 แต่ CTA ไม่แตะ checkout (ผลิตภัณฑ์แยก) — ไม่ใช่บัก display-vs-charge; `lib/release-gate/plans.ts` ใช้ชื่อ `pro` ซ้ำที่ $299 แต่ checkout route เป็น stub (`stripe_not_configured`) ชาร์จอะไรไม่ได้

User-visible benefit:

ทุกเส้นทางที่นำผู้ใช้ไปจ่ายเงินแสดงราคาตรงกับที่ชาร์จจริง, log ของ settlement ไม่หลอกว่าบันทึกแล้ว, และเทส trinity รันในเครื่องได้จริง (10/10)

Next step:

1. รอ CI เขียว → review → merge
2. Reconcile ราคา yearly ใน Stripe + เพิ่ม `displayYearlyUsd` ใน catalog
3. งานฟีเจอร์แยก: เปิด Nerve persistence จริง, Trinity SSE จริง, ตัดสินใจ naming Spine role (Reflexes vs Governance) ให้สอดคล้อง

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BRDx27HZucRTRAtHvXSmX