### PR TITLE
feat(plugins): add dsg-plugins Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,85 +1,62 @@
 {
-  "name": "dsg-control-plane-marketplace",
-  "displayName": "DSG Governance Control Plane — Claude Code Plugin Marketplace",
-  "description": "Official plugin marketplace for the DSG AI Governance Control Plane. Packages Deterministic Safety Gate, Replayable Governance, Compliance Evidence Pack, Runtime Governance, and Hermes Controlled Executor as distributable Claude Code skills.\n\nPitch: Cloudflare = Control Plane of the Internet. Datadog = Control Plane of Observability. DSG = Control Plane of AI Governance.",
-  "version": "1.0.0",
-  "maintainer": "tdealer01-crypto",
-  "repository": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane",
+  "name": "dsg-plugins",
+  "owner": {
+    "name": "DSG ONE / ProofGate",
+    "url": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane"
+  },
+  "metadata": {
+    "description": "Governance-first, evidence-first Claude Code plugins for working inside the DSG ONE / ProofGate Control Plane repository. Each plugin encodes the repo's own operating rules: truth-boundary claim policy, verification ladder, API route and security conventions, and the mandatory PR body format.",
+    "version": "1.0.0",
+    "pluginRoot": "./plugins"
+  },
   "plugins": [
     {
-      "name": "ising-agent",
-      "displayName": "DSG QUBO & Ising Compliance Agent",
-      "description": "Deterministic compliance and optimization plugin: Z3 formal constraint verification, QUBO/Ising policy optimization, continuous what-if simulation, and MCP gateway exports.",
-      "version": "3.0.0",
-      "source": "https://github.com/tdealer01-crypto/Compliance-ising-z3-Deterministic-",
-      "category": "compliance",
-      "tags": ["qubo", "ising", "z3", "compliance", "deterministic", "simulation", "mcp"],
-      "readme": "https://github.com/tdealer01-crypto/Compliance-ising-z3-Deterministic-/blob/main/README.md",
-      "skills": [
-        {
-          "name": "z3-compliance-review",
-          "description": "Z3 deterministic compliance verification and constraint review logic.",
-          "triggerPhrases": [
-            "z3 verify",
-            "formal verification",
-            "compliance review",
-            "deterministic proof",
-            "constraint check"
-          ]
-        }
-      ]
+      "name": "proofgate-review",
+      "source": "./proofgate-review",
+      "description": "Governance-aware code review for the DSG Control Plane. Reviews changes against the repo's API route conventions, security conventions, truth boundary, runtime spine flow, deterministic gate boundary (UNSUPPORTED is never PASS), and Supabase/RLS rules. Includes a security-reviewer subagent.",
+      "version": "1.0.0",
+      "author": { "name": "DSG ONE / ProofGate" },
+      "category": "code-review",
+      "keywords": ["governance", "code-review", "security", "dsg", "proofgate", "evidence-first"]
     },
     {
-      "name": "dsg-governance",
-      "displayName": "DSG Governance Control Plane",
-      "description": "AI Governance Control Plane — every Agent decision provable, auditable, and replayable with Deterministic Gate (Z3/SMT), Cryptographic Proof, Compliance Evidence Pack, and Hermes Controlled Executor.",
+      "name": "dsg-verify",
+      "source": "./dsg-verify",
+      "description": "Slash commands that wrap the repo verification ladder: typecheck, targeted route verification, and a pre-PR check. Commands reference only npm scripts that exist in package.json.",
       "version": "1.0.0",
-      "source": "./",
+      "author": { "name": "DSG ONE / ProofGate" },
+      "category": "testing",
+      "keywords": ["verification", "typecheck", "vitest", "build", "ci", "dsg"]
+    },
+    {
+      "name": "evidence-guard",
+      "source": "./evidence-guard",
+      "description": "Enforces the repo truth boundary and claim policy. Helps classify statements as verified fact / inference / pending / blocked / not verified, and warns about forbidden readiness claims. Ships an advisory PostToolUse hook.",
+      "version": "1.0.0",
+      "author": { "name": "DSG ONE / ProofGate" },
       "category": "governance",
-      "tags": ["ai-governance", "deterministic", "compliance", "audit", "replay", "enterprise"],
-      "readme": "./README.md",
-      "skills": [
-        {
-          "name": "dsg-action-layer-ged",
-          "description": "Primary governance action layer — turns any user goal into an explainable plan, deterministic decision flow, permission verdicts, and browser-first execution after approval.",
-          "triggerPhrases": [
-            "gate this action",
-            "evaluate policy",
-            "check governance",
-            "get a proof",
-            "replay decision",
-            "audit trail",
-            "compliance evidence",
-            "hermes execute",
-            "controlled execution",
-            "DSG gate"
-          ]
-        },
-        {
-          "name": "dsg-github-marketplace-action-controller",
-          "description": "Package and publish DSG gates as GitHub Marketplace Actions with GO/NO-GO validation and audit proof.",
-          "triggerPhrases": [
-            "publish DSG action",
-            "github marketplace action",
-            "package governance",
-            "DSG github action",
-            "deploy governance action"
-          ]
-        },
-        {
-          "name": "dsg-multi-governance-orchestrator",
-          "description": "Multi-source governance for M1/M2 milestones, marketplace/enterprise cutover, and production GO/NO-GO validation.",
-          "triggerPhrases": [
-            "DSG multi",
-            "M1 cutover",
-            "M2 hardening",
-            "marketplace cutover",
-            "architecture page",
-            "production GO/NO-GO",
-            "governance orchestration"
-          ]
-        }
-      ]
+      "keywords": ["truth-boundary", "claim-policy", "evidence", "hooks", "governance", "dsg"]
+    },
+    {
+      "name": "pr-body-helper",
+      "source": "./pr-body-helper",
+      "description": "Generates a PR body that matches the repo's mandatory format (Goal / Files changed / Verification / Known limits / User-visible benefit / Next step), with honest 'Not run' handling for unrun checks.",
+      "version": "1.0.0",
+      "author": { "name": "DSG ONE / ProofGate" },
+      "category": "workflow",
+      "keywords": ["pull-request", "pr-body", "template", "workflow", "dsg"]
+    },
+    {
+      "name": "ising-agent",
+      "source": {
+        "source": "github",
+        "repo": "tdealer01-crypto/Compliance-ising-z3-Deterministic-"
+      },
+      "description": "External deterministic compliance and optimization plugin: Z3 formal constraint verification, QUBO/Ising policy optimization, what-if simulation, and MCP gateway exports. Hosted in a separate repository.",
+      "version": "3.0.0",
+      "author": { "name": "DSG ONE / ProofGate" },
+      "category": "compliance",
+      "keywords": ["qubo", "ising", "z3", "compliance", "deterministic", "simulation", "mcp"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,16 +47,22 @@
       "keywords": ["pull-request", "pr-body", "template", "workflow", "dsg"]
     },
     {
-      "name": "ising-agent",
-      "source": {
-        "source": "github",
-        "repo": "tdealer01-crypto/Compliance-ising-z3-Deterministic-"
-      },
-      "description": "External deterministic compliance and optimization plugin: Z3 formal constraint verification, QUBO/Ising policy optimization, what-if simulation, and MCP gateway exports. Hosted in a separate repository.",
+      "name": "dsg-governance",
+      "source": "./dsg-governance",
+      "description": "AI Governance Control Plane skills: studio-style action layer (plan, deterministic gate, permission verdict, browser-first execution after approval), a GitHub Marketplace Action packager with GO/NO-GO validation, and a multi-source governance orchestrator for M1/M2 cutover. Covers the deterministic gate scaffold, replayable governance, compliance evidence mapping, runtime lifecycle, and the Hermes controlled executor.",
+      "version": "1.0.0",
+      "author": { "name": "DSG ONE / ProofGate" },
+      "category": "governance",
+      "keywords": ["ai-governance", "deterministic-gate", "compliance", "audit", "replay", "hermes", "dsg", "proofgate"]
+    },
+    {
+      "name": "compliance-ising-z3",
+      "source": "./compliance-ising-z3",
+      "description": "Deterministic QUBO/Ising policy-optimization and Z3/SMT-style formal constraint verification, bundled locally from the tdealer01-crypto/Compliance-ising-z3-Deterministic- engine. Includes a z3-compliance-review skill, a compliance-agent subagent, and reference build/test scripts. Constraint checks are Z3/SMT-style in native Kotlin (no external Z3 process).",
       "version": "3.0.0",
       "author": { "name": "DSG ONE / ProofGate" },
       "category": "compliance",
-      "keywords": ["qubo", "ising", "z3", "compliance", "deterministic", "simulation", "mcp"]
+      "keywords": ["qubo", "ising", "z3", "smt", "compliance", "deterministic", "simulation", "audit"]
     }
   ]
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,65 @@
+# DSG Plugins — Claude Code Plugin Marketplace
+
+`dsg-plugins` is a Claude Code plugin marketplace for working **inside** the
+DSG ONE / ProofGate Control Plane repository. Each plugin encodes the repo's
+own operating rules from `CLAUDE.md` and `AGENTS.md` so agents and humans stay
+governance-first and evidence-first.
+
+The marketplace catalog is defined at
+[`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) with
+`metadata.pluginRoot` set to `./plugins`, so each plugin below lives under
+`plugins/<plugin-name>/`.
+
+## Add the marketplace
+
+From Claude Code:
+
+```text
+/plugin marketplace add tdealer01-crypto/tdealer01-crypto-dsg-control-plane
+```
+
+or from a local checkout:
+
+```text
+/plugin marketplace add ./
+```
+
+## Install a plugin
+
+```text
+/plugin install proofgate-review@dsg-plugins
+/plugin install dsg-verify@dsg-plugins
+/plugin install evidence-guard@dsg-plugins
+/plugin install pr-body-helper@dsg-plugins
+```
+
+You can also browse and install interactively with `/plugin`.
+
+## Plugins
+
+| Plugin | What it gives you | Components |
+|--------|-------------------|-----------|
+| **proofgate-review** | Governance-aware code review against the repo's API/security/truth/runtime-spine/gate/Supabase rules | `governance-review` skill, `security-reviewer` agent |
+| **dsg-verify** | Slash commands wrapping the verification ladder (only real npm scripts) | `/typecheck`, `/verify-route`, `/pre-pr-check` |
+| **evidence-guard** | Truth-boundary / claim-policy help plus an advisory hook that flags forbidden readiness claims | `claim-policy` skill, `PostToolUse` hook |
+| **pr-body-helper** | Generates the repo's mandatory PR body format | `/pr-body` command |
+| **ising-agent** | External deterministic Z3/QUBO compliance plugin (separate repo) | hosted at `tdealer01-crypto/Compliance-ising-z3-Deterministic-` |
+
+## Component boundaries
+
+- These plugins are advisory and workflow tooling. They do **not** replace
+  `npm run typecheck`, `npm run test`, or `npm run build` — they help you run
+  and report them honestly.
+- The `evidence-guard` hook is advisory only: it prints a warning to stderr and
+  always exits 0, so it never blocks an edit.
+- Nothing here claims production readiness, certification, or compliance. Follow
+  `CLAUDE.md` section 1 and the `claim-policy` skill for the claim boundary.
+
+## Validate locally
+
+```bash
+claude plugin validate .
+```
+
+This validates the marketplace manifest and each plugin manifest against the
+official Claude Code schema.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -31,6 +31,8 @@ or from a local checkout:
 /plugin install dsg-verify@dsg-plugins
 /plugin install evidence-guard@dsg-plugins
 /plugin install pr-body-helper@dsg-plugins
+/plugin install dsg-governance@dsg-plugins
+/plugin install compliance-ising-z3@dsg-plugins
 ```
 
 You can also browse and install interactively with `/plugin`.
@@ -43,7 +45,8 @@ You can also browse and install interactively with `/plugin`.
 | **dsg-verify** | Slash commands wrapping the verification ladder (only real npm scripts) | `/typecheck`, `/verify-route`, `/pre-pr-check` |
 | **evidence-guard** | Truth-boundary / claim-policy help plus an advisory hook that flags forbidden readiness claims | `claim-policy` skill, `PostToolUse` hook |
 | **pr-body-helper** | Generates the repo's mandatory PR body format | `/pr-body` command |
-| **ising-agent** | External deterministic Z3/QUBO compliance plugin (separate repo) | hosted at `tdealer01-crypto/Compliance-ising-z3-Deterministic-` |
+| **dsg-governance** | AI Governance Control Plane skills: action layer, GitHub Marketplace Action packager, and M1/M2 orchestrator | 3 skills (`dsg-action-layer-ged`, `dsg-github-marketplace-action-controller`, `dsg-multi-governance-orchestrator`) |
+| **compliance-ising-z3** | Deterministic QUBO/Ising optimization and Z3/SMT-style constraint verification, bundled from the source engine repo | `z3-compliance-review` skill, `compliance-agent` agent, reference scripts |
 
 ## Component boundaries
 

--- a/plugins/compliance-ising-z3/.claude-plugin/plugin.json
+++ b/plugins/compliance-ising-z3/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "compliance-ising-z3",
+  "description": "Deterministic QUBO/Ising policy-optimization and Z3/SMT-style formal constraint verification skills, bundled from the tdealer01-crypto/Compliance-ising-z3-Deterministic- engine. Covers deterministic simulated annealing (seeded PRNG, reproducible runs), Z3/SMT-style constraint logic, what-if counterfactual simulation, a SHA-256 provenance audit chain, and multi-regulatory framework mapping.",
+  "version": "3.0.0",
+  "author": { "name": "DSG ONE / ProofGate" },
+  "homepage": "https://github.com/tdealer01-crypto/Compliance-ising-z3-Deterministic-",
+  "keywords": ["qubo", "ising", "z3", "smt", "compliance", "deterministic", "simulation", "audit"]
+}

--- a/plugins/compliance-ising-z3/.claude-plugin/plugin.json
+++ b/plugins/compliance-ising-z3/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "3.0.0",
   "author": { "name": "DSG ONE / ProofGate" },
   "homepage": "https://github.com/tdealer01-crypto/Compliance-ising-z3-Deterministic-",
-  "keywords": ["qubo", "ising", "z3", "smt", "compliance", "deterministic", "simulation", "audit"]
+  "keywords": ["qubo", "ising", "z3", "smt", "compliance", "deterministic", "simulation", "audit", "rest-api", "policy-optimizer"]
 }

--- a/plugins/compliance-ising-z3/README.md
+++ b/plugins/compliance-ising-z3/README.md
@@ -17,6 +17,10 @@ wrapper, assets, or binaries.
   constraint forms, run the engine at a fixed seed, and report a replayable,
   hash-chained decision.
 - `agents/compliance-agent.md` — subagent for deterministic QUBO/Z3 workflows.
+- `skills/qubo-optimization-run/SKILL.md` — how to call the externally deployed
+  DSG QUBO Policy Optimizer API (see below).
+- `references/external-apis.md` — full endpoint inventory for both deployed
+  APIs, with verification dates and curl templates.
 - `scripts/preBuild.sh`, `scripts/postTest.sh` — advisory preflight / post-test
   helper scripts carried over from the source repo, callable via
   `${CLAUDE_PLUGIN_ROOT}/scripts/...`.
@@ -35,6 +39,32 @@ Key source locations in that repo:
 - `app/src/main/java/com/example/data/qubo/` — `QuboModels.kt`,
   `QuboPolicyEngine.kt`, `DeterministicRNG.kt`
 - `app/src/main/java/com/example/data/mcp/McpGatewayEngine.kt`
+
+## External deployed APIs
+
+Two externally deployed REST services relate to this domain. They are separate
+hosted services, not code in this repo. This plugin documents them and provides
+curl templates only — it stores no `api_key` and performs no real solver POST.
+Full details and verification dates are in `references/external-apis.md`.
+
+- **DSG QUBO Policy Optimizer API** (ready) — `https://dsg-qubo-api.vercel.app`.
+  Health check: `GET /health` returned
+  `{"status":"healthy","version":"2.0.0",...}` (verified reachable 2026-07-31).
+  Auth is an `api_key` **query parameter**. Set these env vars at runtime:
+  - `DSG_QUBO_API_BASE` (default `https://dsg-qubo-api.vercel.app`)
+  - `DSG_QUBO_API_KEY` — obtain via `/api/v1/auth/register` or `/login`; provide
+    from the runtime environment, never committed to the repo.
+  See `skills/qubo-optimization-run/SKILL.md`.
+
+- **z3-solver-api** (partially verified) —
+  `https://z3-solver-api-deploy-dsg.vercel.app`. `POST /api/solve` route exists
+  (POST-only; `GET` → 405), verified 2026-07-31. Its request/response
+  **schema is not verified** — do not assume a payload shape.
+
+Claim boundary: these are external deployed services, production-connected,
+reachable via `/health` where noted. No real optimization/solver run has been
+executed from this repo, so do not claim "external Z3 solver invocation
+complete", certification, or any readiness status.
 
 ## Claim boundary
 

--- a/plugins/compliance-ising-z3/README.md
+++ b/plugins/compliance-ising-z3/README.md
@@ -1,0 +1,53 @@
+# compliance-ising-z3
+
+A local Claude Code plugin bundled from the source repository
+[`tdealer01-crypto/Compliance-ising-z3-Deterministic-`](https://github.com/tdealer01-crypto/Compliance-ising-z3-Deterministic-)
+(branch `main`).
+
+The source repo is a native Kotlin/Android engine that performs deterministic
+QUBO/Ising policy optimization and Z3/SMT-style formal constraint verification.
+This plugin bundles the **agent-facing content** (a skill and an agent) plus
+the two reference build/test helper scripts, so an agent can reason about and
+drive the engine. It does **not** bundle the Android app source, Gradle
+wrapper, assets, or binaries.
+
+## Components
+
+- `skills/z3-compliance-review/SKILL.md` — how to frame a policy problem, pick
+  constraint forms, run the engine at a fixed seed, and report a replayable,
+  hash-chained decision.
+- `agents/compliance-agent.md` — subagent for deterministic QUBO/Z3 workflows.
+- `scripts/preBuild.sh`, `scripts/postTest.sh` — advisory preflight / post-test
+  helper scripts carried over from the source repo, callable via
+  `${CLAUDE_PLUGIN_ROOT}/scripts/...`.
+
+## Running the underlying engine
+
+The engine itself lives in the source repo and is built with Gradle:
+
+```bash
+./gradlew :app:build --no-daemon
+./gradlew :app:testDebugUnitTest --no-daemon --stacktrace
+```
+
+Key source locations in that repo:
+
+- `app/src/main/java/com/example/data/qubo/` — `QuboModels.kt`,
+  `QuboPolicyEngine.kt`, `DeterministicRNG.kt`
+- `app/src/main/java/com/example/data/mcp/McpGatewayEngine.kt`
+
+## Claim boundary
+
+- Z3/SMT-style constraint checks are implemented in Kotlin; there is no
+  external Z3 solver process. Do not claim external production Z3 invocation.
+- Determinism holds for a fixed seed and fixed inputs.
+- Regulatory mappings are engineering models, not legal certification.
+
+## Provenance note
+
+The source repo shipped its own custom-schema plugin manifest
+(`.claude-plugin/plugins/ising-agent/` with `SKILL.json` / `.json` agents and
+`preBuild`/`postTest` hooks) that does not conform to the official Claude Code
+plugin schema. This bundle re-expresses the same content in the official format
+(`SKILL.md` + agent `.md` with YAML frontmatter) so it validates with
+`claude plugin validate`. No secrets or `.env` files were bundled.

--- a/plugins/compliance-ising-z3/agents/compliance-agent.md
+++ b/plugins/compliance-ising-z3/agents/compliance-agent.md
@@ -1,0 +1,36 @@
+---
+name: compliance-agent
+description: >-
+  Subagent for deterministic QUBO/Ising and Z3/SMT-style compliance workflows
+  using the Compliance-ising-z3-Deterministic engine. Use to frame a policy
+  optimization problem, select and write constraint forms, run the engine at a
+  fixed seed, interpret the selected controls and provenance hash, and report a
+  replayable, honestly-scoped compliance decision.
+tools: Read, Grep, Glob, Bash
+---
+
+# Compliance Agent (QUBO / Ising / SMT-style)
+
+You help users solve deterministic policy-optimization and constraint-
+verification problems with the engine in
+`tdealer01-crypto/Compliance-ising-z3-Deterministic-`. Follow the
+`z3-compliance-review` skill for the engine's capabilities and constraint
+forms.
+
+## Operating rules
+
+- Treat "deterministic" and "reproducible" as true only for a fixed seed and
+  fixed inputs. Always report the seed and inputs used.
+- The engine uses Z3/SMT-style constraint logic implemented in native Kotlin.
+  Do not claim an external Z3 solver process is invoked.
+- Regulatory mappings are engineering models, not legal certification. Never
+  claim `certified compliance` or `guaranteed compliance` (DSG CLAUDE.md
+  section 1). `UNSUPPORTED` is never `PASS`.
+- When you run a build or test, report the exact command and result. If you did
+  not run it, say `Not run` and why — never fabricate a pass.
+
+## Output
+
+Report: the control set with V/R/C, the constraint forms written explicitly,
+the selected controls and energy at the given seed, the SHA-256 provenance
+hash, any what-if deltas, and the assumptions that bound the claim.

--- a/plugins/compliance-ising-z3/references/external-apis.md
+++ b/plugins/compliance-ising-z3/references/external-apis.md
@@ -1,0 +1,103 @@
+# External deployed APIs
+
+Two externally deployed services relate to this plugin's QUBO/Ising + Z3
+domain. They are separate hosted services, **not** code in this repo. This
+plugin only documents them and provides curl templates; it stores no api_key
+and performs no real solver POST.
+
+All auth values must come from runtime environment variables. Never commit or
+print a real `api_key`, token, or password.
+
+---
+
+## API #1 — DSG QUBO Policy Optimizer API (ready to use)
+
+- Base URL: `https://dsg-qubo-api.vercel.app`
+- Name / version: "DSG QUBO Policy Optimizer API" v2.0.0
+- Auth: `api_key` **query parameter** (register/login to obtain a key)
+- Env vars: `DSG_QUBO_API_BASE` (default `https://dsg-qubo-api.vercel.app`),
+  `DSG_QUBO_API_KEY`
+- Claim boundary: external deployed service, production-connected, reachable
+  via `/health` (verified 2026-07-31). No real optimization run has been
+  executed from this repo; do not claim solver invocation or certification.
+
+### Verified endpoints (probed 2026-07-31)
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/` | Info JSON: name, version, status, docs, stripe_configured |
+| GET | `/health` | Returned `{"status":"healthy","version":"2.0.0",...}` (verified reachable) |
+| GET | `/docs` | Swagger UI |
+| GET | `/openapi.json` | OpenAPI 3.1.0 |
+| POST | `/api/v1/auth/register` | Body `{email, company_name, password, pricing_tier}` |
+| POST | `/api/v1/auth/login` | Body `{email, password}` |
+| POST | `/api/v1/optimization/run?api_key=<KEY>` | Body `OptimizationRequest` (see below) |
+| GET | `/api/v1/optimization/list?api_key=<KEY>&limit=10` | Recent runs |
+| GET | `/api/v1/optimization/{id}?api_key=<KEY>` | Single run |
+| GET | `/api/v1/account/profile?api_key=<KEY>` | Account profile |
+| GET | `/api/v1/account/usage?api_key=<KEY>` | Quota / usage |
+
+`OptimizationRequest` body:
+
+- `domain` (enum, required): `EU_GDPR_AI` | `THAI_PDPA` | `THAI_CRIMINAL_LAW` |
+  `FINTECH`
+- `budget_cap` (number, **required**)
+- `anneal_iterations` (number, optional; example `5000`)
+- `deterministic_seed` (number, optional; example `42`)
+
+### Curl templates
+
+```bash
+export DSG_QUBO_API_BASE="${DSG_QUBO_API_BASE:-https://dsg-qubo-api.vercel.app}"
+# export DSG_QUBO_API_KEY=...   # runtime only; never hardcode in the repo
+
+# Health (safe, no auth)
+curl -s "$DSG_QUBO_API_BASE/health"
+
+# Run an optimization — WARNING: real run, may trigger solver work and may
+# incur cost under the service's pricing tier (Stripe scaffold).
+curl -s -X POST \
+  "$DSG_QUBO_API_BASE/api/v1/optimization/run?api_key=${DSG_QUBO_API_KEY}" \
+  -H "content-type: application/json" \
+  -d '{"domain":"EU_GDPR_AI","budget_cap":1000,"anneal_iterations":5000,"deterministic_seed":42}'
+```
+
+See `skills/qubo-optimization-run/SKILL.md` for the full workflow.
+
+---
+
+## API #2 — z3-solver-api (partially verified)
+
+- Base URL: `https://z3-solver-api-deploy-dsg.vercel.app`
+- Verified endpoint (probed 2026-07-31):
+  - `POST /api/solve` — route exists; `Content-Type: application/json`, CORS
+    `*`. `GET` returns `405`, confirming the route is POST-only.
+- **Request/response schema = NOT VERIFIED (route only).** There is no
+  discovered `/docs` or `/openapi.json`, and no POST was executed. Do not
+  assume field names or invent a payload. Treat the schema as unknown until a
+  real, authorized probe confirms it.
+- Claim boundary: only "route `/api/solve` reachable, POST-only (verified
+  2026-07-31)". Do not claim "external Z3 solver invocation complete" or any
+  readiness/certification status.
+
+### Curl template (schema unverified — placeholder body)
+
+```bash
+export Z3_SOLVER_API_BASE="${Z3_SOLVER_API_BASE:-https://z3-solver-api-deploy-dsg.vercel.app}"
+
+# Route exists but the request schema is UNVERIFIED. The body below is a
+# placeholder only; confirm the real schema before relying on it.
+curl -s -X POST "$Z3_SOLVER_API_BASE/api/solve" \
+  -H "content-type: application/json" \
+  -d '{ "schema": "UNVERIFIED — confirm before use" }'
+```
+
+---
+
+## Secret handling
+
+- No `api_key`, token, or password is stored in this repo.
+- Provide `DSG_QUBO_API_KEY` (and any other credential) from the runtime
+  environment or a secrets manager at call time.
+- Responses from `/auth/register` and `/auth/login` are secret; do not log or
+  commit them.

--- a/plugins/compliance-ising-z3/scripts/postTest.sh
+++ b/plugins/compliance-ising-z3/scripts/postTest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[postTest] Compliance plugin verification..."
+

--- a/plugins/compliance-ising-z3/scripts/preBuild.sh
+++ b/plugins/compliance-ising-z3/scripts/preBuild.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[preBuild] Preflight compliance plugin..."
+

--- a/plugins/compliance-ising-z3/skills/qubo-optimization-run/SKILL.md
+++ b/plugins/compliance-ising-z3/skills/qubo-optimization-run/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: qubo-optimization-run
+description: >-
+  Call the externally deployed DSG QUBO Policy Optimizer API to run a
+  deterministic QUBO/Ising policy optimization. Use when a user wants to run a
+  real optimization against the hosted service rather than the local Kotlin
+  engine: registering/logging in for an api_key, checking account usage, and
+  submitting an optimization run for a regulatory domain under a budget cap.
+  Auth is an `api_key` query parameter that must come from runtime env, never
+  from the repo. Running a real optimization may trigger solver work and may
+  incur cost under the service's pricing tier.
+---
+
+# QUBO Optimization Run (DSG QUBO Policy Optimizer API)
+
+This skill drives the **externally deployed** DSG QUBO Policy Optimizer API.
+It is a separate hosted service, not code in this repo. Use it to run a real
+deterministic QUBO/Ising policy optimization when the user asks for a live run.
+
+## Service identity (verified 2026-07-31)
+
+- Base URL: `https://dsg-qubo-api.vercel.app`
+- Name/version: "DSG QUBO Policy Optimizer API" v2.0.0
+- Reachability: `GET /health` returned
+  `{"status":"healthy","version":"2.0.0",...}` (verified reachable 2026-07-31).
+- Interactive docs: `GET /docs` (Swagger UI), `GET /openapi.json`
+  (OpenAPI 3.1.0).
+
+Claim boundary (CLAUDE.md sections 1, 12): this is an **external deployed
+service, production-connected, reachable via `/health` (verified 2026-07-31)**.
+Do NOT claim "external Z3 solver invocation complete", "certified", or any
+readiness status — a real optimization run has not been executed here, and no
+api_key is stored in this repo.
+
+## Authentication
+
+Auth is an **`api_key` query parameter**. Obtain a key at runtime by
+registering or logging in; never commit or print a real key.
+
+- Set it in the environment before calling: `DSG_QUBO_API_KEY`.
+- Base URL is overridable via `DSG_QUBO_API_BASE`.
+
+```bash
+export DSG_QUBO_API_BASE="${DSG_QUBO_API_BASE:-https://dsg-qubo-api.vercel.app}"
+# export DSG_QUBO_API_KEY=...   # provide at runtime; do NOT hardcode in the repo
+```
+
+Register / login (returns a key or token — treat the response as secret):
+
+```bash
+curl -s -X POST "$DSG_QUBO_API_BASE/api/v1/auth/register" \
+  -H "content-type: application/json" \
+  -d '{"email":"you@example.com","company_name":"Example Co","password":"<runtime>","pricing_tier":"free"}'
+
+curl -s -X POST "$DSG_QUBO_API_BASE/api/v1/auth/login" \
+  -H "content-type: application/json" \
+  -d '{"email":"you@example.com","password":"<runtime>"}'
+```
+
+## Run an optimization
+
+`POST /api/v1/optimization/run?api_key=<KEY>` with an `OptimizationRequest`
+body.
+
+Request fields:
+
+- `domain` (enum, required): `EU_GDPR_AI` | `THAI_PDPA` | `THAI_CRIMINAL_LAW` |
+  `FINTECH`
+- `budget_cap` (number, **required**)
+- `anneal_iterations` (number, optional; example `5000`)
+- `deterministic_seed` (number, optional; example `42` — fix it for
+  reproducible runs)
+
+```bash
+# WARNING: this performs a real run. It may trigger solver work and may incur
+# cost under the service's pricing tier (Stripe scaffold). Only run with the
+# user's intent and a valid runtime api_key.
+curl -s -X POST \
+  "$DSG_QUBO_API_BASE/api/v1/optimization/run?api_key=${DSG_QUBO_API_KEY}" \
+  -H "content-type: application/json" \
+  -d '{
+    "domain": "EU_GDPR_AI",
+    "budget_cap": 1000,
+    "anneal_iterations": 5000,
+    "deterministic_seed": 42
+  }'
+```
+
+## Read results / account
+
+```bash
+# List recent runs
+curl -s "$DSG_QUBO_API_BASE/api/v1/optimization/list?api_key=${DSG_QUBO_API_KEY}&limit=10"
+
+# Fetch a single run by id
+curl -s "$DSG_QUBO_API_BASE/api/v1/optimization/{id}?api_key=${DSG_QUBO_API_KEY}"
+
+# Account profile and usage (check quota/cost before running)
+curl -s "$DSG_QUBO_API_BASE/api/v1/account/profile?api_key=${DSG_QUBO_API_KEY}"
+curl -s "$DSG_QUBO_API_BASE/api/v1/account/usage?api_key=${DSG_QUBO_API_KEY}"
+```
+
+## Safe workflow
+
+1. Confirm the service is up: `GET /health`.
+2. Ensure `DSG_QUBO_API_KEY` is set from runtime env (never from the repo).
+3. Check `account/usage` so you understand quota/cost before a run.
+4. Only then `POST .../optimization/run` with an explicit `budget_cap` and a
+   fixed `deterministic_seed`.
+5. Report the run id, selected controls, and the seed used so the result is
+   replayable. If you did not actually run it, say `Not run` — never fabricate
+   a result.
+
+See `references/external-apis.md` for the full endpoint inventory and for the
+second (partially-verified) z3-solver service.

--- a/plugins/compliance-ising-z3/skills/z3-compliance-review/SKILL.md
+++ b/plugins/compliance-ising-z3/skills/z3-compliance-review/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: z3-compliance-review
+description: >-
+  Reason about deterministic QUBO/Ising policy optimization and Z3/SMT-style
+  formal constraint verification using the Compliance-ising-z3-Deterministic
+  engine. Use when a user asks to optimize a policy/control selection under a
+  budget, verify logical constraints (implication, equivalence, mutual
+  exclusion, at-least-one, cost cap), run a what-if counterfactual on budget
+  shifts, or produce a reproducible, hash-chained compliance decision. The
+  underlying engine is native Kotlin (no external Z3 process); constraint
+  checks are Z3/SMT-style, implemented deterministically.
+---
+
+# Z3 Compliance Review (QUBO / Ising / SMT-style)
+
+This skill wraps the deterministic policy engine from the source repository
+`tdealer01-crypto/Compliance-ising-z3-Deterministic-`. Use it to help a user
+frame a compliance/policy problem, choose the right constraint form, and
+interpret results. It does not embed the Kotlin engine here — it references the
+real engine so runs stay reproducible and auditable.
+
+## What the engine does (verified from the source repo)
+
+- **Deterministic QUBO & Ising matrix engine** — maps business value (V), risk
+  reduction (R), and cost (C) into an upper-triangular QUBO energy matrix, and
+  converts between 0/1 QUBO space and ±1 Ising spins.
+  Source: `app/src/main/java/com/example/data/qubo/QuboModels.kt`,
+  `QuboPolicyEngine.kt`.
+- **Deterministic simulated annealing** — a 32-bit seeded PRNG
+  (`DeterministicRNG.kt`, Mulberry32) gives reproducible runs for a fixed seed
+  (the repo documents `seed = 42L`). Same seed and inputs produce the same
+  trajectory.
+- **Z3/SMT-style constraint verification** — enforced before state transitions.
+  Common forms:
+  - Implication `A → B`: `x_A - x_A*x_B ≤ 0`
+  - Equivalence `A ↔ B`: `(x_A - x_B)^2 = 0`
+  - Mutual exclusion `¬(A ∧ B)`: `x_A*x_B = 0`
+  - At-least-`k`: `Σ x_i ≥ k`
+  - Hard budget cap: `Σ c_i*x_i ≤ Budget`
+- **What-if counterfactual simulator** — evaluates rule divergence and cost/
+  risk/value deltas under hypothetical budget shifts.
+- **SHA-256 provenance audit chain** — each annealing step is bound into an
+  immutable hash chain (sequence, state flips, temperature, energy delta,
+  predecessor hash).
+- **MCP gateway** — `app/src/main/java/com/example/data/mcp/McpGatewayEngine.kt`.
+- **Regulatory mappings** — pre-built rule models for EU GDPR & EU AI Act, Thai
+  PDPA, Thai Criminal Law, and FinTech (see the repo README tables).
+
+## Claim boundary (align with DSG CLAUDE.md sections 1, 12)
+
+- This is a deterministic Kotlin engine with **Z3/SMT-style** constraint logic.
+  Do not claim external production Z3 solver invocation — there is no external
+  Z3 process; the checks are implemented in-engine.
+- "Deterministic" / "reproducible" claims hold only for a fixed seed and fixed
+  inputs. State that assumption when you report a result.
+- Regulatory mappings are engineering models, not legal certification. Do not
+  claim `certified compliance` or `guaranteed compliance`.
+- `UNSUPPORTED` is never `PASS`.
+
+## How to run the engine (from the source repo)
+
+The engine is an Android/Kotlin Gradle project. Build and test commands
+(captured from the repo's plugin environment config):
+
+```bash
+# Build
+./gradlew :app:build --no-daemon
+
+# Unit tests
+./gradlew :app:testDebugUnitTest --no-daemon --stacktrace
+```
+
+Reference helper scripts are bundled with this plugin at
+`${CLAUDE_PLUGIN_ROOT}/scripts/preBuild.sh` and
+`${CLAUDE_PLUGIN_ROOT}/scripts/postTest.sh` (advisory preflight / post-test
+echoes carried over from the source repo). Report `Not run` if you did not run
+a command — do not claim a build/test passed without real output.
+
+## Suggested workflow
+
+1. Restate the policy/control set with V, R, C per candidate.
+2. Pick the constraint forms (implication / equivalence / exclusion / at-least
+   / budget cap) and write them explicitly.
+3. Run the engine with a fixed seed; capture the selected controls, energy, and
+   the provenance hash.
+4. Optionally run a what-if under a budget shift and report the deltas.
+5. Report the decision with its seed, inputs, and audit hash so it is
+   replayable.

--- a/plugins/dsg-governance/.claude-plugin/plugin.json
+++ b/plugins/dsg-governance/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "dsg-governance",
+  "description": "AI Governance Control Plane skills for Claude Code: a studio-style action layer (plan, deterministic gate, permission verdict, browser-first execution after approval), a GitHub Marketplace Action packager with GO/NO-GO validation, and a multi-source governance orchestrator for M1/M2 cutover. Covers the deterministic gate scaffold, replayable governance, compliance evidence mapping, runtime lifecycle, and the Hermes controlled executor.",
+  "version": "1.0.0",
+  "author": { "name": "DSG ONE / ProofGate" },
+  "homepage": "https://tdealer01-crypto-dsg-control-plane.vercel.app",
+  "keywords": [
+    "ai-governance",
+    "deterministic-gate",
+    "compliance",
+    "audit",
+    "replay",
+    "hermes",
+    "policy-as-code",
+    "dsg",
+    "proofgate"
+  ]
+}

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/README.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/README.md
@@ -1,0 +1,2 @@
+# dsg-action-layer-ged
+

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/SKILL.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: dsg-action-layer-ged
+version: 1.0.0
+author: DSG Team
+license: MIT
+description: >-
+  Run a studio-style agent control layer that turns a user goal into an
+  explainable plan, deterministic decision flow, permission verdicts, and
+  browser-first execution after approval. Use when the user
+---
+
+# DSG Action Layer — Governed Execution Skill
+
+DSG ONE / ProofGate Control Plane is **not** an AI Agent framework. It is an **AI Governance Control Plane** — the layer that decides what Agents are _allowed_ to do, captures cryptographic proof of every decision, and makes those decisions replayable months later.
+
+> "Cloudflare = Control Plane of the Internet. Datadog = Control Plane of Observability. **DSG = Control Plane of AI Governance.**"
+
+***
+
+## When to invoke this skill
+
+| User intent                                                 | Use this skill                     |
+| ----------------------------------------------------------- | ---------------------------------- |
+| "Gate this action before running it"                        | ✅ Yes — call `gate-evaluate` first |
+| "Why did the AI decide X six months ago?"                   | ✅ Yes — use replay governance      |
+| "Get a compliance evidence pack for our audit"              | ✅ Yes — use compliance evidence    |
+| "Execute this plan with a credential and conformance check" | ✅ Yes — Hermes executor            |
+| "What governance posture should this AI agent run with?"    | ✅ Yes — runtime governance         |
+| "Build a generic AI feature with no governance requirement" | ❌ Out of scope                     |
+
+***
+
+## 5 Core Capabilities
+
+Read the relevant reference file before answering or implementing any governance question.
+
+| Capability                 | When to use                                                           | Reference                            |
+| -------------------------- | --------------------------------------------------------------------- | ------------------------------------ |
+| Deterministic Safety Gate  | Before any agent action — get PASS/BLOCK/REVIEW + proof hash          | \<references/gate-evaluate.md>       |
+| Replayable Governance      | Audit question: "Why did AI decide X at time T?"                      | \<references/replay-governance.md>   |
+| Compliance Evidence Pack   | Preparing for SOC2 / ISO27001 / EU AI Act / NIST audit                | \<references/compliance-evidence.md> |
+| Runtime Governance         | Lifecycle: Before / During / After agent execution                    | \<references/runtime-governance.md>  |
+| Hermes Controlled Executor | Full Plan → Conformance Check → Credential Grant → Execute → Evidence | \<references/hermes-executor.md>     |
+
+***
+
+## Quick Decision Flow
+
+When a user asks about an AI agent action:
+
+```
+1. PLAN    → What is the goal? What is the risk level?
+2. GATE    → Call POST /api/dsg/v1/gates/evaluate
+             → Get gateStatus: PASS | BLOCK | REVIEW
+             → Get proofHash (cryptographic evidence)
+3. DECIDE  → PASS  → proceed to execution
+             REVIEW → show user the plan, require approval
+             BLOCK  → halt, return reason + proof
+4. EXECUTE → If PASS or approved REVIEW:
+             → Hermes controlled executor (if credential needed)
+             → Or direct execution with audit logging
+5. COMMIT  → POST /api/spine/execute to commit evidence
+             → Runtime evidence stored in Supabase
+6. REPLAY  → Any future audit can replay from stored proof + policy version
+```
+
+***
+
+## Gate Decision Mapping
+
+| gateStatus    | riskLevel       | Action                                        |
+| ------------- | --------------- | --------------------------------------------- |
+| `PASS`        | any             | Proceed. Log proofHash.                       |
+| `REVIEW`      | low–medium      | Show plan to user. Require explicit approval. |
+| `BLOCK`       | any             | Halt. Return reason. Never proceed.           |
+| `UNSUPPORTED` | low             | Map to REVIEW — request human check           |
+| `UNSUPPORTED` | medium–critical | Map to BLOCK — refuse execution               |
+
+**UNSUPPORTED is never PASS.**
+
+***
+
+## Critical rules
+
+* **Never skip the gate** for actions with `riskLevel: medium` or higher.
+* **Never claim `UNSUPPORTED` is safe** — it maps to REVIEW or BLOCK, never PASS.
+* **Always store the proofHash** in execution context for replay.
+* **Policy version must be pinned** in every gate call to ensure replayability.
+* **Credentials must go through Hermes CredentialBroker** — never raw secrets.
+* **Mock state must be false** for any production gate evaluation.
+
+***
+
+## Base URL
+
+```
+https://tdealer01-crypto-dsg-control-plane.vercel.app
+```
+
+Set `DSG_CONTROL_PLANE_URL` to override for local or staging.
+
+***
+
+## Authentication
+
+All gate/proof/compliance endpoints require:
+
+```http
+Authorization: Bearer <DSG_API_KEY>
+```
+
+Obtain API key from the DSG dashboard → API Keys. Free tier: 50 evaluations/month. Upgrade at `/pricing#dsg-gate`.

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/references/README.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/references/README.md
@@ -1,0 +1,2 @@
+# references
+

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/references/compliance-evidence.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/references/compliance-evidence.md
@@ -1,0 +1,103 @@
+# Compliance Evidence Pack — Reference
+
+## What it is
+
+The DSG Compliance Evidence Pack bundles cryptographic attestations for:
+- **SBOM** (Software Bill of Materials) — every dependency at a pinned version
+- **Secret Scanning** — no secrets committed (gitleaks + GitHub secret scanning)
+- **CodeQL** — no high/critical security vulnerabilities in code
+- **Evidence Aggregation** — L1–L5 coverage chain hashes
+- **Hash Bundle** — SHA256 manifest signed over all evidence files
+
+Unlike a plain log, this is an **evidence bundle** ready for third-party auditor review.
+
+---
+
+## Evidence levels (L1–L5)
+
+| Level | Type | What it covers |
+|---|---|---|
+| L1 | Unit evidence | API logic, gate constraint tests |
+| L2 | Integration evidence | End-to-end API + DB integration tests |
+| L3 | Adversarial evidence | Replay attacks, negative cases, boundary violations |
+| L4 | Mutation / Proof evidence | Stryker mutation score, design-time Z3 proofs, oversight |
+| L5 | Provenance / Build evidence | SBOM, secret scan, CodeQL, Sigstore bundle (if available) |
+
+---
+
+## CCVS pipeline
+
+Run locally or in CI:
+
+```bash
+npm run ccvs:pipeline
+```
+
+Generates:
+- `ccvs-evidence.json` — raw evidence aggregation
+- `ccvs-compliance-matrix.json` — L1–L5 matrix with pass/fail/warning
+- `SHA256SUMS` — hash manifest for the evidence bundle
+
+---
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `ccvs-evidence.json` | Evidence collected from test runs |
+| `ccvs-compliance-matrix.json` | Compliance matrix by evidence level |
+| `SHA256SUMS` | Hash manifest for all evidence files |
+| `.gitleaks.toml` | Secret scanning configuration |
+| `openapi.yaml` | API spec for auditor review |
+
+---
+
+## What it maps to
+
+| Standard | DSG evidence |
+|---|---|
+| SOC 2 CC6.1 | CodeQL + secret scan (no credential exposure) |
+| SOC 2 CC8.1 | SBOM + dependency audit |
+| ISO 27001 A.12.6 | Vulnerability management via CodeQL |
+| NIST CSF PR.IP-12 | Vulnerability disclosure and remediation |
+| EU AI Act Art. 17 | Quality management + documentation system |
+| EU AI Act Art. 13 | Transparency — policy manifest + proof hashes |
+
+---
+
+## Claim boundary
+
+Evidence pack is **pre-audit evidence mapping**, not legal certification.
+
+Allowed claims (with evidence):
+- `audit-ready`
+- `compliance-evidence-pack available`
+- `pre-SOC2 evidence mapping`
+- `EU AI Act Art. 9/13/17 documentation trail`
+
+Not allowed without independent third-party audit:
+- `SOC 2 certified`
+- `ISO 27001 certified`
+- `EU AI Act compliant`
+- `third-party audited`
+
+Set `certificationClaim = false` and `independentAuditClaim = false` unless a real audit artifact exists.
+
+---
+
+## Delivery Proof scan (quick check)
+
+```
+POST /api/delivery-proof/scan
+Content-Type: application/json
+
+{
+  "productionUrl": "https://your-deployment.vercel.app",
+  "repoUrl": "https://github.com/your-org/your-repo"
+}
+```
+
+Returns: homepage check, readiness, health, protected-route auth rejection, repo URL presence, and a shareable report ID.
+
+Pricing: Free (1 scan/month), Pro Scan ($49 one-time), Unlimited ($199/month).
+Upgrade at `/pricing#delivery-proof`.

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/references/gate-evaluate.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/references/gate-evaluate.md
@@ -1,0 +1,102 @@
+# Deterministic Safety Gate — Reference
+
+## Endpoint
+
+```
+POST /api/dsg/v1/gates/evaluate
+Authorization: Bearer <DSG_API_KEY>
+Content-Type: application/json
+```
+
+## What it does
+
+Evaluates a proposed agent action against the current policy set using a
+deterministic TypeScript gate engine (Z3-style constraint satisfaction).
+
+Same input + same policy version = same decision, always.
+Every evaluation produces a **proofHash** and **constraintSetHash** for future replay.
+
+## Request shape
+
+```json
+{
+  "agentId": "agent_abc123",
+  "actionId": "act_xyz789",
+  "idempotencyKey": "ik_<uuid>",
+  "nonce": "<random-string>",
+  "riskLevel": "medium",
+  "actionType": "database_write",
+  "actionDescription": "Write customer PII to orders table",
+  "context": {
+    "orgId": "org_111",
+    "workspaceId": "ws_222",
+    "policyVersion": "v2.1.0"
+  }
+}
+```
+
+### Required fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `agentId` | string | Active agent identifier |
+| `actionId` | string | Unique action identifier |
+| `idempotencyKey` | string | Prevents duplicate evaluations |
+| `nonce` | string | Anti-replay nonce |
+| `riskLevel` | `low` \| `medium` \| `high` \| `critical` | Determines UNSUPPORTED mapping |
+| `actionType` | string | Category of the proposed action |
+
+## Response shape
+
+```json
+{
+  "ok": true,
+  "gateStatus": "PASS",
+  "proofStatus": "PASS",
+  "riskLevel": "medium",
+  "proof": {
+    "proofHash": "sha256:abc123...",
+    "constraintSetHash": "sha256:def456...",
+    "policyVersion": "v2.1.0",
+    "inputHash": "sha256:ghi789...",
+    "timestamp": "2026-07-01T09:00:00.000Z",
+    "status": "PASS",
+    "failureReasons": []
+  }
+}
+```
+
+### gateStatus values
+
+| Value | Meaning | Action |
+|---|---|---|
+| `PASS` | All constraints satisfied | Proceed with execution |
+| `BLOCK` | One or more constraints violated | Halt — never proceed |
+| `REVIEW` | Requires human confirmation | Show plan, wait for approval |
+| `UNSUPPORTED` | Constraint cannot be evaluated | Map: low→REVIEW, med/high→BLOCK |
+
+## Quota / Pricing
+
+| Tier | Evals/month | Price |
+|---|---|---|
+| Free | 50 | $0 |
+| Pro | 5 000 | $99/month |
+| Enterprise | Unlimited | $499/month |
+
+Quota exceeded → HTTP 402 `{ requiresUpgrade: true, upgradeUrl: "/pricing#dsg-gate" }`
+
+## Policy manifest (read before calling)
+
+```
+GET /api/dsg/v1/policies/manifest
+```
+
+Returns current `policyVersion`, `constraintSetHash`, and solver metadata.
+Always read the manifest before the first gate call in a session to pin the policy version.
+
+## Z3 / Formal proof boundary
+
+The gate engine is a deterministic TypeScript constraint solver.
+External Z3 solver is **not invoked** by this route.
+Design-time formal proofs are run via `npm run verify:policy` and `npm run proof:revenue`.
+Do not claim "external production Z3 invocation" unless separately verified.

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/references/hermes-executor.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/references/hermes-executor.md
@@ -1,0 +1,143 @@
+# Hermes Controlled Executor — Reference
+
+## What makes it different
+
+Standard agent execution:
+```
+Plan → Execute
+```
+
+Hermes controlled execution:
+```
+Plan
+  → planHash (immutable plan snapshot)
+  → Conformance Check (plan hash must match)
+  → Credential Grant (scoped lease, no raw secrets)
+  → Controlled Execution (command whitelist + path isolation)
+  → Evidence Capture (every step recorded)
+```
+
+This is **Zero Trust for AI Agents** — the execution environment trusts nothing,
+verifies everything, and records proof at every step.
+
+---
+
+## Key source files
+
+| File | Role |
+|---|---|
+| `lib/dsg/brain/plan-attempt.ts` | Immutable plan snapshot + deterministic `planHash` |
+| `lib/dsg/brain/controlled-executor.ts` | Execution grants, credential leases, controlled context |
+| `lib/dsg/brain/conformance-gate.ts` | Validates commands, file paths, plan hash, evidence |
+| `lib/dsg/brain/credential-broker.ts` | Supabase-backed secret lookup + lease/fingerprint creation |
+| `lib/dsg/brain/hermes-plugin.ts` | Orchestration: plan → credentials → execute → validate → evidence |
+
+---
+
+## Execution flow
+
+### 1. Propose plan
+
+```typescript
+const plan = await hermes.proposePlan({
+  goal: "Migrate customer records to new schema",
+  steps: [...],
+  agentId: "agent_abc123",
+  orgId: "org_111"
+});
+// plan.planHash = sha256(JSON.stringify(plan)) — immutable
+```
+
+### 2. Gate the plan
+
+```
+POST /api/dsg/v1/gates/evaluate
+{
+  "agentId": "agent_abc123",
+  "actionId": plan.planHash,
+  "riskLevel": "high",
+  "actionType": "schema_migration",
+  "idempotencyKey": "ik_<uuid>",
+  "nonce": "<nonce>"
+}
+```
+
+Only proceed if `gateStatus: PASS` or operator-approved `REVIEW`.
+
+### 3. Broker credentials
+
+```typescript
+const lease = await credentialBroker.getLease({
+  secretName: "DATABASE_MIGRATION_KEY",
+  planHash: plan.planHash,
+  ttlSeconds: 300
+});
+// lease.fingerprint = redacted token reference — never the raw secret
+```
+
+The broker reads from `dsg_secrets` in Supabase.
+Raw secrets are never exposed to the agent execution context.
+
+### 4. Execute with conformance
+
+```typescript
+const result = await controlledExecutor.execute({
+  plan,
+  lease,
+  allowedCommands: ["pg_dump", "psql", "node migrate.js"],
+  allowedPaths: ["./migrations/", "./scripts/"],
+  evidenceRequired: true
+});
+```
+
+Every command is checked against `allowedCommands`.
+Every file path is checked against `allowedPaths`.
+If either check fails → `CONFORMANCE_BLOCK` — execution halts.
+
+### 5. Capture evidence
+
+After execution, Hermes captures:
+- Executed commands + outputs
+- Files written (within allowed paths only)
+- Plan hash comparison (executed plan must match approved plan)
+- Conformance result: `PASS` | `BLOCK` | `EVIDENCE_MISSING`
+
+Evidence is committed via the runtime commit RPC and stored in Supabase.
+
+---
+
+## Conformance rules (hard)
+
+| Rule | Consequence of violation |
+|---|---|
+| `planHash` must match approved plan | `CONFORMANCE_BLOCK` — halt |
+| Every command must be whitelisted | `CONFORMANCE_BLOCK` — halt |
+| Every changed path must be under allowed canonical path | `CONFORMANCE_BLOCK` — halt |
+| Evidence is required | `EVIDENCE_MISSING` → `CONFORMANCE_BLOCK` |
+| No raw secret exposure | `CREDENTIAL_LEAK` → emergency halt + alert |
+
+**`proposePlan()` is currently a deterministic scaffold/placeholder** unless a current implementation proves live LLM integration. Do not claim live LLM planning without current evidence.
+
+---
+
+## Credential broker boundary
+
+- Broker queries `dsg_secrets` in Supabase and returns scoped leases.
+- Leases have TTL (default 300 seconds for execution window).
+- `fingerprint` field is a redacted reference — never the raw secret value.
+- Encryption metadata is stored with each secret; do not claim complete app-layer encryption or external vaulting without verified implementation.
+
+---
+
+## When to use Hermes vs direct execution
+
+| Scenario | Use Hermes | Use direct |
+|---|---|---|
+| `riskLevel: high` or `critical` action | ✅ Required | ❌ |
+| Action needs scoped database/API credentials | ✅ Required | ❌ |
+| Multi-step plan with branching | ✅ Recommended | ❌ |
+| Simple read-only query, `riskLevel: low` | Optional | ✅ |
+| UI action with no external credential | Optional | ✅ |
+
+Enterprise tier required for full Hermes executor access.
+Pro tier: gate evaluate + proof only.

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/references/replay-governance.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/references/replay-governance.md
@@ -1,0 +1,112 @@
+# Replayable Governance — Reference
+
+## Why replayability matters
+
+Most AI systems:
+```
+AI decides → done
+```
+
+DSG system:
+```
+AI decides
+  → store proof (proofHash)
+  → store evidence (evidenceBundle)
+  → store policy version (policyVersion)
+  → store input hash (inputHash)
+  → Replay possible at any future date
+```
+
+This answers the enterprise audit question:
+> "Why did the AI decide X six months ago?"
+
+Analogous to: financial transaction ledger, aviation black box, clinical trial audit trail.
+
+---
+
+## What is stored per evaluation
+
+| Field | What it enables |
+|---|---|
+| `proofHash` | Prove the exact proof output was produced |
+| `inputHash` | Prove the exact inputs that led to the decision |
+| `constraintSetHash` | Prove which policy constraints were active |
+| `policyVersion` | Pin the exact policy that was in effect |
+| `timestamp` | Temporal ordering for audit |
+| `gateStatus` | The actual decision: PASS / BLOCK / REVIEW |
+| `orgId` + `agentId` | Scoping for multi-tenant replay |
+
+---
+
+## Replay proof endpoint
+
+```
+POST /api/dsg/v1/proofs/prove
+Authorization: Bearer <DSG_API_KEY>
+Content-Type: application/json
+```
+
+```json
+{
+  "proofHash": "sha256:abc123...",
+  "policyVersion": "v2.1.0",
+  "constraintSetHash": "sha256:def456...",
+  "inputHash": "sha256:ghi789...",
+  "agentId": "agent_abc123",
+  "context": { "orgId": "org_111" }
+}
+```
+
+Returns whether the original proof is reproducible and whether the decision
+matches the stored gate status.
+
+---
+
+## Replay requirements
+
+For a decision to be fully replayable:
+
+1. **proofHash** must be stored (from the original gate evaluation response).
+2. **policyVersion** must be known (from `GET /api/dsg/v1/policies/manifest` at time of evaluation).
+3. **inputHash** must match the original inputs.
+4. **constraintSetHash** must match the policy that was active.
+
+If any of these four are missing, replay is degraded:
+- Missing policyVersion → `REVIEW` posture (cannot guarantee same constraints)
+- Missing proofHash → `BLOCK` posture (cannot verify original decision)
+
+---
+
+## Policy version consistency
+
+When calling the gate:
+- Always read `GET /api/dsg/v1/policies/manifest` first to get the current `policyVersion`.
+- Store `policyVersion` alongside every gate result.
+- If the policy version changes mid-session, re-evaluate all pending actions.
+
+A stale `policyVersion` means the replay will compare against a different constraint set — flag this as `REVIEW` in audit output.
+
+---
+
+## Evidence chain for audit
+
+The runtime spine commit RPC stores:
+- `runtime_intent_id` — the unique governed intent
+- `proof` — the full proof object
+- `pipeline_trace` — step-by-step execution trace
+- `ledger_sequence` — sequential truth ordering
+
+Query the Supabase `runtime_evidence` table for audit export.
+Include `runtime_intent_id` in every API response to your users so they can reference it in support/compliance tickets.
+
+---
+
+## Compliance use cases
+
+| Regulation | How replayability helps |
+|---|---|
+| EU AI Act Art. 9 | Show documented risk assessment decisions with cryptographic proof |
+| SOC 2 Type II | Continuous evidence of access control decisions over the audit period |
+| ISO 27001 | Traceable policy decisions for incident investigation |
+| NIST AI RMF | Decision rationale documentation with audit trail |
+| Financial regulators | Same-input / same-output deterministic record |

--- a/plugins/dsg-governance/skills/dsg-action-layer-ged/references/runtime-governance.md
+++ b/plugins/dsg-governance/skills/dsg-action-layer-ged/references/runtime-governance.md
@@ -1,0 +1,117 @@
+# Runtime Governance — Before / During / After — Reference
+
+## The governance lifecycle
+
+Most governance systems check only **before** execution.
+DSG governs at **three points**:
+
+```
+BEFORE execution
+  → Gate evaluate (PASS / BLOCK / REVIEW)
+  → Quota check (rate limit + monthly quota)
+  → Approval workflow (if REVIEW or HIGH risk)
+  → Isolation context setup
+
+DURING execution
+  → Hermes conformance gate (plan hash must match)
+  → Credential lease (scoped, expiring)
+  → Command whitelist enforcement
+  → Path isolation enforcement
+
+AFTER execution
+  → Runtime commit RPC (evidence stored)
+  → Audit trail written to Supabase
+  → Quota decrement recorded
+  → Pipeline trace stored
+  → Proof hash stored for replay
+```
+
+---
+
+## Spine execution entry
+
+All governed execution must go through:
+
+```
+POST /api/spine/execute    (current spine layer)
+POST /api/execute          (stable compatibility alias)
+```
+
+Do not bypass this path for governed actions.
+
+### Expected spine flow
+
+1. Extract the Bearer token from the `Authorization` header.
+2. Normalize payload — require `agent_id`.
+3. Resolve agent from API key (check active status).
+4. Apply rate limits + CORS.
+5. Enforce quota (block before execution if exceeded).
+6. Issue or reuse pending runtime intent.
+7. Execute through spine pipeline.
+8. Commit runtime evidence via runtime commit RPC.
+9. Return `decision`, `reason`, `proof`, `pipeline_trace`, `ledger_sequence`, `usage`.
+
+### Request shape
+
+```json
+{
+  "agent_id": "agent_abc123",
+  "action": {
+    "type": "database_query",
+    "payload": { "query": "SELECT * FROM customers LIMIT 10" }
+  },
+  "context": {
+    "orgId": "org_111",
+    "workspaceId": "ws_222"
+  }
+}
+```
+
+---
+
+## Approval workflow
+
+When `gateStatus: REVIEW`:
+
+1. Present the plan to the operator (show goal, risk, proof hash).
+2. Wait for explicit `APPROVE` or `REJECT` from an authorized user.
+3. Only proceed if `APPROVE` is received — store approval evidence.
+4. Any `REJECT` halts execution permanently for that `actionId`.
+
+Approval evidence is stored alongside the gate proof for full audit trail.
+
+---
+
+## Quota enforcement
+
+| Exceeded | HTTP | Response |
+|---|---|---|
+| Monthly eval quota | 402 | `{ requiresUpgrade: true, tier: "free", upgradeUrl: "/pricing#dsg-gate" }` |
+| Rate limit (per minute) | 429 | `{ error: "rate_limit_exceeded" }` |
+
+Quota is checked **before** execution begins — the agent action is never attempted if quota is exceeded.
+
+---
+
+## Risk level → governance posture
+
+| riskLevel | Gate behavior | Approval required | Hermes required |
+|---|---|---|---|
+| `low` | PASS auto-allowed with evidence | No | No |
+| `medium` | PASS with audit; UNSUPPORTED → REVIEW | No (auto-allow with evidence per delegation gate) | No |
+| `high` | Requires explicit user confirmation | Yes | Recommended |
+| `critical` | Always blocked unless evidence + approval | Yes (mandatory) | Yes |
+
+Source: `lib/spine/permission-gate.ts` — medium risk auto-allows with audit evidence; high/critical require user confirmation review.
+
+---
+
+## Health probes
+
+```
+GET /api/health           → public health check
+GET /api/readiness        → readiness with DB check
+GET /api/agent/status     → lightweight identity + DB connectivity
+```
+
+Use `/api/agent/status` to confirm deployed commit and environment before governed execution.

--- a/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/README.md
+++ b/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/README.md
@@ -1,0 +1,2 @@
+# dsg-github-marketplace-action-controller
+

--- a/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/SKILL.md
+++ b/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: dsg-github-marketplace-action-controller
+version: 1.0.0
+author: DSG Team
+license: MIT
+description: >-
+  Use this skill when creating, packaging, validating, publishing, or
+  maintaining DSG GitHub Marketplace Actions. It turns DSG control-plane,
+  action-layer permission gates, deterministic GO/NO-GO valida
+---
+
+# DSG GitHub Marketplace Action Controller
+
+This skill packages the DSG Governance Control Plane capabilities as distributable **GitHub Marketplace Actions** — reusable CI/CD building blocks that any team can drop into their workflow to gate, audit, and prove AI agent actions.
+
+***
+
+## When to use this skill
+
+| User asks about                                    | Use this skill |
+| -------------------------------------------------- | -------------- |
+| "Create a GitHub Action that gates AI actions"     | ✅ Yes          |
+| "Package the DSG gate as a reusable action"        | ✅ Yes          |
+| "Publish DSG governance to the GitHub Marketplace" | ✅ Yes          |
+| "Add a governance check to our CI pipeline"        | ✅ Yes          |
+| "Validate deployment readiness with DSG proof"     | ✅ Yes          |
+| "Writing a plain GitHub Action unrelated to DSG"   | ❌ Out of scope |
+
+***
+
+## Available DSG GitHub Actions
+
+### 1. `dsg-gate-evaluate` — Gate any action before execution
+
+```yaml
+- uses: tdealer01-crypto/dsg-control-plane/.github/actions/gate-evaluate@v1
+  with:
+    dsg_api_key: ${{ secrets.DSG_API_KEY }}
+    agent_id: ${{ vars.AGENT_ID }}
+    action_type: deployment
+    risk_level: high
+    action_description: "Deploy ${{ github.repository }} to production"
+    idempotency_key: ${{ github.run_id }}-${{ github.run_attempt }}
+```
+
+Output: `gate_status`, `proof_hash`, `policy_version`
+
+### 2. `dsg-compliance-evidence` — Generate compliance evidence pack
+
+```yaml
+- uses: tdealer01-crypto/dsg-control-plane/.github/actions/compliance-evidence@v1
+  with:
+    dsg_api_key: ${{ secrets.DSG_API_KEY }}
+    evidence_level: L3
+    output_path: ./compliance-output/
+```
+
+Output: `evidence_bundle_path`, `hash_manifest_path`, `matrix_json`
+
+### 3. `dsg-go-no-go` — Production GO/NO-GO gate
+
+```yaml
+- uses: tdealer01-crypto/dsg-control-plane/.github/actions/go-no-go@v1
+  with:
+    dsg_api_key: ${{ secrets.DSG_API_KEY }}
+    production_url: https://your-app.vercel.app
+    repo_url: ${{ github.server_url }}/${{ github.repository }}
+```
+
+Output: `go_no_go_decision`, `readiness_report_id`, `proof_hash`
+
+***
+
+## Packaging a new DSG GitHub Action
+
+Structure for a publishable GitHub Marketplace Action:
+
+```
+.github/actions/<action-name>/
+├── action.yml          ← action manifest (inputs, outputs, runs)
+├── src/
+│   └── main.ts         ← TypeScript entry point
+├── dist/
+│   └── index.js        ← compiled + bundled (committed to repo)
+├── README.md           ← marketplace readme
+└── package.json
+```
+
+### `action.yml` template
+
+```yaml
+name: DSG Gate Evaluate
+description: Evaluate a proposed agent action through the DSG deterministic safety gate
+branding:
+  icon: shield
+  color: blue
+inputs:
+  dsg_api_key:
+    description: DSG API key (use secrets)
+    required: true
+  agent_id:
+    description: Active agent identifier
+    required: true
+  action_type:
+    description: Category of the proposed action
+    required: true
+  risk_level:
+    description: Risk level — low | medium | high | critical
+    required: false
+    default: medium
+  action_description:
+    description: Human-readable description of the action
+    required: false
+  idempotency_key:
+    description: Prevents duplicate evaluations
+    required: true
+outputs:
+  gate_status:
+    description: PASS | BLOCK | REVIEW
+  proof_hash:
+    description: SHA256 proof hash for replay
+  policy_version:
+    description: Policy version at time of evaluation
+runs:
+  using: node20
+  main: dist/index.js
+```
+
+***
+
+## GO/NO-GO decision rules (deterministic)
+
+A CI gate MUST fail the workflow when:
+
+| Condition                                               | Decision                       |
+| ------------------------------------------------------- | ------------------------------ |
+| `gate_status == BLOCK`                                  | NO-GO — halt job immediately   |
+| `gate_status == REVIEW` and no human approval           | NO-GO — require approval       |
+| `gate_status == UNSUPPORTED` and `risk_level >= medium` | NO-GO                          |
+| `proof_hash` is empty or missing                        | NO-GO — evidence gap           |
+| HTTP 402 (quota exceeded)                               | NO-GO — upgrade required       |
+| HTTP 429 (rate limit)                                   | Retry with backoff, then NO-GO |
+
+A CI gate MUST pass when:
+
+| Condition                                              | Decision                    |
+| ------------------------------------------------------ | --------------------------- |
+| `gate_status == PASS` and `proof_hash` present         | GO                          |
+| `gate_status == REVIEW` and operator approval recorded | GO (with approval evidence) |
+
+***
+
+## Security rules for action authors
+
+* **Never** echo `dsg_api_key` to logs — use `core.setSecret(apiKey)`.
+* **Never** store `dsg_api_key` in action outputs — only non-sensitive gate results.
+* Always use `secrets.*` for DSG API keys, never `vars.*`.
+* Pin action versions with SHA (`@sha256:...`) for supply-chain security.
+* Build with `ncc` or `esbuild` to produce a self-contained `dist/index.js`.
+
+***
+
+## References
+
+* \<references/action-yml-spec.md> — Full `action.yml` field reference
+* \<references/go-no-go-logic.md> — Complete GO/NO-GO decision tree
+* Gate evaluate API: see `dsg-action-layer-ged` skill → `references/gate-evaluate.md`

--- a/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/references/README.md
+++ b/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/references/README.md
@@ -1,0 +1,2 @@
+# references
+

--- a/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/references/action-yml-spec.md
+++ b/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/references/action-yml-spec.md
@@ -1,0 +1,62 @@
+# GitHub Action `action.yml` Spec — DSG Reference
+
+## Required fields
+
+```yaml
+name: string          # Display name in GitHub Marketplace
+description: string   # One-line description (≤ 125 chars)
+branding:
+  icon: string        # Feather icon name (e.g. shield, lock, check-circle)
+  color: string       # blue | green | orange | red | purple | yellow | gray | white
+inputs:
+  <input_id>:
+    description: string
+    required: boolean
+    default: string   # optional
+outputs:
+  <output_id>:
+    description: string
+runs:
+  using: node20       # or composite
+  main: dist/index.js
+```
+
+## DSG-specific branding convention
+
+All DSG actions use:
+```yaml
+branding:
+  icon: shield
+  color: blue
+```
+
+## Input naming convention
+
+| Input | Type | Notes |
+|---|---|---|
+| `dsg_api_key` | secret | Always required — never logged |
+| `agent_id` | string | Active agent identifier |
+| `action_type` | string | Category label for the action |
+| `risk_level` | enum | `low` \| `medium` \| `high` \| `critical` |
+| `idempotency_key` | string | Use `${{ github.run_id }}-${{ github.run_attempt }}` |
+| `nonce` | string | Auto-generated if omitted |
+
+## Output naming convention
+
+| Output | Type | Notes |
+|---|---|---|
+| `gate_status` | string | `PASS` \| `BLOCK` \| `REVIEW` |
+| `proof_hash` | string | sha256:... — store for replay |
+| `policy_version` | string | Pin for audit trail |
+| `report_id` | string | Shareable evidence report ID |
+
+## Build requirement
+
+Actions must commit a self-contained `dist/index.js`.
+Use `@vercel/ncc` or `esbuild` to bundle:
+
+```bash
+npx @vercel/ncc build src/main.ts -o dist --minify
+```
+
+Commit `dist/` to the repository — GitHub Actions does not run `npm install`.

--- a/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/references/go-no-go-logic.md
+++ b/plugins/dsg-governance/skills/dsg-github-marketplace-action-controller/references/go-no-go-logic.md
@@ -1,0 +1,73 @@
+# GO/NO-GO Decision Logic — DSG Reference
+
+## Decision tree
+
+```
+gate_status == BLOCK
+  → NO-GO (halt immediately, log proofHash as evidence)
+
+gate_status == UNSUPPORTED AND risk_level IN [medium, high, critical]
+  → NO-GO
+
+gate_status == UNSUPPORTED AND risk_level == low
+  → REVIEW (request human check)
+
+gate_status == REVIEW AND no_approval_recorded
+  → NO-GO (gate on approval)
+
+gate_status == REVIEW AND approval_recorded
+  → GO (with approval evidence stored)
+
+gate_status == PASS AND proof_hash present
+  → GO
+
+proof_hash empty OR missing
+  → NO-GO (evidence gap — never proceed without proof)
+
+HTTP 402 (quota exceeded)
+  → NO-GO (upgrade required — show upgradeUrl)
+
+HTTP 429 (rate limit)
+  → Retry with exponential backoff (max 3 retries)
+  → If still 429 after retries → NO-GO
+
+HTTP 5xx
+  → Retry with backoff (max 2 retries)
+  → If still failing → NO-GO (gate is unavailable — fail closed)
+```
+
+## CI workflow integration
+
+```yaml
+- name: DSG Gate — Production Deploy
+  id: dsg_gate
+  uses: tdealer01-crypto/dsg-control-plane/.github/actions/gate-evaluate@v1
+  with:
+    dsg_api_key: ${{ secrets.DSG_API_KEY }}
+    agent_id: ${{ vars.DEPLOY_AGENT_ID }}
+    action_type: production_deployment
+    risk_level: high
+    idempotency_key: ${{ github.run_id }}-${{ github.run_attempt }}
+
+- name: Halt if BLOCK
+  if: steps.dsg_gate.outputs.gate_status == 'BLOCK'
+  run: |
+    echo "DSG Gate BLOCK: ${{ steps.dsg_gate.outputs.proof_hash }}"
+    exit 1
+
+- name: Request approval if REVIEW
+  if: steps.dsg_gate.outputs.gate_status == 'REVIEW'
+  uses: tdealer01-crypto/dsg-control-plane/.github/actions/request-approval@v1
+  with:
+    dsg_api_key: ${{ secrets.DSG_API_KEY }}
+    proof_hash: ${{ steps.dsg_gate.outputs.proof_hash }}
+```
+
+## Fail-closed principle
+
+If the gate endpoint is unreachable or returns an unexpected status:
+- **Always fail closed** (NO-GO)
+- Log the HTTP status and `proofHash` (if available) as evidence
+- Never default to PASS when gate is unavailable
+
+This mirrors financial system design: if the risk engine is down, transactions halt.

--- a/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/README.md
+++ b/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/README.md
@@ -1,0 +1,2 @@
+# dsg-multi-governance-orchestrator
+

--- a/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/SKILL.md
+++ b/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: dsg-multi-governance-orchestrator
+version: 1.0.0
+author: DSG Team
+license: MIT
+description: >-
+  Use this skill for DSG multi-source governance work that combines UI trust
+  upgrades, action-layer permission gates, deterministic execution,
+  marketplace/enterprise cutover, portable SaaS architecture
+---
+
+# DSG Multi-Governance Orchestrator
+
+This skill coordinates **multi-source governance work** across the DSG Control Plane — combining UI trust upgrades, deterministic gate execution, marketplace cutover, architecture documentation, and production GO/NO-GO validation into a single explainable plan.
+
+***
+
+## When to use this skill
+
+| Trigger phrase                               | Task                                                 |
+| -------------------------------------------- | ---------------------------------------------------- |
+| "DSG multi" / "ผสานมัลติ"                    | Multi-source governance orchestration                |
+| "M1 cutover" / "M2 hardening"                | Milestone cutover planning and validation            |
+| "marketplace cutover"                        | Enterprise marketplace launch readiness              |
+| "architecture page" / "DSG ONE architecture" | Architecture page generation                         |
+| "action layer gate"                          | Permission gate integration across multiple services |
+| "deterministic execution"                    | Deterministic pipeline coordination                  |
+| "production GO/NO-GO"                        | Full production readiness gate                       |
+| "Termux/Codex/Multica bootstrap"             | Mobile/local agent setup                             |
+| "5 files" / "ทำเป็นสกิว"                     | Multi-file governance deliverable                    |
+| "launch readiness"                           | M1/M2 launch checklist and validation                |
+
+***
+
+## M1 / M2 Launch Milestones
+
+### M1: Production Cutover
+
+Required green gates before M1 GO:
+
+* [ ] `GET /api/health` → `{ ok: true }`
+* [ ] `GET /api/readiness` → `{ ok: true, db: true }`
+* [ ] `GET /api/agent/status` → correct commit + environment
+* [ ] `POST /api/dsg/v1/gates/evaluate` → PASS with proof hash
+* [ ] Supabase migrations applied (verified by query, not file existence)
+* [ ] Protected routes reject unauthenticated access (401/redirect)
+* [ ] `npm run go:no-go <production-url>` → PASS
+* [ ] Revenue events route functional (authenticated)
+* [ ] DSG gate quota enforced (Free: 50 evals, Pro: 5k, Enterprise: unlimited)
+
+**Default posture: NO-GO until all gates above are green with current evidence.**
+
+### M2: Hardening + Launch
+
+Additional gates for M2:
+
+* [ ] Compliance evidence pack generated (`npm run ccvs:pipeline`)
+* [ ] Secret scanning clean (`npm run test:secrets` or gitleaks CI)
+* [ ] CodeQL clean (no high/critical alerts)
+* [ ] Delivery Proof scan returns shareable report
+* [ ] Stripe billing active (not test mode) for paid tiers
+* [ ] Hermes executor integration test passing (Enterprise tier)
+* [ ] End-to-end replay test: evaluate → store → replay → match
+
+***
+
+## Multi-source orchestration plan format
+
+When the user says "plan the governance for X", produce a plan in this structure:
+
+```
+Goal: <what the user wants to achieve>
+
+Architecture:
+  <describe the governance layers involved>
+
+Ordered Work Stages:
+  Stage 1: Gate evaluation (Before execution)
+  Stage 2: Execution + conformance (During)
+  Stage 3: Evidence commit + replay storage (After)
+  Stage 4: Compliance pack generation (Periodic)
+  Stage 5: Audit export (On demand)
+
+Risks:
+  - <risk 1> → <mitigation>
+  - <risk 2> → <mitigation>
+
+Permission Checkpoints:
+  - HIGH/CRITICAL actions require explicit operator approval
+  - Policy version must be pinned before evaluation
+  - UNSUPPORTED → REVIEW/BLOCK (never PASS)
+
+GO/NO-GO gate:
+  <list the specific evidence items needed before proceeding>
+```
+
+***
+
+## Architecture page generation
+
+When asked to generate a DSG ONE architecture page, include:
+
+1. **Control Plane layers** — Gate / Spine / Evidence / Audit
+2. **Trust boundaries** — what the agent can and cannot do
+3. **Evidence flow** — from gate call to Supabase to replay
+4. **Pricing surface** — Free / Pro / Enterprise entitlements
+5. **Marketplace entry points** — how external teams integrate
+
+Architecture pages are portable SaaS documentation artifacts. Do not claim "production-ready architecture" unless all M1 gates are green.
+
+***
+
+## Termux/Codex/Multica bootstrap
+
+Practical path: `Termux host → proot-distro → Debian guest → Codex CLI + Multica CLI/daemon`
+
+Setup source of truth:
+
+* `scripts/termux-proot-codex-multica-setup.sh`
+* `docs/TERMUX_CODEX_MULTICA_STATUS_AND_PLAN.md`
+
+Do not mark Termux/Codex/Multica setup as merged or validated until real-device validation passes: bootstrap + auth + daemon status + end-to-end smoke task.
+
+***
+
+## Deterministic execution protocol
+
+For multi-agent / parallel work:
+
+1. **T0** — Input lock (snapshot all inputs)
+2. **T1** — Dependency graph build
+3. **T2** — Isolated parallel execution for independent work
+4. **T3** — Deterministic merge by stable ordering
+5. **T4** — Verification gate with replay/hash/check evidence
+
+Same input snapshot must produce same final artifacts, test outcomes, and release decision. Fail fast on: nondeterministic output, hidden shared state, wall-clock leakage, flaky evidence, write collisions.
+
+***
+
+## References
+
+* \<references/m1-m2-checklist.md> — Full M1/M2 gate checklist
+* \<references/architecture-template.md> — Architecture page template
+* Gate API: see `dsg-action-layer-ged` skill → `references/gate-evaluate.md`
+* Hermes: see `dsg-action-layer-ged` skill → `references/hermes-executor.md`

--- a/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/references/README.md
+++ b/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/references/README.md
@@ -1,0 +1,2 @@
+# references
+

--- a/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/references/architecture-template.md
+++ b/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/references/architecture-template.md
@@ -1,0 +1,131 @@
+# DSG ONE Architecture Page Template
+
+## Header
+
+```
+Product: DSG ONE / ProofGate Control Plane
+Version: <current version from GET /api/agent/status>
+Date: <ISO 8601>
+Claim posture: evidence-ready | pre-audit | production-connected
+```
+
+---
+
+## 1. Product identity
+
+**What it is:** AI Governance Control Plane — not an AI Agent, but the layer that
+governs what AI Agents are *allowed* to do.
+
+**Value proposition:**
+> "Every Agent decision provable, auditable, and replayable with Deterministic Gate,
+> Cryptographic Proof, Compliance Evidence Pack, and Hermes Controlled Executor."
+
+**Market position:**
+- Cloudflare → Control Plane of the Internet
+- Datadog → Control Plane of Observability
+- **DSG → Control Plane of AI Governance**
+
+---
+
+## 2. Architecture layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    USER / AGENT REQUEST                     │
+└──────────────────────────┬──────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│              DETERMINISTIC SAFETY GATE (L1)                 │
+│  Input → Policy → Proof → Decision (PASS / BLOCK / REVIEW)  │
+│  proofHash + constraintSetHash + policyVersion stored        │
+└──────────────────────────┬──────────────────────────────────┘
+                           ↓ (if PASS or approved REVIEW)
+┌─────────────────────────────────────────────────────────────┐
+│              RUNTIME SPINE (L2)                             │
+│  Quota check → Approval workflow → Isolation context        │
+│  Before / During / After lifecycle governance               │
+└──────────────────────────┬──────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│              HERMES CONTROLLED EXECUTOR (L3)                │
+│  planHash → Conformance check → Credential lease            │
+│  Command whitelist → Path isolation → Evidence capture      │
+└──────────────────────────┬──────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│              EVIDENCE STORE (Supabase)                      │
+│  proofHash, inputHash, policyVersion, pipeline_trace        │
+│  runtime_intent_id, ledger_sequence, approval record        │
+└──────────────────────────┬──────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────┐
+│              REPLAY ENGINE                                  │
+│  proofHash + policyVersion + inputHash → same decision      │
+│  Answers: "Why did AI decide X six months ago?"             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Trust boundaries
+
+| What agents CAN do | What agents CANNOT do without gate |
+|---|---|
+| Read-only queries (low risk) | Write production data |
+| Public endpoint calls | Access credentials |
+| Cached/deterministic operations | Execute multi-step plans |
+| Return plans for human review | Bypass conformance check |
+
+---
+
+## 4. Evidence flow
+
+```
+Gate call
+  → proofHash stored
+  → policyVersion pinned
+  → inputHash recorded
+
+Execution
+  → planHash matched
+  → commands whitelisted
+  → paths enforced
+  → evidence captured
+
+Commit
+  → runtime_evidence written to Supabase
+  → ledger_sequence incremented
+  → audit trail complete
+
+Replay (any future date)
+  → proofHash + policyVersion + inputHash → reproduce original decision
+  → comparison result: MATCH | MISMATCH | DEGRADED
+```
+
+---
+
+## 5. Pricing surface
+
+| Tier | Evals/month | Price | Features |
+|---|---|---|---|
+| Free | 50 | $0 | Gate evaluate + proof |
+| Pro | 5 000 | $99/month | + Compliance bundle access |
+| Enterprise | Unlimited | $499/month | + SLA + Hermes executor |
+
+Upgrade: `/pricing#dsg-gate`
+
+---
+
+## 6. Open gaps (production hardening)
+
+From current evidence:
+
+| Gap | Status |
+|---|---|
+| UNSUPPORTED decision handling | In progress |
+| Policy version consistency across replicas | In progress |
+| Credential rotation in Hermes broker | Scaffolded, not live |
+| End-to-end replay test | Scaffolded, not validated |
+| Integration coverage | Partial |
+
+These are production hardening items — core architecture is complete.

--- a/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/references/m1-m2-checklist.md
+++ b/plugins/dsg-governance/skills/dsg-multi-governance-orchestrator/references/m1-m2-checklist.md
@@ -1,0 +1,81 @@
+# M1/M2 Gate Checklist — DSG Reference
+
+## M1: Production Cutover checklist
+
+```
+Public health probes
+[ ] GET /api/health                → { ok: true }
+[ ] GET /api/readiness             → { ok: true, db: true }
+[ ] GET /api/agent/status          → correct commit + environment + db check
+
+DSG Gate functionality
+[ ] GET  /api/dsg/v1/policies/manifest → policyVersion + constraintSetHash present
+[ ] POST /api/dsg/v1/gates/evaluate    → gateStatus: PASS with proofHash
+[ ] POST /api/dsg/v1/proofs/prove      → proof reproducible from stored hash
+[ ] GET  /api/dsg/v1/pricing           → tier definitions correct
+
+Auth and protected routes
+[ ] Unauthenticated GET /dashboard → 401 or redirect to login
+[ ] Unauthenticated GET /approvals → 401 or redirect to login
+[ ] Invalid ****** → 401 on all /api/dsg/v1/* routes
+
+Database
+[ ] Supabase migrations applied (verified by query result, not file existence)
+[ ] dsg_gate_usage table exists with correct schema
+[ ] runtime_evidence table exists with correct schema
+
+Deployment
+[ ] Vercel deployment status: Ready
+[ ] Required env vars present by name (not value): DSG_ACCESS_TOKEN, SUPABASE_URL, SUPABASE_ANON_KEY
+[ ] npm run go:no-go <production-url> → PASS
+```
+
+**Default: NO-GO until all boxes checked with current evidence.**
+
+---
+
+## M2: Hardening + Launch checklist
+
+```
+Compliance evidence
+[ ] npm run ccvs:pipeline → L1-L5 matrix generated without FAIL
+[ ] ccvs-compliance-matrix.json present with passing evidence chain
+[ ] SHA256SUMS generated over evidence bundle
+
+Security
+[ ] Secret scanning clean (gitleaks + GitHub secret scanning: 0 open alerts)
+[ ] CodeQL: 0 high/critical open alerts
+[ ] npm audit --audit-level=high → 0 vulnerabilities
+
+Billing
+[ ] Stripe keys are production (not test) for paid tiers
+[ ] DSG Gate Pro ($99/mo) creates Stripe checkout session
+[ ] DSG Gate Enterprise ($499/mo) creates Stripe checkout session
+[ ] Quota enforcement: Free tier blocked at 51st evaluation
+
+Evidence replay
+[ ] End-to-end replay test: evaluate → store proofHash → prove → decision matches
+[ ] Policy version consistency: changing policyVersion invalidates cached replay
+
+Hermes (Enterprise tier only)
+[ ] Plan proposal generates deterministic planHash
+[ ] Conformance gate blocks mismatched planHash
+[ ] Credential broker returns lease fingerprint (not raw secret)
+[ ] Evidence capture stores step results in Supabase
+```
+
+---
+
+## Evidence record format (per M1/M2 gate)
+
+When reporting M1 or M2 status, always include:
+
+```
+Gate: <name>
+Status: GO | NO-GO | PENDING | BLOCKED
+Evidence: <command run + result OR "Not run — <reason>">
+Timestamp: <ISO 8601>
+Known limits: <what is still pending>
+```
+
+Never claim GO without current evidence. Use PENDING if evidence is missing.

--- a/plugins/dsg-verify/.claude-plugin/plugin.json
+++ b/plugins/dsg-verify/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dsg-verify",
+  "description": "Slash commands that wrap the DSG Control Plane verification ladder: typecheck, targeted route verification, and a pre-PR check. References only npm scripts that exist in package.json.",
+  "version": "1.0.0",
+  "author": { "name": "DSG ONE / ProofGate" },
+  "homepage": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane",
+  "keywords": ["verification", "typecheck", "vitest", "build", "ci", "dsg"]
+}

