### PR TITLE
feat: make Control Plane the unified DSG MCP front door

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,4 +1,5 @@
 name: CDK Deploy Infrastructure
+run-name: DSG CDK ${{ inputs.environment }} ${{ inputs.idempotency_key }}
 
 on:
   workflow_dispatch:
@@ -20,10 +21,18 @@ on:
         options:
           - 'true'
           - 'false'
+      idempotency_key:
+        description: 'Stable request identifier; reuse on retries of the same intended deployment'
+        required: true
+        type: string
 
 permissions:
   id-token: write
   contents: read
+
+concurrency:
+  group: dsg-cdk-${{ inputs.environment }}
+  cancel-in-progress: false
 
 jobs:
   validate:
@@ -218,16 +227,19 @@ jobs:
         env:
           ENVIRONMENT: ${{ inputs.environment }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
         run: |
           jq -n \
             --arg environment "$ENVIRONMENT" \
             --arg region "$AWS_REGION" \
+            --arg idempotency_key "$IDEMPOTENCY_KEY" \
             --arg run_id "${{ github.run_id }}" \
             --arg commit_sha "${{ github.sha }}" \
             '{
               status: "PASS",
               environment: $environment,
               region: $region,
+              idempotency_key: $idempotency_key,
               github_run_id: $run_id,
               commit_sha: $commit_sha,
               evidence: [

--- a/.github/workflows/unified-mcp-gateway-verify.yml
+++ b/.github/workflows/unified-mcp-gateway-verify.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'app/api/mcp/route.ts'
+      - 'lib/mcp/unified-auth.ts'
       - 'lib/mcp/unified-tools.ts'
       - 'scripts/verify-unified-mcp-gateway.mjs'
       - '.github/workflows/unified-mcp-gateway-verify.yml'

--- a/.github/workflows/unified-mcp-gateway-verify.yml
+++ b/.github/workflows/unified-mcp-gateway-verify.yml
@@ -1,0 +1,25 @@
+name: Verify Unified DSG MCP Gateway
+
+on:
+  pull_request:
+    paths:
+      - 'app/api/mcp/route.ts'
+      - 'lib/mcp/unified-tools.ts'
+      - 'scripts/verify-unified-mcp-gateway.mjs'
+      - '.github/workflows/unified-mcp-gateway-verify.yml'
+      - '.github/workflows/cdk-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Verify unified gateway contract
+        run: node scripts/verify-unified-mcp-gateway.mjs

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -42,6 +42,30 @@ function rpcError(id: JsonRpcRequest['id'], code: number, message: string) {
   );
 }
 
+function structuredContent(value: unknown): Record<string, unknown> {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return { value };
+}
+
+function rpcToolResult(
+  id: JsonRpcRequest['id'],
+  value: unknown,
+  isError = false,
+) {
+  return rpcResult(id, {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(value ?? null),
+      },
+    ],
+    structuredContent: structuredContent(value),
+    ...(isError ? { isError: true } : {}),
+  });
+}
+
 function androidToolList() {
   return Object.entries(TOOL_POLICY).map(([name, policy]) => ({
     name,
@@ -109,6 +133,11 @@ export async function POST(request: NextRequest) {
     });
   }
 
+  // MCP initialization is a one-way notification and intentionally has no JSON-RPC response body.
+  if (rpc.method === 'notifications/initialized') {
+    return new NextResponse(null, { status: 202 });
+  }
+
   if (rpc.method === 'tools/list') {
     return rpcResult(rpc.id, { tools: toolList() });
   }
@@ -143,18 +172,26 @@ export async function POST(request: NextRequest) {
 
       const unifiedResult = await callUnifiedTool(name as UnifiedToolName, args, auth);
       if (unifiedResult.ok === false) {
-        return rpcError(rpc.id, unifiedResult.code, unifiedResult.message);
+        return rpcToolResult(
+          rpc.id,
+          { error: { code: unifiedResult.code, message: unifiedResult.message } },
+          true,
+        );
       }
-      return rpcResult(rpc.id, unifiedResult.result);
+      return rpcToolResult(rpc.id, unifiedResult.result);
     }
 
     // Route DSG tools to the existing deterministic control-plane handler.
     if ((DSG_TOOL_NAMES as readonly string[]).includes(name)) {
       const dsgResult = await callDsgTool(name as DsgToolName, args);
       if (dsgResult.ok === false) {
-        return rpcError(rpc.id, dsgResult.code, dsgResult.message);
+        return rpcToolResult(
+          rpc.id,
+          { error: { code: dsgResult.code, message: dsgResult.message } },
+          true,
+        );
       }
-      return rpcResult(rpc.id, dsgResult.result);
+      return rpcToolResult(rpc.id, dsgResult.result);
     }
 
     // Route Hermes agent tools to the Hermes tool handler — requires auth.
@@ -165,9 +202,13 @@ export async function POST(request: NextRequest) {
       }
       const hermesResult = await callHermesTool(name, args, request, access.orgId);
       if (hermesResult.ok === false) {
-        return rpcError(rpc.id, hermesResult.code, hermesResult.message);
+        return rpcToolResult(
+          rpc.id,
+          { error: { code: hermesResult.code, message: hermesResult.message } },
+          true,
+        );
       }
-      return rpcResult(rpc.id, hermesResult.result);
+      return rpcToolResult(rpc.id, hermesResult.result);
     }
 
     // Route Android tools to the command envelope builder. Execution still requires owner approval.
@@ -180,7 +221,7 @@ export async function POST(request: NextRequest) {
         toolName: name,
         args,
       });
