### PR TITLE
feat(revenue): schedule revenue crons and add /api/revenue-readiness probe

### DIFF
--- a/app/api/revenue-readiness/route.ts
+++ b/app/api/revenue-readiness/route.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /api/revenue-readiness
+ *
+ * Public probe. Reports whether the revenue loop can turn a governed
+ * execution into a billable Stripe meter event, and names the exact blocker
+ * when it cannot.
+ *
+ * Env vars are reported by name with a boolean only — no values are read into
+ * the response, and the DB figures are aggregate counts with no customer rows.
+ */
+import { getRevenueReadiness } from '../../../lib/billing/revenue-readiness';
+import { handleApiError } from '../../../lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const report = await getRevenueReadiness();
+    return Response.json(report, {
+      status: report.ok ? 200 : 503,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    return handleApiError('api/revenue-readiness', error);
+  }
+}

--- a/lib/billing/revenue-readiness.ts
+++ b/lib/billing/revenue-readiness.ts
@@ -1,0 +1,157 @@
+/**
+ * Revenue readiness report.
+ *
+ * Answers one question in a single call: "what is stopping this deployment
+ * from turning a governed execution into an invoiced dollar?"
+ *
+ * Reports environment variables by NAME only — never values, never prefixes,
+ * never lengths. The DB counters are aggregate only; no customer rows are
+ * returned.
+ */
+import { getSupabaseAdmin } from '../supabase-server';
+
+/** Env vars that must be present before any charge can be raised. */
+const REQUIRED_ENV = [
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_METER_EVENT_NAME',
+  'CRON_SECRET',
+  'SUPABASE_SERVICE_ROLE_KEY',
+] as const;
+
+/** Env vars that unlock specific revenue features but do not block the core loop. */
+const OPTIONAL_ENV = [
+  'STRIPE_METER_ID',
+  'STRIPE_PRICE_PRO',
+  'STRIPE_PRICE_BUSINESS',
+  'OVERAGE_RATE_USD',
+] as const;
+
+/** Cron paths declared in vercel.json that keep the revenue loop moving. */
+const REVENUE_CRONS = [
+  '/api/cron/flush-meter-outbox',
+  '/api/cron/reconcile-meter',
+  '/api/cron/usage-alerts',
+  '/api/cron/trial-invite',
+] as const;
+
+export type EnvPresence = Record<string, boolean>;
+
+export type PipelineCounts = {
+  billingCustomers: number;
+  outboxPending: number;
+  outboxFailed: number;
+  outboxSent: number;
+  reachable: boolean;
+  detail?: string;
+};
+
+export type RevenueReadinessReport = {
+  ok: boolean;
+  stage: 'blocked' | 'configured-idle' | 'flowing';
+  env: {
+    required: EnvPresence;
+    optional: EnvPresence;
+    missingRequired: string[];
+  };
+  pipeline: PipelineCounts;
+  crons: { declared: string[] };
+  blockers: string[];
+  timestamp: string;
+};
+
+function presence(names: readonly string[]): EnvPresence {
+  const out: EnvPresence = {};
+  for (const name of names) {
+    const raw = process.env[name];
+    out[name] = typeof raw === 'string' && raw.trim().length > 0;
+  }
+  return out;
+}
+
+async function countCustomers(): Promise<number> {
+  const { count, error } = await getSupabaseAdmin()
+    .from('billing_customers')
+    .select('*', { count: 'exact', head: true });
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+async function countOutbox(status: string): Promise<number> {
+  const { count, error } = await getSupabaseAdmin()
+    .from('billing_meter_outbox')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', status);
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+async function readPipeline(): Promise<PipelineCounts> {
+  try {
+    const [billingCustomers, outboxPending, outboxFailed, outboxSent] = await Promise.all([
+      countCustomers(),
+      countOutbox('pending'),
+      countOutbox('failed'),
+      countOutbox('sent'),
+    ]);
+    return { billingCustomers, outboxPending, outboxFailed, outboxSent, reachable: true };
+  } catch (error) {
+    return {
+      billingCustomers: 0,
+      outboxPending: 0,
+      outboxFailed: 0,
+      outboxSent: 0,
+      reachable: false,
+      detail: error instanceof Error ? error.message : 'database unreachable',
+    };
+  }
+}
+
+export async function getRevenueReadiness(): Promise<RevenueReadinessReport> {
+  const required = presence(REQUIRED_ENV);
+  const optional = presence(OPTIONAL_ENV);
+  const missingRequired = Object.entries(required)
+    .filter(([, present]) => !present)
+    .map(([name]) => name);
+
+  const pipeline = await readPipeline();
+  const blockers: string[] = [];
+
+  for (const name of missingRequired) {
+    blockers.push(`env ${name} is not set — set it in the deployment environment`);
+  }
+
+  if (!pipeline.reachable) {
+    blockers.push('billing tables unreachable — cannot confirm pipeline state');
+  } else if (pipeline.billingCustomers === 0) {
+    blockers.push(
+      'billing_customers is empty — no org has completed Stripe Checkout, so meterExecution() exits early and nothing is ever billed',
+    );
+  }
+
+  if (pipeline.outboxFailed > 0) {
+    blockers.push(
+      `${pipeline.outboxFailed} meter event(s) in failed state — run /api/cron/reconcile-meter?requeue=true`,
+    );
+  }
+
+  // Stage reflects how far the money actually travels today, not intent.
+  let stage: RevenueReadinessReport['stage'];
+  if (missingRequired.length > 0 || !pipeline.reachable) {
+    stage = 'blocked';
+  } else if (pipeline.outboxSent > 0) {
+    stage = 'flowing';
+  } else {
+    stage = 'configured-idle';
+  }
+
+  return {
+    ok: blockers.length === 0,
+    stage,
+    env: { required, optional, missingRequired },
+    pipeline,
+    crons: { declared: [...REVENUE_CRONS] },
+    blockers,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/billing/revenue-readiness.ts
+++ b/lib/billing/revenue-readiness.ts
@@ -16,6 +16,10 @@ const REQUIRED_ENV = [
   'STRIPE_WEBHOOK_SECRET',
   'STRIPE_METER_EVENT_NAME',
   'CRON_SECRET',
+  // getSupabaseAdmin() reads both of these. Checking only the service-role key
+  // let the report call Supabase satisfied while every query still failed on a
+  // missing URL — precisely the guesswork this endpoint exists to remove.
+  'NEXT_PUBLIC_SUPABASE_URL',
   'SUPABASE_SERVICE_ROLE_KEY',
 ] as const;
 

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,27 @@
     "autoAlias": false,
     "silent": false,
     "autoJobCancelation": true
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/flush-meter-outbox",
+      "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/cron/reconcile-meter",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/usage-alerts",
+      "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/trial-invite",
+      "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/weekly-report",
+      "schedule": "0 10 * * 1"
+    }
+  ]
 }


### PR DESCRIPTION
Goal:

Unblock the metered-billing loop so a governed execution can become an invoiced charge, and make the remaining setup gaps self-reporting instead of something to re-derive by hand each time.

Two defects were found against the live deployment and database:

1. `vercel.json` declared no `crons` key at all, while 27 cron handlers exist under `app/api/cron/`. Nothing ran on a schedule, so queued meter events would never reach Stripe even once they existed.
2. Nothing reported *why* revenue was not flowing, so each investigation restarted from zero.

Files changed:

- `vercel.json` — adds five revenue-critical cron schedules: `flush-meter-outbox` (every 10m), `reconcile-meter` (hourly), `usage-alerts` (daily 08:00 UTC), `trial-invite` (daily 09:00 UTC), `weekly-report` (Mondays 10:00 UTC). `billing-sync` is deliberately excluded — it exports `POST` only and Vercel cron issues `GET`, so scheduling it would 405 on every run.
- `lib/billing/revenue-readiness.ts` — new. Resolves env presence by name, reads aggregate pipeline counters, derives an ordered blocker list and a `stage` of `blocked` / `configured-idle` / `flowing`.
- `app/api/revenue-readiness/route.ts` — new. Public `GET`, returns 200 when unblocked and 503 otherwise.

Secrets handling: env vars are reported as name → boolean. No value, prefix, or length is read into the response. DB figures are `count`-only; no customer rows are returned.

Verification:

- [x] `npm run typecheck` → exit 0, no diagnostics
- [x] `npx vitest run tests/unit` → 197 files, 2844 tests passed, exit 0
- [x] `npm run build` → exit 0; `.next/server/app/api/revenue-readiness/route.js` emitted and `"/api/revenue-readiness"` present in `routes-manifest.json`
- [x] `vercel.json` parsed with `JSON.parse` → valid
- [x] Live probe: `/api/cron/flush-meter-outbox`, `/api/cron/reconcile-meter`, `/api/cron/usage-alerts` each return `401`, not `503` — confirming `CRON_SECRET` is already set in production, since these routes fail closed with 503 when it is absent
- [x] Live SQL against the active Supabase project: `billing_customers` = 0, `billing_meter_outbox` = 0, `usage_events` = 0, `subscriptions` = 34 rows all `plan=trial` with 0 populated `stripe_customer_id`
- [ ] New route not exercised against production — it does not exist there until this merges and deploys
- [ ] Cron schedules not observed firing — that is only verifiable post-deploy

Known limits:

- **Vercel plan gate.** Five cron jobs require Pro. On Hobby the limit is 2 jobs at daily granularity, and the deploy will be rejected. If this project is on Hobby, keep `flush-meter-outbox` and `reconcile-meter` and drop the rest.
- **This PR does not by itself produce revenue.** The dominant blocker is upstream of scheduling: `billing_customers` is empty, so `meterExecution()` resolves a null customer and returns before enqueueing. Until an org completes Stripe Checkout and the webhook writes that row, the outbox stays empty and the new crons will have nothing to flush.
- Whether `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and `STRIPE_METER_EVENT_NAME` are set in production is **not verified** — `/api/billing/meter-health` requires authorization this session did not hold. `/api/revenue-readiness` answers this directly once deployed.
- Cron schedules are UTC. The daily jobs at 08:00/09:00 UTC land at 15:00/16:00 Asia/Bangkok; adjust if the intent was local morning.
- The `stage` field describes observed movement, not certification. `flowing` means at least one meter row reached `sent` — it is not a claim that billing is production-ready.

User-visible benefit:

One call replaces the guesswork:

```bash
curl -s https://tdealer01-crypto-dsg-control-plane.vercel.app/api/revenue-readiness | jq
```

It names each missing env var, reports pipeline counters, and returns a ranked blocker list — so setup state is read, not re-derived, and the answer is the same for everyone who asks.

Next step:

1. Confirm the Vercel plan tier before merging; trim to two crons if Hobby.
2. Merge, deploy, then call `/api/revenue-readiness` and act on `missingRequired`.
3. Register the Stripe webhook endpoint against `/api/billing/webhook` and confirm `checkout.session.completed` writes a `billing_customers` row.
4. Convert one of the 34 trial orgs end to end, then re-check that `billing_meter_outbox` advances `pending → sent`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015DN7hj8jLjXJ5NbXtWCJ74)_