### PR TITLE
feat: add verified repair simulator

### DIFF
--- a/app/api/dsg/v1/repair/simulate/route.ts
+++ b/app/api/dsg/v1/repair/simulate/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '@/lib/authz';
+import { runVerifiedRepair } from '@/lib/dsg/verified-repair';
+import type { VerifiedRepairRequest } from '@/lib/dsg/verified-repair';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Plan-only API surface for the Verified Repair Simulator.
+ * Repository mutation is deliberately not available through this route;
+ * controlled worktree execution is a local/worker boundary.
+ */
+export async function POST(request: NextRequest) {
+  const access = await requireOrgRole(['operator', 'org_admin']);
+  if (!access.ok) return NextResponse.json({ ok: false, error: access.error }, { status: access.status });
+
+  const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ ok: false, error: { code: 'BODY_REQUIRED' } }, { status: 400 });
+  }
+
+  const input: VerifiedRepairRequest = {
+    jobId: body.jobId as string,
+    finding: body.finding as VerifiedRepairRequest['finding'],
+    candidates: body.candidates as VerifiedRepairRequest['candidates'],
+    allowedFiles: body.allowedFiles as string[],
+    approvals: body.approvals as VerifiedRepairRequest['approvals'],
+    solver: body.solver as VerifiedRepairRequest['solver'],
+    createdAt: body.createdAt as string | undefined,
+    actorId: access.userId,
+    source: 'api',
+    // The HTTP route is a plan/evidence surface. It never accepts execute=true.
+    execute: false,
+  };
+
+  const result = await runVerifiedRepair(input);
+  return NextResponse.json({
+    ok: true,
+    data: result,
+    truthBoundary: 'This route produces a candidate plan and Z3 evidence only. It does not modify a repository, merge, deploy, or prove a production fix.',
+  });
+}
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    data: {
+      endpoint: 'POST /api/dsg/v1/repair/simulate',
+      stages: ['candidate_input', 'binary_qubo_plan', 'z3_exact_verification', 'evidence_replay'],
+      defaultMode: 'pinned',
+      mutation: 'disabled',
+      nextStep: 'Run the same verified plan through the local controlled executor with execute=true and validationProfile=full.',
+      statuses: {
+        READY_FOR_CONTROLLED_EXECUTION: 'Plan passed exact verification and is waiting for the isolated worktree executor.',
+        VERIFIED_IN_SIMULATION: 'The isolated worktree validation profile passed; this is not a merge or production claim.',
+        BLOCKED: 'The plan, evidence, approval, solver, or exact verification gate failed.',
+      },
+    },
+  });
+}

--- a/docs/VERIFIED_REPAIR_SIMULATOR.md
+++ b/docs/VERIFIED_REPAIR_SIMULATOR.md
@@ -1,0 +1,63 @@
+# Verified Repair Simulator
+
+The Verified Repair Simulator turns an untrusted set of repair candidates into a reviewable binary plan:
+
+```text
+candidate input → QUBO/Ising proposal → Z3 exact gate → isolated worktree → fixed validation → evidence/replay
+```
+
+The Ising result is only a candidate. Z3, the controlled executor, compiler/tests, security validation, and replay evidence decide whether the result can move forward.
+
+## Use through the unified MCP front door
+
+Call `dsg.repair.simulate` through `/api/mcp` with an issued DSG MCP key or an authenticated operator session.
+
+Required input:
+
+- `jobId`
+- `finding` with severity, execution risk, affected files, and real `sha256:` evidence hashes
+- `candidates` containing exact `file`, `expected`, and `replacement` text
+- `allowedFiles`
+
+The MCP tool is plan-only. It does not edit a repository, create a branch, merge, deploy, or claim a production fix.
+
+## Use through HTTP
+
+```http
+POST /api/dsg/v1/repair/simulate
+```
+
+The route requires an operator or organization-admin session. It returns a decision object even when the plan is blocked, so the user can see the exact reason and next evidence.
+
+The response is in `data`:
+
+- `READY_FOR_CONTROLLED_EXECUTION` — the binary plan passed Z3 and is waiting for the isolated executor.
+- `VERIFIED_IN_SIMULATION` — the local executor ran the selected change in a disposable worktree and the configured validation profile passed. This is not a merge or production claim.
+- `BLOCKED` — input scope, evidence, approval, solver, Z3, executor, or validation failed.
+
+## Run the local controlled executor
+
+The local worker can run the same request in a disposable worktree. It never writes the base checkout.
+
+```bash
+npx tsx scripts/verified-repair.ts \
+  --request ./repair-request.json \
+  --execute \
+  --validation full
+```
+
+The full profile runs fixed commands only:
+
+1. `git diff --check`
+2. `npm run typecheck`
+3. `npm run test:unit`
+4. `npm run build`
+5. `npm audit --omit=dev --audit-level=high --json`
+
+No arbitrary shell command is accepted from a repair candidate. Patch application is exact-text based and rejects traversal, sensitive paths, missing text, repeated text, overlapping changes, and empty diffs.
+
+## Evidence and truth boundary
+
+The evidence pack contains hashes and statuses for the finding, plan, QUBO, Z3 proof, validations, audit chain, and replay. It deliberately does not turn a successful workflow dispatch into a production claim.
+
+The next action after `VERIFIED_IN_SIMULATION` is human review of the evidence and diff, followed by a separate approval-boundary action to create a draft PR. Merge and deployment are outside this simulator.

