### PR TITLE
fix(mcp): auth-gate DSG core tools and add dsg.classifyRisk

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -227,7 +227,13 @@ export async function POST(request: NextRequest) {
     }
 
     // Route DSG tools to the existing deterministic control-plane handler.
+    // Requires the same auth as the unified/platform-deploy tools: these compute
+    // and (for dsg.recordEvidence) are documented to persist evidence envelopes,
+    // so an anonymous caller must not be able to invoke them.
     if ((DSG_TOOL_NAMES as readonly string[]).includes(name)) {
+      const auth = await resolveUnifiedAuth(request, name, rpc.id);
+      if (auth instanceof NextResponse) return auth;
+
       const dsgResult = await callDsgTool(name as DsgToolName, args);
       if (dsgResult.ok === false) {
         return rpcToolResult(

--- a/docs/UNIFIED_MCP_GATEWAY.md
+++ b/docs/UNIFIED_MCP_GATEWAY.md
@@ -62,7 +62,12 @@ A compromise of one derived token does not reveal the root key or make the other
 - `dsg.aimo.solve` — run DSG ONE -> AGI deterministic shards -> Cinema proof gate.
 - `dsg.aws.contract` — return the Plan -> Gate -> AWS execution -> Evidence -> Verification contract.
 - `dsg.aws.deploy` — inspect AWS deployment evidence, run the deterministic gate, require explicit approval, suppress duplicate retries, then dispatch the governed CDK workflow.
+- `dsg.classifyRisk` — deterministic EU AI Act-aligned risk-tier classification from caller-supplied capability flags, sourced from `docs/consult-toolkit/risk-classification-checklist.md`.
 - Existing DSG/Hermes/Android tools remain available through the same `/api/mcp` endpoint.
+
+## Auth on the DSG tool set
+
+`dsg.evaluate`, `dsg.verifyClaim`, `dsg.recordEvidence`, `dsg.exportComplianceBundle`, `dsg.getReadiness`, and `dsg.classifyRisk` require the same auth as the unified/platform-deploy tools (issued DSG API key or an operator/org_admin session). `dsg.recordEvidence` is documented to persist an evidence envelope into the CCVS chain, so it must not be callable anonymously.
 
 ## AWS authorization and evidence
 

--- a/lib/mcp/dsg-tools.ts
+++ b/lib/mcp/dsg-tools.ts
@@ -56,6 +56,8 @@ export async function callDsgTool(
         return handleExportComplianceBundle(args);
       case 'dsg.getReadiness':
         return handleGetReadiness();
+      case 'dsg.classifyRisk':
+        return handleClassifyRisk(args);
       default:
         return { ok: false, code: -32601, message: `Unknown DSG tool: ${String(name)}` };
     }
@@ -257,6 +259,92 @@ function handleExportComplianceBundle(args: Record<string, unknown>): DsgToolRes
   };
 
   return { ok: true, result: matrix };
+}
+
+type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+const RISK_ORDER: RiskLevel[] = ['low', 'medium', 'high', 'critical'];
+
+// Base tier per capability flag, sourced from docs/consult-toolkit/risk-classification-checklist.md.
+// hasNoCurrentAuditTrail / hasNoApprovalBeforeExecution are escalation modifiers, not base tiers,
+// matching the checklist's "Raises risk" wording rather than a standalone classification.
+const CAPABILITY_BASE_RISK: Record<string, RiskLevel> = {
+  canChangeProductionData: 'high',
+  canSendExternalCommunication: 'medium',
+  canMoveMoneyOrApprovePayment: 'critical',
+  canDeploySoftware: 'high',
+  canGrantAccessOrChangePermissions: 'critical',
+  canAccessRegulatedOrSensitiveData: 'high',
+  canCallAdminOrInternalApis: 'high',
+  canAffectMultipleTenants: 'critical',
+};
+
+const ESCALATION_FLAGS = ['hasNoCurrentAuditTrail', 'hasNoApprovalBeforeExecution'] as const;
+
+const REQUIRED_EVIDENCE_BY_LEVEL: Record<RiskLevel, string[]> = {
+  low: ['audit_log'],
+  medium: ['plan_check', 'request_hash', 'record_hash', 'audit_export'],
+  high: ['plan_check', 'approval_or_risk_control', 'invariant_check', 'audit_export'],
+  critical: ['block_by_default', 'explicit_approval_path', 'signed_evidence_bundle_when_available'],
+};
+
+const RECOMMENDED_MODE_BY_LEVEL: Record<RiskLevel, string> = {
+  low: 'log-and-monitor',
+  medium: 'plan-check',
+  high: 'approval-required',
+  critical: 'block-by-default',
+};
+
+function escalate(level: RiskLevel): RiskLevel {
+  const nextIndex = Math.min(RISK_ORDER.indexOf(level) + 1, RISK_ORDER.length - 1);
+  return RISK_ORDER[nextIndex];
+}
+
+function handleClassifyRisk(args: Record<string, unknown>): DsgToolResult {
+  const actionDescription = String(args.actionDescription ?? '').trim();
+  if (!actionDescription) {
+    return { ok: false, code: -32602, message: 'actionDescription is required' };
+  }
+
+  const capabilities = (args.capabilities && typeof args.capabilities === 'object')
+    ? args.capabilities as Record<string, unknown>
+    : {};
+
+  const triggeredBy: string[] = [];
+  let riskLevel: RiskLevel = 'low';
+  for (const [flag, baseLevel] of Object.entries(CAPABILITY_BASE_RISK)) {
+    if (capabilities[flag] === true) {
+      triggeredBy.push(flag);
+      if (RISK_ORDER.indexOf(baseLevel) > RISK_ORDER.indexOf(riskLevel)) {
+        riskLevel = baseLevel;
+      }
+    }
+  }
+
+  let escalated = false;
+  for (const flag of ESCALATION_FLAGS) {
+    if (capabilities[flag] === true) {
+      triggeredBy.push(flag);
+      riskLevel = escalate(riskLevel);
+      escalated = true;
+    }
+  }
+
+  return {
+    ok: true,
+    result: {
+      actionDescription,
+      riskLevel,
+      requiresApproval: riskLevel === 'high' || riskLevel === 'critical',
+      recommendedMode: RECOMMENDED_MODE_BY_LEVEL[riskLevel],
+      requiredEvidence: REQUIRED_EVIDENCE_BY_LEVEL[riskLevel],
+      triggeredBy,
+      escalated,
+      boundary: {
+        sourceDoc: 'docs/consult-toolkit/risk-classification-checklist.md',
+        statement: 'Deterministic classification from caller-supplied capability flags. Not a legal, security, or compliance review. Unanswered flags are treated as false, never as unknown-therefore-high — omit optimistic flags rather than guessing them true.',
+      },
+    },
+  };
 }
 
 function handleGetReadiness(): DsgToolResult {

--- a/lib/mcp/schemas.ts
+++ b/lib/mcp/schemas.ts
@@ -168,6 +168,51 @@ export const DSG_TOOL_SCHEMAS = {
       required: ['ok', 'readinessLevel'],
     },
   },
+
+  'dsg.classifyRisk': {
+    description:
+      'Deterministically classify an AI-proposed action into an EU AI Act-aligned risk tier (low/medium/high/critical), sourced from docs/consult-toolkit/risk-classification-checklist.md. Caller supplies explicit capability flags; ambiguous or unanswered flags never lower the resulting tier.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        actionDescription: {
+          type: 'string',
+          description: 'Human-readable label for the action being classified (used in the returned record only, not in the classification logic).',
+        },
+        capabilities: {
+          type: 'object',
+          description: 'Explicit yes/no answers to the risk-classification checklist questions. Omitted flags are treated as false (lowest risk contribution), never as unknown-therefore-high.',
+          properties: {
+            canChangeProductionData: { type: 'boolean', default: false },
+            canSendExternalCommunication: { type: 'boolean', default: false },
+            canMoveMoneyOrApprovePayment: { type: 'boolean', default: false },
+            canDeploySoftware: { type: 'boolean', default: false },
+            canGrantAccessOrChangePermissions: { type: 'boolean', default: false },
+            canAccessRegulatedOrSensitiveData: { type: 'boolean', default: false },
+            canCallAdminOrInternalApis: { type: 'boolean', default: false },
+            canAffectMultipleTenants: { type: 'boolean', default: false },
+            hasNoCurrentAuditTrail: { type: 'boolean', default: false },
+            hasNoApprovalBeforeExecution: { type: 'boolean', default: false },
+          },
+          additionalProperties: false,
+        },
+      },
+      required: ['actionDescription'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        riskLevel: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+        requiresApproval: { type: 'boolean' },
+        recommendedMode: { type: 'string' },
+        requiredEvidence: { type: 'array', items: { type: 'string' } },
+        triggeredBy: { type: 'array', items: { type: 'string' } },
+        escalated: { type: 'boolean' },
+        boundary: { type: 'object' },
+      },
+      required: ['riskLevel', 'requiresApproval', 'recommendedMode', 'requiredEvidence'],
+    },
+  },
 } as const;
 
 export type DsgToolName = keyof typeof DSG_TOOL_SCHEMAS;

