### PR TITLE
test(render): one-shot live production smoke evidence

### DIFF
--- a/.github/workflows/render-live-smoke-one-shot.yml
+++ b/.github/workflows/render-live-smoke-one-shot.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - chore/render-live-smoke-20260809
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/render-live-smoke-one-shot.yml
 
 permissions:
   contents: read

--- a/.github/workflows/render-live-smoke-one-shot.yml
+++ b/.github/workflows/render-live-smoke-one-shot.yml
@@ -1,0 +1,60 @@
+name: Render Live Smoke One Shot
+
+on:
+  push:
+    branches:
+      - chore/render-live-smoke-20260809
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE_URL: https://tdealer01-crypto-dsg-control-plane.onrender.com
+    steps:
+      - name: Verify live DSG endpoints and fail-closed boundaries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          check_status() {
+            local name="$1"
+            local expected="$2"
+            shift 2
+            local code
+            code="$(curl --silent --show-error --location --max-time 30 --retry 2 --retry-delay 2 --output "/tmp/${name}.body" --write-out '%{http_code}' "$@")"
+            echo "${name}: HTTP ${code} (expected ${expected})"
+            if [[ "${code}" != "${expected}" ]]; then
+              echo "Unexpected status for ${name}"
+              sed -n '1,40p' "/tmp/${name}.body"
+              exit 1
+            fi
+          }
+
+          check_status health 200 "${BASE_URL}/api/health"
+          check_status readiness 200 "${BASE_URL}/api/readiness"
+          check_status mcp_get 200 "${BASE_URL}/api/framer/mcp"
+
+          check_status mcp_initialize 200 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"dsg-live-smoke","version":"1.0.0"}}}' \
+            "${BASE_URL}/api/framer/mcp"
+
+          check_status cors_blocked 403 \
+            --request OPTIONS \
+            --header 'Origin: https://not-allowed.invalid' \
+            --header 'Access-Control-Request-Method: POST' \
+            --header 'Access-Control-Request-Headers: authorization,content-type' \
+            "${BASE_URL}/api/framer/mcp"
+
+          check_status protected_tool_unauthenticated 401 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"dsg.deploy.status","arguments":{}}}' \
+            "${BASE_URL}/api/framer/mcp"
+
+          echo 'Render live smoke PASS'

--- a/.github/workflows/render-live-smoke-one-shot.yml
+++ b/.github/workflows/render-live-smoke-one-shot.yml
@@ -23,19 +23,22 @@ jobs:
       - name: Verify live DSG endpoints and fail-closed boundaries
         shell: bash
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          failures=0
 
           check_status() {
             local name="$1"
             local expected="$2"
             shift 2
             local code
-            code="$(curl --silent --show-error --location --max-time 30 --retry 2 --retry-delay 2 --output "/tmp/${name}.body" --write-out '%{http_code}' "$@")"
+            if ! code="$(curl --silent --show-error --location --max-time 30 --retry 2 --retry-delay 2 --output "/tmp/${name}.body" --write-out '%{http_code}' "$@")"; then
+              code="000"
+            fi
             echo "${name}: HTTP ${code} (expected ${expected})"
             if [[ "${code}" != "${expected}" ]]; then
               echo "Unexpected status for ${name}"
-              sed -n '1,40p' "/tmp/${name}.body"
-              exit 1
+              sed -n '1,40p' "/tmp/${name}.body" 2>/dev/null || true
+              failures=$((failures + 1))
             fi
           }
 
@@ -61,5 +64,10 @@ jobs:
             --header 'Content-Type: application/json' \
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"dsg.deploy.status","arguments":{}}}' \
             "${BASE_URL}/api/framer/mcp"
+
+          if (( failures > 0 )); then
+            echo "Render live smoke FAIL: ${failures} check(s) failed"
+            exit 1
+          fi
 
           echo 'Render live smoke PASS'

--- a/.github/workflows/render-live-smoke-one-shot.yml
+++ b/.github/workflows/render-live-smoke-one-shot.yml
@@ -19,8 +19,9 @@ jobs:
     timeout-minutes: 5
     env:
       BASE_URL: https://tdealer01-crypto-dsg-control-plane.onrender.com
+      FRAMER_ORIGIN: https://multidisciplinary-badger-803385.framer.app
     steps:
-      - name: Verify live DSG endpoints and fail-closed boundaries
+      - name: Verify live DSG endpoints and Framer CORS boundaries
         shell: bash
         run: |
           set -uo pipefail
@@ -51,6 +52,30 @@ jobs:
             --header 'Content-Type: application/json' \
             --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"dsg-live-smoke","version":"1.0.0"}}}' \
             "${BASE_URL}/api/framer/mcp"
