### PR TITLE
fix: honest Trinity tool results + DSG_TOOLS skills behind gate + UI contrast (rebased)

### DIFF
--- a/app/api/dashboard/trinity/chat-stream/route.ts
+++ b/app/api/dashboard/trinity/chat-stream/route.ts
@@ -7,6 +7,10 @@ import { NextResponse } from 'next/server';
 import { Anthropic } from '@anthropic-ai/sdk';
 import * as fs from 'fs';
 import * as path from 'path';
+import { requireOrgRole } from '@/lib/authz';
+import { executeToolSafely } from '@/lib/agent/executor';
+import { DSG_TOOLS } from '@/lib/agent/tools';
+import type { AgentContext } from '@/lib/agent/context';
 import {
   discoverJobsReal,
   executeJobReal,
@@ -95,9 +99,30 @@ const tools = [
       },
     },
   },
+  // DSG platform skills — executed only through executeToolSafely (Hermes + DSG gate).
+  ...DSG_TOOLS.map((tool) => ({
+    name: tool.id,
+    description: tool.description,
+    input_schema: {
+      type: 'object',
+      properties: Object.fromEntries(
+        Object.entries(tool.parameters).map(([key, param]) => [
+          key,
+          { type: param.type, description: param.description },
+        ]),
+      ),
+      required: Object.entries(tool.parameters)
+        .filter(([, param]) => param.required)
+        .map(([key]) => key),
+    },
+  })),
 ];
 