--- a/tests/unit/mcp/dsg-classify-risk.test.ts
+++ b/tests/unit/mcp/dsg-classify-risk.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { callDsgTool } from '@/lib/mcp/dsg-tools';
+
+describe('dsg.classifyRisk', () => {
+  it('rejects a missing actionDescription', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {});
+    expect(result.ok).toBe(false);
+  });
+
+  it('classifies a plain action with no flags as low risk', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {
+      actionDescription: 'read a dashboard widget',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const output = result.result as { riskLevel: string; requiresApproval: boolean };
+      expect(output.riskLevel).toBe('low');
+      expect(output.requiresApproval).toBe(false);
+    }
+  });
+
+  it('classifies money movement as critical', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {
+      actionDescription: 'approve a vendor payout',
+      capabilities: { canMoveMoneyOrApprovePayment: true },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const output = result.result as { riskLevel: string; requiredEvidence: string[] };
+      expect(output.riskLevel).toBe('critical');
+      expect(output.requiredEvidence).toContain('explicit_approval_path');
+    }
+  });
+
+  it('takes the highest triggered base tier, not the last one evaluated', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {
+      actionDescription: 'send a notification and deploy a hotfix',
+      capabilities: {
+        canSendExternalCommunication: true, // medium
+        canDeploySoftware: true, // high
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const output = result.result as { riskLevel: string };
+      expect(output.riskLevel).toBe('high');
+    }
+  });
+
+  it('escalates a level when there is no audit trail, never de-escalates', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {
+      actionDescription: 'send an external email with no logging',
+      capabilities: {
+        canSendExternalCommunication: true, // medium
+        hasNoCurrentAuditTrail: true, // +1
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const output = result.result as { riskLevel: string; escalated: boolean };
+      expect(output.riskLevel).toBe('high');
+      expect(output.escalated).toBe(true);
+    }
+  });
+
+  it('caps escalation at critical instead of overflowing', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {
+      actionDescription: 'grant admin access with no approval',
+      capabilities: {
+        canGrantAccessOrChangePermissions: true, // critical
+        hasNoApprovalBeforeExecution: true, // would overflow past critical
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const output = result.result as { riskLevel: string };
+      expect(output.riskLevel).toBe('critical');
+    }
+  });
+
+  it('never claims certification or independent audit in its boundary', async () => {
+    const result = await callDsgTool('dsg.classifyRisk', {
+      actionDescription: 'deploy software',
+      capabilities: { canDeploySoftware: true },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const output = result.result as { boundary: { statement: string } };
+      expect(output.boundary.statement.toLowerCase()).not.toContain('certified');
+    }
+  });
+});