--- a/plugins/dsg-verify/commands/pre-pr-check.md
+++ b/plugins/dsg-verify/commands/pre-pr-check.md
@@ -1,0 +1,48 @@
+---
+description: Run the full pre-PR verification gate (typecheck, tests, build) for the DSG Control Plane
+allowed-tools: Bash(npm run typecheck), Bash(npm run test), Bash(npm run test:*), Bash(npm run build), Bash(npm run lint)
+---
+
+# /pre-pr-check — Pre-PR verification gate
+
+Run the fuller set of checks before opening a PR, matching the
+TypeScript/app-code tier of the verification ladder (CLAUDE.md section 6).
+Run them in order and stop to report at the first hard failure.
+
+1. Typecheck:
+
+   ```bash
+   npm run typecheck
+   ```
+
+2. Lint (fast, catches obvious issues):
+
+   ```bash
+   npm run lint
+   ```
+
+3. Test suite (or the targeted suites relevant to the change):
+
+   ```bash
+   npm run test
+   ```
+
+4. Build — this is the only check that proves Next.js pages/routes compile:
+
+   ```bash
+   npm run build
+   ```
+
+Key rules (CLAUDE.md sections 6, 23):
+
+- A passing `npm run test` does **not** prove `npm run build` passes. Do not
+  skip the build for page/component/route changes.
+- Report each command with its exact pass/fail result. If a command was not
+  run because the environment is not configured, write `Not run` and the
+  reason — never claim a pass without real output.
+- These checks are for the app. Live DB, live browser, and production
+  go/no-go checks require real credentials and are out of scope here; use
+  `npm run go:no-go <url>` separately when a production gate is in scope.
+
+When done, produce the `Verification:` block for the PR body (see the
+`pr-body-helper` plugin) using the real results.

