### PR TITLE
feat: connect LaunchPad checklist to DSG backend

### DIFF
--- a/app/api/dsg/launchpad/launches/[id]/route.ts
+++ b/app/api/dsg/launchpad/launches/[id]/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
+import { getDsgSupabaseRpcConfig } from '@/lib/dsg/server/supabase-rpc';
+import {
+  LaunchpadLaunchRow,
+  mapLaunchpadRow,
+  parseLaunchpadSections,
+} from '@/lib/dsg/launchpad/types';
+
+function errorStatus(message: string): number {
+  if (message === 'DSG_AUTH_REQUIRED' || message === 'DSG_PERMISSION_DENIED') return 403;
+  if (message === 'LAUNCHPAD_NOT_FOUND') return 404;
+  if (message.startsWith('LAUNCHPAD_INVALID_')) return 400;
+  return 500;
+}
+
+function validUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+async function mutateLaunch(
+  method: 'PATCH' | 'DELETE',
+  id: string,
+  workspaceId: string,
+  body?: Record<string, unknown>,
+): Promise<LaunchpadLaunchRow> {
+  const config = getDsgSupabaseRpcConfig();
+  const url = new URL(`${config.url}/rest/v1/dsg_launchpad_launches`);
+  url.searchParams.set('id', `eq.${id}`);
+  url.searchParams.set('workspace_id', `eq.${workspaceId}`);
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.key}`,
+      'Content-Type': 'application/json',
+      'Content-Profile': 'public',
+      Prefer: 'return=representation',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+  if (!response.ok) throw new Error(text || `LAUNCHPAD_${method}_${response.status}`);
+
+  const rows = text ? (JSON.parse(text) as LaunchpadLaunchRow[]) : [];
+  if (!rows[0]) throw new Error('LAUNCHPAD_NOT_FOUND');
+  return rows[0];
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireVerifiedDsgActor(req.headers, 'write:generated-apps');
+    const { id } = await params;
+    if (!validUuid(id)) throw new Error('LAUNCHPAD_INVALID_ID');
+
+    const body = (await req.json().catch(() => null)) as
+      | { name?: unknown; sections?: unknown }
+      | null;
+    if (!body || (body.name === undefined && body.sections === undefined)) {
+      throw new Error('LAUNCHPAD_INVALID_PATCH');
+    }
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== 'string' || body.name.trim().length === 0 || body.name.length > 200) {
+        throw new Error('LAUNCHPAD_INVALID_NAME');
+      }
+      patch.name = body.name.trim();
+    }
+
+    if (body.sections !== undefined) {
+      const sections = parseLaunchpadSections(body.sections);
+      if (!sections) throw new Error('LAUNCHPAD_INVALID_SECTIONS');
+      patch.sections = sections;
+    }
+
+    const stored = await mutateLaunch('PATCH', id, actor.workspaceId, patch);
+    return NextResponse.json({ ok: true, data: { launch: mapLaunchpadRow(stored) } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'LAUNCHPAD_UPDATE_FAILED';
+    return NextResponse.json(
+      { ok: false, error: { code: message } },
+      { status: errorStatus(message) },
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireVerifiedDsgActor(req.headers, 'write:generated-apps');
+    const { id } = await params;
+    if (!validUuid(id)) throw new Error('LAUNCHPAD_INVALID_ID');
+
+    const deleted = await mutateLaunch('DELETE', id, actor.workspaceId);
+    return NextResponse.json({ ok: true, data: { id: deleted.id } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'LAUNCHPAD_DELETE_FAILED';
+    return NextResponse.json(
+      { ok: false, error: { code: message } },
+      { status: errorStatus(message) },
+    );
+  }
+}

--- a/app/api/dsg/launchpad/launches/route.ts
+++ b/app/api/dsg/launchpad/launches/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { requireVerifiedDsgActor } from '@/lib/dsg/server/context';
+import { getDsgSupabaseRpcConfig, readDsgRest } from '@/lib/dsg/server/supabase-rpc';
+import {
+  LaunchpadLaunchRow,
+  mapLaunchpadRow,
+  parseLaunchpadSections,
+} from '@/lib/dsg/launchpad/types';
+
+function errorStatus(message: string): number {
+  if (message === 'DSG_AUTH_REQUIRED' || message === 'DSG_PERMISSION_DENIED') return 403;
+  if (message.startsWith('LAUNCHPAD_INVALID_')) return 400;
+  return 500;
+}
+
+async function insertLaunch(row: {
+  workspace_id: string;
+  name: string;
+  created_by: string;
+  sections: unknown;
+}): Promise<LaunchpadLaunchRow> {
+  const config = getDsgSupabaseRpcConfig();
+  const response = await fetch(`${config.url}/rest/v1/dsg_launchpad_launches`, {
+    method: 'POST',
+    headers: {
+      apikey: config.key,
+      Authorization: `Bearer ${config.key}`,
+      'Content-Type': 'application/json',
+      'Content-Profile': 'public',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(row),
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text || `LAUNCHPAD_INSERT_${response.status}`);
+  }
+
+  const rows = text ? (JSON.parse(text) as LaunchpadLaunchRow[]) : [];
+  if (!rows[0]) throw new Error('LAUNCHPAD_INSERT_EMPTY_RESPONSE');
+  return rows[0];
+}
+
+export async function GET(req: Request) {
+  try {
+    const actor = await requireVerifiedDsgActor(req.headers, 'read:generated-apps');
+    const config = getDsgSupabaseRpcConfig();
+    const rows = await readDsgRest<LaunchpadLaunchRow[]>(config, 'dsg_launchpad_launches', {
+      workspace_id: `eq.${actor.workspaceId}`,
+      select: 'id,workspace_id,name,created_by,sections,created_at,updated_at',
+      order: 'updated_at.desc',
+    });
+
+    return NextResponse.json({
+      ok: true,
+      data: {
+        launches: rows.map(mapLaunchpadRow),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'LAUNCHPAD_LIST_FAILED';
+    return NextResponse.json(
+      { ok: false, error: { code: message } },
+      { status: errorStatus(message) },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const actor = await requireVerifiedDsgActor(req.headers, 'write:generated-apps');
+    const body = (await req.json().catch(() => null)) as
+      | { name?: unknown; sections?: unknown }
+      | null;
+
+    if (typeof body?.name !== 'string' || body.name.trim().length === 0 || body.name.length > 200) {
+      throw new Error('LAUNCHPAD_INVALID_NAME');
+    }
+
+    const sections = parseLaunchpadSections(body.sections ?? []);
+    if (!sections) throw new Error('LAUNCHPAD_INVALID_SECTIONS');
+
+    const stored = await insertLaunch({
+      workspace_id: actor.workspaceId,
+      name: body.name.trim(),
+      created_by: actor.actorId,
+      sections,
+    });
+
+    return NextResponse.json(
+      { ok: true, data: { launch: mapLaunchpadRow(stored) } },
+      { status: 201 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'LAUNCHPAD_CREATE_FAILED';
+    return NextResponse.json(
+      { ok: false, error: { code: message } },
+      { status: errorStatus(message) },
+    );
+  }
+}

--- a/app/dashboard/launchpad/page.tsx
+++ b/app/dashboard/launchpad/page.tsx
@@ -1,0 +1,59 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { LaunchpadApp } from '@/components/launchpad/LaunchpadApp';
+
+export const dynamic = 'force-dynamic';
+
+export default async function LaunchpadPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login?next=/dashboard/launchpad');
+  }
+
+  const { data: memberships, error } = await supabase
+    .from('dsg_workspace_members')
+    .select('workspace_id, role')
+    .eq('actor_id', user.id)
+    .limit(1);
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-4xl px-6 py-10">
+        <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 p-6">
+          <h1 className="text-xl font-semibold text-white">LaunchPad unavailable</h1>
+          <p className="mt-2 text-sm text-rose-200">Could not resolve your DSG workspace membership.</p>
+          <p className="mt-2 font-mono text-xs text-rose-300">{error.message}</p>
+        </div>
+      </main>
+    );
+  }
+
+  const membership = memberships?.[0];
+  if (!membership?.workspace_id) {
+    return (
+      <main className="mx-auto max-w-4xl px-6 py-10">
+        <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6">
+          <h1 className="text-xl font-semibold text-white">No DSG workspace access</h1>
+          <p className="mt-2 text-sm text-amber-100">Your signed-in account is not a member of a DSG workspace yet.</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      <div className="mx-auto max-w-7xl px-6 pt-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-400">DSG Control Plane</p>
+        <h1 className="mt-2 text-3xl font-bold text-white">LaunchPad Checklist Tracker</h1>
+        <p className="mt-2 max-w-3xl text-sm text-slate-400">
+          Workspace-scoped launch tracking backed by the DSG Supabase backend. Changes are authenticated and persisted through DSG API routes.
+        </p>
+      </div>
+      <LaunchpadApp workspaceId={membership.workspace_id} />
+    </main>
+  );
+}

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -52,6 +52,7 @@ const SECTIONS: NavSection[] = [
     id: 'build',
     label: 'Build',
     items: [
+      { href: '/dashboard/launchpad', label: 'LaunchPad' },
       { href: '/dashboard/agents', label: 'Agents' },
       { href: '/dashboard/executions', label: 'Executions' },
       { href: '/dashboard/live-control', label: 'Live Control' },

--- a/components/launchpad/ChecklistRow.tsx
+++ b/components/launchpad/ChecklistRow.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { LaunchpadChecklistItem } from '@/lib/dsg/launchpad/types';
+
+export function ChecklistRow({ item, onToggle, onNotesChange }: { item: LaunchpadChecklistItem; onToggle: () => void; onNotesChange: (notes: string) => void }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(item.notes);
+
+  useEffect(() => {
+    if (!editing) setDraft(item.notes);
+  }, [item.notes, editing]);
+
+  return (
+    <div className="border-b border-slate-800 py-3 last:border-b-0">
+      <div className="flex items-center gap-3">
+        <input className="h-4 w-4 accent-blue-500" type="checkbox" checked={item.checked} onChange={onToggle} />
+        <span className={`flex-1 text-sm ${item.checked ? 'text-slate-500 line-through' : 'text-slate-200'}`}>{item.label}</span>
+        <button className="rounded px-2 py-1 text-sm hover:bg-slate-800" onClick={() => setEditing((value) => !value)} title="Add/edit notes">{item.notes ? '📝' : '➕'}</button>
+      </div>
+      {item.notes && !editing && <p className="ml-7 mt-2 rounded bg-slate-950/70 px-3 py-2 text-xs italic text-slate-400">{item.notes}</p>}
+      {editing && (
+        <div className="ml-7 mt-2 space-y-2">
+          <textarea className="w-full rounded-lg border border-slate-700 bg-slate-950 p-2 text-sm text-slate-200 outline-none focus:border-blue-500" rows={2} value={draft} maxLength={4000} onChange={(event) => setDraft(event.target.value)} placeholder="Add a note..." />
+          <div className="flex gap-2">
+            <button className="rounded bg-blue-600 px-3 py-1 text-xs font-semibold text-white hover:bg-blue-500" onClick={() => { onNotesChange(draft); setEditing(false); }}>Save</button>
+            <button className="rounded bg-slate-800 px-3 py-1 text-xs text-slate-300 hover:bg-slate-700" onClick={() => { setDraft(item.notes); setEditing(false); }}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/launchpad/LaunchDetail.tsx
+++ b/components/launchpad/LaunchDetail.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import type { LaunchpadLaunch } from '@/lib/dsg/launchpad/types';
+import { ProgressBar } from './ProgressBar';
+import { SectionPanel } from './SectionPanel';
+
+function downloadBlob(filename: string, blob: Blob) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+function safeFilename(name: string) {
+  return name.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'launch';
+}
+
+export function LaunchDetail({ launch, onToggleItem, onNotesChange }: { launch: LaunchpadLaunch; onToggleItem: (sectionId: string, itemId: string) => void; onNotesChange: (sectionId: string, itemId: string, notes: string) => void }) {
+  const totalItems = launch.sections.reduce((sum, section) => sum + section.items.length, 0);
+  const checkedItems = launch.sections.reduce((sum, section) => sum + section.items.filter((item) => item.checked).length, 0);
+  const [showExportMenu, setShowExportMenu] = useState(false);
+
+  const exportCsv = () => {
+    const rows = [['Section', 'Item', 'Status', 'Notes']];
+    for (const section of launch.sections) {
+      for (const item of section.items) rows.push([section.title, item.label, item.checked ? 'Done' : 'Pending', item.notes]);
+    }
+    const csv = rows.map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(',')).join('\n');
+    downloadBlob(`${safeFilename(launch.name)}_checklist.csv`, new Blob([csv], { type: 'text/csv;charset=utf-8' }));
+    setShowExportMenu(false);
+  };
+
+  const exportJson = () => {
+    const data = {
+      name: launch.name,
+      createdAt: launch.createdAt,
+      completionPercent: totalItems ? Math.round((checkedItems / totalItems) * 100) : 0,
+      sections: launch.sections.map((section) => ({
+        title: section.title,
+        items: section.items.map((item) => ({ label: item.label, status: item.checked ? 'Done' : 'Pending', notes: item.notes })),
+      })),
+    };
+    downloadBlob(`${safeFilename(launch.name)}_checklist.json`, new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' }));
+    setShowExportMenu(false);
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-6 md:px-8">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Project launch checklist</p>
+          <h1 className="mt-1 text-2xl font-bold text-white">{launch.name}</h1>
+          <p className="mt-1 text-xs text-slate-500">Created {new Date(launch.createdAt).toLocaleString()}</p>
+        </div>
+        <div className="relative">
+          <button className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500" onClick={() => setShowExportMenu((value) => !value)}>⬇️ Export</button>
+          {showExportMenu && (
+            <div className="absolute right-0 z-20 mt-2 w-44 overflow-hidden rounded-lg border border-slate-700 bg-slate-900 shadow-xl">
+              <button className="block w-full px-4 py-2 text-left text-sm text-slate-200 hover:bg-slate-800" onClick={exportCsv}>📄 Export as CSV</button>
+              <button className="block w-full px-4 py-2 text-left text-sm text-slate-200 hover:bg-slate-800" onClick={exportJson}>📋 Export as JSON</button>
+            </div>
+          )}
+        </div>
+      </div>
+      <ProgressBar totalItems={totalItems} checkedItems={checkedItems} />
+      {launch.sections.map((section) => (
+        <SectionPanel key={section.id} section={section} onToggleItem={(itemId) => onToggleItem(section.id, itemId)} onNotesChange={(itemId, notes) => onNotesChange(section.id, itemId, notes)} />
+      ))}
+    </div>
+  );
+}

--- a/components/launchpad/LaunchSidebar.tsx
+++ b/components/launchpad/LaunchSidebar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { LaunchpadLaunch } from '@/lib/dsg/launchpad/types';
+
+export function LaunchSidebar({ launches, selectedId, onSelect, onNew, onDelete }: { launches: LaunchpadLaunch[]; selectedId: string | null; onSelect: (id: string) => void; onNew: () => void; onDelete: (id: string) => void }) {
+  return (
+    <aside className="w-full border-b border-slate-800 bg-slate-950/80 md:w-72 md:border-b-0 md:border-r">
+      <div className="flex items-center justify-between border-b border-slate-800 px-4 py-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">LaunchPad</p>
+          <h2 className="font-semibold text-white">🚀 Launches</h2>
+        </div>
+        <button className="rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-500" onClick={onNew}>+ New</button>
+      </div>
+      <div className="max-h-72 overflow-y-auto p-2 md:max-h-[calc(100vh-12rem)]">
+        {launches.length === 0 && <p className="px-3 py-8 text-center text-sm text-slate-500">No launches yet</p>}
+        {launches.map((launch) => {
+          const total = launch.sections.reduce((sum, section) => sum + section.items.length, 0);
+          const done = launch.sections.reduce((sum, section) => sum + section.items.filter((item) => item.checked).length, 0);
+          const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+          const active = launch.id === selectedId;
+          return (
+            <button key={launch.id} className={`mb-2 w-full rounded-lg border p-3 text-left transition ${active ? 'border-blue-500 bg-blue-500/10' : 'border-slate-800 bg-slate-900/60 hover:border-slate-700'}`} onClick={() => onSelect(launch.id)}>
+              <div className="flex items-start gap-2">
+                <span className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-100">{launch.name}</span>
+                <span role="button" tabIndex={0} className="rounded px-1 text-xs text-slate-500 hover:bg-slate-800 hover:text-rose-300" title="Delete launch" onClick={(event) => { event.stopPropagation(); onDelete(launch.id); }} onKeyDown={(event) => { if (event.key === 'Enter') { event.stopPropagation(); onDelete(launch.id); } }}>✕</span>
+              </div>
+              <div className="mt-1 flex justify-between gap-3 text-[11px] text-slate-500">
+                <span>{pct}% complete</span>
+                <span>{new Date(launch.createdAt).toLocaleDateString()}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/components/launchpad/LaunchpadApp.tsx
+++ b/components/launchpad/LaunchpadApp.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createClient as createSupabaseClient } from '@/lib/supabase/client';
+import { createLaunchpadClient } from '@/lib/dsg/launchpad/client';
+import type { LaunchpadLaunch } from '@/lib/dsg/launchpad/types';
+import { createDefaultLaunchpadSections } from './defaults';
+import { LaunchSidebar } from './LaunchSidebar';
+import { LaunchDetail } from './LaunchDetail';
+
+export function LaunchpadApp({ workspaceId }: { workspaceId: string }) {
+  const [launches, setLaunches] = useState<LaunchpadLaunch[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showNewDialog, setShowNewDialog] = useState(false);
+  const [newName, setNewName] = useState('');
+  const saveTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const client = useMemo(() => {
+    if (!accessToken) return null;
+    return createLaunchpadClient({ accessToken, workspaceId });
+  }, [accessToken, workspaceId]);
+
+  useEffect(() => {
+    const supabase = createSupabaseClient();
+    let mounted = true;
+
+    void supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setAccessToken(data.session?.access_token ?? null);
+      if (!data.session?.access_token) {
+        setError('AUTH_SESSION_REQUIRED');
+        setLoading(false);
+      }
+    });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) setAccessToken(session?.access_token ?? null);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.subscription.unsubscribe();
+      Object.values(saveTimers.current).forEach(clearTimeout);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    void client.list()
+      .then((items) => {
+        if (cancelled) return;
+        setLaunches(items);
+        setSelectedId((current) => current && items.some((item) => item.id === current) ? current : items[0]?.id ?? null);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'LAUNCHPAD_LOAD_FAILED');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [client]);
+
+  const scheduleSave = useCallback((launch: LaunchpadLaunch) => {
+    if (!client) return;
+    const existing = saveTimers.current[launch.id];
+    if (existing) clearTimeout(existing);
+    saveTimers.current[launch.id] = setTimeout(() => {
+      void client.update(launch.id, { sections: launch.sections })
+        .then((stored) => {
+          setLaunches((current) => current.map((item) => item.id === stored.id ? stored : item));
+        })
+        .catch((err) => setError(err instanceof Error ? err.message : 'LAUNCHPAD_SAVE_FAILED'));
+    }, 500);
+  }, [client]);
+
+  const handleCreate = useCallback(async () => {
+    if (!client || !newName.trim()) return;
+    try {
+      setError(null);
+      const launch = await client.create({ name: newName.trim(), sections: createDefaultLaunchpadSections() });
+      setLaunches((current) => [launch, ...current]);
+      setSelectedId(launch.id);
+      setNewName('');
+      setShowNewDialog(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'LAUNCHPAD_CREATE_FAILED');
+    }
+  }, [client, newName]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!client) return;
+    try {
+      await client.remove(id);
+      setLaunches((current) => {
+        const next = current.filter((item) => item.id !== id);
+        setSelectedId((selected) => selected === id ? next[0]?.id ?? null : selected);
+        return next;
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'LAUNCHPAD_DELETE_FAILED');
+    }
+  }, [client]);
+
+  const mutateSelected = useCallback((mutator: (launch: LaunchpadLaunch) => LaunchpadLaunch) => {
+    setLaunches((current) => {
+      let changed: LaunchpadLaunch | null = null;
+      const next = current.map((launch) => {
+        if (launch.id !== selectedId) return launch;
+        changed = mutator(launch);
+        return changed;
+      });
+      if (changed) scheduleSave(changed);
+      return next;
+    });
+  }, [scheduleSave, selectedId]);
+
+  const handleToggle = useCallback((sectionId: string, itemId: string) => {
+    mutateSelected((launch) => ({
+      ...launch,
+      sections: launch.sections.map((section) => section.id !== sectionId ? section : {
+        ...section,
+        items: section.items.map((item) => item.id === itemId ? { ...item, checked: !item.checked } : item),
+      }),
+    }));
+  }, [mutateSelected]);
+
+  const handleNotes = useCallback((sectionId: string, itemId: string, notes: string) => {
+    mutateSelected((launch) => ({
+      ...launch,
+      sections: launch.sections.map((section) => section.id !== sectionId ? section : {
+        ...section,
+        items: section.items.map((item) => item.id === itemId ? { ...item, notes } : item),
+      }),
+    }));
+  }, [mutateSelected]);
+
+  const selected = launches.find((launch) => launch.id === selectedId) ?? null;
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6 md:px-6">
+      <div className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-950 shadow-2xl">
+        <div className="flex min-h-[72vh] flex-col md:flex-row">
+          <LaunchSidebar launches={launches} selectedId={selectedId} onSelect={setSelectedId} onNew={() => setShowNewDialog(true)} onDelete={handleDelete} />
+          <main className="min-w-0 flex-1 bg-slate-950">
+            {error && <div className="m-4 rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-300">{error}</div>}
+            {loading ? (
+              <div className="flex min-h-[50vh] items-center justify-center text-sm text-slate-400">Loading launches from DSG backend…</div>
+            ) : selected ? (
+              <LaunchDetail launch={selected} onToggleItem={handleToggle} onNotesChange={handleNotes} />
+            ) : (
+              <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 px-6 text-center">
+                <div className="text-4xl">🚀</div>
+                <div>
+                  <h2 className="font-semibold text-white">No launch selected</h2>
+                  <p className="mt-1 text-sm text-slate-500">Create a launch checklist to get started.</p>
+                </div>
+                <button className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500" onClick={() => setShowNewDialog(true)}>Create launch</button>
+              </div>
+            )}
+          </main>
+        </div>
+      </div>
+
+      {showNewDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="w-full max-w-md rounded-2xl border border-slate-700 bg-slate-900 p-5 shadow-2xl">
+            <h3 className="text-lg font-semibold text-white">New Launch Checklist</h3>
+            <p className="mt-1 text-sm text-slate-500">Creates a workspace-scoped launch in the real DSG backend.</p>
+            <input autoFocus className="mt-4 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-blue-500" placeholder="e.g. Auth Service v2.0" maxLength={200} value={newName} onChange={(event) => setNewName(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter') void handleCreate(); }} />
+            <div className="mt-4 flex justify-end gap-2">
+              <button className="rounded-lg bg-slate-800 px-4 py-2 text-sm text-slate-300 hover:bg-slate-700" onClick={() => { setShowNewDialog(false); setNewName(''); }}>Cancel</button>
+              <button className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50" disabled={!newName.trim() || !client} onClick={() => void handleCreate()}>Create</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/launchpad/LaunchpadApp.tsx
+++ b/components/launchpad/LaunchpadApp.tsx
@@ -36,14 +36,14 @@ export function LaunchpadApp({ workspaceId }: { workspaceId: string }) {
       }
     });
 
-    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
       if (mounted) setAccessToken(session?.access_token ?? null);
     });
 
     return () => {
       mounted = false;
-      subscription.subscription.unsubscribe();
-      Object.values(saveTimers.current).forEach(clearTimeout);
+      data.subscription.unsubscribe();
+      Object.values(saveTimers.current).forEach((timer) => clearTimeout(timer));
     };
   }, []);
 

--- a/components/launchpad/ProgressBar.tsx
+++ b/components/launchpad/ProgressBar.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export function ProgressBar({ totalItems, checkedItems }: { totalItems: number; checkedItems: number }) {
+  const pct = totalItems === 0 ? 0 : Math.round((checkedItems / totalItems) * 100);
+
+  return (
+    <div className="mb-6 rounded-xl border border-slate-800 bg-slate-900/70 p-4">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <span className="text-sm font-semibold text-slate-300">Overall Completion</span>
+        <span className="text-2xl font-bold text-white">{pct}%</span>
+      </div>
+      <div className="h-3 overflow-hidden rounded-full bg-slate-800">
+        <div
+          className={`h-full rounded-full transition-[width] duration-300 ${pct === 100 ? 'bg-emerald-500' : 'bg-blue-500'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="mt-2 text-xs text-slate-500">
+        {checkedItems} of {totalItems} tasks complete
+      </p>
+    </div>
+  );
+}