--- a/lib/dsg/verified-repair/canonical.ts
+++ b/lib/dsg/verified-repair/canonical.ts
@@ -1,0 +1,77 @@
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+import type {
+  RepairCandidate,
+  RepairFinding,
+  VerifiedRepairRequest,
+} from './types';
+
+export function sortCandidates(candidates: RepairCandidate[]): RepairCandidate[] {
+  return [...candidates].sort((a, b) => a.id.localeCompare(b.id));
+}
+export function canonicalCandidate(candidate: RepairCandidate): Record<string, unknown> {
+  return {
+    id: candidate.id,
+    changeGroup: candidate.changeGroup,
+    file: candidate.file,
+    expectedHash: sha256Json(candidate.expected),
+    replacementHash: sha256Json(candidate.replacement),
+    rationale: candidate.rationale,
+    score: candidate.score ?? 50,
+    conflictsWith: [...(candidate.conflictsWith ?? [])].sort(),
+    requires: [...(candidate.requires ?? [])].sort(),
+    touchesSensitive: candidate.touchesSensitive === true,
+  };
+}
+
+export function canonicalFinding(finding: RepairFinding): Record<string, unknown> {
+  return {
+    id: finding.id,
+    summary: finding.summary,
+    severity: finding.severity,
+    executionRisk: finding.executionRisk,
+    affectedFiles: [...finding.affectedFiles].sort(),
+    affectedLines: [...(finding.affectedLines ?? [])].sort((a, b) =>
+      `${a.file}:${a.start}:${a.end}`.localeCompare(`${b.file}:${b.start}:${b.end}`),
+    ),
+    evidence: [...finding.evidence]
+      .map((item) => ({ ...item }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    reported: finding.reported !== false,
+  };
+}
+
+export function canonicalRepairRequest(input: VerifiedRepairRequest): Record<string, unknown> {
+  return {
+    schema: 'dsg.verified-repair.plan-input.v1',
+    jobId: input.jobId,
+    baseCommit: input.baseCommit ?? null,
+    finding: canonicalFinding(input.finding),
+    candidates: sortCandidates(input.candidates).map(canonicalCandidate),
+    allowedFiles: [...input.allowedFiles].sort(),
+    approvals: {
+      human: input.approvals?.human === true,
+      security: input.approvals?.security === true,
+    },
+    solver: {
+      mode: input.solver?.mode ?? 'pinned',
+      seed: input.solver?.seed ?? 0,
+    },
+  };
+}
+
+export function hashRepairRequest(input: VerifiedRepairRequest): string {
+  return sha256Json(canonicalRepairRequest(input));
+}
+
+export function hashSelectedPlan(
+  input: VerifiedRepairRequest,
+  selectedCandidateIds: string[],
+  quboHash: string,
+): string {
+  return sha256Json({
+    schema: 'dsg.verified-repair.plan.v1',
+    requestHash: hashRepairRequest(input),
+    selectedCandidateIds: [...selectedCandidateIds].sort(),
+    quboHash,
+  });
+}

--- a/lib/dsg/verified-repair/executor.ts
+++ b/lib/dsg/verified-repair/executor.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { runInSandbox } from '@/lib/executors/terminal-sandbox';
+import { sha256Text } from '@/lib/dsg/runtime/hash';
+import type {
+  RepairCandidate,
+  RepairExecutionResult,
+  RepairValidationProfile,
+  RepairValidationResult,
+  VerifiedRepairRequest,
+} from './types';
+
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_DIFF_BYTES = 1024 * 1024;
+
+type CommandSpec = {
+  name: RepairValidationResult['name'];
+  command: string;
+  args: string[];
+  timeoutMs: number;
+};
+
+const PROFILE_COMMANDS: Record<RepairValidationProfile, CommandSpec[]> = {
+  none: [],
+  fast: [
+    { name: 'diff', command: 'git', args: ['diff', '--check'], timeoutMs: 30_000 },
+    { name: 'typecheck', command: 'npm', args: ['run', 'typecheck'], timeoutMs: 120_000 },
+  ],
+  full: [
+    { name: 'diff', command: 'git', args: ['diff', '--check'], timeoutMs: 30_000 },
+    { name: 'typecheck', command: 'npm', args: ['run', 'typecheck'], timeoutMs: 120_000 },
+    { name: 'unit', command: 'npm', args: ['run', 'test:unit', '--', '--reporter=dot'], timeoutMs: 300_000 },
+    { name: 'build', command: 'npm', args: ['run', 'build'], timeoutMs: 300_000 },
+    { name: 'security', command: 'npm', args: ['audit', '--omit=dev', '--audit-level=high', '--json'], timeoutMs: 120_000 },
+  ],
+};
+
+function safeRepoPath(repoRoot: string, relativePath: string): string {
+  const normalized = relativePath.replaceAll('\\', '/');
+  if (!normalized || normalized.startsWith('/') || normalized.includes('\u0000')) {
+    throw new Error(`INVALID_REPAIR_PATH:${relativePath}`);
+  }
+  if (normalized.split('/').some((part) => part === '..')) {
+    throw new Error(`REPAIR_PATH_TRAVERSAL:${relativePath}`);
+  }
+  const resolvedRoot = path.resolve(repoRoot);
+  const resolved = path.resolve(resolvedRoot, normalized);
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`REPAIR_PATH_OUTSIDE_REPOSITORY:${relativePath}`);
+  }
+  if (/(^|[/\\])(?:\.git|node_modules)(?:[/\\]|$)/i.test(normalized) ||
+      /(^|[/\\])\.env(?:\.|$)/i.test(normalized)) {
+    throw new Error(`REPAIR_PATH_SENSITIVE:${relativePath}`);
+  }
+  return resolved;
+}
+
+function runSafeCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+) {
+  return runInSandbox(command, args, {
+    cwd,
+    timeoutMs,
+    maxOutputBytes: 256 * 1024,
+    env: { CI: '1' },
+  });
+}
+
+function runGit(repoRoot: string, args: string[], timeoutMs = 30_000) {
+  const result = runSafeCommand('git', args, repoRoot, timeoutMs);
+  if (!result.ok) {
+    throw new Error(`GIT_COMMAND_FAILED:${args.join(' ')}:${result.stderr.slice(0, 400)}`);
+  }
+  return result.stdout.trim();
+}
+
+async function applySelectedCandidates(
+  worktreePath: string,
+  candidates: RepairCandidate[],
+): Promise<string[]> {
+  const byFile = new Map<string, RepairCandidate[]>();
+  for (const candidate of candidates) {
+    const list = byFile.get(candidate.file) ?? [];
+    list.push(candidate);
+    byFile.set(candidate.file, list);
+  }
+
+  const changedFiles: string[] = [];
+  for (const [relativeFile, fileCandidates] of [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const absoluteFile = safeRepoPath(worktreePath, relativeFile);
+    const fileStat = await stat(absoluteFile);
+    if (fileStat.size > MAX_FILE_BYTES) throw new Error(`REPAIR_FILE_TOO_LARGE:${relativeFile}`);
+    const original = await readFile(absoluteFile, 'utf8');
+    const replacements = fileCandidates.map((candidate) => {
+      if (!candidate.expected) throw new Error(`EMPTY_EXPECTED_TEXT:${candidate.id}`);
+      const first = original.indexOf(candidate.expected);
+      const last = original.lastIndexOf(candidate.expected);
+      if (first < 0) throw new Error(`EXPECTED_TEXT_NOT_FOUND:${candidate.id}`);
+      if (first !== last) throw new Error(`EXPECTED_TEXT_NOT_UNIQUE:${candidate.id}`);
+      return { candidate, start: first, end: first + candidate.expected.length };
+    });
+
+    const ordered = [...replacements].sort((a, b) => b.start - a.start || a.candidate.id.localeCompare(b.candidate.id));
+    for (let index = 1; index < ordered.length; index += 1) {
+      if (ordered[index - 1].start < ordered[index].end) {
+        throw new Error(`OVERLAPPING_REPAIR_CANDIDATES:${relativeFile}`);
+      }
+    }
+
+    let updated = original;
+    for (const replacement of ordered) {
+      updated = updated.slice(0, replacement.start) + replacement.candidate.replacement + updated.slice(replacement.end);
+    }
+    if (updated === original) throw new Error(`NO_EFFECT_REPAIR:${relativeFile}`);
+    await writeFile(absoluteFile, updated, 'utf8');
+    changedFiles.push(relativeFile);
+  }
+  return changedFiles;
+}
+
+async function runValidationProfile(
+  worktreePath: string,
+  profile: RepairValidationProfile,
+): Promise<RepairValidationResult[]> {
+  const results: RepairValidationResult[] = [];
+  for (const spec of PROFILE_COMMANDS[profile]) {
+    const result = runSafeCommand(spec.command, spec.args, worktreePath, spec.timeoutMs);
+    const combined = `${result.stdout}\n${result.stderr}`;
+    results.push({
+      name: spec.name,
+      ok: result.ok,
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      durationMs: result.durationMs,
+      outputHash: result.outputHash,
+      outputBytes: Buffer.byteLength(combined, 'utf8'),
+      summary: result.ok
+        ? `${spec.name} passed`
+        : `${spec.name} failed${result.timedOut ? ' (timeout)' : ''}: ${result.stderr.slice(0, 240)}`,
+    });
+    if (!result.ok) break;
+  }
+  return results;
+}
+
+/**
+ * Apply a verified plan only to a disposable git worktree, then run a fixed
+ * validation profile. The caller receives hashes and status, never a claim
+ * that the base branch or production has changed.
+ */
+export async function executeRepairInWorktree(
+  request: VerifiedRepairRequest,
+  selectedCandidates: RepairCandidate[],
+): Promise<RepairExecutionResult> {
+  if (!request.repoRoot) throw new Error('REPOSITORY_CHECKOUT_REQUIRED');
+
+  const repoRoot = path.resolve(request.repoRoot);
+  const actualRoot = runGit(repoRoot, ['rev-parse', '--show-toplevel']);
+  if (path.resolve(actualRoot) !== repoRoot) throw new Error('REPOSITORY_ROOT_MISMATCH');
+
+  const baseCommit = request.baseCommit
+    ? runGit(repoRoot, ['rev-parse', '--verify', `${request.baseCommit}^{commit}`])
+    : runGit(repoRoot, ['rev-parse', 'HEAD']);
+  const worktreePath = path.join(repoRoot, `.dsg-verified-repair-${randomUUID()}`);
+  await mkdir(path.dirname(worktreePath), { recursive: true });
+
+  let worktreeAdded = false;
+  let output: RepairExecutionResult;
+  try {
+    runGit(repoRoot, ['worktree', 'add', '--detach', worktreePath, baseCommit], 60_000);
+    worktreeAdded = true;
+    const worktreeCommit = runGit(worktreePath, ['rev-parse', 'HEAD']);
+    const changedFiles = await applySelectedCandidates(worktreePath, selectedCandidates);
+    const diffResult = runInSandbox('git', ['diff', '--no-ext-diff', '--binary', '--'], {
+      cwd: worktreePath,
+      timeoutMs: 30_000,
+      maxOutputBytes: MAX_DIFF_BYTES,
+      env: { CI: '1' },
+    });
+    if (!diffResult.ok) throw new Error(`DIFF_COLLECTION_FAILED:${diffResult.stderr.slice(0, 400)}`);
+    const diffBytes = Buffer.byteLength(diffResult.stdout, 'utf8');
+    if (diffBytes === 0) throw new Error('EMPTY_REPAIR_DIFF');
+    if (diffBytes > MAX_DIFF_BYTES) throw new Error('REPAIR_DIFF_TOO_LARGE');
+
+    const validations = await runValidationProfile(
+      worktreePath,
+      request.validationProfile ?? 'none',
+    );
+
+    output = {
+      controlledExecutorUsed: true,
+      patchApplied: true,
+      baseCommit,
+      worktreeCommit,
+      changedFiles,
+      diffHash: sha256Text(diffResult.stdout),
+      diffBytes,
+      validations,
+      cleanupOk: false,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    let worktreeCommit = baseCommit;
+    if (worktreeAdded) {
+      try {
+        worktreeCommit = runGit(worktreePath, ['rev-parse', 'HEAD']);
+      } catch {
+        worktreeCommit = baseCommit;
+      }
+    }
+    output = {
+      controlledExecutorUsed: worktreeAdded,
+      patchApplied: false,
+      baseCommit,
+      worktreeCommit,
+      changedFiles: [],
+      diffHash: sha256Text(''),
+      diffBytes: 0,
+      validations: [],
+      cleanupOk: false,
+      error: message,
+    };
+  } finally {
+    let cleanupOk = true;
+    if (worktreeAdded) {
+      const remove = runSafeCommand('git', ['worktree', 'remove', '--force', worktreePath], repoRoot, 60_000);
+      if (!remove.ok) {
+        await rm(worktreePath, { recursive: true, force: true }).catch(() => {
+          cleanupOk = false;
+        });
+      }
+    } else {
+      await rm(worktreePath, { recursive: true, force: true }).catch(() => {
+        cleanupOk = false;
+      });
+    }
+    output.cleanupOk = cleanupOk;
+  }
+  return output;
+}

--- a/lib/dsg/verified-repair/index.ts
+++ b/lib/dsg/verified-repair/index.ts
@@ -1,0 +1,25 @@
+export { runVerifiedRepair } from './pipeline';
+export { buildRepairQubo, selectedCandidateIds } from './qubo';
+export { verifyRepairAssignment, resetRepairZ3Context } from './z3';
+export { executeRepairInWorktree } from './executor';
+export { VERIFIED_REPAIR_SCHEMA } from './types';
+export type { RepairQubo } from './qubo';
+export type {
+  RepairApprovals,
+  RepairCandidate,
+  RepairEvidenceRef,
+  RepairExecutionResult,
+  RepairExactStatus,
+  RepairExactVerification,
+  RepairFinding,
+  RepairQuboSummary,
+  RepairSolverConfig,
+  RepairSolverMode,
+  RepairSolverResult,
+  RepairValidationProfile,
+  RepairValidationResult,
+  VerifiedRepairEvidencePack,
+  VerifiedRepairRequest,
+  VerifiedRepairResult,
+  VerifiedRepairStatus,
+} from './types';

--- a/lib/dsg/verified-repair/pipeline.ts
+++ b/lib/dsg/verified-repair/pipeline.ts
@@ -1,0 +1,579 @@
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+import {
+  createAuditLedgerEntry,
+  verifyAuditHashChain,
+  type AuditLedgerEntry,
+} from '@/lib/dsg/runtime/audit';
+import { createEvidenceManifest, type EvidenceManifest } from '@/lib/dsg/runtime/evidence';
+import { verifyReplay } from '@/lib/dsg/runtime/replay';
+import type { EvidenceItem } from '@/lib/dsg/runtime/types';
+import { optimizeWithIsing } from '@/lib/dsg-one/ising-optimizer';
+import { solveQubo } from '@/lib/dsg-one/ising-solver-core';
+import { evaluateSecurityRemediationGate } from '@/lib/dsg/security-remediation/gate';
+import type { SecurityRemediationFacts } from '@/lib/dsg/security-remediation/types';
+import { executeRepairInWorktree } from './executor';
+import {
+  canonicalFinding,
+  hashSelectedPlan,
+  sortCandidates,
+} from './canonical';
+import { buildRepairQubo, selectedCandidateIds, type RepairQubo } from './qubo';
+import { verifyRepairAssignment } from './z3';
+import type {
+  RepairCandidate,
+  RepairExecutionResult,
+  RepairEvidenceRef,
+  RepairFinding,
+  RepairSolverResult,
+  RepairValidationResult,
+  VerifiedRepairEvidencePack,
+  VerifiedRepairRequest,
+  VerifiedRepairResult,
+} from './types';
+import { VERIFIED_REPAIR_SCHEMA } from './types';
+
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SHA_PATTERN = /^[a-f0-9]{7,64}$/i;
+const MAX_CANDIDATES = 128;
+
+function blockedResult(
+  jobId: string,
+  reason: string,
+  nextAction = 'แก้ข้อมูลที่ระบุแล้วส่งแผนเข้าตรวจใหม่',
+  planningOnly = true,
+): VerifiedRepairResult {
+  return {
+    schema: VERIFIED_REPAIR_SCHEMA,
+    jobId,
+    status: 'BLOCKED',
+    verdict: 'BLOCK',
+    planningOnly,
+    selectedCandidateIds: [],
+    gate: {
+      finalDecision: 'BLOCK_INPUT_VALIDATION',
+      allowed: false,
+      claimAllowed: false,
+      reasons: [reason],
+      nextRequiredEvidence: [],
+    },
+    counterexample: [reason],
+    nextAction,
+    userOutcome: `ไม่ผ่าน: ${reason}`,
+  };
+}
+
+function validRelativePath(value: unknown): value is string {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  const normalized = value.replaceAll('\\', '/');
+  return !normalized.startsWith('/') &&
+    !normalized.split('/').some((part) => part === '..' || part === '') &&
+    !/(^|\/)(?:\.git|node_modules)(?:\/|$)/i.test(normalized) &&
+    !/(^|\/)\.env(?:\.|$)/i.test(normalized);
+}
+
+function validEvidence(evidence: unknown): evidence is RepairEvidenceRef[] {
+  return Array.isArray(evidence) && evidence.length > 0 && evidence.every((item) =>
+    item && typeof item === 'object' &&
+    typeof (item as RepairEvidenceRef).id === 'string' &&
+    typeof (item as RepairEvidenceRef).type === 'string' &&
+    HASH_PATTERN.test((item as RepairEvidenceRef).contentHash),
+  );
+}
+
+function validateInput(input: VerifiedRepairRequest): string[] {
+  const errors: string[] = [];
+  if (!input || typeof input !== 'object') return ['REQUEST_REQUIRED'];
+  if (typeof input.jobId !== 'string' || !/^[A-Za-z0-9._:-]{1,128}$/.test(input.jobId)) errors.push('INVALID_JOB_ID');
+  if (!input.finding || typeof input.finding !== 'object') errors.push('FINDING_REQUIRED');
+  if (!Array.isArray(input.allowedFiles) || input.allowedFiles.length === 0) errors.push('ALLOWED_FILES_REQUIRED');
+  if (!Array.isArray(input.candidates) || input.candidates.length === 0) errors.push('CANDIDATES_REQUIRED');
+  if (Array.isArray(input.candidates) && input.candidates.length > MAX_CANDIDATES) errors.push('TOO_MANY_CANDIDATES');
+
+  const finding = input.finding as RepairFinding;
+  if (finding) {
+    if (typeof finding.id !== 'string' || !finding.id.trim() || typeof finding.summary !== 'string' || !finding.summary.trim()) {
+      errors.push('FINDING_ID_AND_SUMMARY_REQUIRED');
+    }
+    if (!['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(finding.severity)) errors.push('INVALID_FINDING_SEVERITY');
+    if (!['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(finding.executionRisk)) errors.push('INVALID_EXECUTION_RISK');
+    if (!Array.isArray(finding.affectedFiles) || finding.affectedFiles.length === 0) errors.push('AFFECTED_FILES_REQUIRED');
+    if (Array.isArray(finding.affectedFiles) && finding.affectedFiles.some((file) => !validRelativePath(file))) errors.push('INVALID_FINDING_FILE');
+    if (!validEvidence(finding.evidence)) errors.push('VERIFIED_FINDING_EVIDENCE_REQUIRED');
+    if (finding.evidence?.every((item) => !['scan_output', 'test_output', 'api_response'].includes(item.type))) {
+      errors.push('REPRO_OR_SCAN_EVIDENCE_REQUIRED');
+    }
+  }
+
+  const allowed = new Set(Array.isArray(input.allowedFiles) ? input.allowedFiles : []);
+  if (Array.isArray(input.allowedFiles) && input.allowedFiles.some((file) => !validRelativePath(file))) errors.push('INVALID_ALLOWED_FILE');
+  const affected = new Set(Array.isArray(finding?.affectedFiles) ? finding.affectedFiles : []);
+  const ids = new Set<string>();
+  for (const candidate of Array.isArray(input.candidates) ? input.candidates : []) {
+    if (!candidate || typeof candidate !== 'object') {
+      errors.push('INVALID_CANDIDATE');
+      continue;
+    }
+    const candidateId = typeof candidate.id === 'string' && candidate.id.trim() ? candidate.id : 'unknown';
+    if (candidateId === 'unknown' || ids.has(candidateId)) errors.push(`DUPLICATE_OR_EMPTY_CANDIDATE:${candidateId}`);
+    if (candidateId !== 'unknown') ids.add(candidateId);
+    if (typeof candidate.changeGroup !== 'string' || !candidate.changeGroup.trim()) errors.push(`CANDIDATE_GROUP_REQUIRED:${candidateId}`);
+    if (!validRelativePath(candidate.file)) errors.push(`INVALID_CANDIDATE_FILE:${candidateId}`);
+    if (typeof candidate.expected !== 'string' || candidate.expected.length === 0) errors.push(`EXPECTED_TEXT_REQUIRED:${candidateId}`);
+    if (typeof candidate.replacement !== 'string') errors.push(`REPLACEMENT_TEXT_REQUIRED:${candidateId}`);
+    if (typeof candidate.rationale !== 'string' || !candidate.rationale.trim()) errors.push(`RATIONALE_REQUIRED:${candidateId}`);
+    if (candidate.conflictsWith !== undefined && (!Array.isArray(candidate.conflictsWith) || candidate.conflictsWith.some((id) => typeof id !== 'string'))) {
+      errors.push(`INVALID_CONFLICTS_WITH:${candidateId}`);
+    }
+    if (candidate.requires !== undefined && (!Array.isArray(candidate.requires) || candidate.requires.some((id) => typeof id !== 'string'))) {
+      errors.push(`INVALID_REQUIRES:${candidateId}`);
+    }
+    if (validRelativePath(candidate.file) && !allowed.has(candidate.file)) errors.push(`FILE_NOT_IN_ALLOWED_SCOPE:${candidateId}`);
+    if (validRelativePath(candidate.file) && !affected.has(candidate.file)) errors.push(`FILE_NOT_IN_FINDING_SCOPE:${candidateId}`);
+  }
+  for (const candidate of Array.isArray(input.candidates) ? input.candidates : []) {
+    const references = [
+      ...(Array.isArray(candidate.conflictsWith) ? candidate.conflictsWith : []),
+      ...(Array.isArray(candidate.requires) ? candidate.requires : []),
+    ];
+    for (const id of references) {
+      if (!ids.has(id)) errors.push(`UNKNOWN_CANDIDATE_REFERENCE:${candidate.id || 'unknown'}:${id}`);
+    }
+  }
+
+  if (input.execute) {
+    if (!input.repoRoot) errors.push('REPOSITORY_CHECKOUT_REQUIRED');
+    if (input.baseCommit && !SHA_PATTERN.test(input.baseCommit)) errors.push('BASE_COMMIT_SHA_REQUIRED');
+    if (!['none', 'fast', 'full'].includes(input.validationProfile ?? 'none')) errors.push('INVALID_VALIDATION_PROFILE');
+  }
+  if (input.solver?.mode !== undefined && !['pinned', 'live'].includes(input.solver.mode)) errors.push('INVALID_SOLVER_MODE');
+  if (input.solver?.seed !== undefined && (!Number.isInteger(input.solver.seed) || input.solver.seed < 0)) errors.push('INVALID_SOLVER_SEED');
+  if (input.solver?.timeoutMs !== undefined && (!Number.isInteger(input.solver.timeoutMs) || input.solver.timeoutMs < 1 || input.solver.timeoutMs > 30_000)) {
+    errors.push('INVALID_SOLVER_TIMEOUT');
+  }
+  if ((input.solver?.mode ?? 'pinned') === 'live' && !process.env.NVIDIA_ISING_API_URL?.trim()) {
+    errors.push('NVIDIA_ISING_API_URL_REQUIRED_FOR_LIVE_SOLVER');
+  }
+  return errors;
+}
+
+function solverSolutionToNumbers(solution: Record<string, number | boolean>): Record<string, number> {
+  return Object.fromEntries(Object.entries(solution).map(([key, value]) => [key, Number(value)]));
+}
+
+async function solveRepairQubo(
+  qubo: RepairQubo,
+  request: VerifiedRepairRequest,
+): Promise<RepairSolverResult> {
+  const mode = request.solver?.mode ?? 'pinned';
+  const seed = request.solver?.seed ?? 0;
+  if (mode === 'pinned') {
+    const startedAt = Date.now();
+    const solved = solveQubo({
+      Q: qubo.Q,
+      linear: qubo.linear,
+      numVariables: qubo.numVariables,
+      seed,
+    });
+    const solution: Record<string, number> = {};
+    for (const [index, variable] of qubo.variables.entries()) solution[variable.id] = solved.solution[index];
+    const solutionHash = sha256Json(Object.entries(solution).sort());
+    return {
+      mode: 'deterministic-local',
+      solverVersion: solved.version,
+      solution,
+      energy: solved.energy + qubo.constant,
+      solveTimeMs: Date.now() - startedAt,
+      quboHash: qubo.problemHash,
+      solutionHash,
+    };
+  }
+
+  const result = await optimizeWithIsing({
+    problemId: request.jobId,
+    quboMatrix: qubo,
+    timeout: request.solver?.timeoutMs ?? 5_000,
+    useMock: false,
+    seed,
+    fallbackToMock: false,
+  });
+  return {
+    mode: 'nvidia-live',
+    solverVersion: result.solverVersion,
+    solution: solverSolutionToNumbers(result.solution),
+    energy: result.energy,
+    confidence: result.confidence,
+    solveTimeMs: result.solveTimeMs,
+    quboHash: result.proofData.quboHash,
+    solutionHash: result.proofData.solutionHash,
+  };
+}
+
+function securityFacts(
+  request: VerifiedRepairRequest,
+  selected: RepairCandidate[],
+  execution: RepairExecutionResult | undefined,
+  manifestPresent: boolean,
+  auditValid: boolean,
+): SecurityRemediationFacts {
+  const sensitive = selected.some((candidate) => candidate.touchesSensitive === true) ||
+    request.finding.executionRisk === 'HIGH' || request.finding.executionRisk === 'CRITICAL';
+  const validationByName = new Map((execution?.validations ?? []).map((item) => [item.name, item]));
+  const validationPassed = (name: RepairValidationResult['name']) => validationByName.get(name)?.ok === true;
+  const profile = request.validationProfile ?? 'none';
+  return {
+    finding_reported: request.finding.reported !== false,
+    finding_evidence_present: request.finding.evidence.length > 0,
+    affected_files_present: request.finding.affectedFiles.length > 0,
+    repro_or_scan_output_present: request.finding.evidence.some((item) => ['scan_output', 'test_output', 'api_response'].includes(item.type)),
+    severity_classified: true,
+    severity: request.finding.severity,
+    execution_risk: request.finding.executionRisk,
+    touches_auth_payment_secrets_admin: sensitive,
+    patch_touches_auth_rbac_crypto_secrets: selected.some((candidate) => candidate.touchesSensitive === true),
+    human_approval_present: request.approvals?.human === true,
+    security_approval_present: request.approvals?.security === true,
+    patch_plan_present: selected.length > 0,
+    plan_hash_present: true,
+    allowed_files_present: true,
+    patch_scope_matches_finding: selected.every((candidate) => request.finding.affectedFiles.includes(candidate.file)),
+    controlled_executor_used: execution?.controlledExecutorUsed === true,
+    patch_applied: execution?.patchApplied === true,
+    tests_passed: profile === 'full' && validationPassed('unit'),
+    build_passed: profile === 'full' && validationPassed('build'),
+    security_scan_passed: profile === 'full' && validationPassed('security'),
+    evidence_manifest_present: manifestPresent,
+    audit_valid: auditValid,
+    deployment_proof_present: false,
+    production_claim_requested: false,
+  };
+}
+
+function gateStatus(finalDecision: string): 'PASS' | 'BLOCK' | 'REVIEW' {
+  if (finalDecision === 'PRODUCTION_FIX_CLAIM_ALLOWED') return 'PASS';
+  if (finalDecision.startsWith('BLOCK_') || finalDecision === 'WAITING_SECURITY_APPROVAL' || finalDecision === 'WAITING_HUMAN_APPROVAL') return 'BLOCK';
+  return 'REVIEW';
+}
+
+function deterministicTimestamp(base: string | undefined, index: number): string {
+  const start = base ? Date.parse(base) : 0;
+  const safeStart = Number.isFinite(start) ? start : 0;
+  return new Date(safeStart + index * 1_000).toISOString();
+}
+
+function createAuditChain(
+  request: VerifiedRepairRequest,
+  planHash: string,
+  exactProofHash: string,
+  decision: 'PASS' | 'BLOCK' | 'REVIEW',
+  evidenceIds: string[],
+): AuditLedgerEntry[] {
+  const entries: AuditLedgerEntry[] = [];
+  const append = (action: string, payload: Record<string, unknown>, index: number, entryDecision: 'PASS' | 'BLOCK' | 'REVIEW') => {
+    const entry = createAuditLedgerEntry({
+      id: `${request.jobId}:${index}:${action}`,
+      previousHash: entries.at(-1)?.currentHash,
+      actorId: request.actorId ?? 'dsg.verified-repair',
+      action,
+      decision: entryDecision,
+      evidenceIds,
+      payload,
+      createdAt: deterministicTimestamp(request.createdAt, index),
+    });
+    entries.push(entry);
+  };
+  append('PLAN_CREATED', { planHash }, 0, 'REVIEW');
+  append('Z3_EXACT_VERIFICATION', { proofHash: exactProofHash }, 1, decision);
+  return entries;
+}
+
+function buildEvidenceItems(
+  request: VerifiedRepairRequest,
+  planHash: string,
+  qubo: RepairQubo,
+  exactProofHash: string,
+  validation: RepairValidationResult[],
+  execution?: RepairExecutionResult,
+): EvidenceItem[] {
+  const base = `${request.jobId}:`;
+  const items: EvidenceItem[] = [
+    { id: `${base}finding`, evidenceType: 'finding', contentHash: sha256Json(canonicalFinding(request.finding)), summary: 'Finding input and source evidence references' },
+    { id: `${base}plan`, evidenceType: 'file', contentHash: planHash, summary: 'Deterministic binary repair plan' },
+    { id: `${base}qubo`, evidenceType: 'file', contentHash: qubo.problemHash, summary: 'Canonical repair QUBO' },
+    { id: `${base}z3`, evidenceType: 'test_output', contentHash: exactProofHash, summary: 'Z3 exact assignment verification' },
+  ];
+  for (const result of validation) {
+    items.push({
+      id: `${base}validation:${result.name}`,
+      evidenceType: result.name === 'security' ? 'scan_output' : 'test_output',
+      contentHash: result.outputHash,
+      summary: result.summary,
+    });
+  }
+  if (execution?.patchApplied) {
+    items.push({
+      id: `${base}execution`,
+      evidenceType: 'file',
+      contentHash: sha256Json({
+        baseCommit: execution.baseCommit,
+        worktreeCommit: execution.worktreeCommit,
+        changedFiles: execution.changedFiles,
+        diffHash: execution.diffHash,
+        diffBytes: execution.diffBytes,
+        cleanupOk: execution.cleanupOk,
+      }),
+      summary: 'Isolated worktree commit and diff binding',
+    });
+  }
+  return items;
+}
+
+function buildEvidencePack(
+  request: VerifiedRepairRequest,
+  qubo: RepairQubo,
+  solver: RepairSolverResult,
+  selected: RepairCandidate[],
+  exact: Awaited<ReturnType<typeof verifyRepairAssignment>>,
+  planHash: string,
+  validation: RepairValidationResult[],
+  execution: RepairExecutionResult | undefined,
+  gateDecision: 'PASS' | 'BLOCK' | 'REVIEW',
+): VerifiedRepairEvidencePack {
+  const evidence = buildEvidenceItems(request, planHash, qubo, exact.proofHash, validation, execution);
+  const evidenceManifest = createEvidenceManifest({
+    id: `${request.jobId}:manifest`,
+    evidence,
+    createdBy: request.actorId ?? 'dsg.verified-repair',
+    createdAt: deterministicTimestamp(request.createdAt, 0),
+  });
+  const auditEntries = createAuditChain(request, planHash, exact.proofHash, gateDecision, evidence.map((item) => item.id));
+  const replay = verifyReplay({
+    planHash,
+    waveHash: qubo.problemHash,
+    evidenceManifest,
+    auditEntries,
+  });
+  const solverReplayHash = solver.mode === 'deterministic-local'
+    ? sha256Json({ solution: solver.solution, energy: solver.energy, solverVersion: solver.solverVersion })
+    : undefined;
+  return {
+    schema: VERIFIED_REPAIR_SCHEMA,
+    jobId: request.jobId,
+    source: request.source ?? 'cli',
+    findingHash: sha256Json(canonicalFinding(request.finding)),
+    planHash,
+    qubo: {
+      problemHash: qubo.problemHash,
+      variableCount: qubo.numVariables,
+      constraintCount: qubo.numConstraints,
+      groups: qubo.groups,
+      candidateOrder: qubo.candidateOrder,
+    },
+    selectedCandidateIds: selected.map((candidate) => candidate.id).sort(),
+    solver: {
+      ...solver,
+      replayHash: solverReplayHash,
+    },
+    exactVerification: exact,
+    validation,
+    evidenceIds: evidence.map((item) => item.id),
+    evidenceManifest: {
+      id: evidenceManifest.id,
+      manifestHash: evidenceManifest.manifestHash,
+      status: evidenceManifest.status === 'COMPLETE' ? 'COMPLETE' : 'BLOCKED',
+    },
+    audit: {
+      entryIds: auditEntries.map((entry) => entry.id),
+      chainValid: verifyAuditHashChain(auditEntries).ok,
+    },
+    replay,
+    determinism: solver.mode === 'deterministic-local'
+      ? { status: 'PASS', proofHash: solverReplayHash }
+      : { status: 'REVIEW', reason: 'Remote solver output requires an independent replay run.' },
+  };
+}
+
+function chooseNextAction(resultStatus: VerifiedRepairResult['status'], execute: boolean): string {
+  if (resultStatus === 'READY_FOR_CONTROLLED_EXECUTION') {
+    return execute
+      ? 'ตรวจรายการ validation ที่ไม่ผ่าน แล้วส่ง candidate ใหม่พร้อมหลักฐาน counterexample'
+      : 'เรียกใช้ local controlled executor ด้วย execute=true และ validationProfile=full';
+  }
+  if (resultStatus === 'VERIFIED_IN_SIMULATION') {
+    return 'ตรวจ evidence pack และ diff hash จากนั้นจึงพิจารณาสร้าง draft PR; ยังไม่ใช่ production fix';
+  }
+  return 'แก้เหตุผล BLOCK/counterexample ที่รายงาน แล้วส่งแผนเข้าตรวจใหม่';
+}
+
+/**
+ * Main Verified Repair Simulator entry point.
+ * It deliberately stops at a verified worktree result; merge/deploy remains a
+ * separate approval-boundary action.
+ */
+export async function runVerifiedRepair(
+  request: VerifiedRepairRequest,
+): Promise<VerifiedRepairResult> {
+  const jobId = typeof request?.jobId === 'string' ? request.jobId : 'unknown';
+  const validationErrors = validateInput(request);
+  if (validationErrors.length > 0) {
+    return blockedResult(jobId, validationErrors.join(','), undefined, request?.execute !== true);
+  }
+
+  let qubo: RepairQubo;
+  try {
+    qubo = buildRepairQubo(request.candidates);
+  } catch (error) {
+    return blockedResult(jobId, `QUBO_BUILD_FAILED:${error instanceof Error ? error.message : String(error)}`, undefined, request.execute !== true);
+  }
+
+  let solver: RepairSolverResult;
+  try {
+    solver = await solveRepairQubo(qubo, request);
+  } catch (error) {
+    return blockedResult(jobId, `SOLVER_FAILED:${error instanceof Error ? error.message : String(error)}`, 'ตรวจ NVIDIA_ISING_API_URL หรือเปลี่ยน solver.mode เป็น pinned แล้วส่งใหม่', request.execute !== true);
+  }
+
+  const exact = await verifyRepairAssignment(
+    qubo,
+    sortCandidates(request.candidates),
+    solver.solution,
+    request.solver?.timeoutMs ?? 5_000,
+  );
+  const selectedIds = selectedCandidateIds(qubo, solver.solution);
+  const candidatesById = new Map(request.candidates.map((candidate) => [candidate.id, candidate]));
+  const selected = selectedIds.map((id) => candidatesById.get(id)).filter((candidate): candidate is RepairCandidate => Boolean(candidate));
+
+  if (!exact.valid) {
+    return {
+      schema: VERIFIED_REPAIR_SCHEMA,
+      jobId,
+      status: 'BLOCKED',
+      verdict: 'BLOCK',
+      planningOnly: !request.execute,
+      selectedCandidateIds: selectedIds,
+      gate: {
+        finalDecision: 'BLOCK_Z3_EXACT_VERIFICATION',
+        allowed: false,
+        claimAllowed: false,
+        reasons: ['Ising/QUBO candidate did not pass the Z3 exact verification gate.'],
+        nextRequiredEvidence: ['counterexample_fix'],
+      },
+      exactVerification: exact,
+      counterexample: exact.counterexample,
+      nextAction: 'แก้ candidate ตาม counterexample แล้วส่งเข้า simulation รอบใหม่; ห้าม apply patch',
+      userOutcome: `ไม่ผ่าน: Z3 ${exact.status.toUpperCase()} — ยังห้ามใช้ patch นี้`,
+    };
+  }
+
+  const initialFacts = securityFacts(request, selected, undefined, false, false);
+  const initialGate = evaluateSecurityRemediationGate(initialFacts);
+  const initialGateStatus = gateStatus(initialGate.final_decision);
+  if (!initialGate.allowed || initialGate.final_decision !== 'PATCH_EXECUTION_ALLOWED') {
+    return {
+      schema: VERIFIED_REPAIR_SCHEMA,
+      jobId,
+      status: 'BLOCKED',
+      verdict: initialGateStatus,
+      planningOnly: !request.execute,
+      selectedCandidateIds: selectedIds,
+      gate: {
+        finalDecision: initialGate.final_decision,
+        allowed: initialGate.allowed,
+        claimAllowed: initialGate.claim_allowed,
+        reasons: initialGate.reasons,
+        nextRequiredEvidence: initialGate.next_required_evidence,
+      },
+      exactVerification: exact,
+      counterexample: initialGate.next_required_evidence,
+      nextAction: 'เพิ่ม approval/evidence ที่ gate ระบุ แล้วส่งแผนเข้าตรวจใหม่',
+      userOutcome: `ยังไม่อนุญาตให้รัน: ${initialGate.final_decision}`,
+    };
+  }
+
+  let execution: RepairExecutionResult | undefined;
+  if (request.execute) {
+    try {
+      execution = await executeRepairInWorktree(request, selected);
+    } catch (error) {
+      execution = {
+        controlledExecutorUsed: false,
+        patchApplied: false,
+        baseCommit: request.baseCommit ?? 'unknown',
+        worktreeCommit: 'unknown',
+        changedFiles: [],
+        diffHash: sha256Json(''),
+        diffBytes: 0,
+        validations: [],
+        cleanupOk: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  const validation = execution?.validations ?? [];
+  const planInput = execution?.baseCommit && execution.baseCommit !== 'unknown'
+    ? { ...request, baseCommit: execution.baseCommit }
+    : request;
+  const planHash = hashSelectedPlan(planInput, selectedIds, qubo.problemHash);
+  const manifestPreview = buildEvidenceItems(request, planHash, qubo, exact.proofHash, validation, execution);
+  const manifest: EvidenceManifest = createEvidenceManifest({
+    id: `${request.jobId}:manifest`,
+    evidence: manifestPreview,
+    createdBy: request.actorId ?? 'dsg.verified-repair',
+    createdAt: deterministicTimestamp(request.createdAt, 0),
+  });
+  const auditPreview = createAuditChain(
+    request,
+    planHash,
+    exact.proofHash,
+    'REVIEW',
+    manifestPreview.map((item) => item.id),
+  );
+  const auditValid = verifyAuditHashChain(auditPreview).ok;
+  const facts = securityFacts(request, selected, execution, manifest.status === 'COMPLETE', auditValid);
+  const finalGate = evaluateSecurityRemediationGate(facts);
+  const finalGateStatus = gateStatus(finalGate.final_decision);
+  const evidencePack = buildEvidencePack(request, qubo, solver, selected, exact, planHash, validation, execution, finalGateStatus);
+
+  let status: VerifiedRepairResult['status'];
+  if (!request.execute) {
+    status = finalGate.allowed ? 'READY_FOR_CONTROLLED_EXECUTION' : 'BLOCKED';
+  } else if (execution?.patchApplied && execution.cleanupOk && finalGate.decisions.verification_passed && evidencePack.replay.status === 'PASS') {
+    status = 'VERIFIED_IN_SIMULATION';
+  } else {
+    status = 'BLOCKED';
+  }
+
+  const verdict: VerifiedRepairResult['verdict'] = status === 'VERIFIED_IN_SIMULATION'
+    ? 'PASS'
+    : status === 'READY_FOR_CONTROLLED_EXECUTION'
+      ? 'REVIEW'
+      : 'BLOCK';
+  const executionFailure = [
+    ...(execution?.error ? [`CONTROLLED_EXECUTOR_FAILED:${execution.error}`] : []),
+    ...(execution && !execution.cleanupOk ? ['CONTROLLED_WORKTREE_CLEANUP_FAILED'] : []),
+  ];
+  return {
+    schema: VERIFIED_REPAIR_SCHEMA,
+    jobId,
+    status,
+    verdict,
+    planningOnly: !request.execute,
+    selectedCandidateIds: selectedIds,
+    gate: {
+      finalDecision: finalGate.final_decision,
+      allowed: finalGate.allowed,
+      claimAllowed: finalGate.claim_allowed,
+      reasons: [...finalGate.reasons, ...executionFailure],
+      nextRequiredEvidence: finalGate.next_required_evidence,
+    },
+    exactVerification: exact,
+    execution,
+    evidencePack,
+    nextAction: chooseNextAction(status, Boolean(request.execute)),
+    userOutcome: status === 'VERIFIED_IN_SIMULATION'
+      ? 'ผ่านใน isolated worktree พร้อม evidence และ replay proof; ยังไม่ merge/deploy'
+      : status === 'READY_FOR_CONTROLLED_EXECUTION'
+        ? 'แผนผ่าน Z3 และพร้อมให้ controlled executor รันใน worktree'
+        : 'ไม่ผ่านและยังห้าม apply patch',
+  };
+}

--- a/lib/dsg/verified-repair/qubo.ts
+++ b/lib/dsg/verified-repair/qubo.ts
@@ -1,0 +1,146 @@
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+import type { QUBOMatrix, QUBOVariable } from '@/lib/dsg-one/qubo-builder';
+import { sortCandidates } from './canonical';
+import type { RepairCandidate } from './types';
+
+export interface RepairQubo extends QUBOMatrix {
+  candidateOrder: string[];
+  groups: string[];
+  conflictPairs: Array<[string, string]>;
+  requirementPairs: Array<[string, string]>;
+}
+const GROUP_PENALTY = 1_000;
+const RELATION_PENALTY = 2_000;
+
+function boundedScore(candidate: RepairCandidate): number {
+  const score = typeof candidate.score === 'number' && Number.isFinite(candidate.score)
+    ? candidate.score
+    : 50;
+  return Math.max(0, Math.min(100, score));
+}
+
+function addSymmetric(matrix: number[][], left: number, right: number, value: number): void {
+  matrix[left][right] += value;
+  matrix[right][left] += value;
+}
+
+function pairKey(left: string, right: string): string {
+  return [left, right].sort().join('\u0000');
+}
+
+/**
+ * Build a deterministic QUBO whose hard constraints are checked again by Z3.
+ * The Ising/QUBO solver proposes a binary repair set; it is never the final
+ * authority for correctness.
+ */
+export function buildRepairQubo(candidates: RepairCandidate[]): RepairQubo {
+  const sorted = sortCandidates(candidates);
+  const groups = [...new Set(sorted.map((candidate) => candidate.changeGroup))].sort();
+  const candidateIndex = new Map(sorted.map((candidate, index) => [candidate.id, index]));
+  const numVariables = sorted.length;
+  const Q = Array.from({ length: numVariables }, () => Array(numVariables).fill(0));
+  const linear = Array<number>(numVariables).fill(0);
+  let constant = 0;
+
+  const variables: QUBOVariable[] = sorted.map((candidate, index) => ({
+    id: `repair_${index}`,
+    type: 'assignment',
+    taskId: candidate.changeGroup,
+    agentId: index,
+  }));
+  const variableMap = new Map(variables.map((variable, index) => [variable.id, index]));
+
+  for (const group of groups) {
+    const members = sorted
+      .map((candidate, index) => ({ candidate, index }))
+      .filter(({ candidate }) => candidate.changeGroup === group);
+
+    // GROUP_PENALTY * (sum(x) - 1)^2.
+    constant += GROUP_PENALTY;
+    for (const { index } of members) linear[index] -= GROUP_PENALTY;
+    for (let left = 0; left < members.length; left += 1) {
+      for (let right = left + 1; right < members.length; right += 1) {
+        addSymmetric(Q, members[left].index, members[right].index, GROUP_PENALTY);
+      }
+    }
+  }
+
+  const conflictSet = new Set<string>();
+  const conflictPairs: Array<[string, string]> = [];
+  const requirementPairs: Array<[string, string]> = [];
+
+  for (const candidate of sorted) {
+    for (const otherId of candidate.conflictsWith ?? []) {
+      if (!candidateIndex.has(otherId)) continue;
+      const key = pairKey(candidate.id, otherId);
+      if (conflictSet.has(key)) continue;
+      conflictSet.add(key);
+      const [leftId, rightId] = key.split('\u0000');
+      conflictPairs.push([leftId, rightId]);
+      const left = candidateIndex.get(leftId)!;
+      const right = candidateIndex.get(rightId)!;
+      // RELATION_PENALTY * x_left * x_right.
+      addSymmetric(Q, left, right, RELATION_PENALTY / 2);
+    }
+
+    for (const requiredId of candidate.requires ?? []) {
+      if (!candidateIndex.has(requiredId)) continue;
+      requirementPairs.push([candidate.id, requiredId]);
+      const candidateVariable = candidateIndex.get(candidate.id)!;
+      const requiredVariable = candidateIndex.get(requiredId)!;
+      // RELATION_PENALTY * x_candidate * (1 - x_required).
+      linear[candidateVariable] += RELATION_PENALTY;
+      addSymmetric(Q, candidateVariable, requiredVariable, -RELATION_PENALTY / 2);
+    }
+  }
+
+  // Lower cost is preferred, while hard relation penalties dominate this term.
+  for (const [index, candidate] of sorted.entries()) {
+    linear[index] += 100 - boundedScore(candidate);
+  }
+
+  for (let left = 0; left < numVariables; left += 1) {
+    for (let right = left + 1; right < numVariables; right += 1) {
+      // Keep the matrix exactly symmetric for every caller.
+      Q[right][left] = Q[left][right];
+    }
+  }
+
+  const candidateOrder = sorted.map((candidate) => candidate.id);
+  const problemHash = sha256Json({
+    schema: 'dsg.verified-repair.qubo.v1',
+    groups,
+    candidateOrder,
+    conflictPairs: [...conflictPairs].sort(),
+    requirementPairs: [...requirementPairs].sort(),
+    Q,
+    linear,
+    constant,
+  });
+
+  return {
+    Q,
+    linear,
+    constant,
+    variables,
+    variableMap,
+    problemHash,
+    numVariables,
+    numConstraints: groups.length + conflictPairs.length + requirementPairs.length,
+    candidateOrder,
+    groups,
+    conflictPairs: conflictPairs.sort(),
+    requirementPairs: requirementPairs.sort(),
+  };
+}
+
+export function selectedCandidateIds(
+  qubo: RepairQubo,
+  solution: Record<string, number | boolean>,
+): string[] {
+  return qubo.variables
+    .filter((variable) => Number(solution[variable.id]) === 1)
+    .map((variable) => qubo.candidateOrder[Number(variable.agentId)])
+    .filter((id): id is string => Boolean(id))
+    .sort();
+}

--- a/lib/dsg/verified-repair/types.ts
+++ b/lib/dsg/verified-repair/types.ts
@@ -1,0 +1,204 @@
+import type {
+  SecurityExecutionRisk,
+  SecuritySeverity,
+} from '@/lib/dsg/security-remediation/types';
+
+export const VERIFIED_REPAIR_SCHEMA = 'dsg.verified-repair.v1' as const;
+
+export type RepairSolverMode = 'pinned' | 'live';
+export type RepairValidationProfile = 'none' | 'fast' | 'full';
+export type VerifiedRepairStatus =
+  | 'READY_FOR_CONTROLLED_EXECUTION'
+  | 'VERIFIED_IN_SIMULATION'
+  | 'BLOCKED';
+
+export type RepairEvidenceType =
+  | 'finding'
+  | 'scan_output'
+  | 'test_output'
+  | 'file_snapshot'
+  | 'api_response'
+  | 'manual_note';
+
+export interface RepairEvidenceRef {
+  id: string;
+  type: RepairEvidenceType;
+  contentHash: string;
+  summary?: string;
+}
+export interface RepairFinding {
+  id: string;
+  summary: string;
+  severity: SecuritySeverity;
+  executionRisk: SecurityExecutionRisk;
+  affectedFiles: string[];
+  affectedLines?: Array<{
+    file: string;
+    start: number;
+    end: number;
+  }>;
+  evidence: RepairEvidenceRef[];
+  reported?: boolean;
+}
+
+/**
+ * A candidate is an exact, text-addressed change. The simulator never accepts
+ * a free-form shell command or an unbounded diff as an executable repair.
+ */
+export interface RepairCandidate {
+  id: string;
+  changeGroup: string;
+  file: string;
+  expected: string;
+  replacement: string;
+  rationale: string;
+  score?: number;
+  conflictsWith?: string[];
+  requires?: string[];
+  touchesSensitive?: boolean;
+}
+
+export interface RepairSolverConfig {
+  mode?: RepairSolverMode;
+  seed?: number;
+  timeoutMs?: number;
+}
+
+export interface RepairApprovals {
+  human?: boolean;
+  security?: boolean;
+}
+
+export interface VerifiedRepairRequest {
+  jobId: string;
+  actorId?: string;
+  source?: 'api' | 'mcp' | 'cli' | 'test';
+  createdAt?: string;
+
+  finding: RepairFinding;
+  candidates: RepairCandidate[];
+  allowedFiles: string[];
+  approvals?: RepairApprovals;
+  solver?: RepairSolverConfig;
+
+  /**
+   * When true, run the selected plan in a disposable git worktree. The base
+   * checkout is never modified by this feature.
+   */
+  execute?: boolean;
+  repoRoot?: string;
+  baseCommit?: string;
+  validationProfile?: RepairValidationProfile;
+}
+
+export interface RepairQuboSummary {
+  problemHash: string;
+  variableCount: number;
+  constraintCount: number;
+  groups: string[];
+  candidateOrder: string[];
+}
+
+export interface RepairSolverResult {
+  mode: 'deterministic-local' | 'nvidia-live';
+  solverVersion: string;
+  solution: Record<string, number>;
+  energy: number;
+  confidence?: number;
+  solveTimeMs: number;
+  quboHash: string;
+  solutionHash: string;
+  replayHash?: string;
+}
+
+export type RepairExactStatus = 'sat' | 'unsat' | 'timeout' | 'error';
+
+export interface RepairExactVerification {
+  status: RepairExactStatus;
+  valid: boolean;
+  proof: string;
+  proofHash: string;
+  z3Version: string;
+  verifyTimeMs: number;
+  constraints: string[];
+  counterexample: string[];
+}
+
+export interface RepairValidationResult {
+  name: 'diff' | 'typecheck' | 'unit' | 'build' | 'security';
+  ok: boolean;
+  exitCode: number | null;
+  timedOut: boolean;
+  durationMs: number;
+  outputHash: string;
+  outputBytes: number;
+  summary: string;
+}
+
+export interface RepairExecutionResult {
+  controlledExecutorUsed: boolean;
+  patchApplied: boolean;
+  baseCommit: string;
+  worktreeCommit: string;
+  changedFiles: string[];
+  diffHash: string;
+  diffBytes: number;
+  validations: RepairValidationResult[];
+  cleanupOk: boolean;
+  error?: string;
+}
+
+export interface VerifiedRepairEvidencePack {
+  schema: typeof VERIFIED_REPAIR_SCHEMA;
+  jobId: string;
+  source: 'api' | 'mcp' | 'cli' | 'test';
+  findingHash: string;
+  planHash: string;
+  qubo: RepairQuboSummary;
+  selectedCandidateIds: string[];
+  solver: RepairSolverResult;
+  exactVerification: RepairExactVerification;
+  validation: RepairValidationResult[];
+  evidenceIds: string[];
+  evidenceManifest: {
+    id: string;
+    manifestHash: string;
+    status: 'COMPLETE' | 'BLOCKED';
+  };
+  audit: {
+    entryIds: string[];
+    chainValid: boolean;
+  };
+  replay: {
+    status: 'PASS' | 'BLOCK' | 'FAILED';
+    replayHash: string;
+    errors: string[];
+  };
+  determinism: {
+    status: 'PASS' | 'REVIEW';
+    proofHash?: string;
+    reason?: string;
+  };
+}
+
+export interface VerifiedRepairResult {
+  schema: typeof VERIFIED_REPAIR_SCHEMA;
+  jobId: string;
+  status: VerifiedRepairStatus;
+  verdict: 'PASS' | 'REVIEW' | 'BLOCK';
+  planningOnly: boolean;
+  selectedCandidateIds: string[];
+  gate: {
+    finalDecision: string;
+    allowed: boolean;
+    claimAllowed: boolean;
+    reasons: string[];
+    nextRequiredEvidence: string[];
+  };
+  exactVerification?: RepairExactVerification;
+  execution?: RepairExecutionResult;
+  evidencePack?: VerifiedRepairEvidencePack;
+  counterexample?: string[];
+  nextAction: string;
+  userOutcome: string;
+}

--- a/lib/dsg/verified-repair/z3.ts
+++ b/lib/dsg/verified-repair/z3.ts
@@ -1,0 +1,184 @@
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+import type { RepairCandidate } from './types';
+import type { RepairExactStatus } from './types';
+import type { RepairQubo } from './qubo';
+
+export interface RepairZ3Context {
+  ctx: any;
+  version: string;
+}
+let z3InitPromise: Promise<RepairZ3Context> | null = null;
+
+async function getZ3Context(): Promise<RepairZ3Context> {
+  if (!z3InitPromise) {
+    z3InitPromise = (async () => {
+      const { init } = await import('z3-solver');
+      const { Context, Z3 } = await init();
+      let version = 'z3-solver-wasm';
+      try {
+        const value = Z3.get_version?.();
+        if (value && typeof value === 'object') {
+          version = `${value.major}.${value.minor}.${value.build_number}`;
+        }
+      } catch {
+        // The pinned package version remains the honest fallback identifier.
+      }
+      return { ctx: Context('dsg-verified-repair'), version };
+    })();
+  }
+  return z3InitPromise;
+}
+
+function diagnosticViolations(
+  qubo: RepairQubo,
+  candidates: RepairCandidate[],
+  assignment: Record<string, number | boolean>,
+): string[] {
+  const byId = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+  const selected = new Set(
+    qubo.variables
+      .filter((variable) => Number(assignment[variable.id]) === 1)
+      .map((variable) => qubo.candidateOrder[Number(variable.agentId)]),
+  );
+  const violations: string[] = [];
+
+  for (const group of qubo.groups) {
+    const count = [...selected].filter((id) => byId.get(id)?.changeGroup === group).length;
+    if (count !== 1) violations.push(`GROUP_${group}_EXACTLY_ONE_GOT_${count}`);
+  }
+  for (const [left, right] of qubo.conflictPairs) {
+    if (selected.has(left) && selected.has(right)) {
+      violations.push(`CONFLICT_${left}_${right}`);
+    }
+  }
+  for (const [candidate, required] of qubo.requirementPairs) {
+    if (selected.has(candidate) && !selected.has(required)) {
+      violations.push(`REQUIREMENT_${candidate}_NEEDS_${required}`);
+    }
+  }
+  return violations;
+}
+
+function proofHash(payload: Record<string, unknown>): string {
+  return sha256Json({ schema: 'dsg.verified-repair.z3-proof.v1', ...payload });
+}
+
+export async function verifyRepairAssignment(
+  qubo: RepairQubo,
+  candidates: RepairCandidate[],
+  assignment: Record<string, number | boolean>,
+  timeoutMs = 5_000,
+): Promise<{
+  status: RepairExactStatus;
+  valid: boolean;
+  proof: string;
+  proofHash: string;
+  z3Version: string;
+  verifyTimeMs: number;
+  constraints: string[];
+  counterexample: string[];
+}> {
+  const startedAt = Date.now();
+  const constraints: string[] = [];
+
+  try {
+    const { ctx, version } = await getZ3Context();
+    const solver = new ctx.Solver();
+    try {
+      solver.set('timeout', Math.min(Math.max(timeoutMs, 1), 30_000));
+    } catch {
+      // The WASM binding may not expose solver timeout on every version.
+    }
+
+    const variables = qubo.variables.map((variable, index) => {
+      const expression = ctx.Int.const(`verified_repair_${index}`);
+      const value = assignment[variable.id];
+      if (!(value === 0 || value === 1 || value === false || value === true)) {
+        throw new Error(`MISSING_OR_NON_BINARY_ASSIGNMENT:${variable.id}`);
+      }
+      solver.add(expression.ge(0), expression.le(1), expression.eq(Number(value)));
+      return expression;
+    });
+
+    for (const group of qubo.groups) {
+      const groupVariables = qubo.variables
+        .map((variable, index) => ({ variable, expression: variables[index] }))
+        .filter(({ variable }) => variable.taskId === group)
+        .map(({ expression }) => expression);
+      if (groupVariables.length === 0) {
+        throw new Error(`NO_VARIABLES_FOR_GROUP:${group}`);
+      }
+      const sum = groupVariables.length === 1
+        ? groupVariables[0]
+        : groupVariables.slice(1).reduce((total: any, expression: any) => total.add(expression), groupVariables[0]);
+      solver.add(sum.eq(1));
+      constraints.push(`group:${group}:exactly_one`);
+    }
+
+    for (const [leftId, rightId] of qubo.conflictPairs) {
+      const leftIndex = qubo.candidateOrder.indexOf(leftId);
+      const rightIndex = qubo.candidateOrder.indexOf(rightId);
+      if (leftIndex < 0 || rightIndex < 0) throw new Error(`UNKNOWN_CONFLICT:${leftId}:${rightId}`);
+      solver.add(variables[leftIndex].add(variables[rightIndex]).le(1));
+      constraints.push(`conflict:${leftId}:${rightId}:at_most_one`);
+    }
+
+    for (const [candidateId, requiredId] of qubo.requirementPairs) {
+      const candidateIndex = qubo.candidateOrder.indexOf(candidateId);
+      const requiredIndex = qubo.candidateOrder.indexOf(requiredId);
+      if (candidateIndex < 0 || requiredIndex < 0) throw new Error(`UNKNOWN_REQUIREMENT:${candidateId}:${requiredId}`);
+      solver.add(variables[candidateIndex].le(variables[requiredIndex]));
+      constraints.push(`requirement:${candidateId}:needs:${requiredId}`);
+    }
+
+    const timeout = new Promise<'timeout'>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout'), Math.max(timeoutMs, 1) + 250);
+      timer.unref?.();
+    });
+    const solverResult = await Promise.race([solver.check(), timeout]);
+    const verifyTimeMs = Date.now() - startedAt;
+    const status: RepairExactStatus = solverResult === 'sat'
+      ? 'sat'
+      : solverResult === 'unsat'
+        ? 'unsat'
+        : 'timeout';
+    const counterexample = status === 'unsat'
+      ? diagnosticViolations(qubo, candidates, assignment)
+      : [];
+    const proof = JSON.stringify({
+      status,
+      assignment,
+      constraints,
+      counterexample,
+      z3Version: version,
+    });
+    return {
+      status,
+      valid: status === 'sat',
+      proof,
+      proofHash: proofHash({ status, assignment, constraints, counterexample, z3Version: version }),
+      z3Version: version,
+      verifyTimeMs,
+      constraints,
+      counterexample,
+    };
+  } catch (error) {
+    const verifyTimeMs = Date.now() - startedAt;
+    const message = error instanceof Error ? error.message : String(error);
+    const proof = JSON.stringify({ status: 'error', message, constraints });
+    return {
+      status: 'error',
+      valid: false,
+      proof,
+      proofHash: proofHash({ status: 'error', message, constraints }),
+      z3Version: 'z3-solver-wasm',
+      verifyTimeMs,
+      constraints,
+      counterexample: [message],
+    };
+  }
+}
+
+export async function resetRepairZ3Context(): Promise<void> {
+  z3InitPromise = null;
+}

--- a/lib/mcp/unified-tools.ts
+++ b/lib/mcp/unified-tools.ts
@@ -2,6 +2,8 @@ import { createHmac } from 'node:crypto';
 import { Octokit } from '@octokit/rest';
 import { callDsgTool } from './dsg-tools';
 import type { UnifiedAuthContext } from './unified-auth';
+import { runVerifiedRepair } from '@/lib/dsg/verified-repair';
+import type { VerifiedRepairRequest } from '@/lib/dsg/verified-repair';
 
 export const UNIFIED_TOOL_SCHEMAS = {
   'dsg.system.status': {
@@ -65,6 +67,34 @@ export const UNIFIED_TOOL_SCHEMAS = {
         },
       },
       required: ['environment', 'approved', 'idempotencyKey'],
+      additionalProperties: false,
+    },
+  },
+  'dsg.repair.simulate': {
+    description: 'Generate a binary repair plan and verify the selected candidate exactly with Z3. This tool is plan-only and never mutates a repository.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        jobId: { type: 'string', minLength: 1, maxLength: 128 },
+        finding: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            summary: { type: 'string' },
+            severity: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] },
+            executionRisk: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] },
+            affectedFiles: { type: 'array', items: { type: 'string' } },
+            evidence: { type: 'array', items: { type: 'object', additionalProperties: true } },
+          },
+          required: ['id', 'summary', 'severity', 'executionRisk', 'affectedFiles', 'evidence'],
+          additionalProperties: true,
+        },
+        candidates: { type: 'array', minItems: 1, maxItems: 128, items: { type: 'object', additionalProperties: true } },
+        allowedFiles: { type: 'array', minItems: 1, items: { type: 'string' } },
+        approvals: { type: 'object', properties: { human: { type: 'boolean' }, security: { type: 'boolean' } }, additionalProperties: false },
+        solver: { type: 'object', properties: { mode: { type: 'string', enum: ['pinned', 'live'] }, seed: { type: 'integer' }, timeoutMs: { type: 'integer' } }, additionalProperties: false },
+      },
+      required: ['jobId', 'finding', 'candidates', 'allowedFiles'],
       additionalProperties: false,
     },
   },