--- a/plugins/dsg-verify/commands/typecheck.md
+++ b/plugins/dsg-verify/commands/typecheck.md
@@ -1,0 +1,28 @@
+---
+description: Run the DSG Control Plane TypeScript typecheck and summarize results
+allowed-tools: Bash(npm run typecheck)
+---
+
+# /typecheck — TypeScript typecheck
+
+Run the repo's typecheck, which is the narrowest check for a TypeScript/app
+code change (CLAUDE.md section 6).
+
+Command:
+
+```bash
+npm run typecheck
+```
+
+This runs `tsc --noEmit -p tsconfig.typecheck.json`.
+
+After running:
+
+- Report the exact command and whether it passed or failed.
+- If it failed, list the first few `error TS...` lines with file:line and
+  propose the smallest fix — do not silence errors by widening types blindly.
+- Remind the reader that a passing typecheck does **not** prove `next build`
+  passes; use `/pre-pr-check` before opening a PR.
+
+If you could not run it (environment not configured), say `Not run` and the
+reason. Do not claim a pass without real output.

--- a/plugins/dsg-verify/commands/verify-route.md
+++ b/plugins/dsg-verify/commands/verify-route.md
@@ -1,0 +1,55 @@
+---
+description: Verify a changed API route with targeted tests per the verification ladder
+argument-hint: "[route path, e.g. app/api/health/route.ts]"
+allowed-tools: Bash(npm run test:*), Bash(npm run typecheck), Bash(bash scripts/check-request-body-safety.sh), Bash(npm audit:*)
+---
+
+# /verify-route — Targeted API route verification
+
+Verify a change to an API route (`$ARGUMENTS`) using the API route / security
+tier of the verification ladder (CLAUDE.md section 6).
+
+Run the narrowest checks that prove the change:
+
+1. Typecheck:
+
+   ```bash
+   npm run typecheck
+   ```
+
+2. Targeted tests — pick the suite that covers the route:
+
+   ```bash
+   npm run test:unit
+   npm run test:integration
+   ```
+
+   If a specific test file exists for the route, prefer running just that file:
+
+   ```bash
+   npm run test -- <path/to/route.test.ts>
+   ```
+
+3. Request body safety (for POST/PUT/PATCH routes):
+
+   ```bash
+   bash scripts/check-request-body-safety.sh
+   ```
+
+4. Dependency audit when the change touches dependencies:
+
+   ```bash
+   npm audit --audit-level=high
+   ```
+
+Reporting rules:
+
+- Report each command and its real pass/fail/warning result.
+- For public endpoints, only run live/local `curl` when the environment is
+  configured and authorized; otherwise say `Not run`.
+- Confirm the route follows conventions: `dynamic = 'force-dynamic'` where
+  needed, async `params` shape for dynamic routes, `readJsonBody(...)` with an
+  explicit max size on critical POST/PUT/PATCH routes, and auth implemented in
+  the route rather than assumed from middleware.
+- A passing Vitest suite does not prove `next build` passes — run `/pre-pr-check`
+  before opening a PR.