### PR DESCRIPTION
Goal:
Close two gaps found while auditing `/api/mcp` (the unified MCP gateway) against the EU AI Act runtime-evidence buyer checklist: (1) the `DSG_TOOL_NAMES` branch of the route (`dsg.evaluate`, `dsg.verifyClaim`, `dsg.recordEvidence`, `dsg.exportComplianceBundle`, `dsg.getReadiness`) had no auth check, unlike the unified/platform-deploy/Hermes branches on the same route — confirmed live via unauthenticated `curl` against production before this fix; (2) risk classification was a static doc (`docs/consult-toolkit/risk-classification-checklist.md`) with no callable tool, the single largest gap against the buyer checklist.

Files changed:
- `app/api/mcp/route.ts` — the `DSG_TOOL_NAMES` branch now calls `resolveUnifiedAuth` before `callDsgTool`, matching the unified/platform-deploy branches.
- `lib/mcp/schemas.ts` — new `dsg.classifyRisk` tool schema.
- `lib/mcp/dsg-tools.ts` — new `handleClassifyRisk`, wired into `callDsgTool`. Deterministic: capability flags map to a base risk tier, `hasNoCurrentAuditTrail`/`hasNoApprovalBeforeExecution` only escalate (capped at `critical`), unanswered flags default to `false` (never to an assumed higher tier).
- `docs/UNIFIED_MCP_GATEWAY.md` — documents the new tool and the auth requirement on the DSG tool set.
- `tests/unit/mcp/dsg-classify-risk.test.ts` — 7 new unit tests covering the missing-input rejection, base-tier selection (highest wins, not last-evaluated), escalation, escalation cap, and the claim-boundary wording.

