### PR TITLE
fix: publish correct OAuth issuer behind Render proxy

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getAuthorizationServerMetadata } from '@/lib/mcp/oauth-helper';
+import { getAuthorizationServerMetadata, getOAuthIssuer } from '@/lib/mcp/oauth-helper';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,8 +20,7 @@ export const dynamic = 'force-dynamic';
  * - Client secret basic authentication
  */
 export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const issuer = `${url.protocol}//${url.host}`;
+  const issuer = getOAuthIssuer(request);
 
   const metadata = getAuthorizationServerMetadata(issuer);
 

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getProtectedResourceMetadata } from '@/lib/mcp/oauth-helper';
+import { getProtectedResourceMetadata, getOAuthIssuer } from '@/lib/mcp/oauth-helper';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,8 +15,7 @@ export const dynamic = 'force-dynamic';
  * 3. Discover token endpoint and other related endpoints
  */
 export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const issuer = `${url.protocol}//${url.host}`;
+  const issuer = getOAuthIssuer(request);
 
   const metadata = getProtectedResourceMetadata(issuer);
 

--- a/lib/mcp/oauth-helper.ts
+++ b/lib/mcp/oauth-helper.ts
@@ -18,7 +18,7 @@ function getStateSecret(): string {
  */
 export function getOAuthIssuer(request: Request): string {
   const configured = process.env.MCP_OAUTH_ISSUER?.trim();
-  if (configured) return configured.replace(/\\/+$/, '');
+  if (configured) return configured.replace(/\/+$/, '');
 
   const url = new URL(request.url);
   const forwardedProto = request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();

--- a/lib/mcp/oauth-helper.ts
+++ b/lib/mcp/oauth-helper.ts
@@ -10,6 +10,24 @@ function getStateSecret(): string {
   return process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET || '';
 }
 
+
+/**
+ * Resolve the public OAuth issuer when the app runs behind a reverse proxy.
+ * Render may expose an internal request URL, so prefer explicit configuration
+ * and otherwise honor the proxy's forwarded origin headers.
+ */
+export function getOAuthIssuer(request: Request): string {
+  const configured = process.env.MCP_OAUTH_ISSUER?.trim();
+  if (configured) return configured.replace(/\\/+$/, '');
+
+  const url = new URL(request.url);
+  const forwardedProto = request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
+  const forwardedHost = request.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
+  const protocol = forwardedProto || url.protocol.replace(':', '');
+  const host = forwardedHost || url.host;
+  return protocol + '://' + host;
+}
+
 type StatePayload = {
   codeChallenge: string;
   nonce: string;


### PR DESCRIPTION
Use the configured public OAuth issuer, with forwarded-origin fallback, so RFC 8414/RFC 9728 metadata never advertises Render's internal localhost origin.