--- a/plugins/evidence-guard/.claude-plugin/plugin.json
+++ b/plugins/evidence-guard/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "evidence-guard",
+  "description": "Enforces the DSG Control Plane truth boundary and claim policy. Helps classify statements as verified fact / inference / pending / blocked / not verified and warns about forbidden readiness claims. Ships an advisory PostToolUse hook.",
+  "version": "1.0.0",
+  "author": { "name": "DSG ONE / ProofGate" },
+  "homepage": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane",
+  "keywords": ["truth-boundary", "claim-policy", "evidence", "hooks", "governance", "dsg"]
+}

--- a/plugins/evidence-guard/hooks/hooks.json
+++ b/plugins/evidence-guard/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/claim-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/evidence-guard/scripts/claim-lint.sh
+++ b/plugins/evidence-guard/scripts/claim-lint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# evidence-guard: advisory PostToolUse hook for the DSG ONE / ProofGate repo.
+#
+# Reads the PostToolUse event JSON on stdin, scans the written/edited content
+# for forbidden readiness claims (CLAUDE.md section 1), and prints an advisory
+# to stderr when one is found. This hook is ADVISORY ONLY: it always exits 0 so
+# it never blocks a legitimate edit. It reminds the author to attach fresh
+# evidence or downgrade the claim (verified fact / inference / pending /
+# blocked / not verified).
+#
+# No external dependencies beyond a POSIX shell and grep. Safe to no-op if
+# stdin is empty or grep is unavailable.
+
+set -u
+
+payload="$(cat 2>/dev/null || true)"
+
+if [ -z "${payload}" ]; then
+  exit 0
+fi
+
+if ! command -v grep >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Forbidden claims that require fresh evidence before use.
+patterns='production-ready|marketplace-ready|enterprise-ready 100%|full customer production go-live|certified compliance|guaranteed compliance|third-party audited|WORM-certified storage|JWT/JWKS auth complete|real cryptographic signing complete|external production Z3 solver invocation|mainnet launched'
+
+matches="$(printf '%s' "${payload}" | grep -ioE "${patterns}" 2>/dev/null | sort -u || true)"
+
+if [ -n "${matches}" ]; then
+  {
+    echo "evidence-guard: advisory — forbidden readiness claim(s) detected in this change:"
+    printf '%s\n' "${matches}" | sed 's/^/  - /'
+    echo "These claims require fresh evidence (CLAUDE.md section 1)."
+    echo "Either attach current evidence or downgrade to: verified fact / inference / pending / blocked / not verified."
+    echo "This is advisory only; the edit was not blocked."
+  } 1>&2
+fi
+
+exit 0

