### PR TITLE
fix: Resolve PR #1041 merge conflict by rebasing onto current main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,17 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# ============ Neon PostgreSQL (Production/Staging) ============
+# Neon connection string for production database (Vercel integration)
+# Format: postgresql://user:password@host/database
+NEON_PG_CONNECTION_STRING=
+# Neon pooled connection string (recommended for serverless)
+NEON_PG_POOLED_CONNECTION_STRING=
+# Neon API key for programmatic database operations
+NEON_API_KEY=
+# Neon project ID
+NEON_PROJECT_ID=
+
 # ============ DSG Core ============
 # Optional: route all /api/* calls from UI to a real remote Control Plane API origin
 # Example: https://dsg-control-plane-production.vercel.app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
+      # Neon PostgreSQL support (optional for production/staging database)
+      NEON_PG_CONNECTION_STRING: ${{ secrets.NEON_PG_CONNECTION_STRING || '' }}
+      NEON_PG_POOLED_CONNECTION_STRING: ${{ secrets.NEON_PG_POOLED_CONNECTION_STRING || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/m1-go-no-go.yml
+++ b/.github/workflows/m1-go-no-go.yml
@@ -24,6 +24,9 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://example.supabase.co' }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY || 'ci-service-role-key-placeholder' }}
+      # Neon PostgreSQL support (optional for production/staging database)
+      NEON_PG_CONNECTION_STRING: ${{ secrets.NEON_PG_CONNECTION_STRING || '' }}
+      NEON_PG_POOLED_CONNECTION_STRING: ${{ secrets.NEON_PG_POOLED_CONNECTION_STRING || '' }}
     outputs:
       status: ${{ steps.runtime.outputs.status }}
     steps:
@@ -58,6 +61,9 @@ jobs:
       PLAYWRIGHT_BASE_URL: ${{ inputs.staging_url }}
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL || 'https://example.supabase.co' }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_KEY || 'ci-service-role-key-placeholder' }}
+      # Neon PostgreSQL support (optional for production/staging database)
+      NEON_PG_CONNECTION_STRING: ${{ secrets.NEON_PG_CONNECTION_STRING || '' }}
+      NEON_PG_POOLED_CONNECTION_STRING: ${{ secrets.NEON_PG_POOLED_CONNECTION_STRING || '' }}
     outputs:
       status: ${{ steps.stage.outputs.status }}
     steps:

--- a/.github/workflows/production-quality-gates.yml
+++ b/.github/workflows/production-quality-gates.yml
@@ -32,6 +32,9 @@ jobs:
       # silently fall back to a hardcoded fake JWT and fail against the real
       # project with a non-permission error.
       SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'ci-anon-key-placeholder' }}
+      # Neon PostgreSQL support (optional for production/staging database)
+      NEON_PG_CONNECTION_STRING: ${{ secrets.NEON_PG_CONNECTION_STRING || '' }}
+      NEON_PG_POOLED_CONNECTION_STRING: ${{ secrets.NEON_PG_POOLED_CONNECTION_STRING || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.mcp.json
+++ b/.mcp.json
@@ -37,6 +37,10 @@
         "SUPABASE_URL": "${SUPABASE_URL}",
         "SUPABASE_SERVICE_KEY": "${SUPABASE_SERVICE_KEY}"
       }
+    },
+    "gitbook-documentation": {
+      "type": "http",
+      "url": "https://gitbook.com/docs/~gitbook/mcp"
     }
   }
 }

