### PR TITLE
fix: honest Trinity tool results + DSG_TOOLS skills behind gate + UI contrast

### DIFF
--- a/app/api/dashboard/trinity/chat-stream/route.ts
+++ b/app/api/dashboard/trinity/chat-stream/route.ts
@@ -63,7 +63,7 @@ const tools = [
   },
   {
     name: 'settle_payment',
-    description: 'Settle payment with real tracking (Nerve Agent)',
+    description: 'Record a settlement request for manual review — fail-closed, no on-chain transfer (Nerve Agent)',
     input_schema: {
       type: 'object',
       properties: {

--- a/app/api/dashboard/trinity/chat-stream/route.ts
+++ b/app/api/dashboard/trinity/chat-stream/route.ts
@@ -7,6 +7,10 @@ import { NextResponse } from 'next/server';
 import { Anthropic } from '@anthropic-ai/sdk';
 import * as fs from 'fs';
 import * as path from 'path';
+import { requireOrgRole } from '@/lib/authz';
+import { executeToolSafely } from '@/lib/agent/executor';
+import { DSG_TOOLS } from '@/lib/agent/tools';
+import type { AgentContext } from '@/lib/agent/context';
 import {
   discoverJobsReal,
   executeJobReal,
@@ -95,9 +99,30 @@ const tools = [
       },
     },
   },
+  // DSG platform skills — executed only through executeToolSafely (Hermes + DSG gate).
+  ...DSG_TOOLS.map((tool) => ({
+    name: tool.id,
+    description: tool.description,
+    input_schema: {
+      type: 'object',
+      properties: Object.fromEntries(
+        Object.entries(tool.parameters).map(([key, param]) => [
+          key,
+          { type: param.type, description: param.description },
+        ]),
+      ),
+      required: Object.entries(tool.parameters)
+        .filter(([, param]) => param.required)
+        .map(([key]) => key),
+    },
+  })),
 ];
 
-async function processToolCall(toolName: string, toolInput: Record<string, unknown>): Promise<string> {
+async function processToolCall(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  context: AgentContext,
+): Promise<string> {
   switch (toolName) {
     case 'discover_jobs':
       return JSON.stringify(
@@ -142,8 +167,16 @@ async function processToolCall(toolName: string, toolInput: Record<string, unkno
       } catch (error) {
         return JSON.stringify({ error: 'Failed to read DSG.md' });
       }
-    default:
-      return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+    default: {
+      // DSG platform skills — always through executeToolSafely so the Hermes
+      // preflight, DSG gate (ALLOW/STABILIZE/BLOCK), and approval-token rules apply.
+      const dsgTool = DSG_TOOLS.find((tool) => tool.id === toolName);
+      if (!dsgTool) {
+        return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+      }
+      const result = await executeToolSafely(dsgTool, toolInput, context);
+      return JSON.stringify(result);
+    }
   }
 }
 
@@ -174,6 +207,11 @@ function createSSEStream(): ReadableStream<Uint8Array> {
 
 export async function POST(request: Request) {
   try {
+    const access = await requireOrgRole(['operator', 'org_admin'], request);
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
     const body = await request.json();
     const userMessage = body.message as string;
     const selectedAgent = body.agent as string || 'All';
@@ -183,6 +221,15 @@ export async function POST(request: Request) {
     if (!userMessage) {
       return NextResponse.json({ error: 'Message required' }, { status: 400 });
     }
+
+    const context: AgentContext = {
+      orgId: access.orgId,
+      role: access.grantedRoles.includes('org_admin') ? 'org_admin' : 'operator',
+      origin: new URL(request.url).origin,
+      authHeader: request.headers.get('authorization') || '',
+      cookieHeader: request.headers.get('cookie') || '',
+      approvalToken: typeof body?.approvalToken === 'string' ? body.approvalToken : undefined,
+    };
 
     // Load DSG.md for context
     let dsgContext = '';
@@ -214,6 +261,8 @@ Trinity: 5-Agent AI Orchestration
 - 🦴 Spine: DSG governance
 
 All tools are connected to real platforms and Supabase. Use them proactively.
+
+You also have DSG platform skills (write_code_file, run_code, terminal sandbox, browser_navigate, fetch_url, realtime_web_search, agent CRUD, execute_action). Write/critical skills run through the DSG gate and may return requiresApproval — report that honestly instead of claiming the action ran.
 
 Language: ${language === 'th' ? 'Thai' : 'English'}
 Agent: ${selectedAgent}${dsgContext}`;
@@ -256,7 +305,7 @@ Agent: ${selectedAgent}${dsgContext}`;
                 timestamp: new Date().toISOString(),
               });
 
-              const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
+              const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
               toolCalls.push(toolUseBlock.name);
 
               sendEvent('tool_result', {
@@ -331,7 +380,7 @@ Agent: ${selectedAgent}${dsgContext}`;
       const toolUseBlock = response.content.find((block: any) => block.type === 'tool_use') as any;
       if (!toolUseBlock || toolUseBlock.type !== 'tool_use') break;
 
-      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
+      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
       toolCalls.push(toolUseBlock.name);
 
       messages.push({ role: 'assistant', content: response.content });

--- a/app/api/dashboard/trinity/chat/route.ts
+++ b/app/api/dashboard/trinity/chat/route.ts
@@ -3,6 +3,10 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import * as fs from 'fs';
 import * as path from 'path';
 import { handleApiError } from '@/lib/security/api-error';
+import { requireOrgRole } from '@/lib/authz';
+import { executeToolSafely } from '@/lib/agent/executor';
+import { DSG_TOOLS } from '@/lib/agent/tools';
+import type { AgentContext } from '@/lib/agent/context';
 import {
   discoverJobsReal,
   executeJobReal,
@@ -91,10 +95,33 @@ const tools = [
       },
     },
   },
+  // DSG platform skills (code sandbox, terminal, browser, web search, agent CRUD).
+  // Executed exclusively through executeToolSafely — Hermes + DSG gate, and
+  // write/critical tools require an approvalToken per the Autonomy Dial.
+  ...DSG_TOOLS.map((tool) => ({
+    name: tool.id,
+    description: tool.description,
+    input_schema: {
+      type: 'object',
+      properties: Object.fromEntries(
+        Object.entries(tool.parameters).map(([key, param]) => [
+          key,
+          { type: param.type, description: param.description },
+        ]),
+      ),
+      required: Object.entries(tool.parameters)
+        .filter(([, param]) => param.required)
+        .map(([key]) => key),
+    },
+  })),
 ];
 
 // Real implementation using live data sources and Supabase
-async function processToolCall(toolName: string, toolInput: Record<string, unknown>): Promise<string> {
+async function processToolCall(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  context: AgentContext,
+): Promise<string> {
   switch (toolName) {
     case 'discover_jobs': {
       const result = await discoverJobsReal(
@@ -168,18 +195,40 @@ async function processToolCall(toolName: string, toolInput: Record<string, unkno
         });
       }
 
-    default:
-      return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+    default: {
+      // DSG platform skills — always through executeToolSafely so the Hermes
+      // preflight, DSG gate (ALLOW/STABILIZE/BLOCK), and approval-token rules apply.
+      const dsgTool = DSG_TOOLS.find((tool) => tool.id === toolName);
+      if (!dsgTool) {
+        return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+      }
+      const result = await executeToolSafely(dsgTool, toolInput, context);
+      return JSON.stringify(result);
+    }
   }
 }
 
 export async function POST(request: Request) {
   try {
+    const access = await requireOrgRole(['operator', 'org_admin'], request);
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
     const body = await request.json();
     const userMessage = body.message as string;
     const selectedAgent = body.agent as string || 'All';
     const language = body.language as string || 'en';
     const modelProvider = (body.model || 'anthropic') as 'anthropic' | 'nvidia';
+
+    const context: AgentContext = {
+      orgId: access.orgId,
+      role: access.grantedRoles.includes('org_admin') ? 'org_admin' : 'operator',
+      origin: new URL(request.url).origin,
+      authHeader: request.headers.get('authorization') || '',
+      cookieHeader: request.headers.get('cookie') || '',
+      approvalToken: typeof body?.approvalToken === 'string' ? body.approvalToken : undefined,
+    };
 
     // Validate API key for selected model
     if (modelProvider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
@@ -233,6 +282,8 @@ You are part of Trinity, a multi-agent AI orchestration system:
 
 You have access to MCP tools. Use them proactively to answer questions.
 
+You also have DSG platform skills (write_code_file, run_code, terminal sandbox, browser_navigate, fetch_url, realtime_web_search, agent CRUD, execute_action). Write/critical skills run through the DSG gate and may return requiresApproval — report that honestly instead of claiming the action ran.
+
 DSG Framework:
 - Deterministic governance with Z3 formal verification
 - Evidence-driven (CCVS L1-L5) decision making
@@ -268,7 +319,7 @@ Always explain tool usage. Be helpful and efficient.`;
 
       if (!toolUseBlock || toolUseBlock.type !== 'tool_use') break;
 
-      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
+      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
       toolCalls.push(toolUseBlock.name);
 
       // Add assistant response and tool result to messages

--- a/app/api/dashboard/trinity/chat/route.ts
+++ b/app/api/dashboard/trinity/chat/route.ts
@@ -59,7 +59,7 @@ const tools = [
   },
   {
     name: 'settle_payment',
-    description: 'Settle payment with real tracking (Nerve Agent)',
+    description: 'Record a settlement request for manual review — fail-closed, no on-chain transfer (Nerve Agent)',
     input_schema: {
       type: 'object',
       properties: {

--- a/app/dsg-one/page.tsx
+++ b/app/dsg-one/page.tsx
@@ -93,7 +93,7 @@ export default function DSGOneLanding() {
             </span>
           </div>
           <h1 className="text-5xl sm:text-6xl font-bold text-white mb-6">
-            Don't Trust AI. <span className="text-emerald-400">Verify Every Decision.</span>
+            Don&apos;t Trust AI. <span className="text-emerald-400">Verify Every Decision.</span>
           </h1>
           <p className="text-xl text-slate-300 mb-4">
             The control plane for AI operations across your entire organization.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -267,31 +267,31 @@ export default function HomePage() {
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">POST /analyze</code>
-                <p className="text-xs text-slate-400">Discover services & confidence</p>
+                <p className="text-xs text-slate-200">Discover services & confidence</p>
               </div>
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">POST /plan</code>
-                <p className="text-xs text-slate-400">Build phases & dependencies</p>
+                <p className="text-xs text-slate-200">Build phases & dependencies</p>
               </div>
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">POST /approve</code>
-                <p className="text-xs text-slate-400">Verify canonical hash</p>
+                <p className="text-xs text-slate-200">Verify canonical hash</p>
               </div>
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">POST /execute</code>
-                <p className="text-xs text-slate-400">Start orchestration</p>
+                <p className="text-xs text-slate-200">Start orchestration</p>
               </div>
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">GET /status/:id</code>
-                <p className="text-xs text-slate-400">Poll phase progress</p>
+                <p className="text-xs text-slate-200">Poll phase progress</p>
               </div>
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">GET /connectors</code>
-                <p className="text-xs text-slate-400">List providers & capabilities</p>
+                <p className="text-xs text-slate-200">List providers & capabilities</p>
               </div>
               <div className="space-y-2">
                 <code className="text-xs font-mono text-amber-200">GET /vault/secrets</code>
-                <p className="text-xs text-slate-400">Org-scoped credentials</p>
+                <p className="text-xs text-slate-200">Org-scoped credentials</p>
               </div>
             </div>
           </div>
@@ -303,12 +303,12 @@ export default function HomePage() {
               <p className="mt-2 text-xs text-slate-300">Step through analyze → plan → approve → execute</p>
             </Link>
             <Link href="/docs/DSG_SETUP_GUIDE.md" className="border border-white/10 bg-white/[0.03] rounded-2xl p-6 hover:border-white/20 transition">
-              <p className="text-sm uppercase tracking-[0.2em] text-slate-400 font-semibold">Docs</p>
+              <p className="text-sm uppercase tracking-[0.2em] text-slate-200 font-semibold">Docs</p>
               <h4 className="mt-2 text-lg font-bold text-white">Setup Guide</h4>
               <p className="mt-2 text-xs text-slate-300">Complete API reference with curl examples</p>
             </Link>
             <Link href="/docs/LICENSING.md" className="border border-white/10 bg-white/[0.03] rounded-2xl p-6 hover:border-white/20 transition">
-              <p className="text-sm uppercase tracking-[0.2em] text-slate-400 font-semibold">Licensing</p>
+              <p className="text-sm uppercase tracking-[0.2em] text-slate-200 font-semibold">Licensing</p>
               <h4 className="mt-2 text-lg font-bold text-white">Pricing Tiers</h4>
               <p className="mt-2 text-xs text-slate-300">Starter, Pro, Enterprise with decision metering</p>
             </Link>
@@ -352,7 +352,7 @@ export default function HomePage() {
             <div className="border border-green-400/30 bg-green-400/5 rounded-2xl p-6">
               <div className="mb-4">
                 <div className="text-5xl font-bold text-green-300 font-mono">3,389</div>
-                <div className="text-sm text-slate-400 mt-1">tests passing</div>
+                <div className="text-sm text-slate-200 mt-1">tests passing</div>
               </div>
               <p className="text-xs text-slate-300 leading-6">
                 <strong>0 failures</strong> across unit, integration, failure, and E2E test suites. Zero test debt.
@@ -365,7 +365,7 @@ export default function HomePage() {
             <div className="border border-blue-400/30 bg-blue-400/5 rounded-2xl p-6">
               <div className="mb-4">
                 <div className="text-5xl font-bold text-blue-300 font-mono">72.08%</div>
-                <div className="text-sm text-slate-400 mt-1">mutation score</div>
+                <div className="text-sm text-slate-200 mt-1">mutation score</div>
               </div>
               <p className="text-xs text-slate-300 leading-6">
                 <strong>High resilience</strong> to code changes. Stryker mutation testing verifies test effectiveness.
@@ -378,7 +378,7 @@ export default function HomePage() {
             <div className="border border-purple-400/30 bg-purple-400/5 rounded-2xl p-6">
               <div className="mb-4">
                 <div className="text-4xl font-bold text-purple-300 font-mono">L1–L5</div>
-                <div className="text-sm text-slate-400 mt-1">CCVS verified</div>
+                <div className="text-sm text-slate-200 mt-1">CCVS verified</div>
               </div>
               <p className="text-xs text-slate-300 leading-6">
                 <strong>Compliance matrix</strong> proves control flow: unit → integration → adversarial → mutation → provenance.
@@ -391,7 +391,7 @@ export default function HomePage() {
             <div className="border border-amber-400/30 bg-amber-400/5 rounded-2xl p-6">
               <div className="mb-4">
                 <div className="text-3xl font-bold text-amber-300 font-mono">285</div>
-                <div className="text-sm text-slate-400 mt-1">test files</div>
+                <div className="text-sm text-slate-200 mt-1">test files</div>
               </div>
               <p className="text-xs text-slate-300 leading-6">
                 <strong>Comprehensive coverage</strong> across deterministic gates, spine execution, and licensing.
@@ -407,33 +407,33 @@ export default function HomePage() {
             <div className="grid gap-4 md:grid-cols-5">
               <div className="text-center">
                 <div className="text-3xl font-bold text-green-300 mb-2">L1</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Unit Tests</strong></p>
-                <p className="text-xs text-slate-500">Isolated component verification</p>
+                <p className="text-xs text-slate-200 mb-2"><strong>Unit Tests</strong></p>
+                <p className="text-xs text-slate-300">Isolated component verification</p>
               </div>
               <div className="flex items-center justify-center text-slate-500">→</div>
               <div className="text-center">
                 <div className="text-3xl font-bold text-green-300 mb-2">L2</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Integration</strong></p>
-                <p className="text-xs text-slate-500">Cross-layer behavior</p>
+                <p className="text-xs text-slate-200 mb-2"><strong>Integration</strong></p>
+                <p className="text-xs text-slate-300">Cross-layer behavior</p>
               </div>
               <div className="flex items-center justify-center text-slate-500">→</div>
               <div className="text-center">
                 <div className="text-3xl font-bold text-green-300 mb-2">L3</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Adversarial</strong></p>
-                <p className="text-xs text-slate-500">Failure scenarios</p>
+                <p className="text-xs text-slate-200 mb-2"><strong>Adversarial</strong></p>
+                <p className="text-xs text-slate-300">Failure scenarios</p>
               </div>
             </div>
             <div className="grid gap-4 md:grid-cols-5 mt-6 pt-6 border-t border-white/10">
               <div className="text-center">
                 <div className="text-3xl font-bold text-purple-300 mb-2">L4</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Mutation</strong></p>
-                <p className="text-xs text-slate-500">Code resilience (72.08%)</p>
+                <p className="text-xs text-slate-200 mb-2"><strong>Mutation</strong></p>
+                <p className="text-xs text-slate-300">Code resilience (72.08%)</p>
               </div>
               <div className="flex items-center justify-center text-slate-500">→</div>
               <div className="text-center">
                 <div className="text-3xl font-bold text-purple-300 mb-2">L5</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Provenance</strong></p>
-                <p className="text-xs text-slate-500">Build & deploy audit</p>
+                <p className="text-xs text-slate-200 mb-2"><strong>Provenance</strong></p>
+                <p className="text-xs text-slate-300">Build & deploy audit</p>
               </div>
               <div className="flex items-center justify-center text-slate-500 col-span-2"></div>
             </div>
@@ -474,12 +474,12 @@ export default function HomePage() {
           <div className="overflow-x-auto rounded-2xl border border-white/10 bg-white/[0.02]">
             <table className="w-full min-w-[640px] text-left text-sm">
               <thead>
-                <tr className="border-b border-white/10 text-slate-400">
+                <tr className="border-b border-white/10 text-slate-200">
                   <th className="px-5 py-4 font-semibold">Capability</th>
                   <th className="px-5 py-4 font-semibold text-emerald-200">DSG ONE</th>
-                  <th className="px-5 py-4 font-semibold">LangGraph</th>
-                  <th className="px-5 py-4 font-semibold">OpenAI Agents</th>
-                  <th className="px-5 py-4 font-semibold">Temporal</th>
+                  <th className="px-5 py-4 font-semibold text-slate-200">LangGraph</th>
+                  <th className="px-5 py-4 font-semibold text-slate-200">OpenAI Agents</th>
+                  <th className="px-5 py-4 font-semibold text-slate-200">Temporal</th>
                 </tr>
               </thead>
               <tbody>

--- a/components/GlobalNav.tsx
+++ b/components/GlobalNav.tsx
@@ -129,7 +129,7 @@ export default function GlobalNav() {
                             <span className="ml-2 rounded-full bg-emerald-400/20 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-emerald-300">New</span>
                           )}
                         </span>
-                        <span className="block text-xs text-slate-400">{item.description}</span>
+                        <span className="block text-xs text-slate-300">{item.description}</span>
                       </span>
                     </Link>
                   ))}
@@ -157,7 +157,7 @@ export default function GlobalNav() {
             {/* Language switcher */}
             <button
               onClick={() => languageStore.setLanguage(lang === 'th' ? 'en' : 'th')}
-              className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm font-semibold text-slate-400 transition hover:border-amber-300/30 hover:text-amber-100"
+              className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:border-amber-300/30 hover:text-amber-100"
               aria-label="Switch language"
             >
               {lang === 'th' ? 'EN' : 'TH'}
@@ -239,7 +239,7 @@ export default function GlobalNav() {
                     </span>
                     <span>
                       <span className="block text-sm font-semibold text-slate-100">{item.title}</span>
-                      <span className="block text-xs text-slate-400">{item.description}</span>
+                      <span className="block text-xs text-slate-300">{item.description}</span>
                     </span>
                   </Link>
                 ))}

--- a/lib/agents/nerve-agent.ts
+++ b/lib/agents/nerve-agent.ts
@@ -73,20 +73,17 @@ export class NerveAgent {
         timestamp: new Date().toISOString(),
       };
 
-      // Persist to Supabase
-      try {
-        // TODO: Reactivate when agentProfileManager is available
-        // await agentProfileManager.recordEarnings({
-        //   job_id: job.id,
-        //   agent_id: profile.agentId,
-        //   amount: job.reward.amount,
-        //   currency: job.reward.currency,
-        //   tx_signature: signature,
-        // });
-        console.log(`[${this.agentName}] ✅ Earnings persisted to Supabase`);
-      } catch (err) {
-        console.warn(`[${this.agentName}] ⚠️ Failed to persist earnings:`, err);
-      }
+      // Supabase persistence not wired yet — do not log success for a write that
+      // never happened. The earnings record is returned to the caller only.
+      // TODO: Reactivate when agentProfileManager is available
+      // await agentProfileManager.recordEarnings({
+      //   job_id: job.id,
+      //   agent_id: profile.agentId,
+      //   amount: job.reward.amount,
+      //   currency: job.reward.currency,
+      //   tx_signature: signature,
+      // });
+      console.log(`[${this.agentName}] ⚠️ Earnings NOT persisted to Supabase (persistence pending; record returned in-memory only)`);
 
       console.log(`[${this.agentName}] ✅ Payment successful: ${signature.substring(0, 20)}...`);
 

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -240,6 +240,9 @@ export async function verifyDeliverableReal(
 
     const startTime = Date.now();
 
+    // Sanitize user-supplied qualityCriteria: trim and validate length
+    const sanitizedCriteria = qualityCriteria?.trim().slice(0, 500) || null;
+
     // Fail-closed: score the stored deliverable content, never a fabricated value.
     const { data: execution } = await supabase
       .from('trinity_executions')
@@ -266,7 +269,7 @@ export async function verifyDeliverableReal(
       .from('trinity_verifications')
       .insert({
         deliverable_id: deliverableId,
-        quality_criteria: qualityCriteria || null,
+        quality_criteria: sanitizedCriteria,
         quality_score: qualityScore,
         verification_status: qualityScore >= 80 ? 'passed' : 'review',
         checks_passed: checksPassed,

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -266,7 +266,7 @@ export async function verifyDeliverableReal(
       .from('trinity_verifications')
       .insert({
         deliverable_id: deliverableId,
-        quality_criteria: qualityCriteria,
+        quality_criteria: qualityCriteria || null,
         quality_score: qualityScore,
         verification_status: qualityScore >= 80 ? 'passed' : 'review',
         checks_passed: checksPassed,

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -163,12 +163,25 @@ export async function discoverJobsReal(
 }
 
 /**
+ * Deterministic quality scoring — same rubric as /api/trinity/execute-job.
+ * Scores content properties (length, evidence markers, category weight);
+ * never fabricates a score from randomness.
+ */
+export function scoreDeliverableQuality(deliverable: string, category?: string): number {
+  let score = 60;
+  if (deliverable.length > 120) score += 10;
+  if (deliverable.includes('Evidence')) score += 10;
+  if (category === 'smart-contract-audit' || category === 'security-review') score += 10;
+  return Math.min(100, score);
+}
+
+/**
  * Execute job - track in Supabase execution table
  */
 export async function executeJobReal(
   jobId: string,
   deliverable: string,
-  executionTimeTarget?: number
+  _executionTimeTarget?: number
 ): Promise<any> {
   try {
     if (!supabase) {
@@ -177,6 +190,7 @@ export async function executeJobReal(
 
     const executionId = `exec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
     const startTime = Date.now();
+    const qualityScore = scoreDeliverableQuality(deliverable);
 
     const { data, error } = await supabase
       .from('trinity_executions')
@@ -185,11 +199,8 @@ export async function executeJobReal(
         job_id: jobId,
         deliverable,
         status: 'completed',
-        quality_score: 85 + Math.random() * 15,
-        execution_time_ms: Math.min(
-          executionTimeTarget || 3000,
-          Date.now() - startTime
-        ),
+        quality_score: qualityScore,
+        execution_time_ms: Date.now() - startTime,
         created_at: new Date().toISOString(),
       })
       .select()
@@ -227,7 +238,29 @@ export async function verifyDeliverableReal(
       return { error: 'Database not configured' };
     }
 
-    const qualityScore = 80 + Math.random() * 20;
+    const startTime = Date.now();
+
+    // Fail-closed: score the stored deliverable content, never a fabricated value.
+    const { data: execution } = await supabase
+      .from('trinity_executions')
+      .select('execution_id, deliverable')
+      .eq('execution_id', deliverableId)
+      .maybeSingle();
+
+    if (!execution?.deliverable) {
+      return {
+        deliverable_id: deliverableId,
+        verification_status: 'review',
+        quality_score: null,
+        issues: ['Deliverable not found — cannot verify, routed to manual review'],
+        verification_time_ms: Date.now() - startTime,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    const qualityScore = scoreDeliverableQuality(execution.deliverable, qualityCriteria);
+    const checksTotal = 10;
+    const checksPassed = Math.floor(qualityScore / 10);
 
     const { data, error } = await supabase
       .from('trinity_verifications')
@@ -236,8 +269,8 @@ export async function verifyDeliverableReal(
         quality_criteria: qualityCriteria,
         quality_score: qualityScore,
         verification_status: qualityScore >= 80 ? 'passed' : 'review',
-        checks_passed: Math.floor(qualityScore / 10),
-        checks_total: 12,
+        checks_passed: checksPassed,
+        checks_total: checksTotal,
         created_at: new Date().toISOString(),
       })
       .select()
@@ -249,10 +282,10 @@ export async function verifyDeliverableReal(
       deliverable_id: deliverableId,
       verification_status: data.verification_status,
       quality_score: qualityScore,
-      checks_passed: data.checks_passed,
-      checks_total: 12,
-      issues: qualityScore < 80 ? ['Minor quality issues detected'] : [],
-      verification_time_ms: Math.random() * 1000,
+      checks_passed: checksPassed,
+      checks_total: checksTotal,
+      issues: qualityScore < 80 ? ['Deterministic rubric below pass threshold — needs review'] : [],
+      verification_time_ms: Date.now() - startTime,
       timestamp: new Date().toISOString(),
     };
   } catch (error) {
@@ -265,7 +298,10 @@ export async function verifyDeliverableReal(
 }
 
 /**
- * Settle payment - integrated with Supabase ledger
+ * Settle payment — fail-closed ledger entry, same posture as settleJob() in workflow.ts.
+ * Records the settlement request for manual review; never fabricates an on-chain
+ * transaction hash, confirmation count, or reputation delta. Real transfers go
+ * through NerveAgent.settlePayment (SolanaClient.transferSOL) only.
  */
 export async function settlePaymentReal(
   executionId: string,
@@ -276,16 +312,14 @@ export async function settlePaymentReal(
       return { error: 'Database not configured' };
     }
 
-    const transactionHash = Math.random().toString(16).slice(2, 66);
-
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('trinity_payments')
       .insert({
         execution_id: executionId,
         amount_sol: amountSol,
-        transaction_hash: transactionHash,
-        status: 'confirmed',
-        confirmations: 32,
+        transaction_hash: null,
+        status: 'pending_manual_review',
+        confirmations: 0,
         created_at: new Date().toISOString(),
       })
       .select()
@@ -296,11 +330,10 @@ export async function settlePaymentReal(
     return {
       execution_id: executionId,
       amount_sol: amountSol,
-      transaction_hash: transactionHash,
-      status: 'confirmed',
-      confirmations: 32,
-      reputation_change: Math.random() * 5,
-      new_reputation: 50 + Math.random() * 50,
+      transaction_hash: null,
+      status: 'pending_manual_review',
+      confirmations: 0,
+      note: 'Settlement recorded fail-closed for manual review. No on-chain transfer was executed by this tool.',
       timestamp: new Date().toISOString(),
     };
   } catch (error) {

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -238,6 +238,11 @@ export async function verifyDeliverableReal(
       return { error: 'Database not configured' };
     }
 
+    // Validate deliverable ID format (alphanumeric + hyphens, max 100 chars)
+    if (!deliverableId || !/^[a-zA-Z0-9\-]{1,100}$/.test(deliverableId)) {
+      return { error: 'Invalid deliverable_id format' };
+    }
+
     const startTime = Date.now();
 
     // Sanitize user-supplied qualityCriteria: trim and validate length

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -258,7 +258,7 @@ export async function verifyDeliverableReal(
       };
     }
 
-    const qualityScore = scoreDeliverableQuality(execution.deliverable, qualityCriteria);
+    const qualityScore = scoreDeliverableQuality(execution.deliverable);
     const checksTotal = 10;
     const checksPassed = Math.floor(qualityScore / 10);
 

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -188,6 +188,16 @@ export async function executeJobReal(
       return { error: 'Database not configured' };
     }
 
+    // Validate jobId format (alphanumeric + hyphens, max 100 chars)
+    if (!jobId || !/^[a-zA-Z0-9\-]{1,100}$/.test(jobId)) {
+      return { error: 'Invalid job_id format' };
+    }
+
+    // Validate deliverable size (max 1MB)
+    if (!deliverable || Buffer.byteLength(deliverable, 'utf-8') > 1024 * 1024) {
+      return { error: 'Deliverable exceeds 1MB size limit' };
+    }
+
     const executionId = `exec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
     const startTime = Date.now();
     const qualityScore = scoreDeliverableQuality(deliverable);
@@ -318,6 +328,15 @@ export async function settlePaymentReal(
   try {
     if (!supabase) {
       return { error: 'Database not configured' };
+    }
+
+    // Validate execution_id format and amount
+    if (!executionId || !/^[a-zA-Z0-9\-]{1,100}$/.test(executionId)) {
+      return { error: 'Invalid execution_id format' };
+    }
+
+    if (typeof amountSol !== 'number' || amountSol <= 0 || amountSol > 1000000) {
+      return { error: 'Invalid amount: must be positive and <= 1000000 SOL' };
     }
 
     const { error } = await supabase


### PR DESCRIPTION
Goal:

Make the Trinity chat tool path honest ("Devin-style": real evidence only, fail-closed when evidence is missing), give it the platform's full DSG_TOOLS skill set behind auth + the DSG gate, and fix unreadable low-contrast text on the public homepage and global navigation.

**1) Trinity honesty fixes (verified by direct file inspection before editing):**
- `executeJobReal` fabricated `quality_score: 85 + Math.random() * 15` → now uses deterministic `scoreDeliverableQuality` (same rubric as `/api/trinity/execute-job`).
- `verifyDeliverableReal` fabricated `80 + Math.random() * 20` and `verification_time_ms: Math.random() * 1000` → now fetches the stored deliverable from `trinity_executions`, scores it deterministically, measures real elapsed time, and fails closed to `review` when the deliverable is not found.
- `settlePaymentReal` fabricated a random tx hash with `status: 'confirmed'` / `confirmations: 32` / random reputation deltas → now fail-closed like `settleJob()` in `lib/trinity/workflow.ts`: records `pending_manual_review` with `transaction_hash: null` and states explicitly that no on-chain transfer was executed.
- `settle_payment` tool description in both Trinity chat routes now states the fail-closed behavior instead of claiming "real tracking".
- `nerve-agent.ts` logged "✅ Earnings persisted to Supabase" while the persistence call is commented out → log now states the honest pending state. (The Solana transfer itself in this path is real via `SolanaClient.transferSOL` and unchanged.)

**2) DSG_TOOLS skills wired into Trinity chat (pattern lifted from `app/api/agent-chat/route.ts`):**
- Both `chat` and `chat-stream` now require `operator`/`org_admin` via `requireOrgRole` before any turn (previously unauthenticated).
- An `AgentContext` (orgId, role, origin, auth/cookie headers, optional `approvalToken`) is built per request.
- All `DSG_TOOLS` skills (write_code_file, run_code, terminal sandbox, browser_navigate, fetch_url, realtime_web_search, agent CRUD, execute_action, …) are exposed to the model with schemas generated from each tool's parameter definitions, and executed exclusively through `executeToolSafely` — Hermes preflight, DSG gate (ALLOW/STABILIZE/BLOCK), and approval-token rules for write/critical tools all apply.
- The 6 Trinity domain tools keep their (now deterministic, fail-closed) implementations; no tool-id collisions.
- System prompts instruct the model to report `requiresApproval` results honestly instead of claiming an action ran.

**3) UX contrast fixes:**
- Homepage (`app/page.tsx`): `text-slate-400/500` → `text-slate-200/300` on API labels, metric-card subtitles, CCVS pipeline labels, and comparison-table headers.
- `components/GlobalNav.tsx`: dropdown/mobile-menu descriptions and language button `text-slate-400` → `text-slate-200/300`.

**4) Build unblock:** escaped an unescaped apostrophe in `app/dsg-one/page.tsx:96` (`react/no-unescaped-entities`) that failed the Vercel build — pre-existing, not introduced by this PR.

Files changed:

- `lib/trinity/real-jobs.ts`
- `app/api/dashboard/trinity/chat/route.ts`
- `app/api/dashboard/trinity/chat-stream/route.ts`
- `lib/agents/nerve-agent.ts`
- `app/page.tsx`
- `components/GlobalNav.tsx`
- `app/dsg-one/page.tsx`

Verification:

- [x] `npm run typecheck` — passed after each change set, no errors
- [x] `npx vitest run tests/unit/trinity-agents.test.ts tests/integration/trinity-dashboard.test.ts tests/integration/trinity6-agent-os.test.ts` — 64/64 passed
- [x] `npx next lint --file` on both Trinity chat routes and `app/dsg-one/page.tsx` — no warnings or errors
- [x] Vercel preview build on 71919e9 — Ready (previous failure was the pre-existing lint error, fixed here)
- [x] CI on PR: CCVS Evidence 4040/4040 passed; Security Evidence PASS (0 vulns, 0 secrets)
- [x] Contrast fixes verified via `npm run dev` + rendered HTML inspection on localhost:3000
- [ ] Live Trinity chat round-trip — Not run (requires ANTHROPIC_API_KEY + authenticated session not configured in this environment)

Known limits:

- `dsg-gate` CI check probes the live production readiness URL; it failed once with a transient 503 at 04:35 UTC — the same endpoint independently returned 200 `ok:true` minutes later. It re-evaluates on this push; not caused by this diff.
- Trinity chat now requires an authenticated org session; any UI calling it anonymously will get 401 (dashboard pages already sit behind Supabase session middleware, so logged-in operators pass cookies automatically).
- Critical skills (`run_code`, `execute_action`, `delete_agent`, …) return `requiresApproval` unless the request carries an `approvalToken` — by design per the Autonomy Dial; the Trinity UI does not yet send one.
- `trinity_payments.transaction_hash` must be nullable for the fail-closed insert to succeed on the live DB; if the column is NOT NULL the call returns an error instead of a fake success — still fail-closed, but should be confirmed against the live schema.
- Not addressed in this PR (needs Supabase migration + live schema evidence): persisting Agent OS `ExecutiveHierarchy` in-memory decisions/registry, and wiring `agentProfileManager.recordEarnings` in `nerve-agent.ts` (TODO remains, now with an honest log).

User-visible benefit:

- Trinity chat can no longer report a payment as "confirmed" with a fabricated transaction hash, or invent quality scores — every number returned is computed from real content, read from the DB, or explicitly routed to manual review.
- Trinity chat gains the platform's real agent skills (code sandbox, terminal, browser, web search, governed execution) with every write/critical action gated and auditable.
- Homepage and navigation text is readable on the dark background.

Next step:

- Have the Trinity UI surface `requiresApproval` results and send `approvalToken` for approved critical actions.
- Confirm `trinity_payments` schema nullability on the live DB, then decide whether `settle_payment` should call the real `NerveAgent.settlePayment` Solana path behind the gate.
- Follow-up PR for Agent OS state persistence (requires migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015X6touZJKBuLEq1XUfXVKw