--- a/plugins/evidence-guard/skills/claim-policy/SKILL.md
+++ b/plugins/evidence-guard/skills/claim-policy/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: claim-policy
+description: >-
+  Apply the DSG ONE / ProofGate truth boundary and claim policy. Use when
+  writing or reviewing any status, readiness, compliance, or capability
+  statement destined for code, docs, commits, PRs, issues, comments, logs, or
+  a response. Classifies each statement as verified fact / inference / pending
+  / blocked / not verified, and flags forbidden readiness claims that require
+  fresh evidence.
+---
+
+# Claim Policy (DSG ONE / ProofGate)
+
+This repository is evidence-first. Do not put false text, fake evidence,
+guessed status, or exaggerated readiness into any artifact. When you make a
+claim, attach its classification and its evidence.
+
+## Classify every important statement
+
+Label each load-bearing statement as exactly one of:
+
+- **verified fact** — backed by inspected repo files, real command output,
+  GitHub/Supabase/Vercel metadata, or a live authorized endpoint response.
+  Cite the evidence (file, command, query, or response).
+- **inference** — a reasonable conclusion from evidence, but not directly
+  observed. Say what it is inferred from.
+- **pending** — expected but not yet checked; state what check would confirm it.
+- **blocked** — cannot be checked now; state the blocker.
+- **not verified** — asserted elsewhere (README, past PR, memory) but not
+  confirmed against current state.
+
+If evidence is missing, use `pending`, `blocked`, or `not verified` — never
+upgrade to `verified fact`.
+
+## Forbidden claims without fresh evidence
+
+Do not use these unless current evidence proves them:
+
+- `production-ready`
+- `marketplace-ready`
+- `enterprise-ready 100%`
+- `full customer production go-live`
+- `certified compliance`
+- `guaranteed compliance`
+- `third-party audited`
+- `WORM-certified storage`
+- `JWT/JWKS auth complete`
+- `real cryptographic signing complete`
+- `external production Z3 solver invocation`
+- `mainnet launched`
+- `TVL / DAU / users`
+
+## Allowed wording (when evidence supports it)
+
+- `production-connected`
+- `evidence-ready`
+- `audit-ready`
+- `governance-enabling`
+- `deterministic gate scaffold`
+- `setup-ready`
+- `pre-audit evidence mapping`
+
+## Common traps (CLAUDE.md section 23)
+
+- Passing `npm test` does not prove `next build` passes.
+- A migration file existing does not prove it is applied to production.
+- A generated Supabase type existing does not prove the live DB object exists.
+- A route file existing does not prove the deployed route is live.
+- A passing design-time proof does not prove end-to-end production proof.
+- `UNSUPPORTED` is never `PASS`.
+- Mock data must never be described as production data.
+- Docs saying "encrypted" are not enough; verify the implementation.
+
+## How to respond
+
+Rewrite risky statements into honest ones. Example:
+
+- Before: "Billing is production-ready."
+- After: "Billing quota gate code exists in `lib/billing/` (verified fact:
+  file inspected). Live Stripe/Supabase billing for the target environment is
+  `not verified` — needs current Stripe/Vercel/Supabase evidence."
+
+When the honest answer is "not ready," say so and give the shortest safe path
+to readiness.