+
+          allowed_code="$(curl --silent --show-error --max-time 30 \
+            --output /tmp/cors_allowed.body \
+            --dump-header /tmp/cors_allowed.headers \
+            --write-out '%{http_code}' \
+            --request OPTIONS \
+            --header "Origin: ${FRAMER_ORIGIN}" \
+            --header 'Access-Control-Request-Method: POST' \
+            --header 'Access-Control-Request-Headers: authorization,content-type' \
+            "${BASE_URL}/api/framer/mcp")"
+          echo "cors_allowed_framer: HTTP ${allowed_code} (expected 204)"
+          if [[ "${allowed_code}" != "204" ]]; then
+            echo 'Framer origin preflight did not return 204'
+            cat /tmp/cors_allowed.headers || true
+            cat /tmp/cors_allowed.body || true
+            failures=$((failures + 1))
+          fi
+          allowed_origin="$(awk 'BEGIN{IGNORECASE=1} /^access-control-allow-origin:/ {sub(/^[^:]+:[[:space:]]*/,""); sub(/\r$/,""); print; exit}' /tmp/cors_allowed.headers)"
+          echo "cors_allowed_origin: ${allowed_origin}"
+          if [[ "${allowed_origin}" != "${FRAMER_ORIGIN}" ]]; then
+            echo "Expected exact ACAO ${FRAMER_ORIGIN}"
+            cat /tmp/cors_allowed.headers || true
+            failures=$((failures + 1))
+          fi
 
           check_status cors_blocked 403 \
             --request OPTIONS \

--- a/.github/workflows/render-live-smoke-one-shot.yml
+++ b/.github/workflows/render-live-smoke-one-shot.yml
@@ -64,24 +64,32 @@ jobs:
             "${BASE_URL}/api/framer/mcp")"
           echo "cors_allowed_framer: HTTP ${allowed_code} (expected 204)"
           if [[ "${allowed_code}" != "204" ]]; then
-            echo 'Framer origin preflight did not return 204'
-            cat /tmp/cors_allowed.headers || true
-            cat /tmp/cors_allowed.body || true
             failures=$((failures + 1))
           fi
           allowed_origin="$(awk 'BEGIN{IGNORECASE=1} /^access-control-allow-origin:/ {sub(/^[^:]+:[[:space:]]*/,""); sub(/\r$/,""); print; exit}' /tmp/cors_allowed.headers)"
           echo "cors_allowed_origin: ${allowed_origin}"
           if [[ "${allowed_origin}" != "${FRAMER_ORIGIN}" ]]; then
             echo "Expected exact ACAO ${FRAMER_ORIGIN}"
-            cat /tmp/cors_allowed.headers || true
             failures=$((failures + 1))
           fi
 
-          check_status cors_blocked 403 \
+          check_status cors_blocked_preflight 403 \
             --request OPTIONS \
             --header 'Origin: https://not-allowed.invalid' \
             --header 'Access-Control-Request-Method: POST' \
             --header 'Access-Control-Request-Headers: authorization,content-type' \
+            "${BASE_URL}/api/framer/mcp"
+
+          check_status cors_blocked_get 403 \
+            --request GET \
+            --header 'Origin: https://not-allowed.invalid' \
+            "${BASE_URL}/api/framer/mcp"
+
+          check_status cors_blocked_post 403 \
+            --request POST \
+            --header 'Origin: https://not-allowed.invalid' \
+            --header 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"bad-origin-smoke","version":"1.0.0"}}}' \
             "${BASE_URL}/api/framer/mcp"
 
           check_status protected_tool_unauthenticated 401 \
@@ -90,9 +98,6 @@ jobs:
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"dsg.deploy.status","arguments":{}}}' \
             "${BASE_URL}/api/framer/mcp"
 
-          # /api/execute applies the distributed rate limiter before auth.
-          # 401 proves the Redis limiter succeeded and the request reached auth;
-          # a Redis/backend failure in production would fail closed as 429.
           check_status execute_limiter_then_auth 401 \
             --request POST \
             --header 'Content-Type: application/json' \

--- a/.github/workflows/render-live-smoke-one-shot.yml
+++ b/.github/workflows/render-live-smoke-one-shot.yml
@@ -65,6 +65,15 @@ jobs:
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"dsg.deploy.status","arguments":{}}}' \
             "${BASE_URL}/api/framer/mcp"
 
+          # /api/execute applies the distributed rate limiter before auth.
+          # 401 proves the Redis limiter succeeded and the request reached auth;
+          # a Redis/backend failure in production would fail closed as 429.
+          check_status execute_limiter_then_auth 401 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data '{}' \
+            "${BASE_URL}/api/execute"
+
           if (( failures > 0 )); then
             echo "Render live smoke FAIL: ${failures} check(s) failed"
             exit 1


### PR DESCRIPTION
Evidence-only external production smoke; intentionally not merged.

Final live evidence against Render commit `88ef17d503a7acca7aec5272b1e5ff1e8c415266` and Framer origin `https://multidisciplinary-badger-803385.framer.app`:
- health: 200
- readiness: 200
- `/api/framer/mcp` GET: 200
- MCP initialize: 200
- allowed Framer preflight: 204
- `Access-Control-Allow-Origin`: exact Framer origin
- disallowed-origin preflight: 403
- disallowed-origin GET: 403 before MCP handler
- disallowed-origin POST: 403 before MCP handler
- unauthenticated protected MCP tool: 401
- `/api/execute` limiter -> auth: 401
- Render Live Smoke One Shot: PASS

This verifies the production backend, Redis/auth boundary, exact Framer CORS allowlist, and server-side origin guard. A real signed-in browser request remains the only missing evidence for authenticated user-session Framer → Render → DSG E2E.