### PR TITLE
fix(rate-limit): support Render Redis and fail closed in production

### DIFF
--- a/lib/health/report.ts
+++ b/lib/health/report.ts
@@ -57,7 +57,7 @@ export async function buildHealthReport() {
   // Health is an operator/monitoring signal, not an abuse-sensitive action.
   // It must not consume the production rate-limit bucket; otherwise uptime
   // checks can mask a healthy service as HTTP 429. Abuse-sensitive endpoints
-  // such as /api/execute remain fail-closed behind the Redis-backed limiter.
+  // such as /api/execute remain fail-closed behind the distributed limiter.
   let dbOk = false;
   try {
     const dbResult = await withTimeout(
@@ -111,8 +111,8 @@ export async function buildHealthReport() {
     rateLimiter: {
       ok: rateLimiterConfigured,
       detail: rateLimiterConfigured
-        ? 'configured; health endpoint does not consume limiter bucket'
-        : 'UPSTASH_REDIS_REST_URL not set — execute gate will fail closed',
+        ? 'distributed rate limiter configured; health endpoint does not consume limiter bucket'
+        : 'No distributed Redis configured (Upstash REST or REDIS_URL) — execute gate will fail closed',
     },
     core: {
       ok: core.ok && dbOk && readiness.ok,

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -1,5 +1,6 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+import { createClient } from 'redis';
 
 type RateLimitOptions = {
   key: string;
@@ -48,32 +49,101 @@ function applyMemoryRateLimit(options: RateLimitOptions): RateLimitResult {
   return { allowed: true, remaining: Math.max(options.limit - existing.count, 0), resetAt: existing.resetAt };
 }
 
-let redis: Redis | null = null;
+let upstashRedis: Redis | null = null;
 const limiters = new Map<string, Ratelimit>();
-let warnedNoRedis = false;
+let warnedNoDistributedRedis = false;
 
-function getRedis(): Redis | null {
-  if (redis) return redis;
+type StandardRedisClient = ReturnType<typeof createClient>;
+let standardRedisClient: StandardRedisClient | null = null;
+let standardRedisConnectPromise: Promise<StandardRedisClient> | null = null;
+
+function getUpstashRedis(): Redis | null {
+  if (upstashRedis) return upstashRedis;
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
-  redis = new Redis({ url, token });
-  return redis;
+  upstashRedis = new Redis({ url, token });
+  return upstashRedis;
 }
 
-function getLimiter(prefix: string, limit: number, windowMs: number): Ratelimit | null {
-  const r = getRedis();
-  if (!r) return null;
+function getUpstashLimiter(prefix: string, limit: number, windowMs: number): Ratelimit | null {
+  const redis = getUpstashRedis();
+  if (!redis) return null;
   const key = `${prefix}:${limit}:${windowMs}`;
   if (!limiters.has(key)) {
     const windowSec = `${Math.ceil(windowMs / 1000)} s` as `${number} s`;
     limiters.set(key, new Ratelimit({
-      redis: r,
+      redis,
       limiter: Ratelimit.fixedWindow(limit, windowSec),
       prefix: `rl:${prefix}`,
     }));
   }
   return limiters.get(key)!;
+}
+
+function getStandardRedisUrl(): string | null {
+  const url = process.env.REDIS_URL?.trim();
+  return url || null;
+}
+
+async function getStandardRedisClient(): Promise<StandardRedisClient | null> {
+  const url = getStandardRedisUrl();
+  if (!url) return null;
+
+  if (!standardRedisClient) {
+    standardRedisClient = createClient({ url });
+    standardRedisClient.on('error', (error) => {
+      console.error('[rate-limit] Redis client error', error);
+    });
+  }
+
+  if (standardRedisClient.isReady) return standardRedisClient;
+
+  if (!standardRedisConnectPromise) {
+    standardRedisConnectPromise = standardRedisClient.connect()
+      .then(() => standardRedisClient!)
+      .catch((error) => {
+        standardRedisConnectPromise = null;
+        throw error;
+      });
+  }
+
+  return standardRedisConnectPromise;
+}
+
+async function applyStandardRedisRateLimit(options: RateLimitOptions): Promise<RateLimitResult> {
+  const client = await getStandardRedisClient();
+  if (!client) throw new Error('standard_redis_not_configured');
+
+  const script = `
+    local count = redis.call('INCR', KEYS[1])
+    if count == 1 then
+      redis.call('PEXPIRE', KEYS[1], ARGV[1])
+    end
+    local ttl = redis.call('PTTL', KEYS[1])
+    return {count, ttl}
+  `;
+
+  const result = await client.eval(script, {
+    keys: [`rl:${options.key}`],
+    arguments: [String(options.windowMs)],
+  });
+
+  if (!Array.isArray(result) || result.length < 2) {
+    throw new Error('invalid_redis_rate_limit_response');
+  }
+
+  const count = Number(result[0]);
+  const ttl = Math.max(Number(result[1]), 0);
+  if (!Number.isFinite(count) || !Number.isFinite(ttl)) {
+    throw new Error('invalid_redis_rate_limit_values');
+  }
+
+  return {
+    allowed: count <= options.limit,
+    remaining: Math.max(options.limit - count, 0),
+    resetAt: Date.now() + ttl,
+  };
 }
 
 export function getRateLimitKey(request: Request, prefix: string) {
@@ -85,23 +155,33 @@ export function getRateLimitKey(request: Request, prefix: string) {
 
 export async function applyRateLimit(options: RateLimitOptions): Promise<RateLimitResult> {
   const prefix = options.key.split(':')[0] || 'default';
-  const limiter = getLimiter(prefix, options.limit, options.windowMs);
+  const upstashLimiter = getUpstashLimiter(prefix, options.limit, options.windowMs);
 
-  if (!limiter) {
-    if (!warnedNoRedis) {
-      console.warn('[rate-limit] UPSTASH_REDIS_REST_URL not set — using in-memory fallback');
-      warnedNoRedis = true;
+  if (upstashLimiter) {
+    try {
+      const { success, remaining, reset } = await upstashLimiter.limit(options.key);
+      return { allowed: success, remaining, resetAt: reset };
+    } catch (error) {
+      console.error('[rate-limit] Upstash limiter error', error);
+      return isProduction() ? blockedResult(options.windowMs) : applyMemoryRateLimit(options);
     }
-    return applyMemoryRateLimit(options);
   }
 
-  try {
-    const { success, remaining, reset } = await limiter.limit(options.key);
-    return { allowed: success, remaining, resetAt: reset };
-  } catch (error) {
-    console.error('[rate-limit] Redis limiter error — falling back to in-memory', error);
-    return applyMemoryRateLimit(options);
+  if (getStandardRedisUrl()) {
+    try {
+      return await applyStandardRedisRateLimit(options);
+    } catch (error) {
+      console.error('[rate-limit] Redis limiter error', error);
+      return isProduction() ? blockedResult(options.windowMs) : applyMemoryRateLimit(options);
+    }
   }
+
+  if (!warnedNoDistributedRedis) {
+    console.warn('[rate-limit] No distributed Redis configured');
+    warnedNoDistributedRedis = true;
+  }
+
+  return isProduction() ? blockedResult(options.windowMs) : applyMemoryRateLimit(options);
 }
 
 export function buildRateLimitHeaders(result: RateLimitResult, limit: number) {
@@ -113,5 +193,8 @@ export function buildRateLimitHeaders(result: RateLimitResult, limit: number) {
 }
 
 export function isRateLimiterConfigured(): boolean {
-  return !!(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
+  const upstashConfigured = !!(
+    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+  );
+  return upstashConfigured || !!getStandardRedisUrl();
 }

--- a/tests/unit/security/rate-limit.test.ts
+++ b/tests/unit/security/rate-limit.test.ts
@@ -37,7 +37,7 @@ describe('getRateLimitKey', () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it('extracts IP from x-forwarded-for header', () => {
@@ -103,7 +103,7 @@ describe('applyRateLimit (in-memory fallback — no Redis)', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it('allows the first request and returns remaining = limit - 1', async () => {
@@ -174,7 +174,7 @@ describe('applyRateLimit (REDIS_URL backend)', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it('uses the standard Redis backend when REDIS_URL is configured', async () => {
@@ -205,7 +205,7 @@ describe('applyRateLimit (production fail-closed)', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it('blocks when no distributed Redis backend is configured', async () => {
@@ -230,7 +230,7 @@ describe('buildRateLimitHeaders', () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it('sets X-RateLimit-Limit to the given limit', () => {
@@ -279,7 +279,7 @@ describe('isRateLimiterConfigured', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it('returns false when no distributed Redis backend is configured', () => {

--- a/tests/unit/security/rate-limit.test.ts
+++ b/tests/unit/security/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the Upstash packages before any module import so the source file never
-// tries to open a real network connection.
+// Mock Redis clients before any module import so tests never open a real
+// network connection.
 vi.mock('@upstash/redis', () => ({
   Redis: vi.fn().mockImplementation(() => ({})),
 }));
@@ -15,6 +15,15 @@ vi.mock('@upstash/ratelimit', () => ({
       fixedWindow: vi.fn().mockReturnValue('fixed-window-limiter'),
     },
   ),
+}));
+
+vi.mock('redis', () => ({
+  createClient: vi.fn().mockImplementation(() => ({
+    isReady: true,
+    connect: vi.fn().mockResolvedValue(undefined),
+    eval: vi.fn().mockResolvedValue([1, 60_000]),
+    on: vi.fn(),
+  })),
 }));
 
 // ─── getRateLimitKey ──────────────────────────────────────────────────────────
@@ -82,9 +91,10 @@ describe('applyRateLimit (in-memory fallback — no Redis)', () => {
   }>;
 
   beforeEach(async () => {
-    // Force the in-memory path by clearing the Upstash env vars.
     vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
     vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
+    vi.stubEnv('REDIS_URL', '');
+    vi.stubEnv('NODE_ENV', 'test');
     vi.useFakeTimers();
     vi.resetModules();
     ({ applyRateLimit } = await import('../../../lib/security/rate-limit'));
@@ -104,21 +114,21 @@ describe('applyRateLimit (in-memory fallback — no Redis)', () => {
 
   it('decrements remaining on each subsequent request', async () => {
     const opts = { key: 'test:ip2', limit: 5, windowMs: 60_000 };
-    await applyRateLimit(opts); // 1st → remaining 4
-    const second = await applyRateLimit(opts); // 2nd → remaining 3
+    await applyRateLimit(opts);
+    const second = await applyRateLimit(opts);
     expect(second.allowed).toBe(true);
     expect(second.remaining).toBe(3);
-    const third = await applyRateLimit(opts); // 3rd → remaining 2
+    const third = await applyRateLimit(opts);
     expect(third.allowed).toBe(true);
     expect(third.remaining).toBe(2);
   });
 
   it('blocks the request when the limit is reached', async () => {
     const opts = { key: 'test:ip3', limit: 3, windowMs: 60_000 };
-    await applyRateLimit(opts); // 1
-    await applyRateLimit(opts); // 2
-    await applyRateLimit(opts); // 3 — limit reached
-    const result = await applyRateLimit(opts); // 4 — should be blocked
+    await applyRateLimit(opts);
+    await applyRateLimit(opts);
+    await applyRateLimit(opts);
+    const result = await applyRateLimit(opts);
     expect(result.allowed).toBe(false);
     expect(result.remaining).toBe(0);
   });
@@ -130,7 +140,6 @@ describe('applyRateLimit (in-memory fallback — no Redis)', () => {
     const blocked = await applyRateLimit(opts);
     expect(blocked.allowed).toBe(false);
 
-    // Advance time past the window so the bucket expires.
     vi.advanceTimersByTime(6_000);
 
     const afterReset = await applyRateLimit(opts);
@@ -142,6 +151,68 @@ describe('applyRateLimit (in-memory fallback — no Redis)', () => {
     const now = Date.now();
     const result = await applyRateLimit({ key: 'test:ip5', limit: 10, windowMs: 30_000 });
     expect(result.resetAt).toBeGreaterThan(now);
+  });
+});
+
+// ─── applyRateLimit (Render/standard Redis path) ──────────────────────────────
+
+describe('applyRateLimit (REDIS_URL backend)', () => {
+  let applyRateLimit: (opts: { key: string; limit: number; windowMs: number }) => Promise<{
+    allowed: boolean;
+    remaining: number;
+    resetAt: number;
+  }>;
+
+  beforeEach(async () => {
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
+    vi.stubEnv('REDIS_URL', 'redis://render-key-value.internal:6379');
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.resetModules();
+    ({ applyRateLimit } = await import('../../../lib/security/rate-limit'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('uses the standard Redis backend when REDIS_URL is configured', async () => {
+    const result = await applyRateLimit({ key: 'execute:ip1', limit: 5, windowMs: 60_000 });
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(result.resetAt).toBeGreaterThan(Date.now());
+  });
+});
+
+// ─── applyRateLimit (production fail-closed) ─────────────────────────────────
+
+describe('applyRateLimit (production fail-closed)', () => {
+  let applyRateLimit: (opts: { key: string; limit: number; windowMs: number }) => Promise<{
+    allowed: boolean;
+    remaining: number;
+    resetAt: number;
+  }>;
+
+  beforeEach(async () => {
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
+    vi.stubEnv('REDIS_URL', '');
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.resetModules();
+    ({ applyRateLimit } = await import('../../../lib/security/rate-limit'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('blocks when no distributed Redis backend is configured', async () => {
+    const result = await applyRateLimit({ key: 'execute:ip2', limit: 5, windowMs: 60_000 });
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.resetAt).toBeGreaterThan(Date.now());
   });
 });
 
@@ -173,7 +244,7 @@ describe('buildRateLimitHeaders', () => {
   });
 
   it('sets X-RateLimit-Reset to resetAt converted to seconds (floor)', () => {
-    const resetAt = 1_700_000_001_500; // 1700000001.5 seconds — should floor to 1700000001
+    const resetAt = 1_700_000_001_500;
     const headers = buildRateLimitHeaders({ allowed: false, remaining: 0, resetAt }, 10);
     expect(headers['X-RateLimit-Reset']).toBe('1700000001');
   });
@@ -202,6 +273,7 @@ describe('isRateLimiterConfigured', () => {
     vi.resetModules();
     vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
     vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
+    vi.stubEnv('REDIS_URL', '');
     ({ isRateLimiterConfigured } = await import('../../../lib/security/rate-limit'));
   });
 
@@ -210,7 +282,7 @@ describe('isRateLimiterConfigured', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns false when both env vars are absent', () => {
+  it('returns false when no distributed Redis backend is configured', () => {
     expect(isRateLimiterConfigured()).toBe(false);
   });
 
@@ -224,10 +296,16 @@ describe('isRateLimiterConfigured', () => {
     expect(isRateLimiterConfigured()).toBe(false);
   });
 
-  it('returns true when both env vars are set', async () => {
+  it('returns true when both Upstash env vars are set', async () => {
     vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://redis.example.com');
     vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'mytoken');
-    // Re-import so the function reads the freshly-stubbed env vars.
+    vi.resetModules();
+    ({ isRateLimiterConfigured } = await import('../../../lib/security/rate-limit'));
+    expect(isRateLimiterConfigured()).toBe(true);
+  });
+
+  it('returns true when REDIS_URL is set', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://render-key-value.internal:6379');
     vi.resetModules();
     ({ isRateLimiterConfigured } = await import('../../../lib/security/rate-limit'));
     expect(isRateLimiterConfigured()).toBe(true);


### PR DESCRIPTION
## Problem
Render production health requires a distributed rate limiter, but the current implementation only recognizes Upstash REST credentials. The Render workspace supports a native Key Value (Redis-compatible) service and the repo already depends on `redis@4.7.1`.

## Changes
- support standard Redis via `REDIS_URL` while keeping Upstash support
- use an atomic Redis Lua increment/expiry window for distributed limiting
- fail closed in production when no distributed Redis backend is configured or the configured backend errors
- keep in-memory fallback for non-production only
- update health wording to recognize either Upstash REST or `REDIS_URL`
- add unit coverage for standard Redis and production fail-closed behavior

## Production boundary
This PR does not claim production PASS. After CI passes, create/configure a Render Key Value instance, set `REDIS_URL`, deploy, and rerun external live smoke. Supabase service-role configuration remains a separate production blocker.