### PR TITLE
feat(framer): add CORS-safe DSG MCP browser facade

### DIFF
--- a/app/api/framer/mcp/route.ts
+++ b/app/api/framer/mcp/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from 'next/server';
+import type { NextResponse } from 'next/server';
+import { GET as mcpGet, POST as mcpPost } from '@/app/api/mcp/route';
+import { buildCorsHeaders, buildPreflightResponse } from '@/lib/security/cors';
+
+export const dynamic = 'force-dynamic';
+
+function withCors(request: NextRequest, response: NextResponse): NextResponse {
+  const corsHeaders = buildCorsHeaders(request);
+  corsHeaders.forEach((value, key) => {
+    response.headers.set(key, value);
+  });
+  return response;
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return buildPreflightResponse(request);
+}
+
+export async function GET(request: NextRequest) {
+  return withCors(request, await mcpGet());
+}
+
+export async function POST(request: NextRequest) {
+  return withCors(request, await mcpPost(request));
+}

--- a/tests/unit/security/api-route-auth-coverage.test.ts
+++ b/tests/unit/security/api-route-auth-coverage.test.ts
@@ -42,6 +42,8 @@ const ALLOWLIST_INTENTIONALLY_PUBLIC: Record<string, string> = {
     'sandboxed to a hardcoded https host allowlist (wikipedia.org only), no DB access',
   '/api/dsg/midmarket-governance-autopilot/production-runtime':
     'pure computation over caller-supplied input, no DB access',
+  '/api/framer/mcp':
+    'CORS-safe proxy to /api/mcp with auth delegated to underlying unified MCP handlers (requireOrgRole, validateStoredUnifiedMcpKey)',
   '/api/playground/evaluate': 'stateless deterministic-gate playground demo, no DB access',
   '/api/stripe-app/gate/summary': 'scaffold — always returns hardcoded zero counts, not wired to storage',
   '/api/nvidia/stream':


### PR DESCRIPTION
## Goal
Expose a browser-safe Framer entry point for the existing Unified DSG MCP without exposing DSG API keys in client code.

## Changes
- add `app/api/framer/mcp/route.ts`
- reuse the existing `/api/mcp` GET/POST handlers rather than duplicating MCP/gate logic
- add OPTIONS preflight through the existing fail-closed CORS helper
- add CORS response headers only for origins allowed by `DSG_ALLOWED_ORIGINS` / existing app origin configuration
- preserve existing MCP auth: DSG issued keys remain supported for non-browser clients; Framer can use verified Supabase user Bearer JWT through `proxy.ts` -> `x-user-id` -> `requireOrgRole`

## Security boundary
- no `Access-Control-Allow-Origin: *`
- no DSG root/API key is embedded in Framer
- no changes to gate, approval, role, idempotency, solver, NVIDIA, or AWS mutation logic
- production Framer origin must be explicitly added to `DSG_ALLOWED_ORIGINS` on Render before browser E2E is considered PASS

## Verification requested
Typecheck, lint, build, security/governance, Unified MCP verification, and E2E should determine merge readiness. Production PASS requires live Render deployment plus a real allowed-origin preflight and authenticated Framer -> Render smoke test.