### PR TITLE
fix(framer): enforce server-side origin guard on MCP facade

### DIFF
--- a/app/api/framer/mcp/route.ts
+++ b/app/api/framer/mcp/route.ts
@@ -1,7 +1,11 @@
 import type { NextRequest } from 'next/server';
-import type { NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { GET as mcpGet, POST as mcpPost } from '@/app/api/mcp/route';
-import { buildCorsHeaders, buildPreflightResponse } from '@/lib/security/cors';
+import {
+  buildCorsHeaders,
+  buildPreflightResponse,
+  resolveAllowedOrigin,
+} from '@/lib/security/cors';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,14 +17,32 @@ function withCors(request: NextRequest, response: NextResponse): NextResponse {
   return response;
 }
 
+function rejectDisallowedOrigin(request: NextRequest): NextResponse | null {
+  const origin = request.headers.get('origin');
+  if (!origin) return null;
+
+  if (!resolveAllowedOrigin(request)) {
+    return NextResponse.json(
+      { error: 'Origin not allowed' },
+      { status: 403, headers: { Vary: 'Origin' } },
+    );
+  }
+
+  return null;
+}
+
 export async function OPTIONS(request: NextRequest) {
   return buildPreflightResponse(request);
 }
 
 export async function GET(request: NextRequest) {
+  const rejected = rejectDisallowedOrigin(request);
+  if (rejected) return rejected;
   return withCors(request, await mcpGet());
 }
 
 export async function POST(request: NextRequest) {
+  const rejected = rejectDisallowedOrigin(request);
+  if (rejected) return rejected;
   return withCors(request, await mcpPost(request));
 }

--- a/tests/unit/security/framer-mcp-cors-route.test.ts
+++ b/tests/unit/security/framer-mcp-cors-route.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  mcpGet: vi.fn(),
+  mcpPost: vi.fn(),
+}));
+
+vi.mock('@/app/api/mcp/route', () => ({
+  GET: mocks.mcpGet,
+  POST: mocks.mcpPost,
+}));
+
+import { GET, POST } from '@/app/api/framer/mcp/route';
+
+describe('/api/framer/mcp server-side origin guard', () => {
+  const allowedOrigin = 'https://multidisciplinary-badger-803385.framer.app';
+
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('DSG_ALLOWED_ORIGINS', allowedOrigin);
+    vi.stubEnv('APP_URL', 'https://tdealer01-crypto-dsg-control-plane.onrender.com');
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://tdealer01-crypto-dsg-control-plane.onrender.com');
+    mocks.mcpGet.mockReset();
+    mocks.mcpPost.mockReset();
+    mocks.mcpGet.mockResolvedValue(NextResponse.json({ ok: true }));
+    mocks.mcpPost.mockResolvedValue(NextResponse.json({ ok: true }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects a disallowed GET origin before the MCP handler runs', async () => {
+    const request = new NextRequest('https://backend.example/api/framer/mcp', {
+      method: 'GET',
+      headers: { Origin: 'https://not-allowed.invalid' },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('vary')).toBe('Origin');
+    expect(mocks.mcpGet).not.toHaveBeenCalled();
+  });
+
+  it('rejects a disallowed POST origin before the MCP handler runs', async () => {
+    const request = new NextRequest('https://backend.example/api/framer/mcp', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://not-allowed.invalid',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+    expect(mocks.mcpPost).not.toHaveBeenCalled();
+  });
+
+  it('allows the exact Framer production origin and returns exact ACAO', async () => {
+    const request = new NextRequest('https://backend.example/api/framer/mcp', {
+      method: 'GET',
+      headers: { Origin: allowedOrigin },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBe(allowedOrigin);
+    expect(response.headers.get('access-control-allow-credentials')).toBe('true');
+    expect(mocks.mcpGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows server-to-server requests with no Origin header', async () => {
+    const request = new NextRequest('https://backend.example/api/framer/mcp', {
+      method: 'GET',
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    expect(mocks.mcpGet).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Purpose
Harden `/api/framer/mcp` so requests that include a disallowed `Origin` are rejected with 403 before unified MCP handlers run. This complements the already-verified preflight CORS behavior.

## Scope
- only `app/api/framer/mcp/route.ts`
- targeted unit tests in `tests/unit/security/framer-mcp-cors-route.test.ts`
- no Render blueprint/config changes
- no auth, gate, solver, billing, or Supabase behavior changes

## Tests added
- disallowed GET origin -> 403 and MCP handler not called
- disallowed POST origin -> 403 and MCP handler not called
- exact production Framer origin -> 200 + exact ACAO
- no Origin header -> allowed for server-to-server use

## Production boundary
Current production already has verified preflight behavior: exact Framer origin 204 with exact ACAO, bad origin 403, health/readiness/MCP green. This PR is an extra server-side hardening layer and is not an authenticated user-session E2E claim.