-      return rpcResult(rpc.id, {
+      return rpcToolResult(rpc.id, {
         commandId: command.commandId,
         executionState: command.executionState,
         requiresOwnerApproval: command.policy.requiresOwnerApproval,
@@ -189,7 +230,11 @@ export async function POST(request: NextRequest) {
         note: 'MCP tools/call creates a command proposal only. Android execution still requires owner approval on device.',
       });
     } catch (error) {
-      return rpcError(rpc.id, -32602, error instanceof Error ? error.message : 'Invalid tool arguments');
+      return rpcToolResult(
+        rpc.id,
+        { error: { code: -32602, message: error instanceof Error ? error.message : 'Invalid tool arguments' } },
+        true,
+      );
     }
   }
 

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -11,9 +11,12 @@ import {
   UNIFIED_TOOL_NAMES,
   UNIFIED_TOOL_SCHEMAS,
   callUnifiedTool,
-  isUnifiedMcpKeyAuthorized,
   type UnifiedToolName,
 } from '@/lib/mcp/unified-tools';
+import {
+  validateStoredUnifiedMcpKey,
+  type UnifiedAuthContext,
+} from '@/lib/mcp/unified-auth';
 import { requireOrgRole } from '@/lib/authz';
 
 export const dynamic = 'force-dynamic';
@@ -116,16 +119,29 @@ export async function POST(request: NextRequest) {
 
     const args = rpc.params?.arguments ?? {};
 
-    // Unified high-value tools require either the single MCP API key or an authenticated operator session.
     if ((UNIFIED_TOOL_NAMES as readonly string[]).includes(name)) {
-      if (!isUnifiedMcpKeyAuthorized(request)) {
-        const access = await requireOrgRole(['operator', 'org_admin']);
+      const storedKey = await validateStoredUnifiedMcpKey(request, name);
+      let auth: UnifiedAuthContext;
+
+      if (storedKey.presented) {
+        if (!storedKey.valid) {
+          return rpcError(rpc.id, -32001, storedKey.reason);
+        }
+        auth = storedKey.context;
+      } else {
+        const access = await requireOrgRole(['operator', 'org_admin'], request);
         if (!access.ok) {
           return rpcError(rpc.id, -32001, access.error ?? 'Unauthorized');
         }
+        auth = {
+          source: 'session',
+          actorId: access.userId,
+          orgId: access.orgId,
+          roles: access.grantedRoles,
+        };
       }
 
-      const unifiedResult = await callUnifiedTool(name as UnifiedToolName, args);
+      const unifiedResult = await callUnifiedTool(name as UnifiedToolName, args, auth);
       if (unifiedResult.ok === false) {
         return rpcError(rpc.id, unifiedResult.code, unifiedResult.message);
       }
@@ -143,7 +159,7 @@ export async function POST(request: NextRequest) {
 
     // Route Hermes agent tools to the Hermes tool handler — requires auth.
     if ((HERMES_TOOL_NAMES as string[]).includes(name)) {
-      const access = await requireOrgRole(['operator', 'org_admin']);
+      const access = await requireOrgRole(['operator', 'org_admin'], request);
       if (!access.ok) {
         return rpcError(rpc.id, -32001, access.error ?? 'Unauthorized');
       }

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -153,7 +153,7 @@ export async function POST(request: NextRequest) {
       let auth: UnifiedAuthContext;
 
       if (storedKey.presented) {
-        if (!storedKey.valid) {
+        if (storedKey.valid === false) {
           return rpcError(rpc.id, -32001, storedKey.reason);
         }
         auth = storedKey.context;

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -7,6 +7,13 @@ import type { DsgToolName } from '@/lib/mcp/schemas';
 import { callDsgTool } from '@/lib/mcp/dsg-tools';
 import { HERMES_TOOL_SCHEMAS, HERMES_TOOL_NAMES } from '@/lib/mcp/hermes-tool-schemas';
 import { callHermesTool } from '@/lib/mcp/hermes-tools';
+import {
+  UNIFIED_TOOL_NAMES,
+  UNIFIED_TOOL_SCHEMAS,
+  callUnifiedTool,
+  isUnifiedMcpKeyAuthorized,
+  type UnifiedToolName,
+} from '@/lib/mcp/unified-tools';
 import { requireOrgRole } from '@/lib/authz';
 
 export const dynamic = 'force-dynamic';
@@ -26,7 +33,10 @@ function rpcResult(id: JsonRpcRequest['id'], result: unknown) {
 }
 
 function rpcError(id: JsonRpcRequest['id'], code: number, message: string) {
-  return NextResponse.json({ jsonrpc: '2.0', id: id ?? null, error: { code, message } }, { status: code === -32601 ? 404 : 400 });
+  return NextResponse.json(
+    { jsonrpc: '2.0', id: id ?? null, error: { code, message } },
+    { status: code === -32601 ? 404 : code === -32001 ? 401 : 400 },
+  );
 }
 
 function androidToolList() {
@@ -59,10 +69,11 @@ function androidToolList() {
 }
 
 function dsgToolList() {
-  return DSG_TOOL_NAMES.map((name) => ({
-    name,
-    ...DSG_TOOL_SCHEMAS[name],
-  }));
+  return DSG_TOOL_NAMES.map((name) => ({ name, ...DSG_TOOL_SCHEMAS[name] }));
+}
+
+function unifiedToolList() {
+  return UNIFIED_TOOL_NAMES.map((name) => ({ name, ...UNIFIED_TOOL_SCHEMAS[name] }));
 }
 
 function hermesToolList() {
@@ -70,16 +81,30 @@ function hermesToolList() {
 }
 
 function toolList() {
-  return [...androidToolList(), ...dsgToolList(), ...hermesToolList()];
+  return [...unifiedToolList(), ...androidToolList(), ...dsgToolList(), ...hermesToolList()];
 }
 
 export async function GET() {
-  return NextResponse.json({ ok: true, tools: toolList(), note: 'Use POST JSON-RPC tools/list or tools/call.' });
+  return NextResponse.json({
+    ok: true,
+    server: 'dsg-control-plane-unified-mcp',
+    version: '1.0.0',
+    tools: toolList(),
+    note: 'One MCP front door for DSG Control Plane, AIMO, AWS governed deployment, runtime, and evidence tools.',
+  });
 }
 
 export async function POST(request: NextRequest) {
   const rpc = (await request.json().catch(() => null)) as JsonRpcRequest | null;
   if (!rpc || rpc.jsonrpc !== '2.0') return rpcError(null, -32600, 'Invalid JSON-RPC request');
+
+  if (rpc.method === 'initialize') {
+    return rpcResult(rpc.id, {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {} },
+      serverInfo: { name: 'dsg-control-plane-unified-mcp', version: '1.0.0' },
+    });
+  }
 
   if (rpc.method === 'tools/list') {
     return rpcResult(rpc.id, { tools: toolList() });
@@ -91,7 +116,23 @@ export async function POST(request: NextRequest) {
 
     const args = rpc.params?.arguments ?? {};
 
-    // Route DSG tools to the DSG tool handler
+    // Unified high-value tools require either the single MCP API key or an authenticated operator session.
+    if ((UNIFIED_TOOL_NAMES as readonly string[]).includes(name)) {
+      if (!isUnifiedMcpKeyAuthorized(request)) {
+        const access = await requireOrgRole(['operator', 'org_admin']);
+        if (!access.ok) {
+          return rpcError(rpc.id, -32001, access.error ?? 'Unauthorized');
+        }
+      }
+
+      const unifiedResult = await callUnifiedTool(name as UnifiedToolName, args);
+      if (unifiedResult.ok === false) {
+        return rpcError(rpc.id, unifiedResult.code, unifiedResult.message);
+      }
+      return rpcResult(rpc.id, unifiedResult.result);
+    }
+
+    // Route DSG tools to the existing deterministic control-plane handler.
     if ((DSG_TOOL_NAMES as readonly string[]).includes(name)) {
       const dsgResult = await callDsgTool(name as DsgToolName, args);
       if (dsgResult.ok === false) {
@@ -100,7 +141,7 @@ export async function POST(request: NextRequest) {
       return rpcResult(rpc.id, dsgResult.result);
     }
 
-    // Route Hermes agent tools to the Hermes tool handler — requires auth
+    // Route Hermes agent tools to the Hermes tool handler — requires auth.
     if ((HERMES_TOOL_NAMES as string[]).includes(name)) {
       const access = await requireOrgRole(['operator', 'org_admin']);
       if (!access.ok) {
@@ -113,7 +154,7 @@ export async function POST(request: NextRequest) {
       return rpcResult(rpc.id, hermesResult.result);
     }
 
-    // Route Android tools to the command envelope builder
+    // Route Android tools to the command envelope builder. Execution still requires owner approval.
     try {
       const command = buildCommandEnvelope({
         sourceKind: 'mcp',

--- a/docs/UNIFIED_MCP_GATEWAY.md
+++ b/docs/UNIFIED_MCP_GATEWAY.md
@@ -1,0 +1,87 @@
+# DSG Unified Control Plane MCP
+
+## Goal
+
+Expose one MCP front door for DSG Control Plane governance, AIMO search/proof, AWS governed deployment, runtime routing, and evidence tools.
+
+```text
+Agent / ChatGPT / Claude / Codex
+            |
+            v
+      DSG Control Plane MCP
+            |
+     Plan -> Gate -> Route
+      /              \
+     v                v
+ AWS workflow      DSG ONE AIMO
+ OIDC/CDK               |
+     |                  v
+ Evidence         AGI Simulation
+ Verification           |
+                        v
+                   Cinema / Z3
+```
+
+## User configuration
+
+A normal MCP user should only need:
+
+- MCP URL: `/api/mcp`
+- one DSG API key (`DSG_API_KEY` / `DSG_MCP_API_KEY` on the server side)
+
+Users do not configure AGI, Cinema, AWS, or service-to-service keys individually.
+
+## Server-side one-time configuration
+
+The infrastructure owner configures this once:
+
+- `DSG_AIMO_ROOT_KEY` — one root secret shared by Control Plane and DSG ONE/AIMO services.
+- `DSG_ONE_MCP_BACKEND_URL` — optional; defaults to `https://dsg-one-v1.vercel.app`.
+- `DSG_GITHUB_AUTOMATION_TOKEN` or the existing `GITHUB_TOKEN` — required only for `dsg.aws.deploy` workflow dispatch.
+
+DSG ONE already supports `DSG_AIMO_SERVICE_REGISTRY` so simulation URL, Cinema URL, and max parallelism are one JSON setting rather than separate client configuration.
+
+## Root-key design
+
+The raw `DSG_AIMO_ROOT_KEY` is never sent between services. Deterministic HMAC tokens are derived by purpose:
+
+```text
+HMAC(root, "dsg-aimo-v1:control-plane")
+HMAC(root, "dsg-aimo-v1:simulation")
+HMAC(root, "dsg-aimo-v1:cinema")
+```
+
+A compromise of one derived token does not reveal the root key or make the other purpose-specific token equal.
+
+## Unified tools
+
+- `dsg.system.status` — gateway/adapter readiness without secret values.
+- `dsg.aimo.status` — inspect the DSG ONE AIMO surface.
+- `dsg.aimo.solve` — run DSG ONE -> AGI deterministic shards -> Cinema proof gate.
+- `dsg.aws.contract` — return the Plan -> Gate -> AWS execution -> Evidence -> Verification contract.
+- `dsg.aws.deploy` — deterministic gate plus explicit approval, then dispatch the governed CDK workflow.
+- Existing DSG/Hermes/Android tools remain available through the same `/api/mcp` endpoint.
+
+## AWS truth boundary
+
+`dsg.aws.deploy` returning `dispatched: true` is **not** deployment PASS. It returns `REVIEW` until the protected GitHub Environment and post-deploy verification evidence complete.
+
+The AWS Agent Toolkit adapter remains responsible for AWS interaction. The current repository infrastructure proves an ECS cluster exists when verification passes; it does not prove a Fargate application service exists until the CDK source actually defines and verifies one.
+
+## AIMO truth boundary
+
+The Control Plane does not weaken the existing AIMO proof contract. A finite QUBO/Ising candidate becomes final only after the Cinema proof verifier returns the required complete certificate. Encoding fidelity from a natural-language olympiad problem remains a separate obligation.
+
+## Verification
+
+Repository contract verifier:
+
+```bash
+node scripts/verify-unified-mcp-gateway.mjs
+```
+
+CI workflow:
+
+```text
+.github/workflows/unified-mcp-gateway-verify.yml
+```

--- a/docs/UNIFIED_MCP_GATEWAY.md
+++ b/docs/UNIFIED_MCP_GATEWAY.md
@@ -24,10 +24,12 @@ Agent / ChatGPT / Claude / Codex
 
 ## User configuration
 
-A normal MCP user should only need:
+A normal MCP client needs only:
 
 - MCP URL: `/api/mcp`
-- one DSG API key (`DSG_API_KEY` / `DSG_MCP_API_KEY` on the server side)
+- one issued DSG API key from `/api/dsg/mcp/keys`
+
+The raw key is shown once at issuance. On every unified tool call the Control Plane hashes it, validates it through the existing `validate_mcp_api_key` RPC, enforces ACTIVE/period/quota state, resolves the actor/org/runtime roles, and records usage. Revoked, expired, over-quota, inactive-actor, or unverifiable keys fail closed.
 
 Users do not configure AGI, Cinema, AWS, or service-to-service keys individually.
 
@@ -37,9 +39,9 @@ The infrastructure owner configures this once:
 
 - `DSG_AIMO_ROOT_KEY` — one root secret shared by Control Plane and DSG ONE/AIMO services.
 - `DSG_ONE_MCP_BACKEND_URL` — optional; defaults to `https://dsg-one-v1.vercel.app`.
-- `DSG_GITHUB_AUTOMATION_TOKEN` or the existing `GITHUB_TOKEN` — required only for `dsg.aws.deploy` workflow dispatch.
+- `DSG_GITHUB_AUTOMATION_TOKEN` — server-side GitHub credential used by governed AWS workflow inspection/dispatch. It must be able to read the workflow, repository secret **names**, target environments, and workflow runs, and to dispatch the CDK workflow.
 
-DSG ONE already supports `DSG_AIMO_SERVICE_REGISTRY` so simulation URL, Cinema URL, and max parallelism are one JSON setting rather than separate client configuration.
+DSG ONE supports `DSG_AIMO_SERVICE_REGISTRY` so simulation URL, Cinema URL, and max parallelism are one JSON setting rather than client configuration.
 
 ## Root-key design
 
@@ -59,8 +61,28 @@ A compromise of one derived token does not reveal the root key or make the other
 - `dsg.aimo.status` — inspect the DSG ONE AIMO surface.
 - `dsg.aimo.solve` — run DSG ONE -> AGI deterministic shards -> Cinema proof gate.
 - `dsg.aws.contract` — return the Plan -> Gate -> AWS execution -> Evidence -> Verification contract.
-- `dsg.aws.deploy` — deterministic gate plus explicit approval, then dispatch the governed CDK workflow.
+- `dsg.aws.deploy` — inspect AWS deployment evidence, run the deterministic gate, require explicit approval, suppress duplicate retries, then dispatch the governed CDK workflow.
 - Existing DSG/Hermes/Android tools remain available through the same `/api/mcp` endpoint.
+
+## AWS authorization and evidence
+
+`dsg.aws.deploy` requires an authenticated actor with `operator` or `org_admin` entitlement. A valid billing key alone does not grant mutation authority.
+
+Before calling the deterministic gate, the gateway verifies the repository contract and supplies the policy evidence keys from real GitHub state:
+
+- `secret_bound` — required repository secret names are configured (`AWS_ROLE_TO_ASSUME`, `AWS_REGION`, `AWS_ACCOUNT_ID`). Secret **values** are never read.
+- `dependency_resolved` — the current workflow contains GitHub OIDC and the corrected `DSGOneStack-$ENVIRONMENT` contract.
+- `testable` — the current workflow contains post-deploy CloudFormation verification.
+- `deploy_target_ready` — the target protected environment exists and required bindings are present.
+- `audit_hook_available` — the workflow emits the verification manifest/evidence artifact.
+
+If the gateway cannot verify any required evidence, the gate remains BLOCKED.
+
+## AWS idempotency
+
+Every `dsg.aws.deploy` call requires a stable `idempotencyKey`. Reuse the same key when retrying the same intended deployment.
+
+The gateway checks existing `cdk-deploy.yml` runs before dispatch. The workflow also records the key in its run name and verification manifest and serializes deployments per environment with GitHub Actions concurrency. Duplicate retries return the existing run instead of silently launching another deployment.
 
 ## AWS truth boundary
 

--- a/lib/mcp/unified-auth.ts
+++ b/lib/mcp/unified-auth.ts
@@ -1,0 +1,156 @@
+import { hashMcpApiKey } from '@/lib/dsg/mcp/api-key-crypto';
+import {
+  callDsgRpc,
+  getDsgSupabaseRpcConfig,
+} from '@/lib/dsg/server/supabase-rpc';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import type { RuntimeRole } from '@/lib/authz';
+
+export type UnifiedAuthContext = {
+  source: 'api-key' | 'session';
+  actorId: string;
+  orgId: string;
+  roles: RuntimeRole[];
+  keyId?: string;
+  planId?: string;
+  callsUsed?: number;
+  callsLimit?: number;
+};
+
+type StoredKeyRow = {
+  key_id: string;
+  actor_id: string;
+  plan_id: string;
+  calls_used: number;
+  calls_limit: number;
+};
+
+type StoredKeyValidation =
+  | { presented: false; valid: false }
+  | { presented: true; valid: false; reason: string }
+  | { presented: true; valid: true; context: UnifiedAuthContext };
+
+function extractRawMcpKey(request: Request): string | undefined {
+  const explicit =
+    request.headers.get('x-dsg-api-key') ?? request.headers.get('x-api-key');
+  if (explicit?.trim()) return explicit.trim();
+
+  const authorization = request.headers.get('authorization');
+  if (!authorization?.toLowerCase().startsWith('bearer ')) return undefined;
+  const bearer = authorization.slice('bearer '.length).trim();
+  return bearer.startsWith('dsg_') ? bearer : undefined;
+}
+
+function normalizeRuntimeRole(value: string): RuntimeRole | null {
+  if (
+    value === 'org_admin' ||
+    value === 'operator' ||
+    value === 'reviewer' ||
+    value === 'runtime_auditor' ||
+    value === 'billing_admin'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+async function resolveStoredKeyActor(
+  authUserId: string,
+): Promise<{ actorId: string; orgId: string; roles: RuntimeRole[] } | null> {
+  const admin = getSupabaseAdmin();
+  const profile = await admin
+    .from('users')
+    .select('id, org_id, is_active, role')
+    .eq('auth_user_id', authUserId)
+    .maybeSingle();
+
+  if (profile.error || !profile.data?.id || !profile.data?.org_id || !profile.data.is_active) {
+    return null;
+  }
+
+  const actorId = String(profile.data.id);
+  const orgId = String(profile.data.org_id);
+  const baseRole = String(profile.data.role ?? '').trim().toLowerCase();
+
+  const roleRows = await admin
+    .from('runtime_roles')
+    .select('role')
+    .eq('org_id', orgId)
+    .eq('user_id', actorId);
+
+  if (roleRows.error) return null;
+
+  const roles = new Set<RuntimeRole>();
+  for (const row of roleRows.data ?? []) {
+    const role = normalizeRuntimeRole(String(row.role));
+    if (role) roles.add(role);
+  }
+
+  // Match the established authz bootstrap behavior for owner/admin profiles.
+  if (baseRole === 'owner' || baseRole === 'admin') {
+    roles.add('org_admin');
+    roles.add('operator');
+    roles.add('reviewer');
+    roles.add('runtime_auditor');
+    roles.add('billing_admin');
+  } else {
+    const baseRuntimeRole = normalizeRuntimeRole(baseRole);
+    if (baseRuntimeRole) roles.add(baseRuntimeRole);
+    if (baseRole === 'viewer' || baseRole === 'guest_auditor') roles.add('reviewer');
+  }
+
+  return { actorId, orgId, roles: Array.from(roles).sort() };
+}
+
+export async function validateStoredUnifiedMcpKey(
+  request: Request,
+  toolName: string,
+): Promise<StoredKeyValidation> {
+  const rawKey = extractRawMcpKey(request);
+  if (!rawKey) return { presented: false, valid: false };
+  if (!rawKey.startsWith('dsg_')) {
+    return { presented: true, valid: false, reason: 'INVALID_MCP_KEY_FORMAT' };
+  }
+
+  try {
+    const keyHash = await hashMcpApiKey(rawKey);
+    const config = getDsgSupabaseRpcConfig();
+    const rows = await callDsgRpc<StoredKeyRow[]>(config, 'validate_mcp_api_key', {
+      p_key_hash: keyHash,
+    });
+    const row = rows?.[0];
+    if (!row?.key_id || !row.actor_id) {
+      return { presented: true, valid: false, reason: 'MCP_KEY_REVOKED_EXPIRED_OR_QUOTA_EXCEEDED' };
+    }
+
+    const actor = await resolveStoredKeyActor(String(row.actor_id));
+    if (!actor) {
+      return { presented: true, valid: false, reason: 'MCP_KEY_ACTOR_NOT_ACTIVE' };
+    }
+
+    // Meter only after the key and actor have both passed authorization checks.
+    await callDsgRpc<void>(config, 'record_mcp_usage', {
+      p_key_id: row.key_id,
+      p_actor_id: row.actor_id,
+      p_tool_name: toolName,
+    });
+
+    return {
+      presented: true,
+      valid: true,
+      context: {
+        source: 'api-key',
+        actorId: actor.actorId,
+        orgId: actor.orgId,
+        roles: actor.roles,
+        keyId: String(row.key_id),
+        planId: String(row.plan_id),
+        callsUsed: Number(row.calls_used),
+        callsLimit: Number(row.calls_limit),
+      },
+    };
+  } catch {
+    // Missing DB configuration, RPC failures, or role-resolution failures deny access.
+    return { presented: true, valid: false, reason: 'MCP_KEY_VALIDATION_UNAVAILABLE' };
+  }
+}

--- a/lib/mcp/unified-tools.ts
+++ b/lib/mcp/unified-tools.ts
@@ -1,0 +1,358 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { Octokit } from '@octokit/rest';
+import { callDsgTool } from './dsg-tools';
+
+export const UNIFIED_TOOL_SCHEMAS = {
+  'dsg.system.status': {
+    description: 'Return the unified DSG Control Plane MCP adapter status without exposing secrets.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  'dsg.aimo.status': {
+    description: 'Check the DSG ONE AIMO harness surface through the unified control-plane gateway.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  'dsg.aimo.solve': {
+    description: 'Run the governed AIMO pipeline through DSG ONE -> DSG AGI Simulation -> Cinema Proof Agent.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        problem: {
+          type: 'object',
+          properties: {
+            problemId: { type: 'string' },
+            statement: { type: 'string' },
+            domain: { type: 'string' },
+            constraints: { type: 'object', additionalProperties: true },
+          },
+          required: ['statement'],
+          additionalProperties: true,
+        },
+        shardCount: { type: 'integer', minimum: 1, maximum: 4096 },
+        parallelism: { type: 'integer', minimum: 1, maximum: 64 },
+        maxCandidatesPerShard: { type: 'integer', minimum: 1, maximum: 64 },
+        requireAllShards: { type: 'boolean' },
+        nvidiaIsing: {
+          type: 'object',
+          properties: {
+            mode: { type: 'string', enum: ['off', 'live', 'pinned'] },
+            pinnedText: { type: 'string' },
+            model: { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+      },
+      required: ['problem'],
+      additionalProperties: false,
+    },
+  },
+  'dsg.aws.contract': {
+    description: 'Return the governed AWS execution contract used by the Control Plane and AWS Agent Toolkit adapter.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  'dsg.aws.deploy': {
+    description: 'Gate and dispatch the repository CDK deployment workflow. Deployment remains REVIEW until post-deploy evidence verifies it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        environment: { type: 'string', enum: ['dev', 'staging', 'prod'] },
+        approved: { type: 'boolean', description: 'Explicit operator approval to dispatch the governed workflow.' },
+      },
+      required: ['environment', 'approved'],
+      additionalProperties: false,
+    },
+  },
+} as const;
+
+export type UnifiedToolName = keyof typeof UNIFIED_TOOL_SCHEMAS;
+export const UNIFIED_TOOL_NAMES = Object.keys(UNIFIED_TOOL_SCHEMAS) as UnifiedToolName[];
+
+export type UnifiedToolResult =
+  | { ok: true; result: unknown }
+  | { ok: false; code: number; message: string };
+
+function secretEquals(actual: string, expected: string): boolean {
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  if (actualBytes.length !== expectedBytes.length) return false;
+  return timingSafeEqual(actualBytes, expectedBytes);
+}
+
+export function isUnifiedMcpKeyAuthorized(request: Request): boolean {
+  const expected = process.env.DSG_MCP_API_KEY ?? process.env.DSG_API_KEY;
+  if (!expected) return false;
+
+  const bearer = request.headers.get('authorization');
+  const bearerValue = bearer?.startsWith('Bearer ') ? bearer.slice('Bearer '.length) : null;
+  const provided =
+    request.headers.get('x-dsg-api-key') ??
+    request.headers.get('x-api-key') ??
+    bearerValue;
+
+  return Boolean(provided && secretEquals(provided, expected));
+}
+
+function dsgOneBaseUrl(): URL {
+  const raw = process.env.DSG_ONE_MCP_BACKEND_URL ?? 'https://dsg-one-v1.vercel.app';
+  const url = new URL(raw);
+  if (process.env.NODE_ENV === 'production' && url.protocol !== 'https:') {
+    throw new Error('DSG_ONE_MCP_BACKEND_URL must use HTTPS in production');
+  }
+  return url;
+}
+
+function aimoRootKey(): string | null {
+  return (
+    process.env.DSG_AIMO_ROOT_KEY?.trim() ||
+    process.env.DSG_MCP_ROOT_KEY?.trim() ||
+    null
+  );
+}
+
+function controlPlaneInternalToken(): string | null {
+  const root = aimoRootKey();
+  if (!root) return null;
+  const digest = createHmac('sha256', root)
+    .update('dsg-aimo-v1:control-plane')
+    .digest('hex');
+  return `dsg_aimo_${digest}`;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text.slice(0, 2000) };
+  }
+}
+
+async function handleAimoStatus(): Promise<UnifiedToolResult> {
+  const url = new URL('/api/dsg/aimo/solve', dsgOneBaseUrl());
+  try {
+    const token = controlPlaneInternalToken();
+    const response = await fetch(url, {
+      headers: token ? { 'X-DSG-Internal-Key': token } : {},
+      signal: AbortSignal.timeout(15_000),
+    });
+    const body = await parseJson(response);
+    return {
+      ok: true,
+      result: {
+        verdict: response.ok ? 'PASS' : 'REVIEW',
+        httpStatus: response.status,
+        backend: 'dsg-one-v1',
+        body,
+        rootKeyConfigured: Boolean(aimoRootKey()),
+      },
+    };
+  } catch (error) {
+    return {
+      ok: true,
+      result: {
+        verdict: 'REVIEW',
+        backend: 'dsg-one-v1',
+        rootKeyConfigured: Boolean(aimoRootKey()),
+        reason: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+async function handleAimoSolve(args: Record<string, unknown>): Promise<UnifiedToolResult> {
+  const internalToken = controlPlaneInternalToken();
+  if (!internalToken) {
+    return {
+      ok: false,
+      code: -32010,
+      message: 'DSG_AIMO_ROOT_KEY is not configured on the Control Plane. Competition compute fails closed.',
+    };
+  }
+
+  const problem = args.problem;
+  if (!problem || typeof problem !== 'object' || typeof (problem as Record<string, unknown>).statement !== 'string') {
+    return { ok: false, code: -32602, message: 'problem.statement is required' };
+  }
+
+  const url = new URL('/api/dsg/aimo/solve', dsgOneBaseUrl());
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-DSG-Internal-Key': internalToken,
+      },
+      body: JSON.stringify(args),
+      signal: AbortSignal.timeout(180_000),
+    });
+    const body = await parseJson(response);
+    if (!response.ok) {
+      return {
+        ok: false,
+        code: -32020,
+        message: `DSG ONE AIMO backend returned HTTP ${response.status}: ${JSON.stringify(body)}`,
+      };
+    }
+    return { ok: true, result: body };
+  } catch (error) {
+    return {
+      ok: false,
+      code: -32021,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function handleSystemStatus(): UnifiedToolResult {
+  return {
+    ok: true,
+    result: {
+      ok: true,
+      gateway: 'DSG Control Plane Unified MCP',
+      version: '1.0.0',
+      oneFrontDoor: true,
+      adapters: {
+        controlPlane: { configured: true, authoritativeGate: true },
+        dsgOne: { configured: true, defaultUrlAvailable: true },
+        aimoInternalRootKey: { configured: Boolean(aimoRootKey()) },
+        awsWorkflowDispatch: {
+          configured: Boolean(process.env.DSG_GITHUB_AUTOMATION_TOKEN ?? process.env.GITHUB_TOKEN),
+          workflow: '.github/workflows/cdk-deploy.yml',
+        },
+      },
+      userConfiguration: ['DSG_MCP_URL', 'DSG_API_KEY'],
+      truthBoundary:
+        'Adapter availability is not production readiness. PASS requires downstream evidence and verification; missing internal credentials fail closed.',
+    },
+  };
+}
+
+function handleAwsContract(): UnifiedToolResult {
+  return {
+    ok: true,
+    result: {
+      adapter: 'AWS Agent Toolkit / governed GitHub OIDC CDK workflow',
+      contract: ['Plan', 'Gate', 'AWS execution', 'Evidence', 'Verification'],
+      workflow: '.github/workflows/cdk-deploy.yml',
+      destructiveRollbackAutomatic: false,
+      productionApprovalRequired: true,
+      finalPassRule:
+        'A workflow dispatch is REVIEW, never PASS. PASS requires accepted CloudFormation state plus captured AWS verification evidence.',
+      currentInfrastructureBoundary:
+        'The current AWS construct proves an ECS cluster only; it does not prove a Fargate application service exists.',
+    },
+  };
+}
+
+async function handleAwsDeploy(args: Record<string, unknown>): Promise<UnifiedToolResult> {
+  const environment = String(args.environment ?? '');
+  if (!['dev', 'staging', 'prod'].includes(environment)) {
+    return { ok: false, code: -32602, message: 'environment must be dev, staging, or prod' };
+  }
+
+  const gate = await callDsgTool('dsg.evaluate', {
+    action: `deploy.aws.${environment}`,
+    actor: 'mcp:unified-control-plane',
+    tool: 'github-actions:cdk-deploy',
+    args: { environment },
+    env: {
+      riskLevel: environment === 'prod' ? 'critical' : 'high',
+      policyRef: 'dsg-aws-agent-toolkit-v1',
+    },
+  });
+
+  if (!gate.ok) return gate;
+  const decision = gate.result as Record<string, unknown>;
+  if (decision.gateStatus !== 'PASS') {
+    return {
+      ok: true,
+      result: {
+        verdict: decision.gateStatus ?? 'BLOCK',
+        dispatched: false,
+        gate: decision,
+        nextAction: 'Resolve the deterministic DSG gate before any AWS mutation.',
+      },
+    };
+  }
+
+  if (args.approved !== true) {
+    return {
+      ok: true,
+      result: {
+        verdict: 'REVIEW',
+        dispatched: false,
+        gate: decision,
+        nextAction: 'Set approved=true only after the operator approves this exact deployment plan.',
+      },
+    };
+  }
+
+  const token = process.env.DSG_GITHUB_AUTOMATION_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (!token) {
+    return {
+      ok: false,
+      code: -32030,
+      message: 'Server-side GitHub workflow credential is not configured. AWS deployment remains BLOCKED.',
+    };
+  }
+
+  const repository = process.env.DSG_CONTROL_PLANE_REPOSITORY ?? 'tdealer01-crypto/tdealer01-crypto-dsg-control-plane';
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo) {
+    return { ok: false, code: -32031, message: 'DSG_CONTROL_PLANE_REPOSITORY must be owner/repo' };
+  }
+
+  const octokit = new Octokit({ auth: token });
+  await octokit.rest.actions.createWorkflowDispatch({
+    owner,
+    repo,
+    workflow_id: 'cdk-deploy.yml',
+    ref: process.env.DSG_AWS_DEPLOY_REF ?? 'main',
+    inputs: {
+      environment,
+      approval_required: 'true',
+    },
+  });
+
+  return {
+    ok: true,
+    result: {
+      verdict: 'REVIEW',
+      dispatched: true,
+      environment,
+      gate: decision,
+      workflow: 'cdk-deploy.yml',
+      nextAction:
+        'Wait for protected-environment approval and post-deploy verification evidence. Do not claim production readiness from dispatch success.',
+    },
+  };
+}
+
+export async function callUnifiedTool(
+  name: UnifiedToolName,
+  args: Record<string, unknown>,
+): Promise<UnifiedToolResult> {
+  try {
+    switch (name) {
+      case 'dsg.system.status':
+        return handleSystemStatus();
+      case 'dsg.aimo.status':
+        return await handleAimoStatus();
+      case 'dsg.aimo.solve':
+        return await handleAimoSolve(args);
+      case 'dsg.aws.contract':
+        return handleAwsContract();
+      case 'dsg.aws.deploy':
+        return await handleAwsDeploy(args);
+      default:
+        return { ok: false, code: -32601, message: `Unknown unified tool: ${String(name)}` };
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      code: -32603,
+      message: error instanceof Error ? error.message : 'Unified MCP tool error',
+    };
+  }
+}

--- a/lib/mcp/unified-tools.ts
+++ b/lib/mcp/unified-tools.ts
@@ -1,6 +1,7 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHmac } from 'node:crypto';
 import { Octokit } from '@octokit/rest';
 import { callDsgTool } from './dsg-tools';
+import type { UnifiedAuthContext } from './unified-auth';
 
 export const UNIFIED_TOOL_SCHEMAS = {
   'dsg.system.status': {
@@ -50,14 +51,20 @@ export const UNIFIED_TOOL_SCHEMAS = {
     inputSchema: { type: 'object', properties: {}, additionalProperties: false },
   },
   'dsg.aws.deploy': {
-    description: 'Gate and dispatch the repository CDK deployment workflow. Deployment remains REVIEW until post-deploy evidence verifies it.',
+    description: 'Gate and idempotently dispatch the repository CDK deployment workflow. Deployment remains REVIEW until post-deploy evidence verifies it.',
     inputSchema: {
       type: 'object',
       properties: {
         environment: { type: 'string', enum: ['dev', 'staging', 'prod'] },
         approved: { type: 'boolean', description: 'Explicit operator approval to dispatch the governed workflow.' },
+        idempotencyKey: {
+          type: 'string',
+          minLength: 8,
+          maxLength: 128,
+          description: 'Stable request identifier reused on retries of the same intended deployment.',
+        },
       },
-      required: ['environment', 'approved'],
+      required: ['environment', 'approved', 'idempotencyKey'],
       additionalProperties: false,
     },
   },
@@ -70,26 +77,16 @@ export type UnifiedToolResult =
   | { ok: true; result: unknown }
   | { ok: false; code: number; message: string };
 
-function secretEquals(actual: string, expected: string): boolean {
-  const actualBytes = Buffer.from(actual);
-  const expectedBytes = Buffer.from(expected);
-  if (actualBytes.length !== expectedBytes.length) return false;
-  return timingSafeEqual(actualBytes, expectedBytes);
-}
-
-export function isUnifiedMcpKeyAuthorized(request: Request): boolean {
-  const expected = process.env.DSG_MCP_API_KEY ?? process.env.DSG_API_KEY;
-  if (!expected) return false;
-
-  const bearer = request.headers.get('authorization');
-  const bearerValue = bearer?.startsWith('Bearer ') ? bearer.slice('Bearer '.length) : null;
-  const provided =
-    request.headers.get('x-dsg-api-key') ??
-    request.headers.get('x-api-key') ??
-    bearerValue;
-
-  return Boolean(provided && secretEquals(provided, expected));
-}
+type AwsGateEvidence = {
+  secret_bound: boolean;
+  dependency_resolved: boolean;
+  testable: boolean;
+  deploy_target_ready: boolean;
+  audit_hook_available: boolean;
+  environmentConfigured: boolean;
+  missingRepositorySecrets: string[];
+  workflowRef: string;
+};
 
 function dsgOneBaseUrl(): URL {
   const raw = process.env.DSG_ONE_MCP_BACKEND_URL ?? 'https://dsg-one-v1.vercel.app';
@@ -125,6 +122,10 @@ async function parseJson(response: Response): Promise<unknown> {
   } catch {
     return { raw: text.slice(0, 2000) };
   }
+}
+
+function hasMutationRole(auth: UnifiedAuthContext): boolean {
+  return auth.roles.includes('operator') || auth.roles.includes('org_admin');
 }
 
 async function handleAimoStatus(): Promise<UnifiedToolResult> {
@@ -204,7 +205,7 @@ async function handleAimoSolve(args: Record<string, unknown>): Promise<UnifiedTo
   }
 }
 
-function handleSystemStatus(): UnifiedToolResult {
+function handleSystemStatus(auth: UnifiedAuthContext): UnifiedToolResult {
   return {
     ok: true,
     result: {
@@ -212,6 +213,7 @@ function handleSystemStatus(): UnifiedToolResult {
       gateway: 'DSG Control Plane Unified MCP',
       version: '1.0.0',
       oneFrontDoor: true,
+      authenticatedBy: auth.source,
       adapters: {
         controlPlane: { configured: true, authoritativeGate: true },
         dsgOne: { configured: true, defaultUrlAvailable: true },
@@ -221,7 +223,7 @@ function handleSystemStatus(): UnifiedToolResult {
           workflow: '.github/workflows/cdk-deploy.yml',
         },
       },
-      userConfiguration: ['DSG_MCP_URL', 'DSG_API_KEY'],
+      userConfiguration: ['MCP URL', 'one issued DSG API key'],
       truthBoundary:
         'Adapter availability is not production readiness. PASS requires downstream evidence and verification; missing internal credentials fail closed.',
     },
@@ -237,6 +239,7 @@ function handleAwsContract(): UnifiedToolResult {
       workflow: '.github/workflows/cdk-deploy.yml',
       destructiveRollbackAutomatic: false,
       productionApprovalRequired: true,
+      idempotencyRequired: true,
       finalPassRule:
         'A workflow dispatch is REVIEW, never PASS. PASS requires accepted CloudFormation state plus captured AWS verification evidence.',
       currentInfrastructureBoundary:
@@ -245,35 +248,129 @@ function handleAwsContract(): UnifiedToolResult {
   };
 }
 
-async function handleAwsDeploy(args: Record<string, unknown>): Promise<UnifiedToolResult> {
+function decodeGitHubContent(content: string | undefined, encoding: string | undefined): string {
+  if (!content) return '';
+  return encoding === 'base64'
+    ? Buffer.from(content.replace(/\n/g, ''), 'base64').toString('utf8')
+    : content;
+}
+
+async function inspectAwsDeployEvidence(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  environment: string,
+  ref: string,
+): Promise<AwsGateEvidence> {
+  let workflow = '';
+  try {
+    const response = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: '.github/workflows/cdk-deploy.yml',
+      ref,
+    });
+    if (!Array.isArray(response.data) && 'content' in response.data) {
+      workflow = decodeGitHubContent(response.data.content, response.data.encoding);
+    }
+  } catch {
+    workflow = '';
+  }
+
+  const requiredSecrets = ['AWS_ROLE_TO_ASSUME', 'AWS_REGION', 'AWS_ACCOUNT_ID'];
+  const secretNames = new Set<string>();
+  try {
+    const response = await octokit.rest.actions.listRepoSecrets({ owner, repo, per_page: 100 });
+    for (const secret of response.data.secrets) secretNames.add(secret.name);
+  } catch {
+    // Lack of permission to verify secret bindings is a fail-closed condition.
+  }
+  const missingRepositorySecrets = requiredSecrets.filter((name) => !secretNames.has(name));
+
+  let environmentConfigured = false;
+  try {
+    await octokit.request('GET /repos/{owner}/{repo}/environments/{environment_name}', {
+      owner,
+      repo,
+      environment_name: environment,
+    });
+    environmentConfigured = true;
+  } catch {
+    environmentConfigured = false;
+  }
+
+  const dependencyResolved =
+    workflow.includes('aws-actions/configure-aws-credentials@v4') &&
+    workflow.includes('id-token: write') &&
+    workflow.includes('DSGOneStack-$ENVIRONMENT');
+  const testable =
+    workflow.includes('Verify Deployment') &&
+    workflow.includes('cloudformation describe-stacks') &&
+    workflow.includes('verification-manifest.json');
+  const auditHookAvailable =
+    workflow.includes('Upload verification evidence') &&
+    workflow.includes('aws-verification-evidence-');
+  const secretBound = missingRepositorySecrets.length === 0;
+
+  return {
+    secret_bound: secretBound,
+    dependency_resolved: dependencyResolved,
+    testable,
+    deploy_target_ready: environmentConfigured && secretBound && dependencyResolved,
+    audit_hook_available: auditHookAvailable,
+    environmentConfigured,
+    missingRepositorySecrets,
+    workflowRef: ref,
+  };
+}
+
+async function findExistingAwsDispatch(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  environment: string,
+  idempotencyKey: string,
+): Promise<{ id: number; status: string | null; conclusion: string | null; htmlUrl: string } | null> {
+  const expectedTitle = `DSG CDK ${environment} ${idempotencyKey}`;
+  const runs = await octokit.rest.actions.listWorkflowRuns({
+    owner,
+    repo,
+    workflow_id: 'cdk-deploy.yml',
+    per_page: 100,
+  });
+
+  for (const run of runs.data.workflow_runs) {
+    if (run.display_title === expectedTitle) {
+      return {
+        id: run.id,
+        status: run.status ?? null,
+        conclusion: run.conclusion ?? null,
+        htmlUrl: run.html_url,
+      };
+    }
+  }
+  return null;
+}
+
+async function handleAwsDeploy(
+  args: Record<string, unknown>,
+  auth: UnifiedAuthContext,
+): Promise<UnifiedToolResult> {
+  if (!hasMutationRole(auth)) {
+    return { ok: false, code: -32001, message: 'AWS deployment requires operator or org_admin entitlement.' };
+  }
+
   const environment = String(args.environment ?? '');
   if (!['dev', 'staging', 'prod'].includes(environment)) {
     return { ok: false, code: -32602, message: 'environment must be dev, staging, or prod' };
   }
 
-  const gate = await callDsgTool('dsg.evaluate', {
-    action: `deploy.aws.${environment}`,
-    actor: 'mcp:unified-control-plane',
-    tool: 'github-actions:cdk-deploy',
-    args: { environment },
-    env: {
-      riskLevel: environment === 'prod' ? 'critical' : 'high',
-      policyRef: 'dsg-aws-agent-toolkit-v1',
-    },
-  });
-
-  if (!gate.ok) return gate;
-  const decision = gate.result as Record<string, unknown>;
-  if (decision.gateStatus !== 'PASS') {
-    return {
-      ok: true,
-      result: {
-        verdict: decision.gateStatus ?? 'BLOCK',
-        dispatched: false,
-        gate: decision,
-        nextAction: 'Resolve the deterministic DSG gate before any AWS mutation.',
-      },
-    };
+  const idempotencyKey = String(args.idempotencyKey ?? '').trim();
+  if (idempotencyKey.length < 8 || idempotencyKey.length > 128) {
+    return { ok: false, code: -32602, message: 'idempotencyKey must contain 8 to 128 characters' };
+  }
+  if (!/^[A-Za-z0-9._:-]+$/.test(idempotencyKey)) {
+    return { ok: false, code: -32602, message: 'idempotencyKey contains unsupported characters' };
   }
 
   if (args.approved !== true) {
@@ -282,7 +379,6 @@ async function handleAwsDeploy(args: Record<string, unknown>): Promise<UnifiedTo
       result: {
         verdict: 'REVIEW',
         dispatched: false,
-        gate: decision,
         nextAction: 'Set approved=true only after the operator approves this exact deployment plan.',
       },
     };
@@ -303,15 +399,94 @@ async function handleAwsDeploy(args: Record<string, unknown>): Promise<UnifiedTo
     return { ok: false, code: -32031, message: 'DSG_CONTROL_PLANE_REPOSITORY must be owner/repo' };
   }
 
+  const workflowRef = process.env.DSG_AWS_DEPLOY_REF ?? 'main';
   const octokit = new Octokit({ auth: token });
+  const evidence = await inspectAwsDeployEvidence(
+    octokit,
+    owner,
+    repo,
+    environment,
+    workflowRef,
+  );
+
+  const gate = await callDsgTool('dsg.evaluate', {
+    action: `deploy.aws.${environment}`,
+    actor: auth.actorId,
+    tool: 'github-actions:cdk-deploy',
+    args: {
+      environment,
+      idempotencyKey,
+      secret_bound: evidence.secret_bound,
+      dependency_resolved: evidence.dependency_resolved,
+      testable: evidence.testable,
+      deploy_target_ready: evidence.deploy_target_ready,
+      audit_hook_available: evidence.audit_hook_available,
+    },
+    env: {
+      riskLevel: environment === 'prod' ? 'critical' : 'high',
+      policyRef: 'dsg-aws-agent-toolkit-v1',
+    },
+  });
+
+  if (!gate.ok) return gate;
+  const decision = gate.result as Record<string, unknown>;
+  if (decision.gateStatus !== 'PASS') {
+    const missingEvidence = [
+      ['secret_bound', evidence.secret_bound],
+      ['dependency_resolved', evidence.dependency_resolved],
+      ['testable', evidence.testable],
+      ['deploy_target_ready', evidence.deploy_target_ready],
+      ['audit_hook_available', evidence.audit_hook_available],
+    ]
+      .filter(([, passed]) => passed !== true)
+      .map(([name]) => name);
+
+    return {
+      ok: true,
+      result: {
+        verdict: decision.gateStatus ?? 'BLOCK',
+        dispatched: false,
+        gate: decision,
+        evidence,
+        missingEvidence,
+        nextAction: 'Resolve the reported AWS evidence bindings before any mutation.',
+      },
+    };
+  }
+
+  const existing = await findExistingAwsDispatch(
+    octokit,
+    owner,
+    repo,
+    environment,
+    idempotencyKey,
+  );
+  if (existing) {
+    return {
+      ok: true,
+      result: {
+        verdict: 'REVIEW',
+        dispatched: false,
+        duplicateSuppressed: true,
+        environment,
+        idempotencyKey,
+        existingRun: existing,
+        gate: decision,
+        evidence,
+        nextAction: 'Reuse the existing workflow run and its verification evidence instead of dispatching a duplicate.',
+      },
+    };
+  }
+
   await octokit.rest.actions.createWorkflowDispatch({
     owner,
     repo,
     workflow_id: 'cdk-deploy.yml',
-    ref: process.env.DSG_AWS_DEPLOY_REF ?? 'main',
+    ref: workflowRef,
     inputs: {
       environment,
       approval_required: 'true',
+      idempotency_key: idempotencyKey,
     },
   });
 
@@ -321,7 +496,9 @@ async function handleAwsDeploy(args: Record<string, unknown>): Promise<UnifiedTo
       verdict: 'REVIEW',
       dispatched: true,
       environment,
+      idempotencyKey,
       gate: decision,
+      evidence,
       workflow: 'cdk-deploy.yml',
       nextAction:
         'Wait for protected-environment approval and post-deploy verification evidence. Do not claim production readiness from dispatch success.',
@@ -332,11 +509,12 @@ async function handleAwsDeploy(args: Record<string, unknown>): Promise<UnifiedTo
 export async function callUnifiedTool(
   name: UnifiedToolName,
   args: Record<string, unknown>,
+  auth: UnifiedAuthContext,
 ): Promise<UnifiedToolResult> {
   try {
     switch (name) {
       case 'dsg.system.status':
-        return handleSystemStatus();
+        return handleSystemStatus(auth);
       case 'dsg.aimo.status':
         return await handleAimoStatus();
       case 'dsg.aimo.solve':
@@ -344,7 +522,7 @@ export async function callUnifiedTool(
       case 'dsg.aws.contract':
         return handleAwsContract();
       case 'dsg.aws.deploy':
-        return await handleAwsDeploy(args);
+        return await handleAwsDeploy(args, auth);
       default:
         return { ok: false, code: -32601, message: `Unknown unified tool: ${String(name)}` };
     }

--- a/scripts/verify-unified-mcp-gateway.mjs
+++ b/scripts/verify-unified-mcp-gateway.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 
 const route = readFileSync('app/api/mcp/route.ts', 'utf8');
 const tools = readFileSync('lib/mcp/unified-tools.ts', 'utf8');
+const auth = readFileSync('lib/mcp/unified-auth.ts', 'utf8');
 const awsWorkflow = readFileSync('.github/workflows/cdk-deploy.yml', 'utf8');
 
 const requiredTools = [
@@ -45,6 +46,54 @@ if (
   fail('derived control-plane root-token contract is missing');
 }
 
+if (
+  route.includes('validateStoredUnifiedMcpKey') &&
+  auth.includes("'validate_mcp_api_key'") &&
+  auth.includes("'record_mcp_usage'") &&
+  auth.includes('hashMcpApiKey') &&
+  !route.includes('isUnifiedMcpKeyAuthorized')
+) {
+  pass('unified client auth uses the issued MCP key store, quota validator, and usage meter');
+} else {
+  fail('unified client auth bypasses or does not fully use the issued MCP key registry');
+}
+
+if (
+  auth.includes(".from('users')") &&
+  auth.includes(".from('runtime_roles')") &&
+  tools.includes("auth.roles.includes('operator')") &&
+  tools.includes("auth.roles.includes('org_admin')")
+) {
+  pass('stored-key actor/org role is resolved before AWS mutation entitlement');
+} else {
+  fail('AWS mutation entitlement is not bound to the stored-key actor role');
+}
+
+const evidenceKeys = [
+  'secret_bound',
+  'dependency_resolved',
+  'testable',
+  'deploy_target_ready',
+  'audit_hook_available',
+];
+for (const evidenceKey of evidenceKeys) {
+  if (tools.includes(`${evidenceKey}: evidence.${evidenceKey}`)) {
+    pass(`AWS deterministic gate evidence supplied: ${evidenceKey}`);
+  } else {
+    fail(`missing AWS deterministic gate evidence: ${evidenceKey}`);
+  }
+}
+
+if (
+  tools.includes('listRepoSecrets') &&
+  tools.includes("GET /repos/{owner}/{repo}/environments/{environment_name}") &&
+  tools.includes("path: '.github/workflows/cdk-deploy.yml'")
+) {
+  pass('AWS evidence is inspected from GitHub workflow, secret bindings, and target environment');
+} else {
+  fail('AWS evidence is not sourced from the live repository contract');
+}
+
 if (tools.includes("verdict: 'REVIEW'") && tools.includes('post-deploy verification evidence')) {
   pass('AWS dispatch cannot be reported as final PASS');
 } else {
@@ -57,16 +106,23 @@ if (tools.includes("callDsgTool('dsg.evaluate'") && tools.includes("riskLevel: e
   fail('AWS deploy does not show deterministic gate enforcement');
 }
 
+if (
+  tools.includes('findExistingAwsDispatch') &&
+  tools.includes('duplicateSuppressed: true') &&
+  awsWorkflow.includes('idempotency_key:') &&
+  awsWorkflow.includes('run-name: DSG CDK ${{ inputs.environment }} ${{ inputs.idempotency_key }}') &&
+  awsWorkflow.includes('group: dsg-cdk-${{ inputs.environment }}') &&
+  awsWorkflow.includes('cancel-in-progress: false')
+) {
+  pass('AWS workflow dispatch is retry-idempotent and serialized per environment');
+} else {
+  fail('AWS workflow idempotency/concurrency contract is incomplete');
+}
+
 if (awsWorkflow.includes('id-token: write') && awsWorkflow.includes('DSGOneStack-$ENVIRONMENT')) {
   pass('AWS workflow uses OIDC and the corrected CDK stack contract');
 } else {
   fail('AWS workflow dependency is not the corrected Agent Toolkit deployment contract');
-}
-
-if (route.includes('isUnifiedMcpKeyAuthorized') && route.includes("requireOrgRole(['operator', 'org_admin'])")) {
-  pass('unified high-value tools require API-key or operator-session authorization');
-} else {
-  fail('unified tool authorization gate is missing');
 }
 
 if (failed) process.exit(1);

--- a/scripts/verify-unified-mcp-gateway.mjs
+++ b/scripts/verify-unified-mcp-gateway.mjs
@@ -30,6 +30,25 @@ if (route.includes("serverInfo: { name: 'dsg-control-plane-unified-mcp'")) {
   fail('MCP initialize does not identify the unified control-plane server');
 }
 
+if (
+  route.includes("rpc.method === 'notifications/initialized'") &&
+  route.includes('new NextResponse(null, { status: 202 })')
+) {
+  pass('MCP initialized notification is accepted as a one-way 202 response');
+} else {
+  fail('MCP initialized notification handshake is incomplete');
+}
+
+if (
+  route.includes('function rpcToolResult') &&
+  route.includes('content: [') &&
+  route.includes('structuredContent: structuredContent(value)')
+) {
+  pass('tools/call returns MCP CallToolResult content and structuredContent');
+} else {
+  fail('tools/call does not use a valid CallToolResult envelope');
+}
+
 for (const tool of requiredTools) {
   if (tools.includes(`'${tool}'`)) pass(`tool registered: ${tool}`);
   else fail(`missing unified tool: ${tool}`);

--- a/scripts/verify-unified-mcp-gateway.mjs
+++ b/scripts/verify-unified-mcp-gateway.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const route = readFileSync('app/api/mcp/route.ts', 'utf8');
+const tools = readFileSync('lib/mcp/unified-tools.ts', 'utf8');
+const awsWorkflow = readFileSync('.github/workflows/cdk-deploy.yml', 'utf8');
+
+const requiredTools = [
+  'dsg.system.status',
+  'dsg.aimo.status',
+  'dsg.aimo.solve',
+  'dsg.aws.contract',
+  'dsg.aws.deploy',
+];
+
+let failed = false;
+function pass(message) {
+  console.log(`PASS: ${message}`);
+}
+function fail(message) {
+  failed = true;
+  console.error(`FAIL: ${message}`);
+}
+
+if (route.includes("serverInfo: { name: 'dsg-control-plane-unified-mcp'")) {
+  pass('MCP initialize identifies the unified control-plane server');
+} else {
+  fail('MCP initialize does not identify the unified control-plane server');
+}
+
+for (const tool of requiredTools) {
+  if (tools.includes(`'${tool}'`)) pass(`tool registered: ${tool}`);
+  else fail(`missing unified tool: ${tool}`);
+}
+
+if (
+  tools.includes('DSG_AIMO_ROOT_KEY') &&
+  tools.includes(".update('dsg-aimo-v1:control-plane')") &&
+  tools.includes("'X-DSG-Internal-Key': internalToken") &&
+  !/DSG_AIMO_ROOT_KEY\s*=\s*['"][^'"]+['"]/.test(tools)
+) {
+  pass('one AIMO root key derives a control-plane token; raw root is not hard-coded or sent');
+} else {
+  fail('derived control-plane root-token contract is missing');
+}
+
+if (tools.includes("verdict: 'REVIEW'") && tools.includes('post-deploy verification evidence')) {
+  pass('AWS dispatch cannot be reported as final PASS');
+} else {
+  fail('AWS dispatch truth boundary is missing');
+}
+
+if (tools.includes("callDsgTool('dsg.evaluate'") && tools.includes("riskLevel: environment === 'prod' ? 'critical' : 'high'")) {
+  pass('AWS mutation is routed through the DSG deterministic gate');
+} else {
+  fail('AWS deploy does not show deterministic gate enforcement');
+}
+
+if (awsWorkflow.includes('id-token: write') && awsWorkflow.includes('DSGOneStack-$ENVIRONMENT')) {
+  pass('AWS workflow uses OIDC and the corrected CDK stack contract');
+} else {
+  fail('AWS workflow dependency is not the corrected Agent Toolkit deployment contract');
+}
+
+if (route.includes('isUnifiedMcpKeyAuthorized') && route.includes("requireOrgRole(['operator', 'org_admin'])")) {
+  pass('unified high-value tools require API-key or operator-session authorization');
+} else {
+  fail('unified tool authorization gate is missing');
+}
+
+if (failed) process.exit(1);
+console.log('Unified DSG Control Plane MCP verification complete.');


### PR DESCRIPTION
## Goal
Expose one DSG Control Plane MCP endpoint for governance/runtime tools, AIMO, and governed AWS deployment.

## One-front-door contract
Normal MCP clients configure only:
- MCP URL: `/api/mcp`
- one issued DSG API key from `/api/dsg/mcp/keys`

They do not configure AGI Simulation, Cinema, or AWS MCP credentials individually.

## Added
- unified MCP server identity on `/api/mcp`
- `dsg.system.status`
- `dsg.aimo.status`
- `dsg.aimo.solve`
- `dsg.aws.contract`
- `dsg.aws.deploy`
- one root-key internal AIMO trust model using purpose-specific HMAC token `dsg-aimo-v1:control-plane`; raw root is never sent
- issued-key auth through existing hashed MCP key registry, ACTIVE/period/quota validation, actor/org/runtime-role resolution, and usage metering
- AWS mutation entitlement requires `operator` or `org_admin`
- AWS deterministic gate receives all five required evidence flags from live GitHub workflow/secret-name/environment inspection
- required AWS `idempotencyKey`, existing-run duplicate suppression, per-environment workflow concurrency, and idempotency key in run name/verification manifest
- MCP `notifications/initialized` handshake support with HTTP 202
- MCP `CallToolResult` envelopes (`content[]`, `structuredContent`, `isError`) for unified, DSG, Hermes, and Android tools
- deterministic gateway verifier + CI workflow
- `docs/UNIFIED_MCP_GATEWAY.md`

## Dependencies resolved
- AWS Agent Toolkit / OIDC / evidence contract: PR #1063 merged to `main` as `3fcd524f69b4382bd65473dbb46e9d2f339ed1c4`
- DSG ONE derived Control Plane internal auth: PR #117 merged to `dsg-one-v1/main` as `200223196e75e94edfba631074e77923d7f5e168`
- AGI Simulation and Cinema purpose-specific shared-root auth are already merged.

## Codex review findings addressed
All five reported P1/P2 findings are fixed and review threads resolved:
1. supply every required AWS gate evidence flag from verified repository state
2. use the existing issued MCP key store rather than a deployment-wide secret bypass
3. make AWS workflow dispatch retry-idempotent and serialized per environment
4. accept MCP `notifications/initialized`
5. return valid MCP `CallToolResult` envelopes

## Verification on final head `8434719c283149dc515706bf977f9d3b375b2747`
PASS:
- Verify Unified DSG MCP Gateway
- Verify AWS Agent Toolkit Integration
- CI (lint, typecheck, runtime subset, full test suite, formal proofs, build and remaining gates)
- CI Security Checks
- DSG Validation & Governance including Z3 Gate Verification and Governance Summary
- Agent Workspace Guard including development/production boundaries, typecheck, migrations, unit suite
- Production Quality Gates
- launch-readiness
- DSG Proof Gate
- HPC Formal Verification
- E2E Playwright Docker
- CCVS Evidence Tests
- DSG Secure Deploy Gate
- API Route Smoke Test
- Security Evidence Collection
- Preview Database Create + Tests

## Security / truth boundary
- no raw AIMO root key crosses service boundaries
- issued keys remain revocable/quota-bound and map to an active actor/org
- AWS mutations fail closed without operator/admin entitlement, verified evidence, deterministic gate PASS, explicit approval, idempotency, or server-side workflow credentials
- a successful AWS workflow dispatch is `REVIEW`, not production PASS
- AIMO final PASS still requires the existing Cinema proof gate

## Deployment boundary
Vercel branch deployments for this project still report `ERROR` / external resource provisioning failure while repository builds/tests/security gates are green. This infrastructure issue is not converted into a code PASS.

Therefore:
- code/repository integration: PASS
- unified MCP merge readiness: PASS
- Vercel live deployment: REVIEW until provisioning succeeds
- production-ready claim: NOT MADE