### PR TITLE
Fix Next.js build type error - invalid ignoreDeprecations value

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
       ]
     },
     "downlevelIteration": true,
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Goal

Fix the Next.js build failure caused by an invalid `ignoreDeprecations` value in TypeScript configuration.

## Files changed

- `tsconfig.json`: Updated `ignoreDeprecations` from invalid value `"6.0"` to valid value `"5.0"`

## Verification

- [x] `npm run build` — Build succeeded with no type errors
  - Compiled successfully in 36.4s
  - TypeScript check passed in 31.8s
  - All 194 pages generated successfully
  - No "Invalid value for '--ignoreDeprecations'" error

## Known limits

- The `ignoreDeprecations` setting suppresses TypeScript deprecation warnings up to version 5.0
- Future TypeScript upgrades may require updating this value if new deprecations are introduced

## User-visible benefit

Build now completes successfully without type errors, allowing deployment to proceed.

## Next step

Ready for review and merge to resolve the build blocker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeSNudtxZyxua3EkRXQ8DN)_