--- a/plugins/pr-body-helper/.claude-plugin/plugin.json
+++ b/plugins/pr-body-helper/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pr-body-helper",
+  "description": "Generates a PR body matching the DSG Control Plane mandatory format (Goal / Files changed / Verification / Known limits / User-visible benefit / Next step), with honest 'Not run' handling for unrun checks.",
+  "version": "1.0.0",
+  "author": { "name": "DSG ONE / ProofGate" },
+  "homepage": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane",
+  "keywords": ["pull-request", "pr-body", "template", "workflow", "dsg"]
+}

--- a/plugins/pr-body-helper/commands/pr-body.md
+++ b/plugins/pr-body-helper/commands/pr-body.md
@@ -1,0 +1,62 @@
+---
+description: Generate a DSG Control Plane PR body in the repo's mandatory format
+argument-hint: "[short goal of the change]"
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*)
+---
+
+# /pr-body — Generate the mandatory PR body
+
+Produce a PR body that matches the required format in CLAUDE.md section 20 and
+the PR hygiene rules in AGENTS.md. Use the change described in `$ARGUMENTS`
+plus the actual working-tree state.
+
+## Gather real context first
+
+Inspect the actual changes (do not invent a file list):
+
+```bash
+git status --short
+git diff --stat
+```
+
+List only files this change actually touched. Never use guessed paths.
+
+## Emit exactly this structure
+
+```text
+Goal:
+<one or two sentences: the user goal this change serves>
+
+Files changed:
+- <path> — <what changed and why>
+- <path> — <what changed and why>
+
+Verification:
+- [ ] <command> — <pass/fail/warning result>
+- [ ] <command> — <pass/fail/warning result>
+
+Known limits:
+- <what is not covered, mock vs live, pending checks>
+
+User-visible benefit:
+- What can the user do now?
+- What became easier?
+- What proof shows it works?
+- What is the next step?
+
+Next step:
+<the shortest safe path forward>
+```
+
+## Rules (CLAUDE.md sections 1, 20; AGENTS.md)
+
+- Every `Verification` line must reflect a command that was actually run. If a
+  command was not run, write `Not run` and the reason — do not fake a pass.
+- Do not hide failing tests. Report failures as warnings with exact output.
+- Do not use forbidden readiness claims (see the `evidence-guard` plugin's
+  `claim-policy` skill) unless fresh evidence supports them.
+- Skip any section that would require pasting secrets, tokens, env values, or
+  private hostnames — describe the code change instead.
+- Leave production release status `NO-GO` unless all live gates pass.
+
+Output only the finished PR body, ready to paste.

