### PR TITLE
fix(render): align Docker runtime with Node 24 requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # CospinDSG / DSG ONE Cloud Run container
 # Runtime boundary: this image contains app code only. Secrets must be mounted through Cloud Run env or Secret Manager.
 
-FROM node:20-bookworm-slim AS deps
+FROM node:24-bookworm-slim AS deps
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY package.json package-lock.json ./
 RUN npm ci
 
-FROM node:20-bookworm-slim AS builder
+FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY --from=deps /app/node_modules ./node_modules
@@ -15,7 +15,7 @@ COPY . .
 RUN npm run build
 RUN npm prune --omit=dev
 
-FROM node:20-bookworm-slim AS runner
+FROM node:24-bookworm-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Problem
Render currently builds the Docker image with Node 20, while `package.json` requires Node >=24.0.0 and current Supabase packages require Node >=22. This produces EBADENGINE warnings during production builds and leaves a runtime compatibility gap.

## Change
- update all Dockerfile stages from `node:20-bookworm-slim` to `node:24-bookworm-slim`
- no application logic, auth, gate, evidence, or Framer behavior changes

## Verification
CI/build/security/governance should validate the runtime-only change before merge. Production PASS requires a Render deploy from the merged commit with the engine warnings removed.