### PR TITLE
Phase 2: Neon multi-tenant infrastructure + Z3 formal proof integration

### DIFF
--- a/docs/PHASE2_PLAN.md
+++ b/docs/PHASE2_PLAN.md
@@ -1,0 +1,206 @@
+# Phase 2: Neon + Z3 Formal Proof Integration Plan
+
+**Branch:** `phase2-test`  
+**Status:** In Progress  
+**Target:** Week 9+ (2026-08-XX)
+
+## Overview
+
+Phase 2 expands DSG ONE from Supabase-only to a dual-database architecture (Supabase + Neon) and integrates Z3 formal proof for deterministic gate decisions at scale. This plan coordinates:
+
+1. **Neon Infrastructure** — PostgreSQL on Neon with multi-tenant RLS
+2. **Z3 Formal Proof** — Apply dsg_gate_decisions table and solver integration
+3. **Load Testing** — 1000 concurrent agents on Phase 2 infrastructure
+4. **GitHub Integration** — Automated PR database branching
+
+---
+
+## Phase 2 Milestones
+
+### Milestone 1: Neon Setup (This Week)
+- [ ] Create Neon project and obtain connection string
+- [ ] Create Phase 2 Neon migrations (org_members, audit_batch_metadata, dsg_gate_decisions)
+- [ ] Set up multi-tenant RLS policies on Neon
+- [ ] Verify connection pooling and performance baseline
+
+### Milestone 2: Z3 Integration
+- [ ] Review and refine dsg_gate_decisions migration (address 7 open blockers)
+- [ ] Apply migration to both Supabase and Neon
+- [ ] Create app-layer route at `POST /api/dsg/v1/gates/evaluate` (currently scaffold only)
+- [ ] Wire solver invocation to the decision recording flow
+
+### Milestone 3: Load Testing
+- [ ] Create load test harness (k6 / Locust script for 1000 concurrent agents)
+- [ ] Benchmark Phase 2 infrastructure under load
+- [ ] Measure gate decision latency, throughput, and error rates
+- [ ] Compare Supabase vs Neon performance
+
+### Milestone 4: GitHub Branching Integration
+- [ ] Create GitHub Action for automated PR database branching
+- [ ] Configure Neon Preview Branches for each PR
+- [ ] Set up branch lifecycle (create on PR, destroy on close/merge)
+
+---
+
+## Current Status
+
+### ✅ Phase 1 Complete (Merged PR #1032)
+- Multi-tenant audit trail with hash-chain integrity
+- RLS recursion prevention via SECURITY DEFINER functions
+- Cross-org isolation enforcement
+- Chain deletion evidence preservation via ON DELETE RESTRICT
+
+### ⏳ Phase 2 Readiness
+- dsg_gate_decisions migration drafted (NOT YET APPLIED)
+- Z3 solver contract validated (external-solver.ts)
+- 10 blockers tracked (3 CRITICAL resolved, 7 remaining open)
+- App-layer route `/api/dsg/v1/gates/evaluate` exists as scaffold
+
+### 📋 Open Blockers (from 20260730000005_DRAFT_dsg_gate_decisions_phase2.sql)
+1. ✅ Governance model misalignment (RESOLVED)
+2. ✅ Z3 output format validation (RESOLVED)
+3. ✅ RLS policy immutability (RESOLVED)
+4. ⏳ Proof verification approach (cached vs live Z3 call per decision)
+5. ⏳ Index requirements review (DBA validation needed)
+6. ⏳ Archive/retention strategy (evidence_retention_until column exists but no job)
+7. ⏳ FK to organizations table (bare org_id UUID, no referential integrity)
+8. ⏳ FK to policy_version table (bare UUID, no constraint)
+9. ⏳ parent_decision_id lineage cycle/cross-org protection
+10. ⏳ App-layer route handler (record_z3_gate_decision() unused in code)
+
+---
+
+## Neon Setup Checklist
+
+### Step 1: Credentials
+- [ ] Create Neon project at https://console.neon.tech
+- [ ] Obtain connection string (postgresql://...)
+- [ ] Store in `.env.local` as `NEON_DATABASE_URL`
+- [ ] Do NOT commit to repo
+
+### Step 2: Migrations
+- [ ] Create `supabase/migrations/20260801000001_phase2_neon_org_members.sql`
+- [ ] Create `supabase/migrations/20260801000002_phase2_neon_audit_batch.sql`
+- [ ] Create `supabase/migrations/20260801000003_phase2_neon_gate_decisions.sql`
+- [ ] Apply migrations to Neon via psql or Neon dashboard
+
+### Step 3: RLS & Security
+- [ ] Enable RLS on org_members, audit_batch_metadata, dsg_gate_decisions
+- [ ] Copy RLS policies from Supabase to Neon
+- [ ] Create SECURITY DEFINER functions (get_user_orgs, verify_audit_batch_chain, etc.)
+- [ ] Verify RLS enforcement via test queries
+
+### Step 4: Performance Baseline
+- [ ] Create basic query execution plans for each table
+- [ ] Measure connection pool latency
+- [ ] Document baseline metrics in `docs/PHASE2_BENCHMARKS.md`
+
+---
+
+## Load Testing Plan
+
+### Test Harness
+```bash
+# 1000 concurrent agents
+# Ramp-up: 0-60s
+# Duration: 300s
+# Endpoints to test:
+#   POST /api/spine/execute (main execution)
+#   POST /api/dsg/v1/gates/evaluate (deterministic gate)
+#   GET /api/audit (audit trail read)
+```
+
+### Metrics to Capture
+- Latency (p50, p95, p99)
+- Throughput (requests/sec)
+- Error rate
+- Gate decision distribution (ALLOW/BLOCK/REVIEW/UNSUPPORTED)
+- Database connection pool utilization
+
+### Success Criteria
+- p99 latency < 2s
+- Error rate < 0.1%
+- Throughput >= 500 req/sec per instance
+- Connection pool stable (no exhaustion)
+
+---
+
+## GitHub Branching Integration
+
+### Expected Flow
+1. User opens PR on `main`
+2. GitHub Action creates Neon Preview Branch
+3. Migrations run on preview branch
+4. PR preview URL includes database connection to preview
+5. On PR close/merge, preview branch destroyed
+
+### Action Configuration
+```yaml
+name: Neon Preview Branch
+on:
+  pull_request:
+    types: [opened, closed]
+
+jobs:
+  manage_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: neondatabase/actions@v1
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          action: create_branch
+          branch_name: pr-${{ github.event.pull_request.number }}
+```
+
+---
+
+## Risk & Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| Neon connection pooling overhead | Baseline test early; may need PgBouncer tuning |
+| Z3 solver timeout on large constraints | Cache proof results; implement timeout fallback to REVIEW |
+| Cross-org data leakage in RLS policies | Apply same policies to Neon as Supabase; test with multi-org queries |
+| Load test overwhelms shared Neon project | Use preview branches for isolation; implement rate limiting |
+| GitHub Action failures break PR flow | Use conditional deployment; alert on action failures |
+
+---
+
+## Timeline
+
+- **This week**: Neon setup + baseline benchmarks
+- **Week 2**: Z3 integration + dsg_gate_decisions application
+- **Week 3**: Load testing + GitHub branching integration
+- **Week 4**: Production readiness review + cutover planning
+
+---
+
+## Verification Commands
+
+```bash
+# Verify Neon connectivity
+psql $NEON_DATABASE_URL -c "SELECT version();"
+
+# Verify migrations applied
+psql $NEON_DATABASE_URL -c "\dt org_members audit_batch_metadata dsg_gate_decisions"
+
+# Verify RLS policies
+psql $NEON_DATABASE_URL -c "SELECT * FROM pg_policies WHERE tablename IN ('org_members', 'audit_batch_metadata', 'dsg_gate_decisions');"
+
+# Run load test locally
+npm run test:load -- --duration 60s --vus 100 --target neon
+
+# Check PR preview branching
+gh api repos/:owner/:repo/actions/workflows
+```
+
+---
+
+## Next Steps
+
+1. Create Neon project and obtain credentials
+2. Create Phase 2 migration files in `supabase/migrations/`
+3. Apply migrations and verify RLS
+4. Create load testing harness
+5. Set up GitHub Actions for preview branching

--- a/supabase/migrations/20260801000001_phase2_neon_org_members.sql
+++ b/supabase/migrations/20260801000001_phase2_neon_org_members.sql
@@ -1,0 +1,68 @@
+-- Phase 2: Organization Members Table for Neon Multi-Tenant Setup
+-- Parallel to Supabase; ensures consistent multi-tenant scoping across both databases
+-- Status: PENDING_NEON_APPLICATION
+
+-- Organization Members Table for multi-tenant org scoping
+-- Links users to organizations for RLS enforcement
+CREATE TABLE IF NOT EXISTS org_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  role TEXT DEFAULT 'member',
+  created_at TIMESTAMPTZ DEFAULT now(),
+
+  UNIQUE(org_id, user_id),
+  CONSTRAINT role_valid CHECK (role IN ('owner', 'admin', 'member', 'viewer'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_members_user ON org_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_org_members_org ON org_members(org_id);
+
+-- SECURITY DEFINER function to check org membership (bypasses RLS to avoid infinite recursion)
+CREATE OR REPLACE FUNCTION get_user_orgs(p_user_id UUID)
+RETURNS TABLE(org_id UUID) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT org_members.org_id
+  FROM org_members
+  WHERE org_members.user_id = p_user_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Enable RLS on org_members to prevent unauthorized membership changes
+ALTER TABLE org_members ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can read org memberships for orgs they belong to (via SECURITY DEFINER helper)
+CREATE POLICY org_members_read ON org_members
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT get_user_orgs(auth.uid())
+    )
+  );
+
+-- Policy: Only service_role can insert/update org memberships
+CREATE POLICY org_members_insert ON org_members
+  FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY org_members_update ON org_members
+  FOR UPDATE
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Grant access
+GRANT SELECT ON org_members TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON org_members TO service_role;
+GRANT EXECUTE ON FUNCTION get_user_orgs TO authenticated, service_role;
+
+-- Comments for documentation
+COMMENT ON TABLE org_members IS
+  'Multi-tenant organization membership (Neon Phase 2). Links users to organizations for RLS enforcement.
+   SECURITY: SECURITY DEFINER function get_user_orgs() provides membership checks without RLS recursion.
+   SECURITY: RLS policies use get_user_orgs() to avoid infinite loops.
+   SECURITY: service_role only can insert/update memberships to prevent privilege escalation.';
+
+COMMENT ON FUNCTION get_user_orgs(UUID) IS
+  'SECURITY DEFINER helper to check organization membership without triggering RLS recursion.
+   Used by RLS policies on org_members and other org-scoped tables.';

--- a/supabase/migrations/20260801000002_phase2_neon_audit_batch_metadata.sql
+++ b/supabase/migrations/20260801000002_phase2_neon_audit_batch_metadata.sql
@@ -1,0 +1,213 @@
+-- Phase 2: Audit Batch Metadata Table for Neon Multi-Tenant Setup
+-- Parallel to Supabase (20260730000007); ensures consistent hash-chain integrity across both databases
+-- Status: PENDING_NEON_APPLICATION
+
+-- Audit Batch Metadata Table for Hash Chain Integrity
+-- Tracks batch hashes, chain links, and verification state for audit trail integrity
+-- Implements tamper detection through hash chain validation
+CREATE TABLE IF NOT EXISTS audit_batch_metadata (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL,
+
+  -- Batch identification and hashing
+  batch_hash TEXT NOT NULL,              -- SHA256(events || previous_hash)
+  previous_hash TEXT,                    -- Hash chain link to previous batch
+  previous_org_id UUID,                  -- Org ID of previous batch (for chain integrity)
+
+  -- Batch statistics
+  event_count INTEGER NOT NULL,          -- Number of events in this batch
+  batch_size_bytes INTEGER,              -- Total size in bytes for quota tracking
+
+  -- Timestamps
+  created_at TIMESTAMPTZ DEFAULT now(),
+  chain_verified_at TIMESTAMPTZ,         -- When hash chain was last validated
+
+  -- Chain verification state
+  verification_status TEXT DEFAULT 'pending',  -- 'pending', 'verified', 'failed'
+
+  -- Constraints
+  CONSTRAINT batch_hash_format CHECK (batch_hash ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT previous_hash_format CHECK (previous_hash IS NULL OR previous_hash ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT event_count_positive CHECK (event_count > 0),
+  CONSTRAINT verification_status_valid CHECK (verification_status IN ('pending', 'verified', 'failed')),
+
+  -- Org-scoped batch hash uniqueness (prevents cross-org collisions)
+  CONSTRAINT batch_hash_org_unique UNIQUE (org_id, batch_hash),
+
+  -- Chain link completeness: if previous_hash is set, previous_org_id must also be set and equal org_id
+  CONSTRAINT chain_link_complete CHECK ((previous_hash IS NULL AND previous_org_id IS NULL) OR (previous_hash IS NOT NULL AND previous_org_id = org_id)),
+
+  -- Foreign key to previous batch (org-scoped chain integrity)
+  -- RESTRICT: prevents deletion of predecessor batches to preserve chain link evidence
+  CONSTRAINT batch_hash_chain_link FOREIGN KEY (previous_org_id, previous_hash)
+    REFERENCES audit_batch_metadata(org_id, batch_hash) ON DELETE RESTRICT
+);
+
+-- Indexes for efficient chain traversal and queries
+CREATE INDEX IF NOT EXISTS idx_audit_batch_metadata_chain
+  ON audit_batch_metadata(batch_hash, previous_hash);
+
+CREATE INDEX IF NOT EXISTS idx_audit_batch_metadata_org
+  ON audit_batch_metadata(org_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_batch_metadata_verification
+  ON audit_batch_metadata(verification_status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_batch_metadata_org_verified
+  ON audit_batch_metadata(org_id, verification_status, created_at DESC);
+
+-- Partial index for unverified batches (for priority verification)
+CREATE INDEX IF NOT EXISTS idx_audit_batch_metadata_unverified
+  ON audit_batch_metadata(created_at DESC)
+  WHERE verification_status = 'pending';
+
+-- Function to compute and verify batch hash chain
+CREATE OR REPLACE FUNCTION verify_audit_batch_chain(p_batch_id UUID)
+RETURNS TABLE(batch_hash TEXT, previous_hash TEXT, verification_status TEXT, is_valid BOOLEAN) AS $$
+DECLARE
+  v_batch audit_batch_metadata;
+  v_prev_count INTEGER;
+BEGIN
+  -- Get the batch
+  SELECT * INTO v_batch FROM audit_batch_metadata WHERE id = p_batch_id;
+
+  IF v_batch IS NULL THEN
+    RAISE EXCEPTION 'Batch not found: %', p_batch_id;
+  END IF;
+
+  -- For the first batch, previous_hash should be NULL
+  IF v_batch.previous_hash IS NOT NULL THEN
+    -- Verify the previous batch exists, is verified, and belongs to the same org (tenant isolation)
+    SELECT COUNT(*) INTO v_prev_count
+      FROM audit_batch_metadata
+      WHERE batch_hash = v_batch.previous_hash
+        AND org_id = v_batch.previous_org_id
+        AND verification_status = 'verified';
+
+    IF v_prev_count = 0 THEN
+      RETURN QUERY SELECT
+        v_batch.batch_hash,
+        v_batch.previous_hash,
+        'failed'::TEXT,
+        FALSE;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Update verification status to verified
+  UPDATE audit_batch_metadata
+    SET verification_status = 'verified',
+        chain_verified_at = now()
+    WHERE id = p_batch_id;
+
+  RETURN QUERY SELECT
+    v_batch.batch_hash,
+    v_batch.previous_hash,
+    'verified'::TEXT,
+    TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Function to detect chain breaks (tamper detection)
+CREATE OR REPLACE FUNCTION detect_chain_break(p_org_id UUID)
+RETURNS TABLE(batch_hash TEXT, previous_hash TEXT, is_broken BOOLEAN, reason TEXT) AS $$
+DECLARE
+  v_batch audit_batch_metadata;
+  v_prev_count INTEGER;
+BEGIN
+  -- Check for batches with missing previous_hash links
+  FOR v_batch IN
+    SELECT * FROM audit_batch_metadata
+    WHERE org_id = p_org_id
+    ORDER BY created_at DESC
+  LOOP
+    IF v_batch.previous_hash IS NOT NULL THEN
+      SELECT COUNT(*) INTO v_prev_count
+        FROM audit_batch_metadata
+        WHERE batch_hash = v_batch.previous_hash;
+
+      IF v_prev_count = 0 THEN
+        RETURN QUERY SELECT
+          v_batch.batch_hash,
+          v_batch.previous_hash,
+          TRUE,
+          'Previous batch not found (possible tampering)';
+      END IF;
+    END IF;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Enable RLS for org-scoped access
+ALTER TABLE audit_batch_metadata ENABLE ROW LEVEL SECURITY;
+
+-- Policy: users can read batch metadata only for their org
+CREATE POLICY audit_batch_metadata_org_read ON audit_batch_metadata
+  FOR SELECT
+  USING (
+    org_id IN (
+      SELECT get_user_orgs(auth.uid())
+    )
+  );
+
+-- Policy: service_role can insert batch metadata
+CREATE POLICY audit_batch_metadata_service_insert ON audit_batch_metadata
+  FOR INSERT
+  WITH CHECK (true);
+
+-- Policy: service_role can update verification status only (restrictive update)
+CREATE POLICY audit_batch_metadata_service_update ON audit_batch_metadata
+  FOR UPDATE
+  WITH CHECK (true)
+  USING (true);
+
+-- Function to safely update verification status (prevents mutation of batch_hash, previous_hash, org_id)
+CREATE OR REPLACE FUNCTION update_batch_verification(
+  p_batch_id UUID,
+  p_verification_status TEXT,
+  p_chain_verified_at TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS void AS $$
+BEGIN
+  IF p_verification_status NOT IN ('pending', 'verified', 'failed') THEN
+    RAISE EXCEPTION 'Invalid verification_status: %', p_verification_status;
+  END IF;
+
+  UPDATE audit_batch_metadata
+    SET verification_status = p_verification_status,
+        chain_verified_at = COALESCE(p_chain_verified_at, chain_verified_at)
+    WHERE id = p_batch_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Revoke public access from verification functions (security: restrict to service_role only)
+REVOKE EXECUTE ON FUNCTION verify_audit_batch_chain(UUID) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION detect_chain_break(UUID) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION update_batch_verification(UUID, TEXT, TIMESTAMPTZ) FROM PUBLIC, anon, authenticated;
+
+-- Grant access
+GRANT SELECT ON audit_batch_metadata TO authenticated;
+GRANT SELECT, INSERT ON audit_batch_metadata TO service_role;
+GRANT EXECUTE ON FUNCTION update_batch_verification TO service_role;
+GRANT EXECUTE ON FUNCTION verify_audit_batch_chain TO service_role;
+GRANT EXECUTE ON FUNCTION detect_chain_break TO service_role;
+
+-- Comments for documentation
+COMMENT ON TABLE audit_batch_metadata IS
+  'Metadata for audit batches including hash chain state and verification status (Neon Phase 2). Used for tamper detection.
+   SECURITY: Org-scoped batch uniqueness (org_id, batch_hash) prevents cross-org chain links.
+   SECURITY: RLS policies use get_user_orgs() SECURITY DEFINER function to avoid recursion.
+   SECURITY: Function-based update restrictions prevent mutation of immutable fields.
+   SECURITY: Verification functions filter by org_id to maintain tenant isolation.
+   SECURITY: FK ON DELETE RESTRICT prevents predecessor deletion that would hide tampering evidence.';
+
+COMMENT ON FUNCTION verify_audit_batch_chain(UUID) IS
+  'Verify the integrity of a batch in the hash chain. Updates verification_status and chain_verified_at only.
+   SECURITY: Filters previous batch lookup by org_id to prevent cross-tenant chain verification.';
+
+COMMENT ON FUNCTION detect_chain_break(UUID) IS
+  'Detect chain breaks in audit trail for an organization (signs of tampering).';
+
+COMMENT ON FUNCTION update_batch_verification(UUID, TEXT, TIMESTAMPTZ) IS
+  'Safely update verification status without allowing mutation of batch_hash, previous_hash, or org_id.
+   Designed to replace direct UPDATE grants for security enforcement.';

--- a/supabase/migrations/20260801000003_phase2_neon_dsg_gate_decisions.sql
+++ b/supabase/migrations/20260801000003_phase2_neon_dsg_gate_decisions.sql
@@ -1,0 +1,214 @@
+-- Phase 2: Z3 Formal Proof Gate Decisions Table for Neon
+-- Derives from: 20260730000005_DRAFT_dsg_gate_decisions_phase2.sql
+-- Status: PENDING_NEON_APPLICATION (proof verification approach TBD)
+--
+-- BLOCKERS (7 remaining open; 3 CRITICAL resolved in Phase 1):
+--   4. Proof verification approach: cached/replayed vs live Z3 call per decision (OPEN)
+--   5. Index requirements: DBA review against real query patterns (OPEN)
+--   6. Archive/retention strategy: evidence_retention_until column exists but no job (OPEN)
+--   7. FK to organizations table: org_id bare UUID, no referential integrity (OPEN)
+--   8. FK to policy_version table: bare UUID, no constraint (OPEN)
+--   9. parent_decision_id lineage: no cycle/cross-org guards (OPEN)
+--   10. App-layer route handler: record_z3_gate_decision() unused; blocker until route is wired (OPEN)
+
+-- Phase 2: Z3 Formal Proof Decision Records
+-- Tracks deterministic gate decisions made by Z3 solver with complete proof trace
+CREATE TABLE IF NOT EXISTS dsg_gate_decisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL,
+  policy_version UUID NOT NULL,
+
+  -- Input context
+  input_hash BYTEA NOT NULL, -- SHA256(input constraints)
+  constraint_set JSONB NOT NULL, -- Full Z3 constraint set
+
+  -- Decision result
+  decision VARCHAR(20) NOT NULL, -- 'ALLOW', 'BLOCK', 'REVIEW', 'UNSUPPORTED'
+  decision_confidence DECIMAL(3, 2) DEFAULT 1.0, -- 0.0 to 1.0
+
+  -- Proof evidence
+  proof_hash BYTEA NOT NULL, -- SHA256 of proof output
+  proof_format VARCHAR(50) DEFAULT 'z3-smt2', -- 'z3-smt2', 'verilog', 'hol', etc.
+
+  -- Z3 Solver Contract (matches ExternalSolverResponse in lib/dsg/deterministic/external-solver.ts)
+  z3_status VARCHAR(10), -- 'sat' | 'unsat' | 'unknown'
+  z3_satisfiable BOOLEAN, -- true/false/null
+  z3_solver_version VARCHAR(50), -- e.g. '4.16.0'
+  z3_time_ms INTEGER, -- solver execution time in milliseconds
+  z3_smt2_hash VARCHAR(64), -- hash of the SMT-LIB v2 input formula
+  z3_error TEXT, -- solver error message if status is error
+  z3_trace JSONB DEFAULT '{}', -- full solver response payload for replay/audit
+
+  -- Decision lineage (for causality chain)
+  parent_decision_id UUID REFERENCES dsg_gate_decisions(id) ON DELETE SET NULL,
+  parent_proof_hash BYTEA, -- Hash of parent proof for chain validation
+
+  -- Policy and compliance context
+  compliance_tags TEXT[] DEFAULT '{}',
+  evidence_retention_until TIMESTAMPTZ,
+
+  -- Audit trail
+  created_by UUID, -- Service/agent creating this decision
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+
+  -- Constraints and validation
+  CONSTRAINT dsg_gate_decision_status_valid
+    CHECK (decision IN ('ALLOW', 'BLOCK', 'REVIEW', 'UNSUPPORTED')),
+  CONSTRAINT dsg_gate_z3_status_valid
+    CHECK (z3_status IS NULL OR z3_status IN ('sat', 'unsat', 'unknown')),
+  CONSTRAINT dsg_gate_confidence_range
+    CHECK (decision_confidence >= 0.0 AND decision_confidence <= 1.0)
+);
+
+-- Indexes for efficient lookup and auditing
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_org_created
+  ON dsg_gate_decisions(org_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_policy_version
+  ON dsg_gate_decisions(policy_version, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_decision
+  ON dsg_gate_decisions(decision);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_input_hash
+  ON dsg_gate_decisions(input_hash);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_proof_hash
+  ON dsg_gate_decisions(proof_hash);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_proof_chain
+  ON dsg_gate_decisions(parent_decision_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_z3_status
+  ON dsg_gate_decisions(z3_status)
+  WHERE z3_status IS NOT NULL;
+
+-- Partial index for high-confidence decisions
+CREATE INDEX IF NOT EXISTS idx_dsg_gate_high_confidence
+  ON dsg_gate_decisions(created_at DESC)
+  WHERE decision_confidence >= 0.95 AND decision IN ('ALLOW', 'BLOCK');
+
+-- Enable RLS for org-scoped access
+ALTER TABLE dsg_gate_decisions ENABLE ROW LEVEL SECURITY;
+
+-- Policy: org members (via get_user_orgs) can read gate decisions (audit and review)
+CREATE POLICY dsg_gate_org_read ON dsg_gate_decisions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users u
+      WHERE u.auth_user_id = auth.uid()
+        AND u.is_active = true
+        AND u.org_id = dsg_gate_decisions.org_id
+    )
+  );
+
+-- Policy: service_role (Z3 solver / gate evaluation backend) can insert decisions
+CREATE POLICY dsg_gate_service_insert ON dsg_gate_decisions
+  FOR INSERT
+  TO service_role
+  WITH CHECK (true);
+
+-- Immutability enforcement: gate decisions are append-only
+-- BEFORE UPDATE/DELETE trigger prevents any mutation post-insert
+CREATE OR REPLACE FUNCTION dsg_prevent_gate_decision_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'dsg_gate_decisions rows are append-only and cannot be updated or deleted (id=%)', OLD.id;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_dsg_gate_decisions_no_update ON dsg_gate_decisions;
+CREATE TRIGGER trg_dsg_gate_decisions_no_update
+  BEFORE UPDATE ON dsg_gate_decisions
+  FOR EACH ROW EXECUTE FUNCTION dsg_prevent_gate_decision_mutation();
+
+DROP TRIGGER IF EXISTS trg_dsg_gate_decisions_no_delete ON dsg_gate_decisions;
+CREATE TRIGGER trg_dsg_gate_decisions_no_delete
+  BEFORE DELETE ON dsg_gate_decisions
+  FOR EACH ROW EXECUTE FUNCTION dsg_prevent_gate_decision_mutation();
+
+-- Helper function: record Z3 gate decision result
+CREATE OR REPLACE FUNCTION record_z3_gate_decision(
+  p_org_id UUID,
+  p_policy_version UUID,
+  p_input_hash BYTEA,
+  p_constraint_set JSONB,
+  p_decision VARCHAR,
+  p_proof_hash BYTEA,
+  p_z3_trace JSONB DEFAULT '{}',
+  p_z3_status VARCHAR DEFAULT NULL,
+  p_z3_satisfiable BOOLEAN DEFAULT NULL,
+  p_z3_solver_version VARCHAR DEFAULT NULL,
+  p_z3_time_ms INTEGER DEFAULT NULL,
+  p_z3_smt2_hash VARCHAR DEFAULT NULL,
+  p_z3_error TEXT DEFAULT NULL,
+  p_confidence DECIMAL DEFAULT 1.0,
+  p_parent_decision_id UUID DEFAULT NULL
+)
+RETURNS UUID AS $$
+DECLARE
+  v_id UUID;
+BEGIN
+  INSERT INTO dsg_gate_decisions (
+    org_id,
+    policy_version,
+    input_hash,
+    constraint_set,
+    decision,
+    proof_hash,
+    z3_trace,
+    z3_status,
+    z3_satisfiable,
+    z3_solver_version,
+    z3_time_ms,
+    z3_smt2_hash,
+    z3_error,
+    decision_confidence,
+    parent_decision_id,
+    created_by
+  )
+  VALUES (
+    p_org_id,
+    p_policy_version,
+    p_input_hash,
+    p_constraint_set,
+    p_decision,
+    p_proof_hash,
+    p_z3_trace,
+    p_z3_status,
+    p_z3_satisfiable,
+    p_z3_solver_version,
+    p_z3_time_ms,
+    p_z3_smt2_hash,
+    p_z3_error,
+    p_confidence,
+    p_parent_decision_id,
+    auth.uid()
+  )
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Grant access
+GRANT SELECT ON dsg_gate_decisions TO authenticated;
+GRANT SELECT, INSERT ON dsg_gate_decisions TO service_role;
+-- Deliberately no UPDATE/DELETE grant to any role: immutability enforced by trigger
+
+-- Comments for future reviewers
+COMMENT ON TABLE dsg_gate_decisions IS
+  'Phase 2 table: Z3 formal proof decisions (Neon). Tracks deterministic gate decisions with complete proof trace.
+   See docs/PHASE2_PLAN.md for open blockers (4-10) and verification approach decisions.
+   APPEND-ONLY: immutability enforced by BEFORE UPDATE/DELETE trigger.';
+
+COMMENT ON FUNCTION record_z3_gate_decision(UUID, UUID, BYTEA, JSONB, VARCHAR, BYTEA, JSONB, VARCHAR, BOOLEAN, VARCHAR, INTEGER, VARCHAR, TEXT, NUMERIC, UUID) IS
+  'Record Z3 formal proof gate decision. Inserts immutable row into dsg_gate_decisions.
+   Called by POST /api/dsg/v1/gates/evaluate when Z3 solver decision is recorded.';
+
+COMMENT ON FUNCTION dsg_prevent_gate_decision_mutation() IS
+  'Prevents UPDATE/DELETE on gate decisions. Enforces append-only constraint for audit trail integrity.';


### PR DESCRIPTION
## Phase 2: Neon + Z3 Formal Proof Integration Setup

**Goal:** Establish Neon parallel database infrastructure and prepare Z3 formal proof integration for deterministic gate decisions at scale.

**Status:** Setup phase (pending Neon credentials and application)

## Summary of Changes

### 📋 Planning & Documentation
- **docs/PHASE2_PLAN.md** — Comprehensive Phase 2 roadmap with:
  - 4 milestones (Neon setup, Z3 integration, load testing, GitHub branching)
  - 7 open blockers (proof verification, archive strategy, FK constraints, etc.)
  - Risk mitigation and verification commands
  - Timeline: 4 weeks to production readiness

### 📦 Neon Migrations
Created 3 new migrations for parallel Neon infrastructure:

1. **20260801000001_phase2_neon_org_members.sql**
   - Multi-tenant organization membership table
   - SECURITY DEFINER get_user_orgs() function for RLS recursion prevention
   - Identical to Supabase Phase 1 org_members for consistency

2. **20260801000002_phase2_neon_audit_batch_metadata.sql**
   - Hash-chain audit trail with tamper detection
   - ON DELETE RESTRICT to preserve evidence
   - Verification functions: verify_audit_batch_chain(), detect_chain_break()
   - Parallel to Supabase migration 20260730000007

3. **20260801000003_phase2_neon_dsg_gate_decisions.sql**
   - Z3 formal proof decision records table
   - Append-only via BEFORE UPDATE/DELETE trigger
   - Tracks solver status, proof hash, decision lineage
   - Based on draft 20260730000005 with blockers documented

## Blockers & Known Limits

**7 Open Blockers** (3 CRITICAL resolved in Phase 1):
- Proof verification approach (cached vs live Z3 per decision) — blocks solver route
- DBA index review against real query patterns — performance risk
- Archive/retention strategy for evidence_retention_until — data lifecycle TBD
- Foreign keys to organizations/policy_version tables — referential integrity open
- parent_decision_id lineage cycle/cross-org guards — data integrity gaps
- App-layer route handler at POST /api/dsg/v1/gates/evaluate — currently unused scaffold
- Neon connection pooling tuning — may need PgBouncer configuration

## Verification

```bash
# Create Neon project and test connection
psql $NEON_DATABASE_URL -c "SELECT version();"

# Apply migrations to Neon
psql $NEON_DATABASE_URL < supabase/migrations/20260801000001_phase2_neon_org_members.sql
psql $NEON_DATABASE_URL < supabase/migrations/20260801000002_phase2_neon_audit_batch_metadata.sql
psql $NEON_DATABASE_URL < supabase/migrations/20260801000003_phase2_neon_dsg_gate_decisions.sql

# Verify RLS policies
psql $NEON_DATABASE_URL -c "SELECT tablename, policyname FROM pg_policies WHERE tablename LIKE 'dsg_%';"
```

**Not run** — environment not configured with Neon credentials; migrations are SQL-validated only.

## Next Steps

**Milestone 1 (This Week):**
1. [ ] Create Neon project at https://console.neon.tech
2. [ ] Obtain connection string and store in .env.local
3. [ ] Apply all 3 Phase 2 migrations to Neon
4. [ ] Verify multi-tenant RLS policies on all tables
5. [ ] Create baseline performance benchmarks

**Milestone 2 (Week 2):**
- Address remaining blockers (proof verification approach, FK constraints)
- Apply dsg_gate_decisions to Supabase production
- Wire POST /api/dsg/v1/gates/evaluate route handler to Z3 solver invocation

**Milestone 3 (Week 3):**
- Create load testing harness (k6 script for 1000 concurrent agents)
- Benchmark both Supabase and Neon under load
- Compare latency, throughput, connection pool utilization

**Milestone 4 (Week 4):**
- Set up GitHub Actions for Neon preview branching
- Configure automated branch lifecycle (create on PR, destroy on close/merge)
- Production readiness review

## User-Visible Impact

- No user-facing changes yet; infrastructure setup phase
- Phase 2 will enable deterministic gate decisions with formal Z3 proof
- 1000+ concurrent agents testable on dual-database architecture
- Audit trail integrity with tamper detection at scale

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVrVCwfBg9Vvm6TmzqTKCn)_