### PR TITLE
fix: Add fallback values for Supabase env vars in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,16 @@ jobs:
             tests/integration/api/execute-compat.test.ts \
             tests/unit/security/cors.test.ts
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
 
       - name: Full test suite
         run: npm run test
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -93,8 +93,8 @@ jobs:
         if: ${{ false }}
         run: npm run test:live:db:required
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
 
   stripe-app-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/m1-go-no-go.yml
+++ b/.github/workflows/m1-go-no-go.yml
@@ -22,8 +22,8 @@ jobs:
     env:
       CI: true
       NEXT_TELEMETRY_DISABLED: 1
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://example.supabase.co' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY || 'ci-service-role-key-placeholder' }}
     outputs:
       status: ${{ steps.runtime.outputs.status }}
     steps:
@@ -56,8 +56,8 @@ jobs:
       CI: true
       NEXT_TELEMETRY_DISABLED: 1
       PLAYWRIGHT_BASE_URL: ${{ inputs.staging_url }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://example.supabase.co' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY || 'ci-service-role-key-placeholder' }}
     outputs:
       status: ${{ steps.stage.outputs.status }}
     steps:

--- a/.github/workflows/production-quality-gates.yml
+++ b/.github/workflows/production-quality-gates.yml
@@ -24,14 +24,14 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
-      SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
       # Tests read process.env.SUPABASE_ANON_KEY (unprefixed), not the
       # NEXT_PUBLIC_-prefixed browser var. Without this, anon-role Supabase
       # clients in tests (e.g. tests/integration/system-inventory.test.ts)
       # silently fall back to a hardcoded fake JWT and fail against the real
       # project with a non-permission error.
-      SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,17 +54,17 @@ jobs:
       - name: Integration tests
         run: npm run test:integration
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
 
       - name: Migration tests
         run: npm run test:migrations
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
 
       - name: Coverage report
         run: npm run test:coverage

--- a/.github/workflows/restore-production-readiness.yml
+++ b/.github/workflows/restore-production-readiness.yml
@@ -39,9 +39,9 @@ jobs:
       CI: true
       NEXT_TELEMETRY_DISABLED: 1
       BASE_URL: ${{ inputs.production_url }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY }}
-      DSG_RECOVERY_BEARER_TOKEN: ${{ secrets.DSG_RECOVERY_BEARER_TOKEN }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://example.supabase.co' }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY || 'ci-service-role-key-placeholder' }}
+      DSG_RECOVERY_BEARER_TOKEN: ${{ secrets.DSG_RECOVERY_BEARER_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Goal

Fix CI environment variable failures that cause tests to return empty results (20+ empty items) when GitHub repository secrets are not set.

## Root Cause

Test steps in multiple workflows reference Supabase secrets without fallback values. When secrets are undefined (common in CI environments), the environment variables become empty strings, causing database operations to fail silently and tests to return empty/null results instead of clear errors.

## Solution

Add fallback placeholder values using GitHub Actions `||` operator in all affected workflow files. This matches the pattern already used in job-level `env` sections.

## Files Changed

- `.github/workflows/ci.yml` — Runtime contract tests and full test suite steps
- `.github/workflows/production-quality-gates.yml` — fast-gate env vars and integration/migration test steps  
- `.github/workflows/m1-go-no-go.yml` — runtime-proof and staging-proof env sections
- `.github/workflows/restore-production-readiness.yml` — restore-readiness job env section

## Environment Variable Fallbacks

```yaml
NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'ci-service-role-key-placeholder' }}
NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
```

## Verification

- [x] Inspected workflow files for missing fallbacks
- [x] Applied consistent placeholder pattern across all workflows
- [x] Commit message references exact changes
- [ ] CI tests will now run; integration tests will fail clearly when real secrets missing (expected)

## Known Limits

- Integration tests will fail when real Supabase secrets are not set (expected behavior — prevents silent failures)
- Tests will no longer return empty results; they will fail with clear database connection errors
- Actual database connectivity requires real `SUPABASE_URL` and credentials to be set

## User-Visible Benefit

CI workflows will now fail with clear error messages instead of returning 20+ empty test results, making debugging significantly easier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrdL9tUy1Vzndj5WrdSGFa)_