--- a/plugins/proofgate-review/.claude-plugin/plugin.json
+++ b/plugins/proofgate-review/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "proofgate-review",
+  "description": "Governance-aware code review for the DSG ONE / ProofGate Control Plane. Reviews changes against the repo's API route conventions, security conventions, truth boundary, runtime spine flow, deterministic gate boundary, and Supabase/RLS rules.",
+  "version": "1.0.0",
+  "author": { "name": "DSG ONE / ProofGate" },
+  "homepage": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane",
+  "keywords": ["governance", "code-review", "security", "dsg", "proofgate"]
+}

--- a/plugins/proofgate-review/agents/security-reviewer.md
+++ b/plugins/proofgate-review/agents/security-reviewer.md
@@ -1,0 +1,70 @@
+---
+name: security-reviewer
+description: >-
+  Security-focused subagent for the DSG ONE / ProofGate Control Plane. Use to
+  audit a diff or set of files for the repo's security rules: no committed
+  secrets, cron routes fail closed without CRON_SECRET, size-limited JSON
+  bodies via readJsonBody, correct CORS helpers, rate limiting, and API auth
+  implemented in the route rather than assumed from middleware. Reports
+  findings with file:line evidence and never invents a violation.
+tools: Read, Grep, Glob, Bash
+---
+
+# Security Reviewer (DSG ONE / ProofGate)
+
+You are a security review subagent for this repository. Audit only what you can
+see in the provided files or the current diff. Anchor every finding to a
+concrete `file:line`. If you cannot confirm something, label it `not verified`
+rather than guessing. Do not print secret values you find — report the location
+and variable name only.
+
+## What to check
+
+1. **No committed or printed secrets** (CLAUDE.md section 9). Search for
+   Supabase service-role keys, Vercel tokens, Stripe keys and webhook secrets,
+   Anthropic/OpenAI/OpenRouter keys, GitHub PATs, cookies, session tokens, and
+   private `.env` values. Only env var *names* belong in the repo. If you find
+   a real-looking secret, report it as a BLOCKER with the file and line, and do
+   not echo the value.
+
+2. **Cron routes fail closed** (CLAUDE.md section 9, 14). Any route under an
+   obvious cron path must reject execution when `CRON_SECRET` is absent. A
+   missing secret must never permit anonymous execution.
+
+3. **Request body safety** (CLAUDE.md section 9). New critical POST/PUT/PATCH
+   routes should use `readJsonBody(...)` with an explicit, small max size.
+   Raw `request.json()` on a critical route is a WARNING unless the blast
+   radius is small and justified in a comment.
+
+4. **API auth is real** (CLAUDE.md section 9). Do not assume `middleware.ts`
+   protects API routes. Confirm the route (or a shared server helper it calls)
+   extracts and validates the Bearer token / API key itself.
+
+5. **CORS and rate limiting** (CLAUDE.md sections 7-9). Routes needing CORS
+   should use `buildCorsHeaders(...)` / `buildPreflightResponse(...)`. Check
+   that public/governed routes apply rate limiting where the surrounding code
+   does.
+
+6. **Dependency overrides** (CLAUDE.md section 9). Flag removal of
+   `overrides` in package.json without an accompanying `npm audit` /
+   build / test justification.
+
+## How to work
+
+- Prefer `Grep` and `Read` over broad shell commands.
+- When useful, run read-only checks such as
+  `bash scripts/check-request-body-safety.sh` or `npm audit --audit-level=high`
+  only if they exist and the environment is configured; otherwise report
+  `Not run` with the reason.
+
+## Output format
+
+```
+BLOCKER — <file:line> — <rule> — <evidence> — <fix>
+WARNING — <file:line> — <rule> — <evidence> — <fix>
+NOTE    — <file:line> — <observation>
+```
+
+Finish with a one-line verdict: `NO-GO` if any BLOCKER remains, otherwise
+`REVIEW` with the open warnings, or `PASS` only when nothing is outstanding and
+you actually inspected the relevant files.