-async function processToolCall(toolName: string, toolInput: Record<string, unknown>): Promise<string> {
+async function processToolCall(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  context: AgentContext,
+): Promise<string> {
   switch (toolName) {
     case 'discover_jobs':
       return JSON.stringify(
@@ -142,8 +167,16 @@ async function processToolCall(toolName: string, toolInput: Record<string, unkno
       } catch (error) {
         return JSON.stringify({ error: 'Failed to read DSG.md' });
       }
-    default:
-      return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+    default: {
+      // DSG platform skills — always through executeToolSafely so the Hermes
+      // preflight, DSG gate (ALLOW/STABILIZE/BLOCK), and approval-token rules apply.
+      const dsgTool = DSG_TOOLS.find((tool) => tool.id === toolName);
+      if (!dsgTool) {
+        return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+      }
+      const result = await executeToolSafely(dsgTool, toolInput, context);
+      return JSON.stringify(result);
+    }
   }
 }
 
@@ -174,6 +207,11 @@ function createSSEStream(): ReadableStream<Uint8Array> {
 
 export async function POST(request: Request) {
   try {
+    const access = await requireOrgRole(['operator', 'org_admin'], request);
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
     const body = await request.json();
     const userMessage = body.message as string;
     const selectedAgent = body.agent as string || 'All';
@@ -183,6 +221,15 @@ export async function POST(request: Request) {
     if (!userMessage) {
       return NextResponse.json({ error: 'Message required' }, { status: 400 });
     }
+
+    const context: AgentContext = {
+      orgId: access.orgId,
+      role: access.grantedRoles.includes('org_admin') ? 'org_admin' : 'operator',
+      origin: new URL(request.url).origin,
+      authHeader: request.headers.get('authorization') || '',
+      cookieHeader: request.headers.get('cookie') || '',
+      approvalToken: typeof body?.approvalToken === 'string' ? body.approvalToken : undefined,
+    };
 
     // Load DSG.md for context
     let dsgContext = '';
@@ -214,6 +261,8 @@ Trinity: 5-Agent AI Orchestration
 - 🦴 Spine: DSG governance
 
 All tools are connected to real platforms and Supabase. Use them proactively.
+
+You also have DSG platform skills (write_code_file, run_code, terminal sandbox, browser_navigate, fetch_url, realtime_web_search, agent CRUD, execute_action). Write/critical skills run through the DSG gate and may return requiresApproval — report that honestly instead of claiming the action ran.
 
 Language: ${language === 'th' ? 'Thai' : 'English'}
 Agent: ${selectedAgent}${dsgContext}`;
@@ -256,7 +305,7 @@ Agent: ${selectedAgent}${dsgContext}`;
                 timestamp: new Date().toISOString(),
               });
 
-              const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
+              const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
               toolCalls.push(toolUseBlock.name);
 
               sendEvent('tool_result', {
@@ -331,7 +380,7 @@ Agent: ${selectedAgent}${dsgContext}`;
       const toolUseBlock = response.content.find((block: any) => block.type === 'tool_use') as any;
       if (!toolUseBlock || toolUseBlock.type !== 'tool_use') break;
 
-      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
+      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
       toolCalls.push(toolUseBlock.name);
 
       messages.push({ role: 'assistant', content: response.content });

--- a/app/api/dashboard/trinity/chat-stream/route.ts
+++ b/app/api/dashboard/trinity/chat-stream/route.ts
@@ -7,10 +7,13 @@ import { NextResponse } from 'next/server';
 import { Anthropic } from '@anthropic-ai/sdk';
 import * as fs from 'fs';
 import * as path from 'path';
-import { requireOrgRole } from '@/lib/authz';
-import { executeToolSafely } from '@/lib/agent/executor';
-import type { AgentContext } from '@/lib/agent/context';
-import { DSG_TOOLS } from '@/lib/agent/tools';
+import {
+  discoverJobsReal,
+  executeJobReal,
+  verifyDeliverableReal,
+  settlePaymentReal,
+  validateGovernanceReal,
+} from '@/lib/trinity/real-jobs';
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -18,44 +21,129 @@ const anthropic = new Anthropic({
 
 export const dynamic = 'force-dynamic';
 
-const tools = DSG_TOOLS.map((tool) => ({
-  name: tool.id,
-  description: tool.description,
-  input_schema: {
-    type: 'object' as const,
-    properties: Object.fromEntries(
-      Object.entries(tool.parameters).map(([k, p]) => [
-        k,
-        {
-          type: p.type,
-          description: p.description,
-          required: p.required,
-        },
-      ]),
-    ),
-    required: Object.entries(tool.parameters)
-      .filter(([, p]) => p.required)
-      .map(([k]) => k),
+// MCP Tools
+const tools = [
+  {
+    name: 'discover_jobs',
+    description: 'Discover available jobs across real platforms (Mind Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        category: { type: 'string', description: 'Job category filter' },
+        difficulty: { type: 'string', enum: ['easy', 'medium', 'hard'] },
+        min_reward: { type: 'number', description: 'Minimum reward in SOL' },
+      },
+      required: ['category'],
+    },
   },
-}));
+  {
+    name: 'execute_job',
+    description: 'Execute a job with real tracking (Hand Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        job_id: { type: 'string' },
+        deliverable: { type: 'string' },
+        execution_time_target: { type: 'number' },
+      },
+      required: ['job_id', 'deliverable'],
+    },
+  },
+  {
+    name: 'verify_deliverable',
+    description: 'Verify deliverable quality (Eye Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        deliverable_id: { type: 'string' },
+        quality_criteria: { type: 'string' },
+      },
+      required: ['deliverable_id'],
+    },
+  },
+  {
+    name: 'settle_payment',
+    description: 'Record a settlement request for manual review — fail-closed, no on-chain transfer (Nerve Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        execution_id: { type: 'string' },
+        amount_sol: { type: 'number' },
+      },
+      required: ['execution_id', 'amount_sol'],
+    },
+  },
+  {
+    name: 'validate_governance',
+    description: 'Validate against real DSG policies (Spine Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        policy_name: { type: 'string' },
+        constraints: { type: 'object' },
+      },
+      required: ['policy_name'],
+    },
+  },
+  {
+    name: 'read_dsg_documentation',
+    description: 'Read DSG.md documentation',
+    input_schema: {
+      type: 'object',
+      properties: {
+        section: { type: 'string' },
+      },
+    },
+  },
+];
 
-async function processToolCall(
-  toolName: string,
-  toolInput: Record<string, unknown>,
-  context: AgentContext,
-): Promise<string> {
-  const tool = DSG_TOOLS.find((t) => t.id === toolName);
-  if (!tool) {
-    return JSON.stringify({ error: `Unknown tool: ${toolName}` });
-  }
-  try {
-    const result = await executeToolSafely(tool, toolInput, context);
-    return JSON.stringify(result);
-  } catch (err) {
-    return JSON.stringify({
-      error: `Tool execution failed: ${toolName}`,
-      message: err instanceof Error ? err.message : 'Unknown error',
-    });
+async function processToolCall(toolName: string, toolInput: Record<string, unknown>): Promise<string> {
+  switch (toolName) {
+    case 'discover_jobs':
+      return JSON.stringify(
+        await discoverJobsReal(
+          toolInput.category as string | undefined,
+          toolInput.difficulty as string | undefined,
+          toolInput.min_reward as number | undefined
+        )
+      );
+    case 'execute_job':
+      return JSON.stringify(
+        await executeJobReal(toolInput.job_id as string, toolInput.deliverable as string, toolInput.execution_time_target as number | undefined)
+      );
+    case 'verify_deliverable':
+      return JSON.stringify(
+        await verifyDeliverableReal(toolInput.deliverable_id as string, toolInput.quality_criteria as string | undefined)
+      );
+    case 'settle_payment':
+      return JSON.stringify(await settlePaymentReal(toolInput.execution_id as string, toolInput.amount_sol as number));
+    case 'validate_governance':
+      return JSON.stringify(
+        await validateGovernanceReal(toolInput.policy_name as string, toolInput.constraints as Record<string, any> | undefined)
+      );
+    case 'read_dsg_documentation':
+      try {
+        const dsgPath = path.join(process.cwd(), 'DSG.md');
+        const dsgContent = fs.readFileSync(dsgPath, 'utf-8');
+        const section = toolInput.section as string;
+        if (section) {
+          const sectionRegex = new RegExp(`## ${section}[\\s\\S]*?(?=##|$)`, 'i');
+          const match = dsgContent.match(sectionRegex);
+          return JSON.stringify({
+            section,
+            found: !!match,
+            content: match ? match[0].slice(0, 2000) : `Section "${section}" not found`,
+          });
+        }
+        return JSON.stringify({
+          section: 'overview',
+          content: dsgContent.slice(0, 2000),
+        });
+      } catch (error) {
+        return JSON.stringify({ error: 'Failed to read DSG.md' });
+      }
+    default:
+      return JSON.stringify({ error: `Unknown tool: ${toolName}` });
   }
 }
 
@@ -86,11 +174,6 @@ function createSSEStream(): ReadableStream<Uint8Array> {
 
 export async function POST(request: Request) {
   try {
-    const access = await requireOrgRole(['operator', 'org_admin']);
-    if (!access.ok) {
-      return NextResponse.json({ error: access.error }, { status: access.status });
-    }
-
     const body = await request.json();
     const userMessage = body.message as string;
     const selectedAgent = body.agent as string || 'All';
@@ -100,15 +183,6 @@ export async function POST(request: Request) {
     if (!userMessage) {
       return NextResponse.json({ error: 'Message required' }, { status: 400 });
     }
-
-    const context: AgentContext = {
-      orgId: access.orgId,
-      role: access.grantedRoles.includes('org_admin') ? 'org_admin' : 'operator',
-      origin: new URL(request.url).origin,
-      authHeader: request.headers.get('authorization') || '',
-      cookieHeader: request.headers.get('cookie') || '',
-      approvalToken: typeof body?.approvalToken === 'string' ? body.approvalToken : undefined,
-    };
 
     // Load DSG.md for context
     let dsgContext = '';
@@ -182,7 +256,7 @@ Agent: ${selectedAgent}${dsgContext}`;
                 timestamp: new Date().toISOString(),
               });
 
-              const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
+              const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
               toolCalls.push(toolUseBlock.name);
 
               sendEvent('tool_result', {
@@ -257,7 +331,7 @@ Agent: ${selectedAgent}${dsgContext}`;
       const toolUseBlock = response.content.find((block: any) => block.type === 'tool_use') as any;
       if (!toolUseBlock || toolUseBlock.type !== 'tool_use') break;
 
-      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
+      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
       toolCalls.push(toolUseBlock.name);
 
       messages.push({ role: 'assistant', content: response.content });

--- a/app/api/dashboard/trinity/chat/route.ts
+++ b/app/api/dashboard/trinity/chat/route.ts
@@ -3,10 +3,13 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import * as fs from 'fs';
 import * as path from 'path';
 import { handleApiError } from '@/lib/security/api-error';
-import { requireOrgRole } from '@/lib/authz';
-import { executeToolSafely } from '@/lib/agent/executor';
-import type { AgentContext } from '@/lib/agent/context';
-import { DSG_TOOLS } from '@/lib/agent/tools';
+import {
+  discoverJobsReal,
+  executeJobReal,
+  verifyDeliverableReal,
+  settlePaymentReal,
+  validateGovernanceReal,
+} from '@/lib/trinity/real-jobs';
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -14,72 +17,169 @@ const anthropic = new Anthropic({
 
 export const dynamic = 'force-dynamic';
 
-const tools = DSG_TOOLS.map((tool) => ({
-  name: tool.id,
-  description: tool.description,
-  input_schema: {
-    type: 'object' as const,
-    properties: Object.fromEntries(
-      Object.entries(tool.parameters).map(([k, p]) => [
-        k,
-        {
-          type: p.type,
-          description: p.description,
-          required: p.required,
-        },
-      ]),
-    ),
-    required: Object.entries(tool.parameters)
-      .filter(([, p]) => p.required)
-      .map(([k]) => k),
+// MCP Tools available to agents
+const tools = [
+  {
+    name: 'discover_jobs',
+    description: 'Discover available jobs across real platforms (Mind Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        category: { type: 'string', description: 'Job category filter (e.g., smart-contract-audit, backend-dev)' },
+        difficulty: { type: 'string', enum: ['easy', 'medium', 'hard'] },
+        min_reward: { type: 'number', description: 'Minimum reward in SOL' },
+      },
+      required: ['category'],
+    },
   },
-}));
+  {
+    name: 'execute_job',
+    description: 'Execute a job with real tracking (Hand Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        job_id: { type: 'string', description: 'Job ID to execute' },
+        deliverable: { type: 'string', description: 'Deliverable content' },
+        execution_time_target: { type: 'number', description: 'Target execution time in ms' },
+      },
+      required: ['job_id', 'deliverable'],
+    },
+  },
+  {
+    name: 'verify_deliverable',
+    description: 'Verify deliverable quality (Eye Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        deliverable_id: { type: 'string', description: 'Deliverable ID to verify' },
+        quality_criteria: { type: 'string', description: 'Quality criteria to check' },
+      },
+      required: ['deliverable_id'],
+    },
+  },
+  {
+    name: 'settle_payment',
+    description: 'Record a settlement request for manual review — fail-closed, no on-chain transfer (Nerve Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        execution_id: { type: 'string', description: 'Execution ID to settle' },
+        amount_sol: { type: 'number', description: 'Amount in SOL' },
+      },
+      required: ['execution_id', 'amount_sol'],
+    },
+  },
+  {
+    name: 'validate_governance',
+    description: 'Validate against real DSG governance policies (Spine Agent)',
+    input_schema: {
+      type: 'object',
+      properties: {
+        policy_name: { type: 'string', description: 'DSG policy to validate against' },
+        constraints: { type: 'object', description: 'Constraints to verify' },
+      },
+      required: ['policy_name'],
+    },
+  },
+  {
+    name: 'read_dsg_documentation',
+    description: 'Read DSG.md documentation for governance and policy reference',
+    input_schema: {
+      type: 'object',
+      properties: {
+        section: { type: 'string', description: 'Section of DSG.md to read (e.g., truth-boundary, runtime-spine)' },
+      },
+    },
+  },
+];
 
-async function processToolCall(
-  toolName: string,
-  toolInput: Record<string, unknown>,
-  context: AgentContext,
-): Promise<string> {
-  const tool = DSG_TOOLS.find((t) => t.id === toolName);
-  if (!tool) {
-    return JSON.stringify({ error: `Unknown tool: ${toolName}` });
-  }
-  try {
-    const result = await executeToolSafely(tool, toolInput, context);
-    return JSON.stringify(result);
-  } catch (err) {
-    return JSON.stringify({
-      error: `Tool execution failed: ${toolName}`,
-      message: err instanceof Error ? err.message : 'Unknown error',
-    });
+// Real implementation using live data sources and Supabase
+async function processToolCall(toolName: string, toolInput: Record<string, unknown>): Promise<string> {
+  switch (toolName) {
+    case 'discover_jobs': {
+      const result = await discoverJobsReal(
+        toolInput.category as string | undefined,
+        toolInput.difficulty as string | undefined,
+        toolInput.min_reward as number | undefined
+      );
+      return JSON.stringify(result);
+    }
+
+    case 'execute_job': {
+      const result = await executeJobReal(
+        toolInput.job_id as string,
+        toolInput.deliverable as string,
+        toolInput.execution_time_target as number | undefined
+      );
+      return JSON.stringify(result);
+    }
+
+    case 'verify_deliverable': {
+      const result = await verifyDeliverableReal(
+        toolInput.deliverable_id as string,
+        toolInput.quality_criteria as string | undefined
+      );
+      return JSON.stringify(result);
+    }
+
+    case 'settle_payment': {
+      const result = await settlePaymentReal(
+        toolInput.execution_id as string,
+        toolInput.amount_sol as number
+      );
+      return JSON.stringify(result);
+    }
+
+    case 'validate_governance': {
+      const result = await validateGovernanceReal(
+        toolInput.policy_name as string,
+        toolInput.constraints as Record<string, any> | undefined
+      );
+      return JSON.stringify(result);
+    }
+
+    case 'read_dsg_documentation':
+      try {
+        const dsgPath = path.join(process.cwd(), 'DSG.md');
+        const dsgContent = fs.readFileSync(dsgPath, 'utf-8');
+
+        const section = toolInput.section as string;
+        if (section) {
+          const sectionRegex = new RegExp(`## ${section}[\\s\\S]*?(?=##|$)`, 'i');
+          const match = dsgContent.match(sectionRegex);
+          return JSON.stringify({
+            section,
+            found: !!match,
+            content: match ? match[0].slice(0, 2000) : `Section "${section}" not found`,
+            total_lines: dsgContent.split('\n').length,
+          });
+        }
+
+        return JSON.stringify({
+          section: 'overview',
+          content: dsgContent.slice(0, 2000),
+          total_size: dsgContent.length,
+          total_lines: dsgContent.split('\n').length,
+        });
+      } catch (error) {
+        return JSON.stringify({
+          error: 'Failed to read DSG.md',
+          available: false,
+        });
+      }
+
+    default:
+      return JSON.stringify({ error: `Unknown tool: ${toolName}` });
   }
 }
 
 export async function POST(request: Request) {
   try {
-    const access = await requireOrgRole(['operator', 'org_admin']);
-    if (!access.ok) {
-      return NextResponse.json({ error: access.error }, { status: access.status });
-    }
-
     const body = await request.json();
     const userMessage = body.message as string;
     const selectedAgent = body.agent as string || 'All';
     const language = body.language as string || 'en';
     const modelProvider = (body.model || 'anthropic') as 'anthropic' | 'nvidia';
-
-    if (!userMessage || userMessage.trim().length === 0) {
-      return NextResponse.json({ error: 'Message required' }, { status: 400 });
-    }
-
-    const context: AgentContext = {
-      orgId: access.orgId,
-      role: access.grantedRoles.includes('org_admin') ? 'org_admin' : 'operator',
-      origin: new URL(request.url).origin,
-      authHeader: request.headers.get('authorization') || '',
-      cookieHeader: request.headers.get('cookie') || '',
-      approvalToken: typeof body?.approvalToken === 'string' ? body.approvalToken : undefined,
-    };
 
     // Validate API key for selected model
     if (modelProvider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
@@ -96,6 +196,10 @@ export async function POST(request: Request) {
         { error: 'API configuration error: NVIDIA_API_KEY not configured' },
         { status: 503 }
       );
+    }
+
+    if (!userMessage || userMessage.trim().length === 0) {
+      return NextResponse.json({ error: 'Message required' }, { status: 400 });
     }
 
     // Load DSG.md for context
@@ -164,7 +268,7 @@ Always explain tool usage. Be helpful and efficient.`;
 
       if (!toolUseBlock || toolUseBlock.type !== 'tool_use') break;
 
-      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
+      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
       toolCalls.push(toolUseBlock.name);
 
       // Add assistant response and tool result to messages

--- a/app/api/dashboard/trinity/chat/route.ts
+++ b/app/api/dashboard/trinity/chat/route.ts
@@ -3,6 +3,10 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import * as fs from 'fs';
 import * as path from 'path';
 import { handleApiError } from '@/lib/security/api-error';
+import { requireOrgRole } from '@/lib/authz';
+import { executeToolSafely } from '@/lib/agent/executor';
+import { DSG_TOOLS } from '@/lib/agent/tools';
+import type { AgentContext } from '@/lib/agent/context';
 import {
   discoverJobsReal,
   executeJobReal,
@@ -91,10 +95,33 @@ const tools = [
       },
     },
   },
+  // DSG platform skills (code sandbox, terminal, browser, web search, agent CRUD).
+  // Executed exclusively through executeToolSafely — Hermes + DSG gate, and
+  // write/critical tools require an approvalToken per the Autonomy Dial.
+  ...DSG_TOOLS.map((tool) => ({
+    name: tool.id,
+    description: tool.description,
+    input_schema: {
+      type: 'object',
+      properties: Object.fromEntries(
+        Object.entries(tool.parameters).map(([key, param]) => [
+          key,
+          { type: param.type, description: param.description },
+        ]),
+      ),
+      required: Object.entries(tool.parameters)
+        .filter(([, param]) => param.required)
+        .map(([key]) => key),
+    },
+  })),
 ];
 
 // Real implementation using live data sources and Supabase
-async function processToolCall(toolName: string, toolInput: Record<string, unknown>): Promise<string> {
+async function processToolCall(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  context: AgentContext,
+): Promise<string> {
   switch (toolName) {
     case 'discover_jobs': {
       const result = await discoverJobsReal(
@@ -168,18 +195,40 @@ async function processToolCall(toolName: string, toolInput: Record<string, unkno
         });
       }
 
-    default:
-      return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+    default: {
+      // DSG platform skills — always through executeToolSafely so the Hermes
+      // preflight, DSG gate (ALLOW/STABILIZE/BLOCK), and approval-token rules apply.
+      const dsgTool = DSG_TOOLS.find((tool) => tool.id === toolName);
+      if (!dsgTool) {
+        return JSON.stringify({ error: `Unknown tool: ${toolName}` });
+      }
+      const result = await executeToolSafely(dsgTool, toolInput, context);
+      return JSON.stringify(result);
+    }
   }
 }
 
 export async function POST(request: Request) {
   try {
+    const access = await requireOrgRole(['operator', 'org_admin'], request);
+    if (!access.ok) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
     const body = await request.json();
     const userMessage = body.message as string;
     const selectedAgent = body.agent as string || 'All';
     const language = body.language as string || 'en';
     const modelProvider = (body.model || 'anthropic') as 'anthropic' | 'nvidia';
+
+    const context: AgentContext = {
+      orgId: access.orgId,
+      role: access.grantedRoles.includes('org_admin') ? 'org_admin' : 'operator',
+      origin: new URL(request.url).origin,
+      authHeader: request.headers.get('authorization') || '',
+      cookieHeader: request.headers.get('cookie') || '',
+      approvalToken: typeof body?.approvalToken === 'string' ? body.approvalToken : undefined,
+    };
 
     // Validate API key for selected model
     if (modelProvider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
@@ -233,6 +282,8 @@ You are part of Trinity, a multi-agent AI orchestration system:
 
 You have access to MCP tools. Use them proactively to answer questions.
 
+You also have DSG platform skills (write_code_file, run_code, terminal sandbox, browser_navigate, fetch_url, realtime_web_search, agent CRUD, execute_action). Write/critical skills run through the DSG gate and may return requiresApproval — report that honestly instead of claiming the action ran.
+
 DSG Framework:
 - Deterministic governance with Z3 formal verification
 - Evidence-driven (CCVS L1-L5) decision making
@@ -268,7 +319,7 @@ Always explain tool usage. Be helpful and efficient.`;
 
       if (!toolUseBlock || toolUseBlock.type !== 'tool_use') break;
 
-      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input);
+      const toolResult = await processToolCall(toolUseBlock.name, toolUseBlock.input, context);
       toolCalls.push(toolUseBlock.name);
 
       // Add assistant response and tool result to messages

--- a/lib/agents/nerve-agent.ts
+++ b/lib/agents/nerve-agent.ts
@@ -6,7 +6,7 @@
  */
 
 import { SolanaClient } from '../solana/client';
-import { agentProfileManager } from '../supabase/agent-profile';
+// import { agentProfileManager } from '../supabase/agent-profile'; // TODO: Reactivate when agent_profiles table exists
 import type {
   JobListing,
   AgentProfile,
@@ -73,19 +73,17 @@ export class NerveAgent {
         timestamp: new Date().toISOString(),
       };
 
-      // Persist to Supabase
-      try {
-        await agentProfileManager.recordEarnings({
-          job_id: job.id,
-          agent_id: profile.agentId,
-          amount: job.reward.amount,
-          currency: job.reward.currency,
-          tx_signature: signature,
-        });
-        console.log(`[${this.agentName}] ✅ Earnings persisted to Supabase`);
-      } catch (err) {
-        console.warn(`[${this.agentName}] ⚠️ Failed to persist earnings:`, err);
-      }
+      // Supabase persistence not wired yet — do not log success for a write that
+      // never happened. The earnings record is returned to the caller only.
+      // TODO: Reactivate when agentProfileManager is available
+      // await agentProfileManager.recordEarnings({
+      //   job_id: job.id,
+      //   agent_id: profile.agentId,
+      //   amount: job.reward.amount,
+      //   currency: job.reward.currency,
+      //   tx_signature: signature,
+      // });
+      console.log(`[${this.agentName}] ⚠️ Earnings NOT persisted to Supabase (persistence pending; record returned in-memory only)`);
 
       console.log(`[${this.agentName}] ✅ Payment successful: ${signature.substring(0, 20)}...`);
 

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -240,6 +240,9 @@ export async function verifyDeliverableReal(
 
     const startTime = Date.now();
 
+    // Sanitize user-supplied qualityCriteria: trim and validate length
+    const sanitizedCriteria = qualityCriteria?.trim().slice(0, 500) || null;
+
     // Fail-closed: score the stored deliverable content, never a fabricated value.
     const { data: execution } = await supabase
       .from('trinity_executions')
@@ -266,7 +269,7 @@ export async function verifyDeliverableReal(
       .from('trinity_verifications')
       .insert({
         deliverable_id: deliverableId,
-        quality_criteria: qualityCriteria || null,
+        quality_criteria: sanitizedCriteria,
         quality_score: qualityScore,
         verification_status: qualityScore >= 80 ? 'passed' : 'review',
         checks_passed: checksPassed,

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -31,14 +31,6 @@ function getCachedOrFetch<T>(
   });
 }
 
-function scoreQuality(deliverable: string, category: string): number {
-  let score = 60;
-  if (deliverable.length > 120) score += 10;
-  if (deliverable.includes('Evidence')) score += 10;
-  if (category === 'smart-contract-audit' || category === 'security-review') score += 10;
-  return Math.min(100, score);
-}
-
 /**
  * Discover jobs from real platforms
  * Sources: GitHub Issues (bounty-labeled), Solana grant programs, internal DSG jobs
@@ -171,13 +163,25 @@ export async function discoverJobsReal(
 }
 
 /**
+ * Deterministic quality scoring — same rubric as /api/trinity/execute-job.
+ * Scores content properties (length, evidence markers, category weight);
+ * never fabricates a score from randomness.
+ */
+export function scoreDeliverableQuality(deliverable: string, category?: string): number {
+  let score = 60;
+  if (deliverable.length > 120) score += 10;
+  if (deliverable.includes('Evidence')) score += 10;
+  if (category === 'smart-contract-audit' || category === 'security-review') score += 10;
+  return Math.min(100, score);
+}
+
+/**
  * Execute job - track in Supabase execution table
  */
 export async function executeJobReal(
   jobId: string,
   deliverable: string,
-  executionTimeTarget?: number,
-  category?: string
+  _executionTimeTarget?: number
 ): Promise<any> {
   try {
     if (!supabase) {
@@ -186,7 +190,7 @@ export async function executeJobReal(
 
     const executionId = `exec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
     const startTime = Date.now();
-    const qualityScore = scoreQuality(deliverable, category || 'general');
+    const qualityScore = scoreDeliverableQuality(deliverable);
 
     const { data, error } = await supabase
       .from('trinity_executions')
@@ -196,10 +200,7 @@ export async function executeJobReal(
         deliverable,
         status: 'completed',
         quality_score: qualityScore,
-        execution_time_ms: Math.min(
-          executionTimeTarget || 3000,
-          Date.now() - startTime
-        ),
+        execution_time_ms: Date.now() - startTime,
         created_at: new Date().toISOString(),
       })
       .select()
@@ -230,16 +231,36 @@ export async function executeJobReal(
  */
 export async function verifyDeliverableReal(
   deliverableId: string,
-  qualityCriteria?: string,
-  deliverable?: string,
-  category?: string
+  qualityCriteria?: string
 ): Promise<any> {
   try {
     if (!supabase) {
       return { error: 'Database not configured' };
     }
 
-    const qualityScore = scoreQuality(deliverable || qualityCriteria || '', category || 'general');
+    const startTime = Date.now();
+
+    // Fail-closed: score the stored deliverable content, never a fabricated value.
+    const { data: execution } = await supabase
+      .from('trinity_executions')
+      .select('execution_id, deliverable')
+      .eq('execution_id', deliverableId)
+      .maybeSingle();
+
+    if (!execution?.deliverable) {
+      return {
+        deliverable_id: deliverableId,
+        verification_status: 'review',
+        quality_score: null,
+        issues: ['Deliverable not found — cannot verify, routed to manual review'],
+        verification_time_ms: Date.now() - startTime,
+        timestamp: new Date().toISOString(),
+      };
+    }
+
+    const qualityScore = scoreDeliverableQuality(execution.deliverable, qualityCriteria);
+    const checksTotal = 10;
+    const checksPassed = Math.floor(qualityScore / 10);
 
     const { data, error } = await supabase
       .from('trinity_verifications')
@@ -248,8 +269,8 @@ export async function verifyDeliverableReal(
         quality_criteria: qualityCriteria,
         quality_score: qualityScore,
         verification_status: qualityScore >= 80 ? 'passed' : 'review',
-        checks_passed: Math.floor(qualityScore / 10),
-        checks_total: 12,
+        checks_passed: checksPassed,
+        checks_total: checksTotal,
         created_at: new Date().toISOString(),
       })
       .select()
@@ -261,10 +282,10 @@ export async function verifyDeliverableReal(
       deliverable_id: deliverableId,
       verification_status: data.verification_status,
       quality_score: qualityScore,
-      checks_passed: data.checks_passed,
-      checks_total: 12,
-      issues: qualityScore < 80 ? ['Minor quality issues detected'] : [],
-      verification_time_ms: 250,
+      checks_passed: checksPassed,
+      checks_total: checksTotal,
+      issues: qualityScore < 80 ? ['Deterministic rubric below pass threshold — needs review'] : [],
+      verification_time_ms: Date.now() - startTime,
       timestamp: new Date().toISOString(),
     };
   } catch (error) {
@@ -277,8 +298,10 @@ export async function verifyDeliverableReal(
 }
 
 /**
- * Settle payment - integrated with Supabase ledger
- * Fail-closed: no live on-chain transfer, requires manual review or NerveAgent path
+ * Settle payment — fail-closed ledger entry, same posture as settleJob() in workflow.ts.
+ * Records the settlement request for manual review; never fabricates an on-chain
+ * transaction hash, confirmation count, or reputation delta. Real transfers go
+ * through NerveAgent.settlePayment (SolanaClient.transferSOL) only.
  */
 export async function settlePaymentReal(
   executionId: string,
@@ -289,7 +312,7 @@ export async function settlePaymentReal(
       return { error: 'Database not configured' };
     }
 
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('trinity_payments')
       .insert({
         execution_id: executionId,
@@ -305,13 +328,12 @@ export async function settlePaymentReal(
     if (error) throw error;
 
     return {
-      ok: true,
       execution_id: executionId,
       amount_sol: amountSol,
       transaction_hash: null,
       status: 'pending_manual_review',
       confirmations: 0,
-      note: 'On-chain transfer not executed. Settlement requires NerveAgent Solana path or manual review.',
+      note: 'Settlement recorded fail-closed for manual review. No on-chain transfer was executed by this tool.',
       timestamp: new Date().toISOString(),
     };
   } catch (error) {

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -266,7 +266,7 @@ export async function verifyDeliverableReal(
       .from('trinity_verifications')
       .insert({
         deliverable_id: deliverableId,
-        quality_criteria: qualityCriteria,
+        quality_criteria: qualityCriteria || null,
         quality_score: qualityScore,
         verification_status: qualityScore >= 80 ? 'passed' : 'review',
         checks_passed: checksPassed,

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -238,6 +238,11 @@ export async function verifyDeliverableReal(
       return { error: 'Database not configured' };
     }
 
+    // Validate deliverable ID format (alphanumeric + hyphens, max 100 chars)
+    if (!deliverableId || !/^[a-zA-Z0-9\-]{1,100}$/.test(deliverableId)) {
+      return { error: 'Invalid deliverable_id format' };
+    }
+
     const startTime = Date.now();
 
     // Sanitize user-supplied qualityCriteria: trim and validate length

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -258,7 +258,7 @@ export async function verifyDeliverableReal(
       };
     }
 
-    const qualityScore = scoreDeliverableQuality(execution.deliverable, qualityCriteria);
+    const qualityScore = scoreDeliverableQuality(execution.deliverable);
     const checksTotal = 10;
     const checksPassed = Math.floor(qualityScore / 10);
 

--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -188,6 +188,16 @@ export async function executeJobReal(
       return { error: 'Database not configured' };
     }
 
+    // Validate jobId format (alphanumeric + hyphens, max 100 chars)
+    if (!jobId || !/^[a-zA-Z0-9\-]{1,100}$/.test(jobId)) {
+      return { error: 'Invalid job_id format' };
+    }
+
+    // Validate deliverable size (max 1MB)
+    if (!deliverable || Buffer.byteLength(deliverable, 'utf-8') > 1024 * 1024) {
+      return { error: 'Deliverable exceeds 1MB size limit' };
+    }
+
     const executionId = `exec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
     const startTime = Date.now();
     const qualityScore = scoreDeliverableQuality(deliverable);
@@ -318,6 +328,15 @@ export async function settlePaymentReal(
   try {
     if (!supabase) {
       return { error: 'Database not configured' };
+    }
+
+    // Validate execution_id format and amount
+    if (!executionId || !/^[a-zA-Z0-9\-]{1,100}$/.test(executionId)) {
+      return { error: 'Invalid execution_id format' };
+    }
+
+    if (typeof amountSol !== 'number' || amountSol <= 0 || amountSol > 1000000) {
+      return { error: 'Invalid amount: must be positive and <= 1000000 SOL' };
     }
 
     const { error } = await supabase

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "lint": "next lint",
+    "lint": "eslint app/ lib/ components/ --ext .ts,.tsx,.js,.jsx",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "db:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > lib/database.types.ts",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

This PR rebases and resolves the merge conflicts from PR #981. The original PR could not merge due to conflicts with changes already on main. This version:

- ✅ Resolves all merge conflicts with the current main branch
- ✅ Maintains all Trinity honesty fixes (deterministic scoring, fail-closed payment settlement)
- ✅ Wires DSG_TOOLS skills into Trinity chat behind org auth + DSG gate
- ✅ Fixes UI contrast issues on homepage and navigation

## Goal:

Make the Trinity chat tool path honest ("Devin-style": real evidence only, fail-closed when evidence is missing), give it the platform's full DSG_TOOLS skill set behind auth + the DSG gate, and fix unreadable low-contrast text on the public homepage and global navigation.

## Files changed:

- `lib/trinity/real-jobs.ts` — Deterministic quality scoring, fail-closed verification
- `app/api/dashboard/trinity/chat/route.ts` — Auth gate + DSG_TOOLS integration
- `app/api/dashboard/trinity/chat-stream/route.ts` — Auth gate + DSG_TOOLS integration
- `lib/agents/nerve-agent.ts` — Honest earnings logging
- `app/page.tsx` — Text contrast improvements
- `components/GlobalNav.tsx` — Navigation contrast fixes
- `app/dsg-one/page.tsx` — Unescaped entity fix

## Verification:

- [x] Rebase completed without functional conflicts
- [x] All Trinity honesty fixtures preserved
- [x] Branch is clean and ready to merge
- [x] CI will re-run checks on this rebased version

## Known limits:

- Live Trinity chat round-trip and critical skills approval flow not tested (requires full environment)
- This is a rebased version of PR #981; the original PR cannot merge due to base branch conflicts

---
_Generated by [Claude Code](https://claude.ai/code/session_014cuC6f37wKnWMSgKTCTojG)_