### PR TITLE
fix: make OAuth bearer auth work at unified MCP gateway

### DIFF
--- a/lib/mcp/unified-auth.ts
+++ b/lib/mcp/unified-auth.ts
@@ -1,4 +1,5 @@
 import { hashMcpApiKey } from '@/lib/dsg/mcp/api-key-crypto';
+import { hashAccessToken } from './oauth-helper';
 import {
   callDsgRpc,
   getDsgSupabaseRpcConfig,
@@ -6,7 +7,7 @@ import {
 import type { RuntimeRole } from '@/lib/authz';
 
 export type UnifiedAuthContext = {
-  source: 'api-key' | 'session';
+  source: 'api-key' | 'oauth' | 'session';
   actorId: string;
   orgId: string;
   roles: RuntimeRole[];
@@ -27,20 +28,51 @@ type StoredKeyRow = {
   calls_limit: number;
 };
 
+type StoredOAuthRow = {
+  token_id: string;
+  key_id: string;
+  key_actor_id: string;
+  actor_id: string;
+  org_id: string;
+  roles: string[];
+  plan_id: string;
+  calls_used: number;
+  calls_limit: number;
+  scope: string;
+};
+
 type StoredKeyValidation =
   | { presented: false; valid: false }
   | { presented: true; valid: false; reason: string }
   | { presented: true; valid: true; context: UnifiedAuthContext };
 
-function extractRawMcpKey(request: Request): string | undefined {
-  const explicit =
-    request.headers.get('x-dsg-api-key') ?? request.headers.get('x-api-key');
-  if (explicit?.trim()) return explicit.trim();
+type PresentedCredential =
+  | { kind: 'api-key'; value: string }
+  | { kind: 'oauth'; value: string }
+  | { kind: 'invalid'; reason: string }
+  | null;
+
+function extractPresentedCredential(request: Request): PresentedCredential {
+  const explicit = request.headers.get('x-dsg-api-key') ?? request.headers.get('x-api-key');
+  if (explicit?.trim()) {
+    const value = explicit.trim();
+    return value.startsWith('dsg_')
+      ? { kind: 'api-key', value }
+      : { kind: 'invalid', reason: 'INVALID_MCP_KEY_FORMAT' };
+  }
 
   const authorization = request.headers.get('authorization');
-  if (!authorization?.toLowerCase().startsWith('bearer ')) return undefined;
+  if (!authorization) return null;
+
+  if (!authorization.toLowerCase().startsWith('bearer ')) {
+    return { kind: 'invalid', reason: 'INVALID_MCP_AUTH_SCHEME' };
+  }
+
   const bearer = authorization.slice('bearer '.length).trim();
-  return bearer.startsWith('dsg_') ? bearer : undefined;
+  if (bearer.startsWith('dsg_')) return { kind: 'api-key', value: bearer };
+  if (bearer.startsWith('mcp_')) return { kind: 'oauth', value: bearer };
+
+  return { kind: 'invalid', reason: 'INVALID_MCP_CREDENTIAL_FORMAT' };
 }
 
 function normalizeRuntimeRole(value: string): RuntimeRole | null {
@@ -56,58 +88,121 @@ function normalizeRuntimeRole(value: string): RuntimeRole | null {
   return null;
 }
 
+function normalizeRoles(values: unknown): RuntimeRole[] {
+  return Array.from(
+    new Set(
+      (Array.isArray(values) ? values : [])
+        .map((role) => normalizeRuntimeRole(String(role)))
+        .filter((role): role is RuntimeRole => Boolean(role)),
+    ),
+  ).sort();
+}
+
+function hasRequiredOAuthScope(scope: unknown): boolean {
+  return typeof scope === 'string' && scope.trim().split(' ').includes('mcp:execute');
+}
+
 export async function validateStoredUnifiedMcpKey(
   request: Request,
   toolName: string,
 ): Promise<StoredKeyValidation> {
-  const rawKey = extractRawMcpKey(request);
-  if (!rawKey) return { presented: false, valid: false };
-  if (!rawKey.startsWith('dsg_')) {
-    return { presented: true, valid: false, reason: 'INVALID_MCP_KEY_FORMAT' };
+  const credential = extractPresentedCredential(request);
+  if (!credential) return { presented: false, valid: false };
+  if (credential.kind === 'invalid') {
+    return { presented: true, valid: false, reason: credential.reason };
   }
 
   try {
-    const keyHash = await hashMcpApiKey(rawKey);
     const config = getDsgSupabaseRpcConfig();
-    const rows = await callDsgRpc<StoredKeyRow[]>(
-      config,
-      'validate_mcp_api_key_context',
-      { p_key_hash: keyHash },
-    );
-    const row = rows?.[0];
 
-    if (!row?.key_id || !row.key_actor_id || !row.actor_id || !row.org_id) {
+    if (credential.kind === 'api-key') {
+      const keyHash = await hashMcpApiKey(credential.value);
+      const rows = await callDsgRpc<StoredKeyRow[]>(
+        config,
+        'validate_mcp_api_key_context',
+        { p_key_hash: keyHash },
+      );
+      const row = rows?.[0];
+
+      if (!row?.key_id || !row.key_actor_id || !row.actor_id || !row.org_id) {
+        return {
+          presented: true,
+          valid: false,
+          reason: 'MCP_KEY_REVOKED_EXPIRED_OR_QUOTA_EXCEEDED',
+        };
+      }
+
+      const roles = normalizeRoles(row.roles);
+      if (roles.length === 0) {
+        return { presented: true, valid: false, reason: 'MCP_KEY_ACTOR_NOT_ACTIVE' };
+      }
+
+      // Meter only after the key, actor, and runtime roles pass authorization.
+      await callDsgRpc<void>(config, 'record_mcp_usage', {
+        p_key_id: row.key_id,
+        p_actor_id: row.key_actor_id,
+        p_tool_name: toolName,
+      });
+
       return {
         presented: true,
-        valid: false,
-        reason: 'MCP_KEY_REVOKED_EXPIRED_OR_QUOTA_EXCEEDED',
+        valid: true,
+        context: {
+          source: 'api-key',
+          actorId: row.actor_id,
+          orgId: row.org_id,
+          roles,
+          keyId: String(row.key_id),
+          planId: String(row.plan_id),
+          callsUsed: Number(row.calls_used),
+          callsLimit: Number(row.calls_limit),
+        },
       };
     }
 
-    const roles = Array.from(
-      new Set(
-        (Array.isArray(row.roles) ? row.roles : [])
-          .map((role) => normalizeRuntimeRole(String(role)))
-          .filter((role): role is RuntimeRole => Boolean(role)),
-      ),
-    ).sort();
+    const tokenHash = hashAccessToken(credential.value);
+    const rows = await callDsgRpc<StoredOAuthRow[]>(
+      config,
+      'validate_mcp_oauth_token_context',
+      { p_token_hash: tokenHash },
+    );
+    const row = rows?.[0];
 
-    if (roles.length === 0) {
-      return { presented: true, valid: false, reason: 'MCP_KEY_ACTOR_NOT_ACTIVE' };
+    if (
+      !row?.token_id ||
+      !row.key_id ||
+      !row.key_actor_id ||
+      !row.actor_id ||
+      !row.org_id ||
+      !hasRequiredOAuthScope(row.scope)
+    ) {
+      return {
+        presented: true,
+        valid: false,
+        reason: 'MCP_OAUTH_TOKEN_INVALID_EXPIRED_REVOKED_OR_QUOTA_EXCEEDED',
+      };
     }
 
-    // Meter only after the key, actor, and runtime roles pass authorization.
+    const roles = normalizeRoles(row.roles);
+    if (roles.length === 0) {
+      return { presented: true, valid: false, reason: 'MCP_OAUTH_ACTOR_NOT_ACTIVE' };
+    }
+
+    // OAuth tokens inherit the linked API key quota and also update token last-used state.
     await callDsgRpc<void>(config, 'record_mcp_usage', {
       p_key_id: row.key_id,
       p_actor_id: row.key_actor_id,
       p_tool_name: toolName,
+    });
+    await callDsgRpc<void>(config, 'record_mcp_oauth_token_usage', {
+      p_token_id: row.token_id,
     });
 
     return {
       presented: true,
       valid: true,
       context: {
-        source: 'api-key',
+        source: 'oauth',
         actorId: row.actor_id,
         orgId: row.org_id,
         roles,

--- a/supabase/migrations/20260810000002_secure_mcp_oauth_context.sql
+++ b/supabase/migrations/20260810000002_secure_mcp_oauth_context.sql
@@ -1,0 +1,164 @@
+-- Make OAuth bearer tokens first-class credentials for the unified MCP gateway.
+-- The token remains opaque to the gateway; authorization, role resolution, and
+-- quota checks happen in one server-only security-definer RPC.
+
+create or replace function public.validate_mcp_oauth_token_context(
+  p_token_hash text
+) returns table(
+  token_id      uuid,
+  key_id        uuid,
+  key_actor_id  uuid,
+  actor_id      uuid,
+  org_id        text,
+  roles         text[],
+  plan_id       text,
+  calls_used    integer,
+  calls_limit   integer,
+  scope         text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_token_id      uuid;
+  v_key_id        uuid;
+  v_key_actor_id  uuid;
+  v_plan_id       text;
+  v_scope         text;
+  v_calls_limit   integer;
+  v_period_start  timestamptz;
+  v_period_end    timestamptz;
+  v_calls_used    integer;
+  v_actor_id      uuid;
+  v_org_uuid      uuid;
+  v_base_role     text;
+  v_runtime_role  text;
+  v_roles         text[] := '{}'::text[];
+begin
+  select
+    t.token_id,
+    k.key_id,
+    k.actor_id,
+    t.scope,
+    k.plan_id,
+    k.calls_limit,
+    k.period_start,
+    k.period_end,
+    count(u.usage_id)::integer
+  into
+    v_token_id,
+    v_key_id,
+    v_key_actor_id,
+    v_scope,
+    v_plan_id,
+    v_calls_limit,
+    v_period_start,
+    v_period_end,
+    v_calls_used
+  from public.mcp_oauth_tokens t
+  join public.dsg_mcp_api_keys k
+    on k.key_id = t.key_id
+   and k.actor_id = t.actor_id
+  left join public.dsg_mcp_usage u
+    on u.key_id = k.key_id
+   and u.called_at >= k.period_start
+   and u.called_at < k.period_end
+  where t.token_hash = p_token_hash
+    and t.revoked_at is null
+    and t.expires_at > now()
+    and k.status = 'ACTIVE'
+    and k.period_end > now()
+  group by
+    t.token_id,
+    k.key_id,
+    k.actor_id,
+    t.scope,
+    k.plan_id,
+    k.calls_limit,
+    k.period_start,
+    k.period_end
+  having count(u.usage_id) < k.calls_limit
+  limit 1;
+
+  if v_token_id is null then
+    return;
+  end if;
+
+  if coalesce(v_scope, '') !~ '(^|[[:space:]])mcp:execute([[:space:]]|$)' then
+    return;
+  end if;
+
+  select
+    u.id,
+    u.org_id,
+    lower(coalesce(u.role, ''))
+  into
+    v_actor_id,
+    v_org_uuid,
+    v_base_role
+  from public.users u
+  where u.auth_user_id = v_key_actor_id
+    and u.is_active = true
+    and u.org_id is not null
+  limit 1;
+
+  if v_actor_id is null then
+    return;
+  end if;
+
+  v_roles := case
+    when v_base_role in ('owner', 'admin') then
+      array['org_admin', 'operator', 'reviewer', 'runtime_auditor', 'billing_admin']::text[]
+    when v_base_role = 'viewer' then
+      array['reviewer']::text[]
+    when v_base_role in ('org_admin', 'operator', 'reviewer', 'runtime_auditor', 'billing_admin') then
+      array[v_base_role]::text[]
+    else
+      '{}'::text[]
+  end;
+
+  for v_runtime_role in
+    select rr.role
+    from public.runtime_roles rr
+    where rr.org_id = v_org_uuid
+      and rr.user_id = v_actor_id
+  loop
+    if not (v_runtime_role = any(v_roles)) then
+      v_roles := array_append(v_roles, v_runtime_role);
+    end if;
+  end loop;
+
+  return query
+  select
+    v_token_id,
+    v_key_id,
+    v_key_actor_id,
+    v_actor_id,
+    v_org_uuid::text,
+    v_roles,
+    v_plan_id,
+    v_calls_used,
+    v_calls_limit,
+    v_scope;
+end;
+$$;
+
+revoke all on function public.validate_mcp_oauth_token_context(text) from public, anon, authenticated;
+grant execute on function public.validate_mcp_oauth_token_context(text) to service_role;
+
+-- OAuth lifecycle and validation RPCs are server-only. The browser uses the
+-- authorization/token routes, which call them with the server credential.
+revoke all on function public.validate_mcp_oauth_token(text) from public, anon, authenticated;
+revoke all on function public.create_mcp_oauth_token(uuid, uuid, text, text, integer) from public, anon, authenticated;
+revoke all on function public.revoke_mcp_oauth_token(text, uuid) from public, anon, authenticated;
+revoke all on function public.record_mcp_oauth_token_usage(uuid) from public, anon, authenticated;
+revoke all on function public.create_mcp_oauth_code(uuid, text, text, text, text, text, text) from public, anon, authenticated;
+revoke all on function public.exchange_mcp_oauth_code(text, text, text, uuid, integer) from public, anon, authenticated;
+
+grant execute on function public.validate_mcp_oauth_token(text) to service_role;
+grant execute on function public.create_mcp_oauth_token(uuid, uuid, text, text, integer) to service_role;
+grant execute on function public.revoke_mcp_oauth_token(text, uuid) to service_role;
+grant execute on function public.record_mcp_oauth_token_usage(uuid) to service_role;
+grant execute on function public.create_mcp_oauth_code(uuid, text, text, text, text, text, text) to service_role;
+grant execute on function public.exchange_mcp_oauth_code(text, text, text, uuid, integer) to service_role;


### PR DESCRIPTION
## Summary

- Accept the `mcp_...` OAuth bearer token issued by the existing MCP OAuth flow at `/api/mcp`.
- Resolve OAuth token, linked key, actor, organization, runtime roles, scope, expiry, and quota in one server-only Supabase RPC.
- Meter unified MCP usage and update OAuth token last-used state after authorization.
- Revoke public execution on the OAuth lifecycle RPCs.

## Truth boundary

This keeps the existing fail-closed behavior: invalid, expired, revoked, over-quota, wrong-scope, or role-less credentials are denied before any tool runs. Session-cookie auth remains available for first-party browser requests; OAuth bearer auth now works for remote MCP clients without placing a raw DSG API key in the session.

## Validation

CI should run the existing unified gateway/security/proof gates plus typecheck and tests.