@@ -506,6 +536,24 @@ async function handleAwsDeploy(
   };
 }
 
+async function handleRepairSimulation(
+  args: Record<string, unknown>,
+  auth: UnifiedAuthContext,
+): Promise<UnifiedToolResult> {
+  const input: VerifiedRepairRequest = {
+    jobId: args.jobId as string,
+    finding: args.finding as VerifiedRepairRequest['finding'],
+    candidates: args.candidates as VerifiedRepairRequest['candidates'],
+    allowedFiles: args.allowedFiles as string[],
+    approvals: args.approvals as VerifiedRepairRequest['approvals'],
+    solver: args.solver as VerifiedRepairRequest['solver'],
+    actorId: auth.actorId,
+    source: 'mcp',
+    execute: false,
+  };
+  return { ok: true, result: await runVerifiedRepair(input) };
+}
+
 export async function callUnifiedTool(
   name: UnifiedToolName,
   args: Record<string, unknown>,
@@ -523,6 +571,8 @@ export async function callUnifiedTool(
         return handleAwsContract();
       case 'dsg.aws.deploy':
         return await handleAwsDeploy(args, auth);
+      case 'dsg.repair.simulate':
+        return await handleRepairSimulation(args, auth);
       default:
         return { ok: false, code: -32601, message: `Unknown unified tool: ${String(name)}` };
     }

--- a/scripts/verified-repair.ts
+++ b/scripts/verified-repair.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { runVerifiedRepair } from '../lib/dsg/verified-repair';
+import type { VerifiedRepairRequest } from '../lib/dsg/verified-repair';
+
+function argument(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(name);
+}
+
+async function main(): Promise<void> {
+  const requestPath = argument('--request');
+  if (!requestPath) {
+    throw new Error('Usage: npx tsx scripts/verified-repair.ts --request ./repair-request.json [--execute] [--validation fast|full]');
+  }
+
+  const parsed = JSON.parse(await readFile(path.resolve(requestPath), 'utf8')) as VerifiedRepairRequest;
+  const execute = hasFlag('--execute');
+  const validation = argument('--validation') as VerifiedRepairRequest['validationProfile'] | undefined;
+  const result = await runVerifiedRepair({
+    ...parsed,
+    source: 'cli',
+    execute,
+    repoRoot: execute ? process.cwd() : undefined,
+    validationProfile: validation ?? parsed.validationProfile ?? 'none',
+  });
+
+  // Evidence is intentionally hash/status oriented; candidate source text is
+  // never printed by the CLI.
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (result.status === 'BLOCKED') process.exitCode = 2;
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/verify-unified-mcp-gateway.mjs
+++ b/scripts/verify-unified-mcp-gateway.mjs
@@ -13,6 +13,7 @@ const requiredTools = [
   'dsg.aimo.solve',
   'dsg.aws.contract',
   'dsg.aws.deploy',
+  'dsg.repair.simulate',
 ];
 
 let failed = false;
@@ -117,6 +118,17 @@ if (tools.includes("verdict: 'REVIEW'") && tools.includes('post-deploy verificat
   pass('AWS dispatch cannot be reported as final PASS');
 } else {
   fail('AWS dispatch truth boundary is missing');
+}
+
+if (
+  tools.includes("'dsg.repair.simulate'") &&
+  tools.includes('runVerifiedRepair') &&
+  tools.includes('execute: false') &&
+  tools.includes('never mutates a repository')
+) {
+  pass('Verified Repair Simulator is exposed through the unified MCP front door as a plan-only tool');
+} else {
+  fail('Verified Repair Simulator MCP contract is missing or mutation boundary is unclear');
 }
 
 if (tools.includes("callDsgTool('dsg.evaluate'") && tools.includes("riskLevel: environment === 'prod' ? 'critical' : 'high'")) {

--- a/tests/dsg/verified-repair-simulator.test.ts
+++ b/tests/dsg/verified-repair-simulator.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { sha256Json } from '@/lib/dsg/runtime/hash';
+import {
+  buildRepairQubo,
+  runVerifiedRepair,
+  verifyRepairAssignment,
+} from '@/lib/dsg/verified-repair';
+import type { VerifiedRepairRequest } from '@/lib/dsg/verified-repair';
+
+function request(overrides: Partial<VerifiedRepairRequest> = {}): VerifiedRepairRequest {
+  return {
+    jobId: 'repair-test-001',
+    actorId: 'test-actor',
+    source: 'test',
+    createdAt: '2026-08-09T00:00:00.000Z',
+    finding: {
+      id: 'finding-001',
+      summary: 'The bounded branch uses the wrong constant.',
+      severity: 'LOW',
+      executionRisk: 'LOW',
+      affectedFiles: ['src/example.ts'],
+      evidence: [
+        {
+          id: 'scan-001',
+          type: 'scan_output',
+          contentHash: sha256Json('scan output'),
+          summary: 'Deterministic scan output',
+        },
+      ],
+    },
+    allowedFiles: ['src/example.ts'],
+    candidates: [
+      {
+        id: 'candidate-a',
+        changeGroup: 'fix-constant',
+        file: 'src/example.ts',
+        expected: 'const value = 1;',
+        replacement: 'const value = 2;',
+        rationale: 'Matches the verified finding.',
+        score: 90,
+      },
+      {
+        id: 'candidate-b',
+        changeGroup: 'fix-constant',
+        file: 'src/example.ts',
+        expected: 'const value = 1;',
+        replacement: 'const value = 3;',
+        rationale: 'Alternative candidate for the same change group.',
+        score: 10,
+      },
+    ],
+    solver: { mode: 'pinned', seed: 7 },
+    execute: false,
+    ...overrides,
+  };
+}
+
+describe('Verified Repair Simulator', () => {
+  it('selects a binary candidate plan, passes exact Z3, and stops before mutation', async () => {
+    const result = await runVerifiedRepair(request());
+
+    expect(result.status).toBe('READY_FOR_CONTROLLED_EXECUTION');
+    expect(result.verdict).toBe('REVIEW');
+    expect(result.planningOnly).toBe(true);
+    expect(result.selectedCandidateIds).toHaveLength(1);
+    expect(result.exactVerification?.status).toBe('sat');
+    expect(result.exactVerification?.valid).toBe(true);
+    expect(result.evidencePack?.replay.status).toBe('PASS');
+    expect(result.evidencePack?.audit.chainValid).toBe(true);
+    expect(result.userOutcome).toContain('พร้อม');
+  }, 30_000);
+
+  it('replays pinned planning deterministically for the same input', async () => {
+    const first = await runVerifiedRepair(request());
+    const second = await runVerifiedRepair(request());
+
+    expect(first.selectedCandidateIds).toEqual(second.selectedCandidateIds);
+    expect(first.evidencePack?.planHash).toBe(second.evidencePack?.planHash);
+    expect(first.evidencePack?.exactVerification.proofHash).toBe(second.evidencePack?.exactVerification.proofHash);
+    expect(first.evidencePack?.replay.replayHash).toBe(second.evidencePack?.replay.replayHash);
+    expect(first.evidencePack?.determinism.status).toBe('PASS');
+  }, 30_000);
+
+  it('blocks a candidate outside the approved scope before solver execution', async () => {
+    const result = await runVerifiedRepair(request({
+      candidates: [{
+        ...request().candidates[0],
+        file: '../outside.ts',
+      }],
+    }));
+
+    expect(result.status).toBe('BLOCKED');
+    expect(result.gate.finalDecision).toBe('BLOCK_INPUT_VALIDATION');
+    expect(result.counterexample?.join(',')).toContain('INVALID_CANDIDATE_FILE');
+  });
+
+  it('blocks a plan without scan or reproduction evidence', async () => {
+    const base = request();
+    const result = await runVerifiedRepair({
+      ...base,
+      finding: { ...base.finding, evidence: [{ ...base.finding.evidence[0], type: 'manual_note' }] },
+    });
+
+    expect(result.status).toBe('BLOCKED');
+    expect(result.counterexample?.join(',')).toContain('REPRO_OR_SCAN_EVIDENCE_REQUIRED');
+  });
+
+  it('uses Z3 as the authority for conflict constraints', async () => {
+    const candidates = [
+      { ...request().candidates[0], id: 'left', changeGroup: 'left', conflictsWith: ['right'] },
+      { ...request().candidates[0], id: 'right', changeGroup: 'right', conflictsWith: ['left'] },
+    ];
+    const qubo = buildRepairQubo(candidates);
+    const result = await verifyRepairAssignment(
+      qubo,
+      candidates,
+      { repair_0: 1, repair_1: 1 },
+    );
+
+    expect(result.status).toBe('unsat');
+    expect(result.valid).toBe(false);
+    expect(result.counterexample).toContain('CONFLICT_left_right');
+  }, 30_000);
+
+  it('fails closed when live NVIDIA Ising mode has no configured endpoint', async () => {
+    const previous = process.env.NVIDIA_ISING_API_URL;
+    delete process.env.NVIDIA_ISING_API_URL;
+    try {
+      const result = await runVerifiedRepair(request({ solver: { mode: 'live' } }));
+      expect(result.status).toBe('BLOCKED');
+      expect(result.counterexample?.join(',')).toContain('NVIDIA_ISING_API_URL_REQUIRED_FOR_LIVE_SOLVER');
+    } finally {
+      if (previous === undefined) delete process.env.NVIDIA_ISING_API_URL;
+      else process.env.NVIDIA_ISING_API_URL = previous;
+    }
+  });
+});


### PR DESCRIPTION
## What changed

Adds a Verified Repair Simulator that converts bounded repair candidates into a deterministic binary repair plan and keeps every mutation behind explicit proof gates.

- Adds QUBO/Ising candidate planning with pinned deterministic mode and fail-closed NVIDIA live mode.
- Re-verifies solver assignments with exact Z3 constraints for exactly-one groups, conflicts, and requirements.
- Adds finding/evidence validation, scope and sensitive-path checks, security remediation gates, audit hash chains, evidence manifests, and replay proofs.
- Adds a disposable git worktree executor with exact-text replacements and fixed validation profiles.
- Exposes plan-only `dsg.repair.simulate` through the unified MCP front door and `POST /api/dsg/v1/repair/simulate`.
- Adds a CLI, documentation, and focused tests.
- Does not merge, deploy, mutate the base checkout, or claim a production fix.

## Validation

- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run test:unit -- --reporter=dot` — passed: 203 files / 2,897 tests
- `npx vitest run tests/dsg/verified-repair-simulator.test.ts --reporter=dot` — passed: 6 tests
- `node scripts/verify-unified-mcp-gateway.mjs` — passed
- `npm run build` — passed (with the repository's existing Turbopack NFT warning)
- `npm audit --omit=dev --audit-level=high --json` — 0 high/critical vulnerabilities
- Disposable executor smoke test — Z3 sat, exact replacement, typecheck passed, cleanup passed; correctly remained BLOCKED under the fast profile because unit/build/security evidence was not requested.

## Truth boundary

This is a draft PR for review. `VERIFIED_IN_SIMULATION` means the selected plan passed inside an isolated worktree with the configured validation evidence; it is not a merge, deployment, or production-fix claim.