--- a/docs/NEON_SETUP.md
+++ b/docs/NEON_SETUP.md
@@ -1,0 +1,221 @@
+# Neon PostgreSQL Integration Guide
+
+This guide explains how to set up Neon PostgreSQL for the DSG control plane, either as a production database or for testing/development.
+
+## Overview
+
+Neon is a serverless PostgreSQL platform that provides:
+- Auto-scaling compute
+- Branching for safe schema changes
+- Connection pooling for serverless environments
+- Vercel integration for automated environment setup
+
+The DSG control plane supports both **Supabase** (current primary) and **Neon** for PostgreSQL database backends.
+
+## Setup Steps
+
+### 1. Create a Neon Project
+
+1. Visit [console.neon.tech](https://console.neon.tech)
+2. Create a new project (or select existing project)
+3. Note your project credentials:
+   - **Project ID**: `<your-project-id>`
+   - **Database Name**: `neondb` (default)
+   - **Role**: `neondb_owner` (default)
+
+### 2. Generate Neon Connection Strings
+
+#### Option A: Neon Dashboard
+
+1. Go to **Project** → **Database**
+2. Select your role and find the connection string
+3. Two connection types:
+   - **Direct**: For standard PostgreSQL clients
+   - **Pooled**: For serverless/lambda functions (recommended)
+
+#### Option B: Neon CLI
+
+```bash
+# Install Neon CLI
+npm install -g neon
+
+# Get connection strings
+neon projects list
+neon connection-string <project-id>
+```
+
+### 3. Environment Variables
+
+Add to `.env` or Vercel project settings:
+
+```bash
+# Primary Neon connection (direct)
+NEON_PG_CONNECTION_STRING=postgresql://[user]:[password]@[host]/[database]
+
+# Pooled connection (recommended for serverless)
+NEON_PG_POOLED_CONNECTION_STRING=postgresql://[user]:[password]@[host]:6432/[database]
+
+# Neon API key (optional, for programmatic operations)
+NEON_API_KEY=<your-neon-api-key>
+
+# Neon project ID (optional)
+NEON_PROJECT_ID=<your-project-id>
+```
+
+### 4. Vercel Integration (Recommended)
+
+1. **Install Neon Integration in Vercel:**
+   - Go to Vercel Dashboard → Integrations
+   - Search for "Neon"
+   - Click "Install"
+   - Authorize Neon account
+
+2. **Add Integration to Project:**
+   - Select project: `tdealer01-crypto-dsg-control-plane`
+   - Database branching options:
+     - ✅ **Production**: Create branch for production deployments
+     - ✅ **Preview**: Create branches for preview deployments
+   - Custom prefix: `neon_pg` (or your preference, letters/digits/underscores only)
+   - Leave "Sensitive" unchecked
+
+3. **Vercel Auto-Configuration:**
+   Environment variables automatically created:
+   - `NEON_PG_CONNECTION_STRING` — production
+   - `NEON_PG_POOLED_CONNECTION_STRING` — pooled (recommended)
+   - `NEON_PG_DATABASE_URL` — alternate naming
+
+### 5. Run Migrations
+
+#### Supabase-to-Neon Migration
+
+If migrating from Supabase to Neon:
+
+```bash
+# 1. Dump Supabase schema
+pg_dump --no-owner --no-privileges \
+  postgresql://[supabase_user]:[password]@[supabase_host]/postgres \
+  > schema.sql
+
+# 2. Apply to Neon
+psql $NEON_PG_CONNECTION_STRING < schema.sql
+```
+
+#### Fresh Neon Setup
+
+For new Neon databases, apply existing DSG migrations:
+
+```bash
+# 1. Install Supabase CLI (if not already installed)
+npm install -g supabase
+
+# 2. Apply migrations to Neon
+npx supabase db push \
+  --db-url $NEON_PG_CONNECTION_STRING
+```
+
+Or manually run migrations:
+
+```bash
+# Connect to Neon and run SQL migrations from supabase/migrations/
+psql $NEON_PG_CONNECTION_STRING \
+  -f supabase/migrations/001_initial_schema.sql
+```
+
+### 6. Test Configuration
+
+```bash
+# Test connection
+psql $NEON_PG_POOLED_CONNECTION_STRING -c "SELECT version();"
+
+# Run DSG migration tests
+npm run test:migrations
+```
+
+## Configuration Options
+
+### Environment Variables
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `NEON_PG_CONNECTION_STRING` | Direct connection (non-pooled) | `postgresql://user:pass@host/db` |
+| `NEON_PG_POOLED_CONNECTION_STRING` | PgBouncer pooled connection | `postgresql://user:pass@host:6432/db` |
+| `NEON_API_KEY` | Neon API access (optional) | `pne_...` |
+| `NEON_PROJECT_ID` | Neon project ID (optional) | `xyz123` |
+
+### CI/CD Configuration
+
+All GitHub workflows automatically support Neon:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/production-quality-gates.yml`
+- `.github/workflows/m1-go-no-go.yml`
+- `.github/workflows/restore-production-readiness.yml`
+
+To enable Neon in CI:
+
+1. **Add GitHub secrets:**
+   ```
+   NEON_PG_CONNECTION_STRING
+   NEON_PG_POOLED_CONNECTION_STRING
+   NEON_API_KEY (optional)
+   ```
+
+2. **Workflows automatically detect and use** Neon connection strings when secrets are set
+
+## Supabase vs Neon Comparison
+
+| Feature | Supabase | Neon |
+|---------|----------|------|
+| **PostgreSQL Version** | Latest | Latest |
+| **Auth Support** | Built-in | Manual (JWT) |
+| **Real-time API** | ✅ Included | ❌ Not included |
+| **Serverless** | ✅ Native | ✅ Native |
+| **Branch Support** | ❌ Limited | ✅ Full branching |
+| **Vercel Integration** | ✅ Via env | ✅ Native marketplace |
+| **Connection Pooling** | PgBouncer | PgBouncer |
+
+## Troubleshooting
+
+### Connection Refused
+
+```bash
+# Check Neon status
+curl -s https://neon.tech/status | jq .
+
+# Verify credentials
+psql postgresql://user:pass@host/db -c "SELECT 1;"
+```
+
+### Pooled vs Direct Connection
+
+- **Use Pooled** (`host:6432`): Serverless functions, short-lived connections
+- **Use Direct** (`host:5432`): Long-running processes, persistent connections
+
+### SSL/TLS Errors
+
+Neon requires SSL. Add to connection string:
+
+```
+?sslmode=require
+```
+
+Or set environment variable:
+
+```bash
+export PGSSLMODE=require
+```
+
+## Next Steps
+
+1. ✅ Create Neon project and get connection strings
+2. ✅ Add environment variables to Vercel and local `.env`
+3. ✅ Run migrations: `npm run test:migrations`
+4. ✅ Verify CI passes with Neon secrets
+5. ✅ Monitor Neon dashboard for performance
+
+## Resources
+
+- [Neon Documentation](https://neon.tech/docs)
+- [Neon Vercel Integration](https://neon.tech/docs/guides/vercel)
+- [Connection String Guide](https://neon.tech/docs/connect/connect-from-any-app)
+- [Branching for Deployments](https://neon.tech/docs/guides/branching-neon-postgres)


### PR DESCRIPTION
## Goal

Fix PR #1041 merge issues by rebasing the Neon PostgreSQL and GitBook MCP integration changes onto the current main branch.

## Problem

PR #1041 had a merge conflict because the branch had diverged from the current main with no common ancestor. This typically occurs when repository history changes or force-pushes occur.

## Solution

1. **Identified root cause**: The PR branch was based on old history that no longer shares a merge-base with the current main
2. **Fixed by rebasing**: Reset the branch to the current main and reapplied all PR #1041 changes:
   - Added GitBook documentation MCP server to `.mcp.json`
   - Added Neon PostgreSQL environment variables to `.env.example`
   - Updated CI/CD workflows with Neon support (ci.yml, production-quality-gates.yml, m1-go-no-go.yml)
   - Created comprehensive `docs/NEON_SETUP.md` guide

## Files Changed

### Configuration & MCP
- **`.mcp.json`** — Added GitBook documentation MCP server integration
- **`.env.example`** — Added Neon PostgreSQL connection environment variables

### CI/CD Workflows
- **`.github/workflows/ci.yml`** — Added Neon env vars to verify job
- **`.github/workflows/production-quality-gates.yml`** — Added Neon env vars to fast-gate job
- **`.github/workflows/m1-go-no-go.yml`** — Added Neon env vars to runtime-proof and staging-proof jobs

### Documentation
- **`docs/NEON_SETUP.md`** — Comprehensive Neon integration guide covering:
  - Project creation and credential setup
  - Vercel integration (marketplace)
  - Connection string configuration
  - Migration strategies (Supabase → Neon)
  - CI/CD setup
  - Troubleshooting guide

## Verification

- ✅ Branch rebased onto current main
- ✅ All PR #1041 changes successfully reapplied
- ✅ Commit history clean and mergeable
- ✅ No merge conflicts
- ✅ Configuration is backward compatible with Supabase-only setup

## Known Limits

- Neon integration is **optional** — Supabase remains the primary database backend
- Workflows will use Neon only when `NEON_PG_CONNECTION_STRING` and `NEON_PG_POOLED_CONNECTION_STRING` secrets are set
- No schema changes required; Neon supports same PostgreSQL dialect as Supabase
- Vercel Neon integration requires marketplace installation (manual step)

## User-Visible Benefit

1. **Database Flexibility** — Can now optionally use Neon for production/staging
2. **Documentation Access** — GitBook MCP enables Claude Code to access product documentation directly
3. **CI/CD Readiness** — Workflows are pre-configured to support Neon when secrets are available

## Next Steps

1. **Verify CI passes** on this branch before merging
2. **Optional**: Set up Neon project (see `docs/NEON_SETUP.md`)
3. **Optional**: Add Neon GitHub secrets for CI/CD support
4. **Optional**: Install Neon integration in Vercel marketplace
5. Current Supabase setup continues to work without changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGVLnodf2RmGAB4m8o85qU)_