### PR TITLE
feat: add governed MCP deploy for Netlify Render and Supabase

### DIFF
--- a/.github/workflows/dsg-platform-deploy.yml
+++ b/.github/workflows/dsg-platform-deploy.yml
@@ -1,0 +1,330 @@
+name: DSG Governed Platform Deploy
+run-name: DSG Platform ${{ inputs.target }} ${{ inputs.environment }} ${{ inputs.idempotency_key }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Governed deployment target
+        required: true
+        type: choice
+        options:
+          - netlify
+          - render
+          - supabase
+      environment:
+        description: Deployment environment
+        required: true
+        type: choice
+        options:
+          - preview
+          - staging
+          - prod
+      idempotency_key:
+        description: Stable deployment request identifier
+        required: true
+        type: string
+      ref:
+        description: Optional Git ref to deploy
+        required: false
+        default: ''
+        type: string
+      supabase_mode:
+        description: Supabase mutation surface
+        required: false
+        default: all
+        type: choice
+        options:
+          - migrations
+          - functions
+          - all
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dsg-platform-${{ inputs.target }}-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  validate-plan:
+    name: Validate governed deployment plan
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Validate inputs
+        shell: bash
+        env:
+          TARGET: ${{ inputs.target }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          REF: ${{ inputs.ref }}
+          SUPABASE_MODE: ${{ inputs.supabase_mode }}
+        run: |
+          set -euo pipefail
+          case "$TARGET" in
+            netlify|render|supabase) ;;
+            *) echo "Unsupported deployment target" >&2; exit 2 ;;
+          esac
+          case "$ENVIRONMENT" in
+            preview|staging|prod) ;;
+            *) echo "Unsupported environment" >&2; exit 2 ;;
+          esac
+          if [[ ! "$IDEMPOTENCY_KEY" =~ ^[A-Za-z0-9._:-]{8,128}$ ]]; then
+            echo "Invalid idempotency key" >&2
+            exit 2
+          fi
+          if [[ -n "$REF" ]] && { [[ ${#REF} -gt 160 ]] || [[ "$REF" == *".."* ]] || [[ "$REF" == -* ]] || [[ ! "$REF" =~ ^[A-Za-z0-9._/@:-]+$ ]]; }; then
+            echo "Invalid ref" >&2
+            exit 2
+          fi
+          case "$SUPABASE_MODE" in
+            migrations|functions|all) ;;
+            *) echo "Unsupported Supabase mode" >&2; exit 2 ;;
+          esac
+          printf '%s\n' \
+            "target=$TARGET" \
+            "environment=$ENVIRONMENT" \
+            "idempotency_key=$IDEMPOTENCY_KEY" \
+            "ref=${REF:-<provider-default>}" \
+            "supabase_mode=$SUPABASE_MODE"
+
+  deploy-netlify:
+    name: Trigger Netlify deploy
+    needs: validate-plan
+    if: ${{ inputs.target == 'netlify' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Trigger build hook
+        id: trigger
+        shell: bash
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${NETLIFY_BUILD_HOOK_URL:-}" ]]; then
+            echo "NETLIFY_BUILD_HOOK_URL is not configured" >&2
+            exit 3
+          fi
+          payload=$(printf '{"dsg":{"idempotencyKey":"%s","environment":"%s"}}' "$IDEMPOTENCY_KEY" "$ENVIRONMENT")
+          http_code=$(curl --silent --show-error --output provider-response.txt --write-out '%{http_code}' \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            "$NETLIFY_BUILD_HOOK_URL")
+          if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            echo "Netlify build hook returned HTTP $http_code" >&2
+            cat provider-response.txt >&2 || true
+            exit 4
+          fi
+          echo "http_code=$http_code" >> "$GITHUB_OUTPUT"
+
+      - name: Capture evidence
+        shell: bash
+        env:
+          HTTP_CODE: ${{ steps.trigger.outputs.http_code }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          response = Path('provider-response.txt').read_bytes() if Path('provider-response.txt').exists() else b''
+          evidence = {
+              'provider': 'netlify',
+              'environment': os.environ['ENVIRONMENT'],
+              'idempotencyKey': os.environ['IDEMPOTENCY_KEY'],
+              'dispatchHttpStatus': int(os.environ['HTTP_CODE']),
+              'providerResponseSha256': hashlib.sha256(response).hexdigest(),
+              'verdict': 'REVIEW',
+              'truthBoundary': 'A successful build-hook request proves dispatch only, not a successful production deployment.'
+          }
+          Path('deployment-evidence.json').write_text(json.dumps(evidence, indent=2, sort_keys=True) + '\n')
+          PY
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-deployment-evidence-netlify-${{ inputs.environment }}-${{ inputs.idempotency_key }}
+          path: |
+            deployment-evidence.json
+            provider-response.txt
+          if-no-files-found: error
+          retention-days: 30
+
+  deploy-render:
+    name: Trigger Render deploy
+    needs: validate-plan
+    if: ${{ inputs.target == 'render' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Trigger deploy hook
+        id: trigger
+        shell: bash
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RENDER_DEPLOY_HOOK_URL:-}" ]]; then
+            echo "RENDER_DEPLOY_HOOK_URL is not configured" >&2
+            exit 3
+          fi
+          http_code=$(curl --silent --show-error --output provider-response.txt --write-out '%{http_code}' \
+            --request POST \
+            "$RENDER_DEPLOY_HOOK_URL")
+          if [[ "$http_code" != "200" && "$http_code" != "202" ]]; then
+            echo "Render deploy hook returned HTTP $http_code" >&2
+            cat provider-response.txt >&2 || true
+            exit 4
+          fi
+          echo "http_code=$http_code" >> "$GITHUB_OUTPUT"
+
+      - name: Capture evidence
+        shell: bash
+        env:
+          HTTP_CODE: ${{ steps.trigger.outputs.http_code }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          response = Path('provider-response.txt').read_bytes() if Path('provider-response.txt').exists() else b''
+          deploy_id = None
+          try:
+              parsed = json.loads(response.decode() or '{}')
+              deploy_id = parsed.get('id') or parsed.get('deploy', {}).get('id')
+          except Exception:
+              pass
+          evidence = {
+              'provider': 'render',
+              'environment': os.environ['ENVIRONMENT'],
+              'idempotencyKey': os.environ['IDEMPOTENCY_KEY'],
+              'dispatchHttpStatus': int(os.environ['HTTP_CODE']),
+              'deployId': deploy_id,
+              'providerResponseSha256': hashlib.sha256(response).hexdigest(),
+              'verdict': 'REVIEW',
+              'truthBoundary': 'A successful deploy-hook request proves dispatch only. Provider deployment state must still be verified.'
+          }
+          Path('deployment-evidence.json').write_text(json.dumps(evidence, indent=2, sort_keys=True) + '\n')
+          PY
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-deployment-evidence-render-${{ inputs.environment }}-${{ inputs.idempotency_key }}
+          path: |
+            deployment-evidence.json
+            provider-response.txt
+          if-no-files-found: error
+          retention-days: 30
+
+  deploy-supabase:
+    name: Deploy Supabase changes
+    needs: validate-plan
+    if: ${{ inputs.target == 'supabase' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - name: Checkout requested source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref_name }}
+          fetch-depth: 1
+
+      - name: Verify Supabase secret bindings
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${SUPABASE_ACCESS_TOKEN:-}" || { echo 'SUPABASE_ACCESS_TOKEN is not configured' >&2; exit 3; }
+          test -n "${SUPABASE_DB_PASSWORD:-}" || { echo 'SUPABASE_DB_PASSWORD is not configured' >&2; exit 3; }
+          test -n "${SUPABASE_PROJECT_REF:-}" || { echo 'SUPABASE_PROJECT_REF is not configured' >&2; exit 3; }
+          test -f supabase/config.toml || { echo 'supabase/config.toml is missing' >&2; exit 3; }
+
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v2
+        with:
+          version: 2.84.2
+
+      - name: Link project
+        shell: bash
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Preflight pending migrations
+        if: ${{ inputs.supabase_mode == 'migrations' || inputs.supabase_mode == 'all' }}
+        shell: bash
+        run: supabase db push --dry-run | tee supabase-migration-dry-run.txt
+
+      - name: Apply migrations
+        if: ${{ inputs.supabase_mode == 'migrations' || inputs.supabase_mode == 'all' }}
+        shell: bash
+        run: supabase db push | tee supabase-migration-push.txt
+
+      - name: Deploy Edge Functions
+        if: ${{ inputs.supabase_mode == 'functions' || inputs.supabase_mode == 'all' }}
+        shell: bash
+        run: supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF" --use-api | tee supabase-functions-deploy.txt
+
+      - name: Capture provider state
+        shell: bash
+        run: |
+          set -euo pipefail
+          supabase migration list > supabase-migration-list.txt 2>&1 || true
+          supabase functions list --project-ref "$SUPABASE_PROJECT_REF" > supabase-functions-list.txt 2>&1 || true
+
+      - name: Capture evidence
+        shell: bash
+        env:
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          SUPABASE_MODE: ${{ inputs.supabase_mode }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib, json, os, subprocess
+          from pathlib import Path
+          files = [
+              'supabase-migration-dry-run.txt',
+              'supabase-migration-push.txt',
+              'supabase-functions-deploy.txt',
+              'supabase-migration-list.txt',
+              'supabase-functions-list.txt',
+          ]
+          hashes = {}
+          for name in files:
+              path = Path(name)
+              if path.exists():
+                  hashes[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+          commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
+          evidence = {
+              'provider': 'supabase',
+              'environment': os.environ['ENVIRONMENT'],
+              'idempotencyKey': os.environ['IDEMPOTENCY_KEY'],
+              'mode': os.environ['SUPABASE_MODE'],
+              'sourceCommit': commit,
+              'evidenceSha256': hashes,
+              'verdict': 'REVIEW',
+              'truthBoundary': 'CLI success proves requested mutations completed, but final PASS still requires application-level verification.'
+          }
+          Path('deployment-evidence.json').write_text(json.dumps(evidence, indent=2, sort_keys=True) + '\n')
+          PY
+
+      - name: Upload deployment evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsg-deployment-evidence-supabase-${{ inputs.environment }}-${{ inputs.idempotency_key }}
+          path: |
+            deployment-evidence.json
+            supabase-*.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -133,18 +133,19 @@ function toolList() {
 async function resolveUnifiedAuth(
   request: NextRequest,
   toolName: string,
+  rpcId: JsonRpcRequest['id'],
 ): Promise<UnifiedAuthContext | NextResponse> {
   const storedKey = await validateStoredUnifiedMcpKey(request, toolName);
   if (storedKey.presented) {
     if (storedKey.valid === false) {
-      return rpcError(null, -32001, storedKey.reason);
+      return rpcError(rpcId, -32001, storedKey.reason);
     }
     return storedKey.context;
   }
 
   const access = await requireOrgRole(['operator', 'org_admin'], request);
   if (!access.ok) {
-    return rpcError(null, -32001, access.error ?? 'Unauthorized');
+    return rpcError(rpcId, -32001, access.error ?? 'Unauthorized');
   }
   return {
     source: 'session',
@@ -192,7 +193,7 @@ export async function POST(request: NextRequest) {
     const args = rpc.params?.arguments ?? {};
 
     if ((UNIFIED_TOOL_NAMES as readonly string[]).includes(name)) {
-      const auth = await resolveUnifiedAuth(request, name);
+      const auth = await resolveUnifiedAuth(request, name, rpc.id);
       if (auth instanceof NextResponse) return auth;
 
       const unifiedResult = await callUnifiedTool(name as UnifiedToolName, args, auth);
@@ -207,7 +208,7 @@ export async function POST(request: NextRequest) {
     }
 
     if ((PLATFORM_DEPLOY_TOOL_NAMES as readonly string[]).includes(name)) {
-      const auth = await resolveUnifiedAuth(request, name);
+      const auth = await resolveUnifiedAuth(request, name, rpc.id);
       if (auth instanceof NextResponse) return auth;
 
       const deployResult = await callPlatformDeployTool(

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -14,6 +14,12 @@ import {
   type UnifiedToolName,
 } from '@/lib/mcp/unified-tools';
 import {
+  PLATFORM_DEPLOY_TOOL_NAMES,
+  PLATFORM_DEPLOY_TOOL_SCHEMAS,
+  callPlatformDeployTool,
+  type PlatformDeployToolName,
+} from '@/lib/mcp/platform-deploy-tools';
+import {
   validateStoredUnifiedMcpKey,
   type UnifiedAuthContext,
 } from '@/lib/mcp/unified-auth';
@@ -103,21 +109,58 @@ function unifiedToolList() {
   return UNIFIED_TOOL_NAMES.map((name) => ({ name, ...UNIFIED_TOOL_SCHEMAS[name] }));
 }
 
+function platformDeployToolList() {
+  return PLATFORM_DEPLOY_TOOL_NAMES.map((name) => ({
+    name,
+    ...PLATFORM_DEPLOY_TOOL_SCHEMAS[name],
+  }));
+}
+
 function hermesToolList() {
   return HERMES_TOOL_SCHEMAS;
 }
 
 function toolList() {
-  return [...unifiedToolList(), ...androidToolList(), ...dsgToolList(), ...hermesToolList()];
+  return [
+    ...unifiedToolList(),
+    ...platformDeployToolList(),
+    ...androidToolList(),
+    ...dsgToolList(),
+    ...hermesToolList(),
+  ];
+}
+
+async function resolveUnifiedAuth(
+  request: NextRequest,
+  toolName: string,
+): Promise<UnifiedAuthContext | NextResponse> {
+  const storedKey = await validateStoredUnifiedMcpKey(request, toolName);
+  if (storedKey.presented) {
+    if (storedKey.valid === false) {
+      return rpcError(null, -32001, storedKey.reason);
+    }
+    return storedKey.context;
+  }
+
+  const access = await requireOrgRole(['operator', 'org_admin'], request);
+  if (!access.ok) {
+    return rpcError(null, -32001, access.error ?? 'Unauthorized');
+  }
+  return {
+    source: 'session',
+    actorId: access.userId,
+    orgId: access.orgId,
+    roles: access.grantedRoles,
+  };
 }
 
 export async function GET() {
   return NextResponse.json({
     ok: true,
     server: 'dsg-control-plane-unified-mcp',
-    version: '1.0.0',
+    version: '1.1.0',
     tools: toolList(),
-    note: 'One MCP front door for DSG Control Plane, AIMO, AWS governed deployment, runtime, and evidence tools.',
+    note: 'One MCP front door for DSG Control Plane, AIMO, AWS, Netlify, Render, Supabase, runtime, and evidence tools.',
   });
 }
 
@@ -129,7 +172,7 @@ export async function POST(request: NextRequest) {
     return rpcResult(rpc.id, {
       protocolVersion: '2024-11-05',
       capabilities: { tools: {} },
-      serverInfo: { name: 'dsg-control-plane-unified-mcp', version: '1.0.0' },
+      serverInfo: { name: 'dsg-control-plane-unified-mcp', version: '1.1.0' },
     });
   }
 
@@ -149,26 +192,8 @@ export async function POST(request: NextRequest) {
     const args = rpc.params?.arguments ?? {};
 
     if ((UNIFIED_TOOL_NAMES as readonly string[]).includes(name)) {
-      const storedKey = await validateStoredUnifiedMcpKey(request, name);
-      let auth: UnifiedAuthContext;
-
-      if (storedKey.presented) {
-        if (storedKey.valid === false) {
-          return rpcError(rpc.id, -32001, storedKey.reason);
-        }
-        auth = storedKey.context;
-      } else {
-        const access = await requireOrgRole(['operator', 'org_admin'], request);
-        if (!access.ok) {
-          return rpcError(rpc.id, -32001, access.error ?? 'Unauthorized');
-        }
-        auth = {
-          source: 'session',
-          actorId: access.userId,
-          orgId: access.orgId,
-          roles: access.grantedRoles,
-        };
-      }
+      const auth = await resolveUnifiedAuth(request, name);
+      if (auth instanceof NextResponse) return auth;
 
       const unifiedResult = await callUnifiedTool(name as UnifiedToolName, args, auth);
       if (unifiedResult.ok === false) {
@@ -179,6 +204,25 @@ export async function POST(request: NextRequest) {
         );
       }
       return rpcToolResult(rpc.id, unifiedResult.result);
+    }
+
+    if ((PLATFORM_DEPLOY_TOOL_NAMES as readonly string[]).includes(name)) {
+      const auth = await resolveUnifiedAuth(request, name);
+      if (auth instanceof NextResponse) return auth;
+
+      const deployResult = await callPlatformDeployTool(
+        name as PlatformDeployToolName,
+        args,
+        auth,
+      );
+      if (deployResult.ok === false) {
+        return rpcToolResult(
+          rpc.id,
+          { error: { code: deployResult.code, message: deployResult.message } },
+          true,
+        );
+      }
+      return rpcToolResult(rpc.id, deployResult.result);
     }
 
     // Route DSG tools to the existing deterministic control-plane handler.

--- a/lib/mcp/platform-deploy-tools.ts
+++ b/lib/mcp/platform-deploy-tools.ts
@@ -1,0 +1,515 @@
+import { Octokit } from '@octokit/rest';
+import { callDsgTool } from './dsg-tools';
+import type { UnifiedAuthContext } from './unified-auth';
+
+export const PLATFORM_DEPLOY_TOOL_SCHEMAS = {
+  'dsg.deploy.status': {
+    description:
+      'Return governed deployment adapter readiness for Netlify, Render, and Supabase. GitHub Actions is the dispatcher and evidence boundary.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  'dsg.deploy.execute': {
+    description:
+      'Gate and idempotently dispatch a governed deployment to Netlify, Render, or Supabase. Dispatch success remains REVIEW until provider evidence is verified.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', enum: ['netlify', 'render', 'supabase'] },
+        environment: { type: 'string', enum: ['preview', 'staging', 'prod'] },
+        approved: {
+          type: 'boolean',
+          description: 'Explicit operator approval for this exact deployment plan.',
+        },
+        idempotencyKey: {
+          type: 'string',
+          minLength: 8,
+          maxLength: 128,
+          description: 'Stable request identifier reused on retries of the same intended deployment.',
+        },
+        ref: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 160,
+          description: 'Optional Git ref to deploy. Provider configuration still controls what is accepted.',
+        },
+        supabaseMode: {
+          type: 'string',
+          enum: ['migrations', 'functions', 'all'],
+          description: 'Supabase-only mutation surface. Defaults to all.',
+        },
+      },
+      required: ['target', 'environment', 'approved', 'idempotencyKey'],
+      additionalProperties: false,
+    },
+  },
+} as const;
+
+export type PlatformDeployToolName = keyof typeof PLATFORM_DEPLOY_TOOL_SCHEMAS;
+export const PLATFORM_DEPLOY_TOOL_NAMES = Object.keys(
+  PLATFORM_DEPLOY_TOOL_SCHEMAS,
+) as PlatformDeployToolName[];
+
+export type PlatformDeployToolResult =
+  | { ok: true; result: unknown }
+  | { ok: false; code: number; message: string };
+
+type DeployTarget = 'netlify' | 'render' | 'supabase';
+type DeployEnvironment = 'preview' | 'staging' | 'prod';
+
+type DeploymentEvidence = {
+  secret_bound: boolean;
+  dependency_resolved: boolean;
+  testable: boolean;
+  deploy_target_ready: boolean;
+  audit_hook_available: boolean;
+  missingRepositorySecrets: string[];
+  workflowRef: string;
+  workflowPath: string;
+};
+
+const WORKFLOW_PATH = '.github/workflows/dsg-platform-deploy.yml';
+const WORKFLOW_ID = 'dsg-platform-deploy.yml';
+
+const REQUIRED_SECRETS: Record<DeployTarget, readonly string[]> = {
+  netlify: ['NETLIFY_BUILD_HOOK_URL'],
+  render: ['RENDER_DEPLOY_HOOK_URL'],
+  supabase: ['SUPABASE_ACCESS_TOKEN', 'SUPABASE_PROJECT_REF', 'SUPABASE_DB_PASSWORD'],
+};
+
+function hasMutationRole(auth: UnifiedAuthContext): boolean {
+  return auth.roles.includes('operator') || auth.roles.includes('org_admin');
+}
+
+function githubToken(): string | null {
+  return (
+    process.env.DSG_GITHUB_AUTOMATION_TOKEN?.trim() ||
+    process.env.GITHUB_TOKEN?.trim() ||
+    null
+  );
+}
+
+function repositoryName(): { owner: string; repo: string } | null {
+  const repository =
+    process.env.DSG_CONTROL_PLANE_REPOSITORY ??
+    'tdealer01-crypto/tdealer01-crypto-dsg-control-plane';
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+function workflowRef(): string {
+  return process.env.DSG_PLATFORM_DEPLOY_REF?.trim() || 'main';
+}
+
+function decodeGitHubContent(content: string | undefined, encoding: string | undefined): string {
+  if (!content) return '';
+  return encoding === 'base64'
+    ? Buffer.from(content.replace(/\n/g, ''), 'base64').toString('utf8')
+    : content;
+}
+
+function validateTarget(value: unknown): DeployTarget | null {
+  return value === 'netlify' || value === 'render' || value === 'supabase'
+    ? value
+    : null;
+}
+
+function validateEnvironment(value: unknown): DeployEnvironment | null {
+  return value === 'preview' || value === 'staging' || value === 'prod'
+    ? value
+    : null;
+}
+
+function validateIdempotencyKey(value: unknown): string | null {
+  const key = String(value ?? '').trim();
+  if (key.length < 8 || key.length > 128) return null;
+  if (!/^[A-Za-z0-9._:-]+$/.test(key)) return null;
+  return key;
+}
+
+function validateRef(value: unknown): string | null {
+  if (value === undefined || value === null || value === '') return '';
+  const ref = String(value).trim();
+  if (!ref || ref.length > 160) return null;
+  if (!/^[A-Za-z0-9._/@:-]+$/.test(ref)) return null;
+  if (ref.includes('..') || ref.startsWith('-')) return null;
+  return ref;
+}
+
+function validateSupabaseMode(value: unknown): 'migrations' | 'functions' | 'all' | null {
+  if (value === undefined || value === null || value === '') return 'all';
+  return value === 'migrations' || value === 'functions' || value === 'all'
+    ? value
+    : null;
+}
+
+async function inspectDeploymentEvidence(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  target: DeployTarget,
+  ref: string,
+): Promise<DeploymentEvidence> {
+  let workflow = '';
+  try {
+    const response = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: WORKFLOW_PATH,
+      ref,
+    });
+    if (!Array.isArray(response.data) && 'content' in response.data) {
+      workflow = decodeGitHubContent(response.data.content, response.data.encoding);
+    }
+  } catch {
+    workflow = '';
+  }
+
+  const secretNames = new Set<string>();
+  try {
+    const response = await octokit.rest.actions.listRepoSecrets({ owner, repo, per_page: 100 });
+    for (const secret of response.data.secrets) secretNames.add(secret.name);
+  } catch {
+    // Fail closed if secret binding cannot be verified with the configured GitHub credential.
+  }
+
+  const missingRepositorySecrets = REQUIRED_SECRETS[target].filter(
+    (name) => !secretNames.has(name),
+  );
+
+  const dependencyResolved =
+    workflow.includes("target:") &&
+    workflow.includes("netlify") &&
+    workflow.includes("render") &&
+    workflow.includes("supabase") &&
+    !workflow.toLowerCase().includes('vercel');
+  const testable =
+    workflow.includes('deployment-evidence.json') &&
+    workflow.includes('actions/upload-artifact@v4');
+  const auditHookAvailable =
+    workflow.includes('idempotency_key') &&
+    workflow.includes('run-name: DSG Platform');
+  const secretBound = missingRepositorySecrets.length === 0;
+
+  return {
+    secret_bound: secretBound,
+    dependency_resolved: dependencyResolved,
+    testable,
+    deploy_target_ready: secretBound && dependencyResolved && testable,
+    audit_hook_available: auditHookAvailable,
+    missingRepositorySecrets,
+    workflowRef: ref,
+    workflowPath: WORKFLOW_PATH,
+  };
+}
+
+async function findExistingDispatch(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  target: DeployTarget,
+  environment: DeployEnvironment,
+  idempotencyKey: string,
+): Promise<{ id: number; status: string | null; conclusion: string | null; htmlUrl: string } | null> {
+  const expectedTitle = `DSG Platform ${target} ${environment} ${idempotencyKey}`;
+  const runs = await octokit.rest.actions.listWorkflowRuns({
+    owner,
+    repo,
+    workflow_id: WORKFLOW_ID,
+    per_page: 100,
+  });
+
+  for (const run of runs.data.workflow_runs) {
+    if (run.display_title === expectedTitle) {
+      return {
+        id: run.id,
+        status: run.status ?? null,
+        conclusion: run.conclusion ?? null,
+        htmlUrl: run.html_url,
+      };
+    }
+  }
+  return null;
+}
+
+async function handleStatus(): Promise<PlatformDeployToolResult> {
+  const token = githubToken();
+  const repo = repositoryName();
+  if (!token || !repo) {
+    return {
+      ok: true,
+      result: {
+        verdict: 'BLOCK',
+        dispatcher: 'github-actions',
+        targets: ['netlify', 'render', 'supabase'],
+        vercelSupported: false,
+        githubCredentialConfigured: Boolean(token),
+        repositoryConfigured: Boolean(repo),
+        nextAction: 'Configure the GitHub automation credential and repository binding before deployment.',
+      },
+    };
+  }
+
+  const octokit = new Octokit({ auth: token });
+  const ref = workflowRef();
+  const readiness: Record<string, DeploymentEvidence> = {};
+  for (const target of ['netlify', 'render', 'supabase'] as const) {
+    readiness[target] = await inspectDeploymentEvidence(
+      octokit,
+      repo.owner,
+      repo.repo,
+      target,
+      ref,
+    );
+  }
+
+  const allReady = Object.values(readiness).every(
+    (item) => item.deploy_target_ready && item.audit_hook_available,
+  );
+
+  return {
+    ok: true,
+    result: {
+      verdict: allReady ? 'PASS' : 'REVIEW',
+      dispatcher: 'github-actions',
+      targets: ['netlify', 'render', 'supabase'],
+      vercelSupported: false,
+      workflow: WORKFLOW_PATH,
+      readiness,
+      truthBoundary:
+        'Adapter readiness is not deployment success. A dispatch remains REVIEW until provider-side evidence is captured and verified.',
+    },
+  };
+}
+
+async function handleExecute(
+  args: Record<string, unknown>,
+  auth: UnifiedAuthContext,
+): Promise<PlatformDeployToolResult> {
+  if (!hasMutationRole(auth)) {
+    return {
+      ok: false,
+      code: -32001,
+      message: 'Platform deployment requires operator or org_admin entitlement.',
+    };
+  }
+
+  const target = validateTarget(args.target);
+  if (!target) {
+    return {
+      ok: false,
+      code: -32602,
+      message: 'target must be netlify, render, or supabase. Vercel is intentionally unsupported.',
+    };
+  }
+
+  const environment = validateEnvironment(args.environment);
+  if (!environment) {
+    return { ok: false, code: -32602, message: 'environment must be preview, staging, or prod' };
+  }
+
+  const idempotencyKey = validateIdempotencyKey(args.idempotencyKey);
+  if (!idempotencyKey) {
+    return {
+      ok: false,
+      code: -32602,
+      message: 'idempotencyKey must be 8-128 characters using letters, digits, dot, underscore, colon, or dash',
+    };
+  }
+
+  const ref = validateRef(args.ref);
+  if (ref === null) {
+    return { ok: false, code: -32602, message: 'ref contains unsupported characters' };
+  }
+
+  const supabaseMode = validateSupabaseMode(args.supabaseMode);
+  if (!supabaseMode) {
+    return {
+      ok: false,
+      code: -32602,
+      message: 'supabaseMode must be migrations, functions, or all',
+    };
+  }
+
+  if (target !== 'supabase' && args.supabaseMode !== undefined) {
+    return {
+      ok: false,
+      code: -32602,
+      message: 'supabaseMode is only valid when target=supabase',
+    };
+  }
+
+  if (args.approved !== true) {
+    return {
+      ok: true,
+      result: {
+        verdict: 'REVIEW',
+        dispatched: false,
+        target,
+        environment,
+        nextAction: 'Set approved=true only after approving this exact target, environment, ref, and mutation scope.',
+      },
+    };
+  }
+
+  const token = githubToken();
+  if (!token) {
+    return {
+      ok: false,
+      code: -32030,
+      message: 'Server-side GitHub workflow credential is not configured. Deployment remains BLOCKED.',
+    };
+  }
+
+  const repository = repositoryName();
+  if (!repository) {
+    return {
+      ok: false,
+      code: -32031,
+      message: 'DSG_CONTROL_PLANE_REPOSITORY must be owner/repo',
+    };
+  }
+
+  const dispatchRef = workflowRef();
+  const octokit = new Octokit({ auth: token });
+  const evidence = await inspectDeploymentEvidence(
+    octokit,
+    repository.owner,
+    repository.repo,
+    target,
+    dispatchRef,
+  );
+
+  const gate = await callDsgTool('dsg.evaluate', {
+    action: `deploy.${target}.${environment}`,
+    actor: auth.actorId,
+    tool: `github-actions:${WORKFLOW_ID}`,
+    args: {
+      target,
+      environment,
+      idempotencyKey,
+      ref,
+      supabaseMode: target === 'supabase' ? supabaseMode : undefined,
+      secret_bound: evidence.secret_bound,
+      dependency_resolved: evidence.dependency_resolved,
+      testable: evidence.testable,
+      deploy_target_ready: evidence.deploy_target_ready,
+      audit_hook_available: evidence.audit_hook_available,
+    },
+    env: {
+      riskLevel: environment === 'prod' ? 'critical' : 'high',
+      policyRef: 'dsg-mcp-platform-deploy-v1',
+    },
+  });
+
+  if (!gate.ok) return gate;
+  const decision = gate.result as Record<string, unknown>;
+  if (decision.gateStatus !== 'PASS') {
+    const missingEvidence = [
+      ['secret_bound', evidence.secret_bound],
+      ['dependency_resolved', evidence.dependency_resolved],
+      ['testable', evidence.testable],
+      ['deploy_target_ready', evidence.deploy_target_ready],
+      ['audit_hook_available', evidence.audit_hook_available],
+    ]
+      .filter(([, passed]) => passed !== true)
+      .map(([name]) => name);
+
+    return {
+      ok: true,
+      result: {
+        verdict: decision.gateStatus ?? 'BLOCK',
+        dispatched: false,
+        target,
+        environment,
+        gate: decision,
+        evidence,
+        missingEvidence,
+        nextAction: 'Resolve the reported provider secret/workflow evidence bindings before mutation.',
+      },
+    };
+  }
+
+  const existing = await findExistingDispatch(
+    octokit,
+    repository.owner,
+    repository.repo,
+    target,
+    environment,
+    idempotencyKey,
+  );
+  if (existing) {
+    return {
+      ok: true,
+      result: {
+        verdict: 'REVIEW',
+        dispatched: false,
+        duplicateSuppressed: true,
+        target,
+        environment,
+        idempotencyKey,
+        existingRun: existing,
+        gate: decision,
+        evidence,
+        nextAction: 'Reuse the existing workflow run and verify its provider evidence instead of dispatching a duplicate.',
+      },
+    };
+  }
+
+  await octokit.rest.actions.createWorkflowDispatch({
+    owner: repository.owner,
+    repo: repository.repo,
+    workflow_id: WORKFLOW_ID,
+    ref: dispatchRef,
+    inputs: {
+      target,
+      environment,
+      idempotency_key: idempotencyKey,
+      ref,
+      supabase_mode: supabaseMode,
+    },
+  });
+
+  return {
+    ok: true,
+    result: {
+      verdict: 'REVIEW',
+      dispatched: true,
+      target,
+      environment,
+      idempotencyKey,
+      workflow: WORKFLOW_PATH,
+      gate: decision,
+      evidence,
+      nextAction:
+        'Read the workflow run and deployment-evidence artifact. Do not claim PASS until provider-side verification succeeds.',
+    },
+  };
+}
+
+export async function callPlatformDeployTool(
+  name: PlatformDeployToolName,
+  args: Record<string, unknown>,
+  auth: UnifiedAuthContext,
+): Promise<PlatformDeployToolResult> {
+  try {
+    switch (name) {
+      case 'dsg.deploy.status':
+        return await handleStatus();
+      case 'dsg.deploy.execute':
+        return await handleExecute(args, auth);
+      default:
+        return {
+          ok: false,
+          code: -32601,
+          message: `Unknown platform deployment tool: ${String(name)}`,
+        };
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      code: -32603,
+      message: error instanceof Error ? error.message : 'Platform deployment MCP tool error',
+    };
+  }
+}


### PR DESCRIPTION
## Goal
Add one governed MCP deployment entry point without adding Vercel as a deployment target.

## User flow
1. MCP client calls `dsg.deploy.status` to see what is configured/missing.
2. MCP client calls `dsg.deploy.execute` with `target=netlify|render|supabase`, environment, approval, and idempotency key.
3. DSG deterministic gate evaluates verified workflow/secret bindings.
4. GitHub Actions dispatches the provider mutation.
5. Workflow uploads `deployment-evidence.json` plus provider evidence.
6. Dispatch remains `REVIEW`; final `PASS` requires downstream/provider verification.

## Changes
- Add `lib/mcp/platform-deploy-tools.ts`
  - `dsg.deploy.status`
  - `dsg.deploy.execute`
  - operator/org_admin authorization
  - explicit approval
  - idempotency suppression via workflow run name
  - fail-closed secret/workflow inspection
  - DSG gate integration
- Add `.github/workflows/dsg-platform-deploy.yml`
  - Netlify build hook
  - Render deploy hook
  - Supabase migrations/functions via pinned Supabase CLI 2.84.2
  - evidence artifacts
- Wire platform tools into `/api/mcp` unified front door.
- Vercel is intentionally not a deployment target.

## Required repository secrets
- Netlify: `NETLIFY_BUILD_HOOK_URL`
- Render: `RENDER_DEPLOY_HOOK_URL`
- Supabase: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_REF`, `SUPABASE_DB_PASSWORD`

## Truth boundary
A successful workflow dispatch or provider hook is not production readiness. Results remain `REVIEW` until downstream deployment state and application-level verification are captured as evidence.

## Verification requested from CI
Typecheck, lint, build/tests, and workflow validation should determine merge readiness. No PASS claim is made before checks complete.