Verification:
- [x] `npm run typecheck` — clean, no errors (pre-existing TS5101 deprecation notices confirmed present on `main` too via `git stash`, unrelated to this change)
- [x] `npm run test -- tests/unit/mcp/dsg-classify-risk.test.ts` — 7/7 passed
- [x] `npm run test -- tests/unit/mcp-oauth-helper.test.ts tests/unit/security/framer-mcp-cors-route.test.ts tests/integration/mcp-context-discovery.test.ts` — no regressions (20 passed, 14 pre-existing skips)
- [x] Live production `curl` against `POST /api/mcp` `dsg.getReadiness` and `dsg.exportComplianceBundle` with no auth header, prior to this fix, to confirm the gap was real and not just a static-read inference
- [ ] `npm run build` — not run (no environment/DB secrets configured in this session; typecheck + targeted unit tests are the narrowest relevant check for this change per the repo's verification ladder)
- [ ] Live re-check of the same unauthenticated `dsg.getReadiness` call against production after this PR deploys, to confirm it now returns 401 — not run, since that requires this PR to merge and deploy first

Known limits:
- `dsg.recordEvidence` still does not persist anything to the CCVS chain today (it only computes and returns an envelope hash) — the auth fix closes the exposure *before* that persistence is implemented, it does not add the persistence itself.
- `dsg.classifyRisk` is a deterministic flag-based classifier, not an NLP/AI classifier — it will not infer capabilities from a free-text description; the caller must supply explicit capability flags. This is intentional (matches the repo's no-guessing/never-downgrade risk posture) but means integration work is needed wherever a caller only has a free-text action description today.
- Model inventory (`dsg.listRegisteredAgents`) and per-decision framework attribution (`regulatoryControlIds` on `dsg.evaluate`) from the same gap analysis are not part of this PR.

User-visible benefit:
- The five existing DSG governance/evidence tools on `/api/mcp` can no longer be called anonymously.
- MCP clients (Claude, other agents) can now call `dsg.classifyRisk` to get a deterministic EU AI Act-aligned risk tier, required-evidence list, and approval requirement for a proposed action, instead of only having a static checklist doc.

Next step:
- After merge/deploy, re-run the unauthenticated live `curl` check against production to confirm `dsg.getReadiness`/`dsg.exportComplianceBundle` now reject anonymous calls.
- Follow-up PR(s) for `regulatoryControlIds` on `dsg.evaluate` and `dsg.listRegisteredAgents` (model inventory), per the gap analysis this PR is based on.

---
_Generated by [Claude Code](https://claude.ai/code/session_011h3SooxjNjQvnDMgmL7YbQ)_