### PR TITLE
fix(supabase): support modern backend secret key

### DIFF
--- a/lib/deployment/readiness.ts
+++ b/lib/deployment/readiness.ts
@@ -1,6 +1,6 @@
 import { getDSGCoreConfig, getDSGCoreHealth } from '../dsg-core';
 import { checkFinanceGovernanceReadiness } from '../finance-governance/readiness';
-import { getSupabaseAdmin } from '../supabase-server';
+import { getSupabaseAdmin, hasSupabaseServerCredential } from '../supabase-server';
 
 type CheckResult = {
   ok: boolean;
@@ -53,8 +53,13 @@ async function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = RE
 }
 
 export async function getDeploymentReadiness(): Promise<ReadinessReport> {
-  const requiredEnv = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'DSG_CORE_MODE'];
+  const requiredEnv = ['NEXT_PUBLIC_SUPABASE_URL', 'DSG_CORE_MODE'];
   const missingEnv = requiredEnv.filter((name) => !process.env[name]);
+  // Preserve the legacy readiness label for API compatibility while accepting
+  // the modern SUPABASE_SECRET_KEY as the preferred backend credential.
+  if (!hasSupabaseServerCredential()) {
+    missingEnv.splice(1, 0, 'SUPABASE_SERVICE_ROLE_KEY');
+  }
   const envCheck = buildCheck(missingEnv.length === 0, missingEnv.length ? `missing:${missingEnv.join(',')}` : undefined);
 
   const nextAuthSecret = buildCheck(Boolean(process.env.NEXTAUTH_SECRET), process.env.NEXTAUTH_SECRET ? undefined : 'NEXTAUTH_SECRET missing');
@@ -142,7 +147,7 @@ export async function getDeploymentReadiness(): Promise<ReadinessReport> {
   };
 
   // Production readiness is fail-closed: a green release gate requires the
-  // environment, service-role DB probe, DSG core, and finance backend to pass.
+  // environment, privileged DB probe, DSG core, and finance backend to pass.
   // Local developers can opt out only with READINESS_STRICT=false; production
   // and preview deploys default to strict checks.
   const strictReadiness = parseBooleanFlag(process.env.READINESS_STRICT, process.env.NODE_ENV === 'production' || Boolean(process.env.VERCEL));

--- a/lib/finance-governance/readiness.ts
+++ b/lib/finance-governance/readiness.ts
@@ -1,4 +1,4 @@
-import { getSupabaseAdmin } from '../supabase-server';
+import { getSupabaseAdmin, hasSupabaseServerCredential } from '../supabase-server';
 
 type ReadinessCheck = {
   name: string;
@@ -28,11 +28,16 @@ const REQUIRED_TABLES = [
 ];
 
 function envCheck(name: string): ReadinessCheck {
+  const configured = name === 'SUPABASE_SERVICE_ROLE_KEY'
+    ? hasSupabaseServerCredential()
+    : Boolean(process.env[name]);
+
   return {
+    // Preserve the existing check name for response-schema compatibility.
     name: `env:${name}`,
-    ok: Boolean(process.env[name]),
+    ok: configured,
     required: true,
-    message: process.env[name] ? 'configured' : 'missing',
+    message: configured ? 'configured' : 'missing',
   };
 }
 

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -15,19 +15,35 @@ function withTimeoutFetch(input: RequestInfo | URL, init?: RequestInit): Promise
   }).finally(() => clearTimeout(timeout));
 }
 
+/**
+ * Prefer Supabase's modern backend-only secret API key and retain the legacy
+ * service_role key as a compatibility fallback during migration.
+ */
+export function getSupabaseServerCredential(): string | null {
+  const secretKey = process.env.SUPABASE_SECRET_KEY?.trim();
+  if (secretKey) return secretKey;
+
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  return serviceRoleKey || null;
+}
+
+export function hasSupabaseServerCredential(): boolean {
+  return Boolean(getSupabaseServerCredential());
+}
+
 export function getSupabaseAdmin() {
   if (adminClient) {
     return adminClient;
   }
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const serverCredential = getSupabaseServerCredential();
 
-  if (!url || !serviceRoleKey) {
+  if (!url || !serverCredential) {
     throw new Error('Missing Supabase server environment variables');
   }
 
-  adminClient = createClient<Database>(url, serviceRoleKey, {
+  adminClient = createClient<Database>(url, serverCredential, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/tests/unit/supabase-server-secret-key.test.ts
+++ b/tests/unit/supabase-server-secret-key.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('Supabase server credential selection', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('SUPABASE_SECRET_KEY', '');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers SUPABASE_SECRET_KEY when both credentials are present', async () => {
+    vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_modern');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'legacy-service-role');
+
+    const { getSupabaseServerCredential, hasSupabaseServerCredential } = await import('../../lib/supabase-server');
+
+    expect(getSupabaseServerCredential()).toBe('sb_secret_modern');
+    expect(hasSupabaseServerCredential()).toBe(true);
+  });
+
+  it('falls back to SUPABASE_SERVICE_ROLE_KEY for compatibility', async () => {
+    vi.stubEnv('SUPABASE_SECRET_KEY', '');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'legacy-service-role');
+
+    const { getSupabaseServerCredential, hasSupabaseServerCredential } = await import('../../lib/supabase-server');
+
+    expect(getSupabaseServerCredential()).toBe('legacy-service-role');
+    expect(hasSupabaseServerCredential()).toBe(true);
+  });
+
+  it('returns null and false when no privileged backend credential exists', async () => {
+    const { getSupabaseServerCredential, hasSupabaseServerCredential } = await import('../../lib/supabase-server');
+
+    expect(getSupabaseServerCredential()).toBeNull();
+    expect(hasSupabaseServerCredential()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
Production readiness currently hard-codes the legacy `SUPABASE_SERVICE_ROLE_KEY`. Supabase now recommends backend-only `sb_secret_...` API keys while legacy `service_role` remains a compatibility path.

## Changes
- prefer `SUPABASE_SECRET_KEY` for the server/admin Supabase client
- fall back to `SUPABASE_SERVICE_ROLE_KEY` for backward compatibility
- deployment readiness accepts either backend credential while preserving the existing response field/check names
- finance-governance readiness accepts either backend credential
- no client/browser exposure; the key remains server-only

## Production boundary
This PR does not create or expose a Supabase secret. After CI passes and this merges, production still requires a real `sb_secret_...` value to be created in Supabase Settings > API Keys and stored directly in Render as `SUPABASE_SECRET_KEY`. Then redeploy and rerun live health/readiness/Framer MCP smoke.