### PR TITLE
refactor(stripe): pin apiVersion on every Stripe client

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '../../../../lib/supabase/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { ensureUserWorkspace, isWorkspaceFailure } from '../../../../lib/auth/ensure-user-workspace';
@@ -29,7 +30,7 @@ function getStripeClient() {
     throw new Error('Missing STRIPE_SECRET_KEY');
   }
 
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 function normalizePlan(value: unknown): PlanKey {

--- a/app/api/billing/portal/route.ts
+++ b/app/api/billing/portal/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '../../../../lib/supabase/server';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
 import { handleApiError } from '../../../../lib/security/api-error';
@@ -12,7 +13,7 @@ function getStripeClient() {
     throw new Error('Missing STRIPE_SECRET_KEY');
   }
 
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 export async function POST(request: Request) {

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { internalErrorMessage, logApiError } from '../../../../lib/security/api-error';
 import type { Database, Json } from '../../../../lib/database.types';
@@ -24,7 +25,7 @@ function getStripeClient() {
     throw new Error('Missing STRIPE_SECRET_KEY');
   }
 
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 function getPriceMap(): Map<string, PriceMapping> {

--- a/app/api/cron/billing-sync/route.ts
+++ b/app/api/cron/billing-sync/route.ts
@@ -3,6 +3,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { handleApiError } from '@/lib/security/api-error';
 
@@ -13,7 +14,7 @@ function getStripeClient(): Stripe {
   if (!secretKey) {
     throw new Error('Missing STRIPE_SECRET_KEY');
   }
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 type SyncResult = {

--- a/app/api/dsg/mcp/subscribe/route.ts
+++ b/app/api/dsg/mcp/subscribe/route.ts
@@ -1,12 +1,13 @@
 // ERROR_HANDLER_EXEMPT - legacy error handling, migrate to handleApiError
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 
 function getStripe() {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
-  return new Stripe(key);
+  return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/dsg/templates/[id]/purchase/route.ts
+++ b/app/api/dsg/templates/[id]/purchase/route.ts
@@ -1,6 +1,7 @@
 // ERROR_HANDLER_EXEMPT - legacy error handling, migrate to handleApiError
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
 import { getDsgSupabaseRpcConfig, readDsgRest, callDsgRpc } from '@/lib/dsg/server/supabase-rpc';
 import {
@@ -13,7 +14,7 @@ import type { DsgMarketTemplate } from '@/lib/dsg/app-builder/templates/template
 function getStripe() {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) throw new Error('STRIPE_SECRET_KEY not configured');
-  return new Stripe(key);
+  return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
 type TemplateRow = {

--- a/app/api/marketplace/checkout/route.ts
+++ b/app/api/marketplace/checkout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '@/lib/supabase/server';
 import { getTemplate } from '@/lib/marketplace/templates';
 
@@ -31,7 +32,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'template_is_free' }, { status: 400 });
   }
 
-  const stripe = new Stripe(secret);
+  const stripe = new Stripe(secret, { apiVersion: STRIPE_API_VERSION });
   const origin = req.headers.get('origin') ?? process.env.NEXT_PUBLIC_APP_URL ?? 'https://localhost:3000';
 
   const checkoutSession = await stripe.checkout.sessions.create({

--- a/app/api/marketplace/products/[id]/checkout/route.ts
+++ b/app/api/marketplace/products/[id]/checkout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { logApiError, internalErrorMessage } from '@/lib/security/api-error';
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '@/lib/security/rate-limit';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 
 export const dynamic = 'force-dynamic';
 
@@ -71,7 +72,7 @@ export async function POST(request: Request, { params }: { params: Promise<Param
 
     // Dynamically import Stripe to avoid bundling issues
     const Stripe = require('stripe').default;
-    const stripe = new Stripe(stripeSecretKey);
+    const stripe = new Stripe(stripeSecretKey, { apiVersion: STRIPE_API_VERSION });
 
     // Create Stripe checkout session
     const session = await stripe.checkout.sessions.create({

--- a/app/api/marketplace/seller-checkout/route.ts
+++ b/app/api/marketplace/seller-checkout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '@/lib/supabase/server';
 import { logApiError, internalErrorMessage } from '@/lib/security/api-error';
 import {
@@ -144,7 +145,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Initialize Stripe client
-    const stripe = new Stripe(stripeKey);
+    const stripe = new Stripe(stripeKey, { apiVersion: STRIPE_API_VERSION });
     const origin = req.headers.get('origin') ?? process.env.NEXT_PUBLIC_APP_URL ?? 'https://localhost:3000';
 
     // Create Stripe Checkout Session with Stripe Connect transfer

--- a/app/api/marketplace/sellers/[id]/status/route.ts
+++ b/app/api/marketplace/sellers/[id]/status/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '@/lib/supabase/server';
 import { logApiError, internalErrorMessage } from '@/lib/security/api-error';
 import { buildCorsHeaders, buildPreflightResponse } from '@/lib/security/cors';
@@ -93,7 +94,7 @@ export async function GET(
     }
 
     // Check Stripe account status to determine KYC verification
-    const stripe = new Stripe(stripeSecretKey);
+    const stripe = new Stripe(stripeSecretKey, { apiVersion: STRIPE_API_VERSION });
 
     const stripeAccount = await stripe.accounts.retrieve(seller.stripe_account_id);
 

--- a/app/api/marketplace/sellers/onboard/route.ts
+++ b/app/api/marketplace/sellers/onboard/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '@/lib/supabase/server';
 import { logApiError, internalErrorMessage } from '@/lib/security/api-error';
 import { buildCorsHeaders, buildPreflightResponse } from '@/lib/security/cors';
@@ -101,7 +102,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     // Initialize Stripe client
-    const stripe = new Stripe(stripeSecretKey);
+    const stripe = new Stripe(stripeSecretKey, { apiVersion: STRIPE_API_VERSION });
 
     // Create Stripe Connected Account using Accounts v2 API
     // Reference: https://docs.stripe.com/connect/accounts-v2

--- a/app/api/marketplace/verify/route.ts
+++ b/app/api/marketplace/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '@/lib/supabase/server';
 import { getTemplate } from '@/lib/marketplace/templates';
 import { dsgOneClient } from '@/lib/dsg-one/client';
@@ -24,7 +25,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'sessionId and templateId are required' }, { status: 400 });
   }
 
-  const stripe = new Stripe(secret);
+  const stripe = new Stripe(secret, { apiVersion: STRIPE_API_VERSION });
 
   const checkoutSession = await stripe.checkout.sessions.retrieve(sessionId);
   if (checkoutSession.payment_status !== 'paid') {

--- a/app/api/release-gate/check/route.ts
+++ b/app/api/release-gate/check/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { runReleaseGate } from '../../../../lib/release-gate/checker';
 import { hasReleaseGateProAccess } from '../../../../lib/release-gate/entitlements';
 
@@ -15,7 +16,7 @@ export async function GET(req: NextRequest) {
 
   if (sessionId && process.env.STRIPE_SECRET_KEY) {
     try {
-      const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+      const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: STRIPE_API_VERSION });
       const session = await stripe.checkout.sessions.retrieve(sessionId);
       const email = session.customer_details?.email ?? null;
 

--- a/app/api/revenue/[action]/route.ts
+++ b/app/api/revenue/[action]/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { createClient } from '@supabase/supabase-js';
 import { PostHog } from 'posthog-node';
 import { handleApiError } from '@/lib/security/api-error';
@@ -14,7 +15,7 @@ export const dynamic = 'force-dynamic';
 // ========== INIT ==========
 
 function getStripe() {
-  return new Stripe(process.env.STRIPE_SECRET_KEY || '');
+  return new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: STRIPE_API_VERSION });
 }
 
 function getSupabase() {

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -14,6 +14,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
 async function upsertSubscriptionEntitlement(stripe: Stripe, subscription: Stripe.Subscription) {
@@ -72,7 +73,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'stripe_not_configured' }, { status: 501 });
   }
 
-  const stripe = new Stripe(secret);
+  const stripe = new Stripe(secret, { apiVersion: STRIPE_API_VERSION });
   const sig = req.headers.get('stripe-signature');
   const body = await req.text();
 

--- a/app/api/webhooks/stripe/checkout-complete/route.ts
+++ b/app/api/webhooks/stripe/checkout-complete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { logApiError, handleApiError } from '@/lib/security/api-error';
 import { hashDeterministicValue } from '@/lib/dsg/deterministic/proof-hash';
@@ -94,7 +95,7 @@ function getStripeClient(): Stripe {
   if (!secretKey) {
     throw new Error('Missing STRIPE_SECRET_KEY');
   }
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 function getWebhookSecret(): string {

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 import { POST as handleBillingWebhook } from '@/app/api/billing/webhook/route';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { insertRevenueEvent } from '@/lib/revenue/events';
@@ -29,7 +30,7 @@ function getStripeClient(): Stripe {
     throw new Error('Missing STRIPE_SECRET_KEY');
   }
 
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 function getWebhookSecret(): string {

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -15,6 +15,7 @@
  */
 
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 
 type MeterEventResult =
   | { ok: true; eventId: string }
@@ -44,7 +45,7 @@ type OutboxRow = {
 function getStripe(): Stripe | null {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) return null;
-  return new Stripe(key);
+  return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
 function getMeterEventName(): string | null {

--- a/lib/billing/reconciliation.ts
+++ b/lib/billing/reconciliation.ts
@@ -9,6 +9,7 @@
  */
 
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -52,7 +53,7 @@ const STUCK_THRESHOLD_MINUTES = 10;
 function getStripe(): Stripe | null {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) return null;
-  return new Stripe(key);
+  return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
 function getMeterId(): string | null {

--- a/lib/stripe-api-version.ts
+++ b/lib/stripe-api-version.ts
@@ -1,0 +1,16 @@
+/**
+ * The Stripe API version every client in this repository pins to.
+ *
+ * Without an explicit `apiVersion`, each client silently adopts whatever
+ * version the installed SDK defaults to, so bumping the `stripe` dependency
+ * changes live request/response shapes with no diff to review. Pinning here
+ * makes that a deliberate, single-line change.
+ *
+ * Currently matches the default of `stripe@22.3.0`, so this pin is a no-op
+ * against today's behaviour — it only takes effect on a future SDK upgrade.
+ *
+ * To move it: bump this constant, then re-read the Stripe API changelog for
+ * every version crossed before merging.
+ * https://docs.stripe.com/upgrades
+ */
+export const STRIPE_API_VERSION = '2026-06-24.dahlia' as const;

--- a/lib/stripe-products.ts
+++ b/lib/stripe-products.ts
@@ -13,6 +13,7 @@
  */
 
 import Stripe from 'stripe';
+import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 
 export type PlanKey = 'pro' | 'business' | 'enterprise';
 export type BillingInterval = 'monthly' | 'yearly';
@@ -58,7 +59,7 @@ export function getStripeClient(): Stripe {
   if (!secretKey) {
     throw new Error('Missing STRIPE_SECRET_KEY environment variable');
   }
-  return new Stripe(secretKey);
+  return new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION });
 }
 
 /**


### PR DESCRIPTION
Goal:

Stop a future `stripe` dependency bump from silently changing live API behaviour.

All 20 `new Stripe(...)` call sites passed only a secret key and no config object, so each one adopted whatever API version the installed SDK happened to default to. Upgrading the SDK would change request and response shapes across billing, checkout, webhooks, metering and Connect — with no diff anywhere to review.

Files changed:

- `lib/stripe-api-version.ts` — new. Exports a single `STRIPE_API_VERSION` constant.
- 20 call sites across `app/api/**` and `lib/**` — each now passes `{ apiVersion: STRIPE_API_VERSION }`.

Pinning through one constant rather than repeating the literal 20 times means the next version move is a one-line change, not another 20-file sweep.

One site needed hand editing: `app/api/marketplace/products/[id]/checkout/route.ts` constructs its client from `require('stripe').default` inside the handler instead of a top-level import.

Verification:

- [x] `npm run typecheck` → exit 0, no diagnostics
- [x] `npx vitest run tests/unit` → 197 files, 2844 tests passed, exit 0
- [x] `npm run build` → exit 0
- [x] `grep -rn "new Stripe(" app lib --include=*.ts | grep -v apiVersion` → no matches, so all 20 are pinned
- [x] `grep -rn "apiVersion.*apiVersion"` → no matches, so the rewrite did not double-apply
- [x] Pinned value cross-checked against the installed SDK: `node_modules/stripe/cjs/apiVersion.js` exports `2026-06-24.dahlia`

Known limits:

- **Behaviour-neutral today.** The pinned value is exactly what `stripe@22.3.0` already defaults to, so this changes nothing about current requests. It only takes effect on a future SDK upgrade — which is the entire point, and also means this PR cannot be proven to "work" by observing behaviour change.
- Nineteen of the twenty edits were applied by a scripted rewrite over a uniform single-argument pattern. The greps above are what establish it landed correctly; the diff is worth a skim rather than a trust-me.
- No test asserts the pinned version. If that guarantee matters, a unit test comparing `STRIPE_API_VERSION` against the SDK's exported `ApiVersion` would catch drift on the next `npm update` — say the word and I will add it.
- Does not address the separate recommendation to move from a secret key (`sk_`) to a restricted key (`rk_`). That is a dashboard and environment change, not a code change.

User-visible benefit:

None directly. This is upgrade safety: `npm update stripe` can no longer alter payment behaviour without an explicit, reviewable change to one line.

Next step:

1. Review and merge.
2. When bumping the `stripe` dependency in future, bump `STRIPE_API_VERSION` in the same PR and read the Stripe changelog for every version crossed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015DN7hj8jLjXJ5NbXtWCJ74)_