### PR TITLE
fix(deterministic): enforce truthful external solver evidence

### DIFF
--- a/lib/dsg/deterministic/external-solver.ts
+++ b/lib/dsg/deterministic/external-solver.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import type {
   DeterministicConstraintResult,
   DeterministicProofRequest,
@@ -15,8 +16,13 @@ export type ExternalSolverResponse = {
   solver_version: string;
   time_ms: number;
   smt2_hash: string;
+  nonce?: string;
   error?: string;
 };
+
+export function hashSmt2(smt2: string): string {
+  return crypto.createHash("sha256").update(smt2).digest("hex");
+}
 
 /**
  * Generate SMT-LIB v2 formula from deterministic constraints.
@@ -32,12 +38,10 @@ export function generateSmt2ForProof(
   const manifest = getDeterministicPolicyManifest();
   const context = request.context ?? {};
 
-  // Build boolean variables for each constraint
   const boolDeclarations = constraints
     .map((c) => `(declare-const ${c.constraintId} Bool)`)
     .join("\n");
 
-  // Assert actual values from context
   const contextAssertions = constraints
     .map((c) => {
       const contextValue = context[c.evidenceKey] === true ? "true" : "false";
@@ -45,12 +49,10 @@ export function generateSmt2ForProof(
     })
     .join("\n");
 
-  // Require all constraints to be true (hard gates)
   const requiredConstraints = constraints
     .map((c) => c.constraintId)
     .join(" ");
 
-  // Build the complete formula
   return `; DSG Deterministic Proof Verification
 ; Policy: ${manifest.policyRef} v${manifest.policyVersion}
 ; Generated for proof request with nonce: ${request.nonce}
@@ -72,8 +74,6 @@ ${contextAssertions}
 
 /**
  * Invoke external Z3 solver via HTTP.
- * DSG_EXTERNAL_SOLVER_URL should be set to the full endpoint, e.g., https://z3-solver-api.vercel.app/api/solve
- * Returns null if disabled or fails; returns result if successful.
  */
 export async function invokeExternalSolver(
   smt2: string,
@@ -86,22 +86,39 @@ export async function invokeExternalSolver(
     return null;
   }
 
+  let parsedSolverUrl: URL;
+  try {
+    parsedSolverUrl = new URL(solverUrl);
+  } catch {
+    console.error("[ExternalSolver] Invalid solver URL");
+    return null;
+  }
+
+  if (parsedSolverUrl.protocol !== "https:" && process.env.NODE_ENV === "production") {
+    console.error("[ExternalSolver] Production solver URL must use HTTPS");
+    return null;
+  }
+
   const timeoutMs = parseInt(
     process.env.DSG_SOLVER_TIMEOUT_MS || "5000",
     10
   );
+  const smt2Hash = hashSmt2(smt2);
+  const solverApiKey = process.env.DSG_EXTERNAL_SOLVER_API_KEY;
 
   try {
     const controller = new AbortController();
     const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs + 1000);
 
-    const response = await fetch(solverUrl, {
+    const response = await fetch(parsedSolverUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...(solverApiKey ? { Authorization: `Bearer ${solverApiKey}` } : {}),
       },
       body: JSON.stringify({
         smt2,
+        smt2_hash: smt2Hash,
         timeout_ms: timeoutMs,
         nonce: request.nonce,
       }),
@@ -119,9 +136,8 @@ export async function invokeExternalSolver(
 
     const result = (await response.json()) as ExternalSolverResponse;
 
-    // Validate response shape
-    if (!result.status || !result.solver_version) {
-      console.error("[ExternalSolver] Invalid response format", result);
+    if (!isValidExternalSolverResult(result, { smt2Hash, nonce: request.nonce })) {
+      console.error("[ExternalSolver] Invalid or unbound response", result);
       return null;
     }
 
@@ -142,27 +158,35 @@ export async function invokeExternalSolver(
   }
 }
 
-/**
- * Determine if external solver claim should be marked as invoked.
- * Only true if:
- * 1. Solver responded with sat/unsat (not "unknown")
- * 2. No errors in response
- * 3. Response time is reasonable
- */
 export function isValidExternalSolverResult(
-  result: ExternalSolverResponse
+  result: ExternalSolverResponse,
+  expected?: { smt2Hash?: string; nonce?: string },
 ): boolean {
   if (!result || result.error) {
     return false;
   }
 
-  // "unknown" status doesn't count as external solver invocation
   if (result.status === "unknown") {
     return false;
   }
 
-  // Must have solver version and reasonable timing
   if (!result.solver_version || result.time_ms < 0) {
+    return false;
+  }
+
+  if (result.status === "sat" && result.satisfiable !== true) {
+    return false;
+  }
+
+  if (result.status === "unsat" && result.satisfiable !== false) {
+    return false;
+  }
+
+  if (expected?.smt2Hash && result.smt2_hash !== expected.smt2Hash) {
+    return false;
+  }
+
+  if (expected?.nonce && result.nonce && result.nonce !== expected.nonce) {
     return false;
   }
 

--- a/lib/dsg/deterministic/proof-cache.ts
+++ b/lib/dsg/deterministic/proof-cache.ts
@@ -1,19 +1,14 @@
 /**
  * Hybrid Proof Verification Strategy
  *
- * Path A (Cached): Fast deterministic replay from stored proof records
- * Path B (Live): Fresh Z3 solver invocation for verification/audit
- *
- * Decision flow:
- * 1. Try cache lookup by input_hash on dsg_gate_decisions table
- * 2. If hit && no verification flag: return cached proof (fast)
- * 3. If miss || verification flag: invoke live Z3 solver (fresh)
- * 4. Record/update decision in dsg_gate_decisions for future replay
+ * This module currently provides durable decision history plus live proof
+ * generation. Cached proof replay is intentionally disabled until full proof
+ * JSON is persisted and integrity-checked before reuse.
  */
 
 import type { DeterministicProof, DeterministicProofRequest } from './types';
 import { createClient } from '@supabase/supabase-js';
-import crypto from 'crypto';
+import { hashDeterministicValue } from './proof-hash';
 
 interface CachedProofRecord {
   id: string;
@@ -26,34 +21,31 @@ interface CachedProofRecord {
 }
 
 /**
- * Compute SHA256 hash of input constraints for cache lookup
+ * Compute the canonical request hash used by proof generation and persistence.
  */
 export function hashProofInput(request: DeterministicProofRequest): string {
-  const input = JSON.stringify({
+  return hashDeterministicValue({
     planId: request.planId ?? null,
     context: request.context ?? {},
-    policyRef: request.policyRef,
-    policyVersion: request.policyVersion,
+    policyRef: request.policyRef ?? null,
+    policyVersion: request.policyVersion ?? null,
     riskLevel: request.riskLevel ?? 'medium',
+    verificationMode: request.verificationMode ?? null,
     nonce: request.nonce,
     idempotencyKey: request.idempotencyKey,
   });
-  return crypto.createHash('sha256').update(input).digest('hex');
 }
 
 /**
- * Path A (Cached): Look up proof from dsg_gate_decisions table
- * Returns null if not found or verification requested
+ * Decision-history lookup only. Do not treat this record as a replayable proof
+ * until full proof JSON is stored and verified.
  */
 export async function tryGetCachedProof(
   orgId: string,
   inputHash: string,
   options: { verifyFresh?: boolean } = {},
 ): Promise<CachedProofRecord | null> {
-  if (options.verifyFresh) {
-    // Skip cache if verification requested
-    return null;
-  }
+  if (options.verifyFresh) return null;
 
   try {
     const supabase = createClient(
@@ -71,24 +63,20 @@ export async function tryGetCachedProof(
       .single();
 
     if (error) {
-      if (error.code === 'PGRST116') {
-        // Not found — expected on cache miss
-        return null;
-      }
-      console.warn('Cache lookup error:', error);
+      if (error.code === 'PGRST116') return null;
+      console.warn('Decision history lookup error:', error);
       return null;
     }
 
     return data as CachedProofRecord;
   } catch (err) {
-    console.warn('Proof cache lookup failed:', err);
+    console.warn('Decision history lookup failed:', err);
     return null;
   }
 }
 
 /**
- * Path B (Live): Record or update Z3 proof decision in dsg_gate_decisions
- * Called after proof generation to store for future cache hits
+ * Record the exact verified proof decision in dsg_gate_decisions.
  */
 export async function recordProofDecision(
   orgId: string,
@@ -103,7 +91,7 @@ export async function recordProofDecision(
 
     const { data, error } = await supabase
       .from('dsg_gate_decisions')
-      .insert({
+      .upsert({
         org_id: orgId,
         policy_version: policyVersionId || proof.policyVersion,
         input_hash: proof.inputHash,
@@ -116,12 +104,18 @@ export async function recordProofDecision(
                  proof.status === 'BLOCK' ? 'BLOCK' : 'REVIEW',
         decision_confidence: proof.status === 'PASS' ? 1.0 : 0.5,
         proof_hash: proof.proofHash,
-        proof_format: 'dsg-deterministic-v1',
-        z3_status: proof.solver?.name === 'z3' ? 'sat' : null,
-        z3_satisfiable: proof.status === 'PASS' || proof.status === 'REVIEW',
-        z3_solver_version: proof.solver?.version,
-        z3_smt2_hash: proof.inputHash,
-        z3_trace: proof.evidenceBoundary,
+        proof_format: 'dsg-deterministic-v2',
+        z3_status: proof.solver.invoked ? proof.solver.status ?? null : null,
+        z3_satisfiable: proof.solver.invoked ? proof.solver.satisfiable ?? null : null,
+        z3_solver_version: proof.solver.invoked ? proof.solver.version : null,
+        z3_smt2_hash: proof.solver.invoked ? proof.solver.smt2Hash ?? null : null,
+        z3_trace: {
+          solver: proof.solver,
+          evidenceBoundary: proof.evidenceBoundary,
+          replayProtection: proof.replayProtection,
+        },
+      }, {
+        onConflict: 'org_id,input_hash,policy_version,proof_hash',
       })
       .select('id')
       .single();
@@ -138,39 +132,31 @@ export async function recordProofDecision(
   }
 }
 
-/**
- * Hybrid wrapper: Check cache first, fall back to live solver
- */
 export interface HybridProofOptions {
   orgId: string;
-  verifyFresh?: boolean; // If true, skip cache and invoke live Z3
-  recordResult?: boolean; // If true, store result in cache
+  verifyFresh?: boolean;
+  recordResult?: boolean;
 }
 
 export async function evaluateProofWithHybridStrategy(
   request: DeterministicProofRequest,
   options: HybridProofOptions,
   proveFn: (req: DeterministicProofRequest) => Promise<DeterministicProof>,
-): Promise<{ proof: DeterministicProof; source: 'cached' | 'live' }> {
+): Promise<{ proof: DeterministicProof; source: 'live' }> {
   const inputHash = hashProofInput(request);
 
-  // Try Path A (Cached)
-  const cached = await tryGetCachedProof(options.orgId, inputHash, {
+  const previous = await tryGetCachedProof(options.orgId, inputHash, {
     verifyFresh: options.verifyFresh,
   });
 
-  if (cached) {
-    console.log(`[Proof Cache] HIT: ${inputHash.slice(0, 8)}...`);
-    // Return cached proof structure (reconstruct from record)
-    // For now, fall through to live to ensure we have full proof object
-    // TODO: Store full proof JSON in z3_trace to enable full replay
+  if (previous) {
+    console.log(
+      `[Proof History] MATCH: ${inputHash.slice(0, 8)}...; replay disabled pending full-proof verification`,
+    );
   }
 
-  // Path B (Live) or cache miss
-  console.log(`[Proof Cache] MISS/VERIFY: ${inputHash.slice(0, 8)}... (invoking live Z3)`);
   const proof = await proveFn(request);
 
-  // Record result for future cache hits
   if (options.recordResult) {
     await recordProofDecision(options.orgId, proof);
   }

--- a/lib/dsg/deterministic/proof-engine.ts
+++ b/lib/dsg/deterministic/proof-engine.ts
@@ -4,6 +4,8 @@ import type {
   DeterministicProof,
   DeterministicProofRequest,
   DeterministicProofStatus,
+  DeterministicSolverEvidence,
+  DeterministicVerificationMode,
 } from "./types";
 import { buildProofHash, hashDeterministicValue } from "./proof-hash";
 import { getDeterministicPolicyManifest } from "./policy-manifest";
@@ -11,8 +13,7 @@ import { getDeterministicSolverMetadata } from "./solver-metadata";
 import {
   generateSmt2ForProof,
   invokeExternalSolver,
-  isValidExternalSolverResult,
-  type ExternalSolverResponse,
+  hashSmt2,
 } from "./external-solver";
 
 function boolValue(context: Record<string, unknown>, key: string) {
@@ -29,32 +30,41 @@ function statusFromFailures(
   return "PASS";
 }
 
-/**
- * Attempt to invoke external Z3 solver and update solver metadata.
- * Returns updated solver metadata if successful; original metadata on failure.
- * Always falls back to static check on error/timeout.
- */
-async function tryInvokeExternalSolverAndUpdateMetadata(
+function resolveVerificationMode(
+  request: DeterministicProofRequest,
+): DeterministicVerificationMode {
+  if (request.verificationMode) return request.verificationMode;
+  if (request.riskLevel === "high" || request.riskLevel === "critical") {
+    return "external_required";
+  }
+  if (request.riskLevel === "medium") return "external_preferred";
+  return "static_allowed";
+}
+
+async function resolveSolverEvidence(
   constraints: DeterministicConstraintResult[],
   request: DeterministicProofRequest,
-  defaultSolver: ReturnType<typeof getDeterministicSolverMetadata>,
-): Promise<ReturnType<typeof getDeterministicSolverMetadata>> {
-  // Generate SMT-LIB2 representation of the constraints
+): Promise<DeterministicSolverEvidence> {
+  const fallback = getDeterministicSolverMetadata();
   const smt2 = generateSmt2ForProof(request, constraints);
+  const result = await invokeExternalSolver(smt2, request);
 
-  // Attempt to invoke external solver
-  const solverResult = await invokeExternalSolver(smt2, request);
-
-  // If external solver failed or returned invalid result, return default
-  if (!solverResult || !isValidExternalSolverResult(solverResult)) {
-    return defaultSolver;
+  if (!result) {
+    return {
+      name: fallback.name,
+      version: fallback.version,
+      invoked: false,
+    };
   }
 
-  // External solver succeeded; update metadata
   return {
     name: "z3",
-    version: solverResult.solver_version,
-    externalSolverInvoked: true,
+    version: result.solver_version,
+    invoked: true,
+    status: result.status,
+    satisfiable: result.satisfiable,
+    smt2Hash: result.smt2_hash || hashSmt2(smt2),
+    timeMs: result.time_ms,
   };
 }
 
@@ -71,7 +81,7 @@ function deterministicProofTimestamp(inputHash: string) {
   return new Date(seconds * 1000).toISOString();
 }
 
-export function isProductionReadyDeterministicProof(
+export function isStructurallyCompleteDeterministicProof(
   proof: DeterministicProof,
 ): boolean {
   return (
@@ -90,38 +100,29 @@ export function isProductionReadyDeterministicProof(
   );
 }
 
+/** @deprecated Prefer isStructurallyCompleteDeterministicProof. */
+export const isProductionReadyDeterministicProof =
+  isStructurallyCompleteDeterministicProof;
+
 export async function proveDeterministicPlan(
   request: DeterministicProofRequest,
 ): Promise<DeterministicProof> {
   const manifest = getDeterministicPolicyManifest();
-  let solver = getDeterministicSolverMetadata();
   const policyRef = request.policyRef ?? manifest.policyRef;
   const policyVersion = request.policyVersion ?? manifest.policyVersion;
   const context = request.context ?? {};
+  const verificationMode = resolveVerificationMode(request);
 
   const constraints: DeterministicConstraintResult[] = manifest.constraints.map(
-    (constraint) => {
-      const passed = boolValue(context, constraint.evidenceKey);
-      return {
-        ...constraint,
-        passed,
-      };
-    },
+    (constraint) => ({
+      ...constraint,
+      passed: boolValue(context, constraint.evidenceKey),
+    }),
   );
 
-  // Try to invoke external Z3 solver (if enabled and configured)
-  if (
-    process.env.DSG_DETERMINISTIC_EXTERNAL_SOLVER_ENABLED === "true" &&
-    process.env.DSG_EXTERNAL_SOLVER_URL
-  ) {
-    solver = await tryInvokeExternalSolverAndUpdateMetadata(
-      constraints,
-      request,
-      solver,
-    );
-  }
+  const solver = await resolveSolverEvidence(constraints, request);
 
-  const failureReasons = constraints
+  const failureReasons: DeterministicFailureReason[] = constraints
     .filter((constraint) => !constraint.passed)
     .map((constraint) => ({
       code: constraint.constraintId,
@@ -130,13 +131,58 @@ export async function proveDeterministicPlan(
       severity: constraint.severity,
     }));
 
-  const status = statusFromFailures(failureReasons);
+  const localStatus = statusFromFailures(failureReasons);
+  let status = localStatus;
+
+  if (solver.invoked && solver.status === "unsat") {
+    if (localStatus === "PASS") {
+      failureReasons.push({
+        code: "external_solver_disagreement",
+        message:
+          "External Z3 returned UNSAT while local deterministic checks returned PASS.",
+        severity: "critical",
+      });
+    }
+    status = "BLOCK";
+  }
+
+  if (solver.invoked && solver.status === "sat" && localStatus !== "PASS") {
+    failureReasons.push({
+      code: "external_solver_disagreement",
+      message:
+        "External Z3 returned SAT while local deterministic checks found failed constraints.",
+      severity: "critical",
+    });
+    status = "BLOCK";
+  }
+
+  if (!solver.invoked && verificationMode === "external_required") {
+    failureReasons.push({
+      code: "external_solver_required",
+      message:
+        "External verification is required for this request but no verified solver result was available.",
+      severity: "critical",
+    });
+    status = "BLOCK";
+  }
+
+  if (!solver.invoked && verificationMode === "external_preferred" && status === "PASS") {
+    failureReasons.push({
+      code: "external_solver_unavailable",
+      message:
+        "External verification was preferred but unavailable; manual review is required.",
+      severity: "high",
+    });
+    status = "REVIEW";
+  }
+
   const inputHash = hashDeterministicValue({
     planId: request.planId ?? null,
     context,
     policyRef,
     policyVersion,
     riskLevel: request.riskLevel ?? "medium",
+    verificationMode,
     nonce: request.nonce,
     idempotencyKey: request.idempotencyKey,
   });
@@ -153,7 +199,7 @@ export async function proveDeterministicPlan(
     proofId,
     status,
     timestamp,
-    solver: { name: solver.name, version: solver.version },
+    solver,
     policyRef,
     policyVersion,
     constraintsChecked: constraints.length,
@@ -168,10 +214,7 @@ export async function proveDeterministicPlan(
     proofId,
     status,
     timestamp,
-    solver: {
-      name: solver.name,
-      version: solver.version,
-    },
+    solver,
     policyRef,
     policyVersion,
     constraintsChecked: constraints.length,
@@ -183,13 +226,14 @@ export async function proveDeterministicPlan(
     model: {
       planId: request.planId ?? null,
       riskLevel: request.riskLevel ?? "medium",
+      verificationMode,
     },
     failureReasons,
     constraints,
     evidenceBoundary: {
       statement:
-        "This DSG-native deterministic proof is evidence-derived from the checked policy constraints, replay-protection inputs, policy reference, constraint-set hash, proof hash, input hash, and solver metadata. It does not claim an external Z3 production solver, third-party certification, WORM-certified storage, or cryptographic-signing completion.",
-      externalSolverInvoked: solver.externalSolverInvoked,
+        "This DSG-native deterministic proof records checked policy constraints, replay-protection inputs, policy reference, constraint-set hash, proof hash, input hash, and verified solver evidence when available. It does not claim third-party certification, WORM-certified storage, or cryptographic-signing completion.",
+      externalSolverInvoked: solver.invoked,
       productionReadyClaim: false,
       externalZ3ProductionSolverClaim: false,
       certificationClaim: false,
@@ -200,7 +244,8 @@ export async function proveDeterministicPlan(
   };
 
   proof.evidenceBoundary.productionReadyClaim =
-    isProductionReadyDeterministicProof(proof);
+    isStructurallyCompleteDeterministicProof(proof) &&
+    (verificationMode !== "external_required" || solver.invoked);
 
   return proof;
 }

--- a/lib/dsg/deterministic/proof-engine.ts
+++ b/lib/dsg/deterministic/proof-engine.ts
@@ -34,6 +34,19 @@ function resolveVerificationMode(
   request: DeterministicProofRequest,
 ): DeterministicVerificationMode {
   if (request.verificationMode) return request.verificationMode;
+
+  const solverRequired = process.env.DSG_SOLVER_REQUIRED === "true";
+  const solverConfigured =
+    process.env.DSG_DETERMINISTIC_EXTERNAL_SOLVER_ENABLED === "true" &&
+    Boolean(process.env.DSG_EXTERNAL_SOLVER_URL);
+
+  if (solverRequired) return "external_required";
+
+  // Preserve the deterministic static gate when no external solver is wired.
+  // Deployments that require external verification must set DSG_SOLVER_REQUIRED
+  // or pass verificationMode="external_required" explicitly.
+  if (!solverConfigured) return "static_allowed";
+
   if (request.riskLevel === "high" || request.riskLevel === "critical") {
     return "external_required";
   }

--- a/lib/dsg/deterministic/types.ts
+++ b/lib/dsg/deterministic/types.ts
@@ -8,6 +8,10 @@ export type DeterministicSolverName =
   | "rule_engine"
   | "static_check"
   | "none";
+export type DeterministicVerificationMode =
+  | "static_allowed"
+  | "external_preferred"
+  | "external_required";
 
 // Verification sentinel: export type DeterministicGateStatus = 'PASS' | 'BLOCK' | 'REVIEW'
 // Canonical DSG gate output intentionally excludes UNSUPPORTED.
@@ -42,14 +46,21 @@ export type DeterministicReplayProtection = {
   requestHash: string;
 };
 
+export type DeterministicSolverEvidence = {
+  name: DeterministicSolverName;
+  version: string;
+  invoked: boolean;
+  status?: "sat" | "unsat" | "unknown";
+  satisfiable?: boolean;
+  smt2Hash?: string;
+  timeMs?: number;
+};
+
 export type DeterministicProof = {
   proofId: string;
   status: DeterministicProofStatus;
   timestamp: string;
-  solver: {
-    name: DeterministicSolverName;
-    version: string;
-  };
+  solver: DeterministicSolverEvidence;
   policyRef: string;
   policyVersion: string;
   constraintsChecked: number;
@@ -149,6 +160,7 @@ export type DeterministicProofRequest = {
   policyRef?: string;
   policyVersion?: string;
   riskLevel?: DeterministicRiskLevel;
+  verificationMode?: DeterministicVerificationMode;
   previousProofHash?: string;
   nonce: string;
   idempotencyKey: string;


### PR DESCRIPTION
## Summary

Fixes the deterministic proof truth-integrity defects identified in the deep code audit.

### Changes
- Add structured external solver evidence to `DeterministicProof`.
- Add verification modes: `static_allowed`, `external_preferred`, and `external_required`.
- Bind solver responses to the submitted SMT-LIB hash and validate SAT/UNSAT consistency.
- Require HTTPS for the production solver endpoint and support bearer authentication.
- Make external solver disagreement fail closed.
- Preserve deterministic static-gate behavior when no external solver is configured.
- Require verified external solver results for high/critical requests when the solver is configured, when `DSG_SOLVER_REQUIRED=true`, or when the request explicitly selects `external_required`.
- Persist actual Z3 status, satisfiability, SMT hash, timing, and version instead of inferred values.
- Replace non-functional cache claims with explicit decision-history behavior until full-proof replay is implemented.
- Use canonical deterministic hashing for decision-history lookups.
- Rename the broad production-readiness predicate to structural completeness while retaining a compatibility alias.

## Important deployment requirements

1. The database must have a unique constraint compatible with:

```sql
(org_id, input_hash, policy_version, proof_hash)
```

2. Deployments that require external verification must set:

```text
DSG_SOLVER_REQUIRED=true
DSG_DETERMINISTIC_EXTERNAL_SOLVER_ENABLED=true
DSG_EXTERNAL_SOLVER_URL=https://...
```

or send `verificationMode="external_required"` in the proof request.

## Validation status
- TypeScript: passed in GitHub Actions on the first revision
- Lint: passed in GitHub Actions on the first revision
- Unit tests: passed in GitHub Actions on the first revision
- Integration tests: passed in GitHub Actions on the first revision
- Z3 gate: first revision failed because static CI requests defaulted to high-risk external-required mode; commit `f7b04f3` preserves the documented static CI contract when no solver is configured

## Validation still required
- Confirm rerun of Z3 Gate and Governance Summary is green
- External solver contract test including echoed `smt2_hash`
- Migration or schema verification for the composite unique constraint
- Integration tests for external-required failure, solver disagreement, and truthful persistence