--- a/plugins/proofgate-review/skills/governance-review/SKILL.md
+++ b/plugins/proofgate-review/skills/governance-review/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: governance-review
+description: >-
+  Review code changes in the DSG ONE / ProofGate Control Plane against the
+  repository's own operating rules. Use when reviewing a diff, PR, or new
+  file that touches app/api routes, lib/spine or lib/runtime, lib/dsg
+  deterministic gate code, Supabase migrations, or any change that makes a
+  status/readiness claim. Checks API route conventions, security conventions,
+  the truth boundary, runtime spine flow, the deterministic gate boundary
+  (UNSUPPORTED is never PASS), and Supabase/RLS scoping.
+---
+
+# Governance Review (DSG ONE / ProofGate)
+
+This skill reviews changes against the rules that actually govern this
+repository. It does not replace `npm run typecheck`, `npm run test`, or
+`npm run build` — it is a human-readable review pass to run alongside them.
+
+Anchor every finding to a concrete file and line. Do not claim a rule is
+violated without pointing at the exact code. When you are unsure, label the
+finding `not verified` rather than guessing.
+
+## Review checklist
+
+### 1. Truth boundary (CLAUDE.md section 1)
+
+- Flag any code comment, doc string, log line, PR text, or response that uses
+  a blocked claim without fresh evidence: `production-ready`,
+  `marketplace-ready`, `enterprise-ready 100%`, `certified compliance`,
+  `guaranteed compliance`, `third-party audited`, `WORM-certified storage`,
+  `JWT/JWKS auth complete`, `real cryptographic signing complete`,
+  `external production Z3 solver invocation`, `mainnet launched`,
+  `TVL / DAU / users`.
+- Allowed wording when evidence supports it: `production-connected`,
+  `evidence-ready`, `audit-ready`, `governance-enabling`,
+  `deterministic gate scaffold`, `setup-ready`, `pre-audit evidence mapping`.
+- Mock/demo data must be labelled as such and never described as production
+  data.
+
+### 2. API route conventions (CLAUDE.md sections 7-8)
+
+- Route handlers live in `app/api/**/route.ts`.
+- Routes that must not be statically cached export `dynamic = 'force-dynamic'`.
+- Next.js 15 dynamic params use the async shape
+  `params: Promise<{ id: string }>` and `await params` before reading.
+- Prefer `NextResponse.json(...)` for responses and `handleApiError(...)`
+  where the existing route style uses it.
+- New critical POST/PUT/PATCH routes should use `readJsonBody(...)` with an
+  explicit max size instead of raw `request.json()`; if raw `request.json()`
+  is used, the blast radius must be small and justified.
+
+### 3. Security conventions (CLAUDE.md section 9)
+
+- No secrets committed or printed: Supabase service-role keys, Vercel tokens,
+  Stripe keys/webhook secrets, model provider keys, GitHub PATs, cookies,
+  session tokens, private `.env` values, customer data. Only document env var
+  names.
+- Cron routes must fail closed when `CRON_SECRET` is absent — a missing secret
+  must not allow anonymous execution.
+- Do not assume `middleware.ts` protects API routes; API auth must be
+  implemented in the route or a shared server helper.
+- CORS routes use `buildCorsHeaders(...)` / `buildPreflightResponse(...)`.
+- Dependency `overrides` in package.json should not be removed without audit
+  and justification.
+
+### 4. Runtime spine (CLAUDE.md section 11)
+
+- Governed execution goes through `/api/execute`, `/api/intent`, or
+  `/api/spine/execute`. Do not write around the runtime commit/audit path for
+  governed actions.
+- Expected flow: resolve agent from Bearer token and `agent_id`; check quota
+  and org/agent status; create or reuse the runtime intent/approval key; run
+  the pipeline; commit lineage/audit via the runtime commit RPC; return
+  decision, proof, trace, usage, and sequence metadata.
+- Errors mentioning `runtime_commit_execution`, PostgREST schema cache, or
+  missing runtime RPC/tables point to `docs/RUNBOOK_DEPLOY.md` recovery, not an
+  ad hoc fix.
+
+### 5. Deterministic gate boundary (CLAUDE.md section 12)
+
+- `POST /api/dsg/v1/gates/evaluate` is a DSG-native deterministic adapter; it
+  does not invoke an external Z3 solver. Do not let a change claim external
+  production Z3 invocation from that route.
+- `UNSUPPORTED` must never map to `PASS`. Low-risk `UNSUPPORTED` maps to
+  `REVIEW`; medium/high-risk `UNSUPPORTED` maps to `BLOCK`.
+- Design-time proof scripts (`npm run verify:policy`, `npm run proof:revenue`)
+  prove only the exact models they check; do not upgrade them to end-to-end
+  product proof.
+
+### 6. Supabase and RLS (CLAUDE.md section 10)
+
+- A migration file existing does not prove it is applied; a generated type
+  existing does not prove the live object exists. Say `migration file exists`,
+  not `live DB ready`, without a query result.
+- Dangerous SQL (`DROP`, `TRUNCATE`, broad RLS disablement, permissive
+  policies) needs explicit review and evidence.
+- RLS changes must state who can read/write and how org/workspace scoping is
+  enforced.
+- If schema changes, `lib/database.types.ts` should be regenerated and
+  `npm run typecheck` run.
+
+## Output format
+
+Group findings by severity, and for each finding give file:line, the rule, and
+a concrete suggestion:
+
+```
+BLOCKER  — <file:line> — <rule> — <why> — <suggested fix>
+WARNING  — <file:line> — <rule> — <why> — <suggested fix>
+NOTE     — <file:line> — <observation>
+```
+
+End with the verification the author still needs to run from the ladder
+(section 6), e.g. `npm run typecheck`, targeted `npm run test -- <file>`,
+`npm run build`. If you did not run a check yourself, say `Not run` and why.


### PR DESCRIPTION
Slack thread: https://dsgone.slack.com/archives/D0BGVD99EE6/p1785503955640929?thread_ts=1784612065.947589&cid=D0BGVD99EE6

Goal:

Provide a valid, official-schema Claude Code plugin marketplace (`dsg-plugins`) inside this repo, packaging the repository's own governance-first / evidence-first operating rules as installable plugins. Keep the existing governance plugin, bundle the ising/z3 compliance engine locally, and document its two externally deployed REST APIs (documentation + curl templates only, no secrets).

Files changed (across three commits on this branch):

Marketplace
- `.claude-plugin/marketplace.json` — replaced the previous custom-schema catalog (which failed `claude plugin validate`) with an official-schema `dsg-plugins` marketplace: `owner` object, `metadata.pluginRoot: ./plugins`, six local plugin entries (no external sources).

Plugins (all local, under `./plugins`)
- `proofgate-review/**` — `governance-review` skill + `security-reviewer` agent, encoding the repo's API/security/truth-boundary/runtime-spine/gate/Supabase review rules.
- `dsg-verify/**` — `/typecheck`, `/verify-route`, `/pre-pr-check` slash commands wrapping only npm scripts that exist in `package.json` plus `scripts/check-request-body-safety.sh`.
- `evidence-guard/**` — `claim-policy` skill + advisory `PostToolUse` hook (`claim-lint.sh` warns on forbidden readiness claims, always exits 0).
- `pr-body-helper/**` — `/pr-body` command producing the mandatory PR format.
- `dsg-governance/**` — migrated non-destructively from the existing root plugin: markdown skill content copied for three skills; app-owned `skill.ts` files not copied/moved; root `skills/` left untouched.
- `compliance-ising-z3/**` — bundled locally from `tdealer01-crypto/Compliance-ising-z3-Deterministic-` (Android/Kotlin QUBO/Ising + Z3/SMT-style engine), re-expressed in official format; Android app source/Gradle/assets excluded (bundle 52K); no secrets bundled.

External API documentation (new — under `compliance-ising-z3`, docs + curl only)
- `skills/qubo-optimization-run/SKILL.md` — how to call the DSG QUBO Policy Optimizer API (`https://dsg-qubo-api.vercel.app`, v2.0.0). Verified endpoints, `api_key` query-parameter auth, `domain` enum, required `budget_cap`, `deterministic_seed`, curl templates using `${DSG_QUBO_API_BASE}` / `${DSG_QUBO_API_KEY}`. Warns a real run may trigger solver work / cost.
- `references/external-apis.md` — endpoint inventory for both base URLs (probe date 2026-07-31). Marks `z3-solver-api` `POST /api/solve` as route-only with an UNVERIFIED request/response schema.
- `README.md` — new "External deployed APIs" section (base URLs, `/health`, runtime env vars; `DSG_QUBO_API_KEY` from runtime, never committed).
- `plugin.json` — added `rest-api` / `policy-optimizer` keywords.

Docs
- `plugins/README.md` — add/install instructions for all six plugins.

Verification (real results):

- [x] `claude plugin validate .` — marketplace: `Validation passed`.
- [x] `claude plugin validate ./plugins/<name>` for all six plugins — all `Validation passed`.
- [x] `JSON.parse` on all manifests — parse OK.
- [x] Skill/agent frontmatter — each has `name` + `description` (including new `qubo-optimization-run`).
- [x] Secret grep over the external-API files — no `api_key`/token/password values (passwords are `<runtime>` placeholders; keys are `${DSG_QUBO_API_KEY}` / `<KEY>`).
- [x] `evidence-guard` hook smoke test — forbidden-claim sample produced the advisory and exit 0.
- [x] No `.ts` in `plugins/`; sources have no `..`; six plugin names kebab-case and unique.
- [ ] `npm run typecheck` / `npm run test` / `npm run build` — Not run. All added files are Markdown/JSON/shell tooling outside the Next.js `tsconfig` include path.

Known limits:

- Plugins are advisory workflow/documentation tooling; they do not replace `npm run typecheck`, `npm run test`, or `npm run build`.
- The external APIs are documented only. No real optimization/solver run was executed from this repo, and no `api_key` is stored. The DSG QUBO API is reachable via `/health` (verified 2026-07-31); the `z3-solver-api` `/api/solve` route exists (POST-only) but its schema is not verified.
- `evidence-guard` hook is advisory (stderr, exit 0) and a substring scan.
- `dsg-governance` migrated by copy; original root plugin files remain unchanged. `compliance-ising-z3` bundles agent-facing content only; the Kotlin/Gradle engine must be built in the source repo. Constraint checks are Z3/SMT-style in native Kotlin — no external Z3 process invoked.

User-visible benefit:

- What can the user do now? Add this repo as a Claude Code marketplace, install six governance/compliance plugins, and follow verified curl templates to call the deployed DSG QUBO API.
- What became easier? Governance review, the verification ladder, staying in the truth boundary, the mandatory PR body, and driving the external QUBO optimizer.
- What proof shows it works? `claude plugin validate` passes for the marketplace and all six plugins; the DSG QUBO `/health` check verified reachable (2026-07-31); the hook smoke test produced the expected advisory and exit 0.
- What is the next step? Set `DSG_QUBO_API_KEY` at runtime and try `skills/qubo-optimization-run` against a real domain/budget.

Next step:

Optionally add CI validation of the manifests, verify the `z3-solver-api` `/api/solve` schema with an authorized probe, and decide whether to retire the original root `dsg-governance` plugin definition now that it is mirrored under `plugins/`.