--- a/components/launchpad/SectionPanel.tsx
+++ b/components/launchpad/SectionPanel.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useState } from 'react';
+import type { LaunchpadSection } from '@/lib/dsg/launchpad/types';
+import { ChecklistRow } from './ChecklistRow';
+
+export function SectionPanel({ section, onToggleItem, onNotesChange }: { section: LaunchpadSection; onToggleItem: (itemId: string) => void; onNotesChange: (itemId: string, notes: string) => void }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const done = section.items.filter((item) => item.checked).length;
+
+  return (
+    <section className="mb-4 overflow-hidden rounded-xl border border-slate-800 bg-slate-900/70">
+      <button className="flex w-full items-center gap-3 bg-slate-900 px-4 py-3 text-left hover:bg-slate-800/80" onClick={() => setCollapsed((value) => !value)}>
+        <span className="text-xl">{section.icon}</span>
+        <span className="flex-1 font-semibold text-white">{section.title}</span>
+        <span className="rounded-full bg-indigo-500/15 px-2 py-0.5 text-xs font-semibold text-indigo-300">{done}/{section.items.length}</span>
+        <span className="text-slate-500">{collapsed ? '▸' : '▾'}</span>
+      </button>
+      {!collapsed && (
+        <div className="px-4 py-1">
+          {section.items.map((item) => (
+            <ChecklistRow key={item.id} item={item} onToggle={() => onToggleItem(item.id)} onNotesChange={(notes) => onNotesChange(item.id, notes)} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/launchpad/defaults.ts
+++ b/components/launchpad/defaults.ts
@@ -1,0 +1,46 @@
+import type { LaunchpadSection } from '@/lib/dsg/launchpad/types';
+
+const SECTION_DEFS = [
+  { id: 'pre-launch', title: 'Pre-Launch', icon: '🔧' },
+  { id: 'launch-day', title: 'Launch Day', icon: '🚀' },
+  { id: 'post-launch', title: 'Post-Launch', icon: '📊' },
+] as const;
+
+const ITEMS: Record<(typeof SECTION_DEFS)[number]['id'], string[]> = {
+  'pre-launch': [
+    'Code review completed',
+    'Unit tests passing',
+    'Integration tests passing',
+    'Documentation updated',
+    'Security review done',
+    'Performance benchmarks met',
+  ],
+  'launch-day': [
+    'Deploy to production',
+    'Monitor error rates',
+    'Monitor latency metrics',
+    'Announce to stakeholders',
+    'Update status page',
+    'Verify rollback plan ready',
+  ],
+  'post-launch': [
+    'Schedule retrospective',
+    'Review success metrics',
+    'Close out JIRA tickets',
+    'Archive feature branch',
+    'Update runbooks',
+    'Celebrate the team 🎉',
+  ],
+};
+
+export function createDefaultLaunchpadSections(): LaunchpadSection[] {
+  return SECTION_DEFS.map((section) => ({
+    ...section,
+    items: ITEMS[section.id].map((label, index) => ({
+      id: `${section.id}-${index}`,
+      label,
+      checked: false,
+      notes: '',
+    })),
+  }));
+}

--- a/lib/dsg/launchpad/client.ts
+++ b/lib/dsg/launchpad/client.ts
@@ -1,0 +1,79 @@
+import type { LaunchpadLaunch, LaunchpadSection } from './types';
+
+type LaunchpadClientOptions = {
+  baseUrl?: string;
+  accessToken: string;
+  workspaceId: string;
+};
+
+type ApiEnvelope<T> = {
+  ok: boolean;
+  data?: T;
+  error?: { code?: string };
+};
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  if (!baseUrl) return '';
+  return baseUrl.replace(/\/$/, '');
+}
+
+export function createLaunchpadClient(options: LaunchpadClientOptions) {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+
+  async function request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${options.accessToken}`,
+        'x-dsg-workspace-id': options.workspaceId,
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    const payload = (await response.json().catch(() => null)) as ApiEnvelope<T> | null;
+    if (!response.ok || !payload?.ok || payload.data === undefined) {
+      const code = payload?.error?.code ?? `LAUNCHPAD_HTTP_${response.status}`;
+      throw new Error(code);
+    }
+
+    return payload.data;
+  }
+
+  return {
+    async list(): Promise<LaunchpadLaunch[]> {
+      const data = await request<{ launches: LaunchpadLaunch[] }>('/api/dsg/launchpad/launches');
+      return data.launches;
+    },
+
+    async create(input: { name: string; sections: LaunchpadSection[] }): Promise<LaunchpadLaunch> {
+      const data = await request<{ launch: LaunchpadLaunch }>('/api/dsg/launchpad/launches', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
+      return data.launch;
+    },
+
+    async update(
+      id: string,
+      patch: { name?: string; sections?: LaunchpadSection[] },
+    ): Promise<LaunchpadLaunch> {
+      const data = await request<{ launch: LaunchpadLaunch }>(
+        `/api/dsg/launchpad/launches/${encodeURIComponent(id)}`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(patch),
+        },
+      );
+      return data.launch;
+    },
+
+    async remove(id: string): Promise<string> {
+      const data = await request<{ id: string }>(
+        `/api/dsg/launchpad/launches/${encodeURIComponent(id)}`,
+        { method: 'DELETE' },
+      );
+      return data.id;
+    },
+  };
+}

--- a/lib/dsg/launchpad/types.ts
+++ b/lib/dsg/launchpad/types.ts
@@ -1,0 +1,94 @@
+export type LaunchpadChecklistItem = {
+  id: string;
+  label: string;
+  checked: boolean;
+  notes: string;
+};
+
+export type LaunchpadSection = {
+  id: string;
+  title: string;
+  icon: string;
+  items: LaunchpadChecklistItem[];
+};
+
+export type LaunchpadLaunch = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  createdBy: string;
+  sections: LaunchpadSection[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LaunchpadLaunchRow = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  created_by: string;
+  sections: unknown;
+  created_at: string;
+  updated_at: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validString(value: unknown, maxLength: number, allowEmpty = false): value is string {
+  if (typeof value !== 'string') return false;
+  if (!allowEmpty && value.trim().length === 0) return false;
+  return value.length <= maxLength;
+}
+
+export function parseLaunchpadSections(value: unknown): LaunchpadSection[] | null {
+  if (!Array.isArray(value) || value.length > 20) return null;
+
+  const sections: LaunchpadSection[] = [];
+  for (const rawSection of value) {
+    if (!isRecord(rawSection)) return null;
+    if (!validString(rawSection.id, 120) || !validString(rawSection.title, 200)) return null;
+    if (!validString(rawSection.icon, 32, true)) return null;
+    if (!Array.isArray(rawSection.items) || rawSection.items.length > 100) return null;
+
+    const items: LaunchpadChecklistItem[] = [];
+    for (const rawItem of rawSection.items) {
+      if (!isRecord(rawItem)) return null;
+      if (!validString(rawItem.id, 120) || !validString(rawItem.label, 500)) return null;
+      if (typeof rawItem.checked !== 'boolean') return null;
+      if (!validString(rawItem.notes, 4000, true)) return null;
+
+      items.push({
+        id: rawItem.id,
+        label: rawItem.label,
+        checked: rawItem.checked,
+        notes: rawItem.notes,
+      });
+    }
+
+    sections.push({
+      id: rawSection.id,
+      title: rawSection.title,
+      icon: rawSection.icon,
+      items,
+    });
+  }
+
+  return sections;
+}
+
+export function mapLaunchpadRow(row: LaunchpadLaunchRow): LaunchpadLaunch {
+  const sections = parseLaunchpadSections(row.sections);
+  if (!sections) throw new Error('LAUNCHPAD_STORED_SECTIONS_INVALID');
+
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    name: row.name,
+    createdBy: row.created_by,
+    sections,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/supabase/migrations/202608080856_create_dsg_launchpad_launches.sql
+++ b/supabase/migrations/202608080856_create_dsg_launchpad_launches.sql
@@ -1,0 +1,30 @@
+create table if not exists dsg_launchpad_launches (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null,
+  name text not null,
+  created_by text not null,
+  sections jsonb not null default '[]'::jsonb,
+  source text not null default 'DSG_LAUNCHPAD',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint dsg_launchpad_launches_name_check check (
+    char_length(btrim(name)) between 1 and 200
+  ),
+  constraint dsg_launchpad_launches_sections_array_check check (
+    jsonb_typeof(sections) = 'array'
+  )
+);
+
+create index if not exists dsg_launchpad_launches_workspace_updated_idx
+  on dsg_launchpad_launches(workspace_id, updated_at desc);
+
+create index if not exists dsg_launchpad_launches_created_by_idx
+  on dsg_launchpad_launches(created_by);
+
+alter table dsg_launchpad_launches enable row level security;
+
+comment on table dsg_launchpad_launches is
+  'Workspace-scoped persistent storage for DSG LaunchPad project launch checklists. Access is mediated by verified DSG API routes; direct anonymous access is denied by RLS.';
+
+comment on column dsg_launchpad_launches.sections is
+  'Checklist sections/items persisted as JSONB using the LaunchPad client data model.';


### PR DESCRIPTION
## What this adds
- workspace-scoped `dsg_launchpad_launches` Supabase table
- authenticated LaunchPad list/create/update/delete API
- reusable LaunchPad API client
- `/dashboard/launchpad` UI integrated into DSG Control Plane
- Build → LaunchPad navigation entry
- checklist create/delete/toggle/notes/progress + CSV/JSON export

## Security model
- reuses `requireVerifiedDsgActor`
- reads require `read:generated-apps`
- writes require `write:generated-apps`
- workspace scope comes from the verified actor, never from request JSON
- browser uses the signed-in user's Supabase access token; service-role credentials never go to the client
- server resolves workspace membership from `dsg_workspace_members`
- RLS is enabled on the LaunchPad table; direct anonymous access has no policy

## Verified in DSG dev
- migration applied to Supabase project `dsg-control-plane-dev`
- `dsg_launchpad_launches` exists with RLS enabled
- imported two real exported launch records supplied by the user: `v2.0` and `DSG`
- database verification returned 3 sections and 18/18 checked items for each record
- existing `dsg_workspace_members` SELECT policy scopes membership to the current actor

## Latest-head validation
- Type check: passed
- Unit tests: passed
- Lint: passed
- Build job: queued/running after validation
- remaining security/E2E/governance checks still pending
- Vercel Git preview attempts reported `Resource provisioning failed` before build logs were produced; this is not a code-build verdict

## Not claimed yet
- migration has not been applied to production Supabase
- PR remains draft and unmerged until build/security/E2E checks pass
