### PR TITLE
feat: monetize Encoding Proof Gate via Framer + existing billing

### DIFF
--- a/app/api/dsg/v1/encoding/prove/route.ts
+++ b/app/api/dsg/v1/encoding/prove/route.ts
@@ -2,24 +2,37 @@
  * Encoding Proof Gate API Route
  * POST /api/dsg/v1/encoding/prove
  *
- * Validates QUBO/Ising encodings and generates encoding proofs.
+ * Validates QUBO/Ising encodings and generates deterministic encoding proofs.
+ * Access is authenticated, org-rate-limited, and metered through the existing
+ * DSG gate entitlement pipeline.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createEncodingProof } from '@/lib/dsg/deterministic/encoding-proof-engine';
 import { handleApiError } from '@/lib/security/api-error';
 import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import {
+  requireDsgAuth,
+  dsgAuthError,
+  logDsgApiCall,
+} from '@/lib/dsg/auth/require-dsg-auth';
+import {
+  checkGateEntitlement,
+  recordGateEvaluation,
+} from '@/lib/dsg/gate-entitlement';
+import {
   ProblemEncoding,
-  EncodingProveRequest,
   EncodingProveSuccessResponse,
   EncodingProveErrorResponse,
 } from '@/lib/dsg/deterministic/encoding-proof-types';
 
 export const dynamic = 'force-dynamic';
 
-/**
- * Validate request payload structure
- */
 function validateRequest(data: any): { valid: boolean; error?: string } {
   if (!data.problemId || typeof data.problemId !== 'string') {
     return { valid: false, error: 'problemId is required and must be a string' };
@@ -48,10 +61,7 @@ function validateRequest(data: any): { valid: boolean; error?: string } {
   return { valid: true };
 }
 
-/**
- * Validate encoding structure
- */
-function validateEncoding(encoding: any): { valid: boolean; error?: string } {
+function validateEncoding(encoding: any, encodingType: string): { valid: boolean; error?: string } {
   if (!Number.isInteger(encoding.variableCount) || encoding.variableCount <= 0) {
     return { valid: false, error: 'variableCount must be a positive integer' };
   }
@@ -59,6 +69,10 @@ function validateEncoding(encoding: any): { valid: boolean; error?: string } {
   const kind = encoding.kind;
   if (!kind || !['qubo-v1', 'ising-v1'].includes(kind)) {
     return { valid: false, error: 'encoding.kind must be "qubo-v1" or "ising-v1"' };
+  }
+
+  if (kind !== encodingType) {
+    return { valid: false, error: 'encoding.kind must match encodingType' };
   }
 
   if (kind === 'qubo-v1') {
@@ -80,39 +94,55 @@ function validateEncoding(encoding: any): { valid: boolean; error?: string } {
   return { valid: true };
 }
 
-/**
- * POST /api/dsg/v1/encoding/prove
- *
- * Request body:
- * {
- *   "problemId": "string",
- *   "encodingType": "qubo-v1" | "ising-v1",
- *   "encoding": { ... },
- *   "nonce": "string",
- *   "idempotencyKey": "string"
- * }
- *
- * Response: EncodingProveResponse
- */
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  const caller = await requireDsgAuth(req);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const startMs = Date.now();
+
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(req, `dsg-encoding-proof:${caller.orgId}`),
+    limit: 60,
+    windowMs: 60_000,
+  });
+  const rateLimitHeaders = buildRateLimitHeaders(rateLimit, 60);
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limit_exceeded' },
+      { status: 429, headers: rateLimitHeaders },
+    );
+  }
+
+  const entitlement = await checkGateEntitlement(caller.orgId);
+  if (!entitlement.allowed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: entitlement.message,
+        requiresUpgrade: true,
+        tier: entitlement.tier,
+        upgradeUrl: entitlement.upgradeUrl,
+      },
+      { status: 402, headers: rateLimitHeaders },
+    );
+  }
+
   try {
-    // Parse request body
-    let data: any;
-    try {
-      data = await req.json();
-    } catch (err) {
+    const parsedBody = await readJsonBody(req, { maxBytes: 32_000 });
+    if (!parsedBody.ok) {
       return NextResponse.json(
         {
           ok: false,
-          error: 'invalid_request_body',
+          error: parsedBody.error,
           status: 'BLOCK',
-          failureReasons: ['Request body must be valid JSON'],
+          failureReasons: [parsedBody.error],
         } satisfies EncodingProveErrorResponse,
-        { status: 400 }
+        { status: parsedBody.status, headers: rateLimitHeaders },
       );
     }
 
-    // Validate request structure
+    const data = parsedBody.value as any;
     const requestValidation = validateRequest(data);
     if (!requestValidation.valid) {
       return NextResponse.json(
@@ -122,12 +152,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           status: 'BLOCK',
           failureReasons: [requestValidation.error || 'Invalid request format'],
         } satisfies EncodingProveErrorResponse,
-        { status: 400 }
+        { status: 400, headers: rateLimitHeaders },
       );
     }
 
-    // Validate encoding structure
-    const encodingValidation = validateEncoding(data.encoding);
+    const encodingValidation = validateEncoding(data.encoding, data.encodingType);
     if (!encodingValidation.valid) {
       return NextResponse.json(
         {
@@ -136,45 +165,61 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           status: 'BLOCK',
           failureReasons: [encodingValidation.error || 'Invalid encoding structure'],
         } satisfies EncodingProveErrorResponse,
-        { status: 400 }
+        { status: 400, headers: rateLimitHeaders },
       );
     }
 
-    // Create encoding proof
-    const encoding = data.encoding as ProblemEncoding;
-    const proof = createEncodingProof(encoding);
+    const proof = createEncodingProof(data.encoding as ProblemEncoding);
+    const statusCode = proof.status === 'BLOCK' ? 422 : 200;
+    const headers = new Headers(rateLimitHeaders);
+    headers.set('X-Proof-ID', proof.proofId);
+    headers.set('X-Encoding-Hash', proof.encodingHash);
 
-    // Return success response
-    if (proof.status === 'PASS') {
-      return NextResponse.json(
-        {
-          ok: true,
-          proofId: proof.proofId,
-          status: proof.status,
-          proof,
-        } satisfies EncodingProveSuccessResponse,
-        {
-          status: 200,
-          headers: {
-            'X-Proof-ID': proof.proofId,
-            'X-Encoding-Hash': proof.encodingHash,
-          },
-        }
-      );
-    }
+    const response = proof.status === 'PASS'
+      ? NextResponse.json(
+          {
+            ok: true,
+            proofId: proof.proofId,
+            status: proof.status,
+            proof,
+          } satisfies EncodingProveSuccessResponse,
+          { status: statusCode, headers },
+        )
+      : NextResponse.json(
+          {
+            ok: false,
+            error: 'encoding_validation_failed',
+            status: proof.status,
+            failedChecks: proof.failedChecks,
+            failureReasons: proof.failureReasons,
+          } satisfies EncodingProveErrorResponse,
+          { status: statusCode, headers },
+        );
 
-    // Return block/review response
-    return NextResponse.json(
-      {
-        ok: false,
-        error: 'encoding_validation_failed',
-        status: proof.status,
-        failedChecks: proof.failedChecks,
-        failureReasons: proof.failureReasons,
-      } satisfies EncodingProveErrorResponse,
-      { status: proof.status === 'BLOCK' ? 422 : 200 }
+    void logDsgApiCall({
+      orgId: caller.orgId,
+      actorType: caller.actorType,
+      apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+      userId: caller.actorType === 'user' ? caller.userId : undefined,
+      route: 'encoding/prove',
+      statusCode,
+      gateStatus: proof.status,
+      proofId: proof.proofId,
+      durationMs: Date.now() - startMs,
+    });
+
+    void recordGateEvaluation(
+      proof.proofId,
+      caller.orgId,
+      'encoding/prove',
+      proof.status,
+      Date.now() - startMs,
     );
+
+    return response;
   } catch (error) {
-    return handleApiError('api/dsg/v1/encoding/prove', error);
+    return handleApiError('api/dsg/v1/encoding/prove', error, {
+      headers: rateLimitHeaders,
+    });
   }
 }

--- a/app/framer/encoding-proof/checkout/route.ts
+++ b/app/framer/encoding-proof/checkout/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * One-click revenue handoff for the public Framer Encoding Proof product page.
+ *
+ * Framer never receives Stripe secrets or DSG session internals. This route
+ * forwards the browser's existing authenticated session to the canonical DSG
+ * billing endpoint, then redirects the user to the Stripe-hosted Checkout URL.
+ */
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const origin = requestUrl.origin;
+
+  const headers = new Headers({ 'content-type': 'application/json' });
+  const cookie = request.headers.get('cookie');
+  const authorization = request.headers.get('authorization');
+  if (cookie) headers.set('cookie', cookie);
+  if (authorization) headers.set('authorization', authorization);
+
+  try {
+    const checkout = await fetch(`${origin}/api/billing/checkout`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        plan: 'pro',
+        interval: 'monthly',
+      }),
+      cache: 'no-store',
+      redirect: 'manual',
+    });
+
+    if (checkout.status === 401) {
+      const next = encodeURIComponent('/framer/encoding-proof/checkout');
+      return NextResponse.redirect(`${origin}/login?next=${next}`);
+    }
+
+    const payload = await checkout.json().catch(() => null) as { url?: string; error?: string } | null;
+    if (!checkout.ok || !payload?.url) {
+      const reason = encodeURIComponent(payload?.error || `checkout_http_${checkout.status}`);
+      return NextResponse.redirect(`${origin}/pricing?checkout=error&source=framer-encoding-proof&reason=${reason}`);
+    }
+
+    return NextResponse.redirect(payload.url);
+  } catch {
+    return NextResponse.redirect(`${origin}/pricing?checkout=error&source=framer-encoding-proof`);
+  }
+}

--- a/lib/billing/fulfillment.ts
+++ b/lib/billing/fulfillment.ts
@@ -1,37 +1,74 @@
 /**
- * Idempotent entitlement fulfillment.
+ * Idempotent subscription fulfillment.
  *
- * Invariants (Z3-style):
- *   I1: fulfillSubscription called N times = same DB state as called once
- *       (achieved via UPDATE … WHERE id = orgId — idempotent write)
- *   I2: revokeSubscription always sets plan = 'free', never null
- *   I3: Neither function throws on Supabase error — returns Result<void>
+ * Invariants:
+ *   I1: repeated fulfillment converges on the same org + gate entitlement state
+ *   I2: revoked subscriptions always converge to the free plan/tier
+ *   I3: a paid DSG plan never leaves the deterministic gate quota at free
+ *   I4: neither function throws on Supabase errors; failures are returned
  */
 
 import { getSupabaseAdmin } from '../supabase-server';
 import { effectivePlan } from './entitlements';
+import { DSG_GATE_TIERS } from '../dsg/gate-entitlement';
 
 export type FulfillResult = {
   ok: boolean;
   error?: string;
 };
 
+type GateTier = 'free' | 'pro' | 'enterprise';
+
 /**
- * Update organizations.plan to reflect an active/trialing subscription.
- * Called on checkout.session.completed, customer.subscription.created,
- * and customer.subscription.updated.
+ * Billing has a Business plan while the deterministic Gate currently exposes
+ * Free / Pro / Enterprise tiers. Business receives the verified Pro gate tier;
+ * Enterprise receives Enterprise. Unknown/non-gate products remain Free.
+ */
+export function gateTierForBillingPlan(plan: string): GateTier {
+  if (plan === 'enterprise') return 'enterprise';
+  if (plan === 'pro' || plan === 'business') return 'pro';
+  return 'free';
+}
+
+async function syncGateEntitlement(
+  orgId: string,
+  effectiveBillingPlan: string,
+): Promise<FulfillResult> {
+  const tier = gateTierForBillingPlan(effectiveBillingPlan);
+  const tierSpec = DSG_GATE_TIERS[tier];
+  const supabase = getSupabaseAdmin();
+  const { error } = await (supabase as any)
+    .from('dsg_gate_entitlements')
+    .upsert(
+      {
+        org_id: orgId,
+        tier,
+        evals_per_month: tierSpec.evalsPerMonth,
+      },
+      { onConflict: 'org_id' },
+    );
+
+  if (error) {
+    return { ok: false, error: `gate_entitlement_sync_failed:${error.message}` };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Update organizations.plan and the deterministic gate entitlement for an
+ * active/trialing subscription. Called by the canonical Stripe webhook.
  */
 export async function fulfillSubscription(
   orgId: string,
   planKey: string,
-  status: string
+  status: string,
 ): Promise<FulfillResult> {
   if (!orgId || !planKey) {
     return { ok: false, error: 'orgId and planKey are required' };
   }
 
   const plan = effectivePlan(status, planKey);
-
   const supabase = getSupabaseAdmin();
   const { error } = await supabase
     .from('organizations')
@@ -42,12 +79,12 @@ export async function fulfillSubscription(
     return { ok: false, error: error.message };
   }
 
-  return { ok: true };
+  return syncGateEntitlement(orgId, plan);
 }
 
 /**
- * Downgrade organizations.plan to 'free' when a subscription is canceled,
- * unpaid, or permanently failed.
+ * Downgrade both organizations.plan and the deterministic gate entitlement
+ * when a subscription is canceled, unpaid, or permanently failed.
  */
 export async function revokeSubscription(orgId: string): Promise<FulfillResult> {
   if (!orgId) {
@@ -64,5 +101,5 @@ export async function revokeSubscription(orgId: string): Promise<FulfillResult> 
     return { ok: false, error: error.message };
   }
 
-  return { ok: true };
+  return syncGateEntitlement(orgId, 'free');
 }

--- a/lib/billing/fulfillment.ts
+++ b/lib/billing/fulfillment.ts
@@ -5,7 +5,9 @@
  *   I1: repeated fulfillment converges on the same org + gate entitlement state
  *   I2: revoked subscriptions always converge to the free plan/tier
  *   I3: a paid DSG plan never leaves the deterministic gate quota at free
- *   I4: neither function throws on Supabase errors; failures are returned
+ *   I4: persistence failures throw so the canonical Stripe webhook releases
+ *       its event claim and Stripe can retry instead of acknowledging partial
+ *       entitlement state
  */
 
 import { getSupabaseAdmin } from '../supabase-server';
@@ -33,7 +35,7 @@ export function gateTierForBillingPlan(plan: string): GateTier {
 async function syncGateEntitlement(
   orgId: string,
   effectiveBillingPlan: string,
-): Promise<FulfillResult> {
+): Promise<void> {
   const tier = gateTierForBillingPlan(effectiveBillingPlan);
   const tierSpec = DSG_GATE_TIERS[tier];
   const supabase = getSupabaseAdmin();
@@ -49,10 +51,8 @@ async function syncGateEntitlement(
     );
 
   if (error) {
-    return { ok: false, error: `gate_entitlement_sync_failed:${error.message}` };
+    throw new Error(`gate_entitlement_sync_failed:${error.message}`);
   }
-
-  return { ok: true };
 }
 
 /**
@@ -76,10 +76,11 @@ export async function fulfillSubscription(
     .eq('id', orgId);
 
   if (error) {
-    return { ok: false, error: error.message };
+    throw new Error(`organization_entitlement_sync_failed:${error.message}`);
   }
 
-  return syncGateEntitlement(orgId, plan);
+  await syncGateEntitlement(orgId, plan);
+  return { ok: true };
 }
 
 /**
@@ -98,8 +99,9 @@ export async function revokeSubscription(orgId: string): Promise<FulfillResult> 
     .eq('id', orgId);
 
   if (error) {
-    return { ok: false, error: error.message };
+    throw new Error(`organization_entitlement_revoke_failed:${error.message}`);
   }
 
-  return syncGateEntitlement(orgId, 'free');
+  await syncGateEntitlement(orgId, 'free');
+  return { ok: true };
 }

--- a/lib/dsg/gate-entitlement.ts
+++ b/lib/dsg/gate-entitlement.ts
@@ -1,39 +1,30 @@
 /**
  * DSG Gate API — Pricing & Entitlement Logic
  *
- * Controls access to POST /api/dsg/v1/gates/evaluate
- * and POST /api/dsg/v1/proofs/prove based on org tier.
+ * Controls access to DSG deterministic gate/proof APIs based on org tier.
+ * Current metered routes:
+ * - POST /api/dsg/v1/gates/evaluate
+ * - POST /api/dsg/v1/proofs/prove
+ * - POST /api/dsg/v1/encoding/prove
  *
  * Revenue model:
- *   Free        — 50 gate evaluations / month  (lead magnet)
+ *   Free        — 50 evaluations / month
  *   Pro         — $99/month  — 5 000 evals / month + compliance bundle access
- *   Enterprise  — $499/month — unlimited evals + SLA + Hermes executor access
- *
- * Phase 1: in-memory quota bookkeeping.
- *   All authenticated orgs receive the free tier automatically.
- *   Phase 2 will persist usage to dsg_gate_usage and wire Stripe metered billing.
- *
- * API CONTRACT (gate evaluate / proof prove — quota exceeded):
- * {
- *   ok: false,
- *   error: "Quota exceeded — upgrade to DSG Gate Pro",
- *   requiresUpgrade: true,
- *   tier: "free",
- *   upgradeUrl: "/pricing#dsg-gate"
- * }
- * HTTP 402 Payment Required
+ *   Enterprise  — $499/month — high-limit evals + SLA + Hermes executor access
  */
 
 import { reportMeterEvent } from '@/lib/billing/metered';
 import { insertRevenueEvent } from '@/lib/revenue/events';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 
+export type DsgMeteredGateRoute = 'gates/evaluate' | 'proofs/prove' | 'encoding/prove';
+
 // ─── Tier definitions ────────────────────────────────────────────────────────
 
 export interface DsgGateTier {
   tier: 'free' | 'pro' | 'enterprise';
   evalsPerMonth: number;
-  priceUsdCents: number; // 0 = free
+  priceUsdCents: number;
   billingPeriod: 'monthly' | 'none';
   description: string;
   features: string[];
@@ -58,7 +49,7 @@ export const DSG_GATE_TIERS: Record<string, DsgGateTier> = {
   pro: {
     tier: 'pro',
     evalsPerMonth: 5_000,
-    priceUsdCents: 99_00, // $99/month
+    priceUsdCents: 99_00,
     billingPeriod: 'monthly',
     description: 'Pro — $99/month — 5 000 gate evaluations/month',
     features: [
@@ -75,7 +66,7 @@ export const DSG_GATE_TIERS: Record<string, DsgGateTier> = {
   enterprise: {
     tier: 'enterprise',
     evalsPerMonth: 999_999,
-    priceUsdCents: 499_00, // $499/month
+    priceUsdCents: 499_00,
     billingPeriod: 'monthly',
     description: 'Enterprise — $499/month — Unlimited evaluations',
     features: [
@@ -178,12 +169,7 @@ async function countEvalsThisPeriod(orgId: string): Promise<number> {
   return countResult.count || 0;
 }
 
-/**
- * Check whether an org is allowed to call the DSG gate / proof API.
- *
- * Phase 1: All authenticated orgs receive the free tier automatically.
- * Phase 2: Will query dsg_gate_entitlements + dsg_gate_usage from Supabase.
- */
+/** Check whether an org is allowed to call a metered DSG gate/proof API. */
 export async function checkGateEntitlement(
   orgId: string | null,
 ): Promise<GateEntitlementCheck> {
@@ -230,16 +216,11 @@ export async function checkGateEntitlement(
   };
 }
 
-/**
- * Record a gate evaluation call for metered billing.
- *
- * Phase 1: console log only.
- * Phase 2: INSERT into dsg_gate_usage and fire Stripe meter event when overages apply.
- */
+/** Record one metered deterministic evaluation/proof call. */
 export async function recordGateEvaluation(
   evalId: string,
   orgId: string | null,
-  route: 'gates/evaluate' | 'proofs/prove',
+  route: DsgMeteredGateRoute,
   gateStatus: string,
   durationMs: number,
 ): Promise<{ recorded: boolean; meterEventId?: string; error?: string }> {
@@ -309,10 +290,6 @@ export async function recordGateEvaluation(
   }
 }
 
-/**
- * Reset monthly evaluation counters (call via cron).
- * Phase 2 only — requires dsg_gate_usage table.
- */
 export async function resetMonthlyGateCounters(): Promise<{
   reset: number;
   error?: string;

--- a/tests/integration/encoding-proof-api.test.ts
+++ b/tests/integration/encoding-proof-api.test.ts
@@ -2,42 +2,124 @@
  * Integration tests for Encoding Proof API Route
  */
 
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { ProblemEncoding } from '@/lib/dsg/deterministic/encoding-proof-types';
-
-// Mock the route handler
-import { POST } from '@/app/api/dsg/v1/encoding/prove/route';
 import { NextRequest } from 'next/server';
 
-/**
- * Helper to create NextRequest for testing
- */
+const accessMocks = vi.hoisted(() => ({
+  requireDsgAuth: vi.fn(),
+  logDsgApiCall: vi.fn(),
+  checkGateEntitlement: vi.fn(),
+  recordGateEvaluation: vi.fn(),
+  applyRateLimit: vi.fn(),
+}));
+
+vi.mock('@/lib/dsg/auth/require-dsg-auth', () => ({
+  requireDsgAuth: accessMocks.requireDsgAuth,
+  dsgAuthError: (caller: { status: number; error: string }) =>
+    new Response(JSON.stringify({ ok: false, error: caller.error }), {
+      status: caller.status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  logDsgApiCall: accessMocks.logDsgApiCall,
+}));
+
+vi.mock('@/lib/dsg/gate-entitlement', () => ({
+  checkGateEntitlement: accessMocks.checkGateEntitlement,
+  recordGateEvaluation: accessMocks.recordGateEvaluation,
+}));
+
+vi.mock('@/lib/security/rate-limit', () => ({
+  applyRateLimit: accessMocks.applyRateLimit,
+  buildRateLimitHeaders: () => ({
+    'x-ratelimit-limit': '60',
+    'x-ratelimit-remaining': '59',
+  }),
+  getRateLimitKey: () => 'encoding-proof-test',
+}));
+
+import { POST } from '@/app/api/dsg/v1/encoding/prove/route';
+
 function createRequest(body: any): NextRequest {
   return new NextRequest('http://localhost:3000/api/dsg/v1/encoding/prove', {
     method: 'POST',
+    headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
 }
 
+function validQuboBody() {
+  return {
+    problemId: 'prob_test_001',
+    encodingType: 'qubo-v1',
+    encoding: {
+      kind: 'qubo-v1',
+      variableCount: 10,
+      constant: '0',
+      linear: [{ index: 0, weight: '1.0' }],
+      quadratic: [{ i: 0, j: 1, weight: '1.0' }],
+    } as ProblemEncoding,
+    nonce: 'nonce_123',
+    idempotencyKey: 'idem_key_123',
+  };
+}
+
 describe('Encoding Proof API Route', () => {
+  beforeEach(() => {
+    accessMocks.requireDsgAuth.mockReset().mockResolvedValue({
+      ok: true,
+      orgId: 'org_test',
+      actorType: 'user',
+      userId: 'user_test',
+    });
+    accessMocks.logDsgApiCall.mockReset().mockResolvedValue(undefined);
+    accessMocks.checkGateEntitlement.mockReset().mockResolvedValue({
+      allowed: true,
+      tier: 'pro',
+      message: 'Allowed',
+      upgradeUrl: '/pricing',
+    });
+    accessMocks.recordGateEvaluation.mockReset().mockResolvedValue(undefined);
+    accessMocks.applyRateLimit.mockReset().mockResolvedValue({ allowed: true });
+  });
+
+  describe('access control', () => {
+    it('requires authentication', async () => {
+      accessMocks.requireDsgAuth.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        error: 'Unauthorized',
+      });
+
+      const res = await POST(createRequest(validQuboBody()));
+      expect(res.status).toBe(401);
+    });
+
+    it('blocks callers without entitlement', async () => {
+      accessMocks.checkGateEntitlement.mockResolvedValueOnce({
+        allowed: false,
+        tier: 'free',
+        message: 'Monthly quota exceeded',
+        upgradeUrl: '/pricing',
+      });
+
+      const res = await POST(createRequest(validQuboBody()));
+      expect(res.status).toBe(402);
+      const data = await res.json();
+      expect(data.requiresUpgrade).toBe(true);
+    });
+
+    it('enforces the per-org rate limit', async () => {
+      accessMocks.applyRateLimit.mockResolvedValueOnce({ allowed: false });
+
+      const res = await POST(createRequest(validQuboBody()));
+      expect(res.status).toBe(429);
+    });
+  });
+
   describe('POST /api/dsg/v1/encoding/prove', () => {
     it('should accept valid QUBO encoding and return PASS', async () => {
-      const body = {
-        problemId: 'prob_test_001',
-        encodingType: 'qubo-v1',
-        encoding: {
-          kind: 'qubo-v1',
-          variableCount: 10,
-          constant: '0',
-          linear: [{ index: 0, weight: '1.0' }],
-          quadratic: [{ i: 0, j: 1, weight: '1.0' }],
-        } as ProblemEncoding,
-        nonce: 'nonce_123',
-        idempotencyKey: 'idem_key_123',
-      };
-
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(validQuboBody()));
 
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -47,6 +129,8 @@ describe('Encoding Proof API Route', () => {
       expect(data.proof).toBeDefined();
       expect(data.proof.checks.linear_terms_valid).toBe(true);
       expect(data.proof.checks.quadratic_terms_valid).toBe(true);
+      expect(accessMocks.recordGateEvaluation).toHaveBeenCalled();
+      expect(accessMocks.logDsgApiCall).toHaveBeenCalled();
     });
 
     it('should accept valid Ising encoding and return PASS', async () => {
@@ -64,8 +148,7 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_456',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -79,15 +162,14 @@ describe('Encoding Proof API Route', () => {
         encodingType: 'qubo-v1',
         encoding: {
           kind: 'qubo-v1',
-          variableCount: 100, // Exceeds MAX_VARIABLES=62 (HIGH severity)
-          linear: [{ index: 0, weight: 'NaN' }], // CRITICAL severity
+          variableCount: 100,
+          linear: [{ index: 0, weight: 'NaN' }],
         } as ProblemEncoding,
         nonce: 'nonce_789',
         idempotencyKey: 'idem_key_789',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(422);
       const data = await res.json();
@@ -104,14 +186,13 @@ describe('Encoding Proof API Route', () => {
         encodingType: 'qubo-v1',
         encoding: {
           kind: 'qubo-v1',
-          variableCount: 100, // Exceeds MAX_VARIABLES=62 (HIGH severity only)
+          variableCount: 100,
         } as ProblemEncoding,
         nonce: 'nonce_review',
         idempotencyKey: 'idem_key_review',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -132,8 +213,7 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_nan',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(422);
       const data = await res.json();
@@ -148,14 +228,13 @@ describe('Encoding Proof API Route', () => {
         encoding: {
           kind: 'qubo-v1',
           variableCount: 5,
-          constant: '1.5e7', // Exceeds coefficient magnitude limit
+          constant: '1.5e7',
         } as ProblemEncoding,
         nonce: 'nonce_review',
         idempotencyKey: 'idem_key_review',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -171,8 +250,7 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_test',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(400);
       const data = await res.json();
@@ -189,8 +267,7 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_test',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(400);
       const data = await res.json();
@@ -200,6 +277,7 @@ describe('Encoding Proof API Route', () => {
     it('should reject malformed JSON', async () => {
       const req = new NextRequest('http://localhost:3000/api/dsg/v1/encoding/prove', {
         method: 'POST',
+        headers: { 'content-type': 'application/json' },
         body: 'not valid json',
       });
 
@@ -208,7 +286,6 @@ describe('Encoding Proof API Route', () => {
       expect(res.status).toBe(400);
       const data = await res.json();
       expect(data.ok).toBe(false);
-      expect(data.error).toBe('invalid_request_body');
     });
 
     it('should include proof headers in success response', async () => {
@@ -223,8 +300,7 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_headers',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.headers.get('X-Proof-ID')).toBeTruthy();
       expect(res.headers.get('X-Encoding-Hash')).toBeTruthy();
@@ -232,12 +308,12 @@ describe('Encoding Proof API Route', () => {
       expect(res.headers.get('X-Encoding-Hash')).toMatch(/^[a-f0-9]{64}$/);
     });
 
-    it('should validate encoding kind matches encoding.kind', async () => {
+    it('should reject encoding.kind mismatch', async () => {
       const body = {
         problemId: 'prob_kind_mismatch',
         encodingType: 'qubo-v1',
         encoding: {
-          kind: 'ising-v1', // Mismatch with encodingType
+          kind: 'ising-v1',
           variableCount: 5,
           h: [{ index: 0, weight: '1.0' }],
         } as ProblemEncoding,
@@ -245,13 +321,10 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_mismatch',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
-
-      // The route doesn't validate this mismatch explicitly, but the proof engine will
+      const res = await POST(createRequest(body));
+      expect(res.status).toBe(400);
       const data = await res.json();
-      // Should still work since we're just validating the encoding structure
-      expect(data).toBeDefined();
+      expect(data.error).toBe('invalid_encoding_structure');
     });
 
     it('should handle empty linear and quadratic arrays', async () => {
@@ -268,8 +341,7 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_key_empty',
       };
 
-      const req = createRequest(body);
-      const res = await POST(req);
+      const res = await POST(createRequest(body));
 
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -300,15 +372,12 @@ describe('Encoding Proof API Route', () => {
         idempotencyKey: 'idem_2',
       };
 
-      const req1 = createRequest(body1);
-      const res1 = await POST(req1);
+      const res1 = await POST(createRequest(body1));
       const data1 = await res1.json();
 
-      const req2 = createRequest(body2);
-      const res2 = await POST(req2);
+      const res2 = await POST(createRequest(body2));
       const data2 = await res2.json();
 
-      // Same encoding should produce same proofId
       expect(data1.proofId).toBe(data2.proofId);
       expect(data1.proof.encodingHash).toBe(data2.proof.encodingHash);
     });

--- a/tests/integration/framer-encoding-proof-checkout.test.ts
+++ b/tests/integration/framer-encoding-proof-checkout.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/framer/encoding-proof/checkout/route';
+
+describe('Framer Encoding Proof checkout handoff', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects unauthenticated visitors to login and preserves return path', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const request = new Request('https://control.example/framer/encoding-proof/checkout');
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://control.example/login?next=%2Fframer%2Fencoding-proof%2Fcheckout',
+    );
+  });
+
+  it('redirects an authenticated visitor to the Stripe Checkout URL', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ ok: true, url: 'https://checkout.stripe.com/c/pay/test' }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const request = new Request('https://control.example/framer/encoding-proof/checkout', {
+      headers: { cookie: 'sb-session=test' },
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://checkout.stripe.com/c/pay/test');
+  });
+
+  it('falls back to pricing when Checkout cannot be created', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: 'Missing Stripe price configuration' }),
+      { status: 500, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const request = new Request('https://control.example/framer/encoding-proof/checkout');
+    const response = await GET(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/pricing?checkout=error&source=framer-encoding-proof');
+  });
+});

--- a/tests/unit/billing/fulfillment.test.ts
+++ b/tests/unit/billing/fulfillment.test.ts
@@ -1,26 +1,61 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockUpdate = vi.fn().mockResolvedValue({ error: null });
-const mockEq = vi.fn().mockReturnValue({ error: null });
 const mockFrom = vi.fn();
 
 vi.mock('../../../lib/supabase-server', () => ({
   getSupabaseAdmin: vi.fn(() => ({ from: mockFrom })),
 }));
 
-import { fulfillSubscription, revokeSubscription } from '../../../lib/billing/fulfillment';
-import { getSupabaseAdmin } from '../../../lib/supabase-server';
+vi.mock('../../../lib/billing/metered', () => ({
+  reportMeterEvent: vi.fn(),
+}));
 
-function setupMock(error: unknown = null) {
-  const chain = { update: vi.fn(), eq: vi.fn() };
-  chain.update.mockReturnValue(chain);
-  chain.eq.mockResolvedValue({ error });
-  mockFrom.mockReturnValue(chain);
-  return chain;
+vi.mock('../../../lib/revenue/events', () => ({
+  insertRevenueEvent: vi.fn(),
+}));
+
+import {
+  fulfillSubscription,
+  revokeSubscription,
+  gateTierForBillingPlan,
+} from '../../../lib/billing/fulfillment';
+
+function setupMock(options: { orgError?: any; gateError?: any } = {}) {
+  const orgChain: any = {
+    update: vi.fn(),
+    eq: vi.fn(),
+  };
+  orgChain.update.mockReturnValue(orgChain);
+  orgChain.eq.mockResolvedValue({ error: options.orgError ?? null });
+
+  const gateChain: any = {
+    upsert: vi.fn().mockResolvedValue({ error: options.gateError ?? null }),
+  };
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'organizations') return orgChain;
+    if (table === 'dsg_gate_entitlements') return gateChain;
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  return { orgChain, gateChain };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe('gateTierForBillingPlan', () => {
+  it('maps Pro and Business to the verified Pro gate tier', () => {
+    expect(gateTierForBillingPlan('pro')).toBe('pro');
+    expect(gateTierForBillingPlan('business')).toBe('pro');
+  });
+
+  it('maps Enterprise to Enterprise and unknown products to Free', () => {
+    expect(gateTierForBillingPlan('enterprise')).toBe('enterprise');
+    expect(gateTierForBillingPlan('finance_skills')).toBe('free');
+    expect(gateTierForBillingPlan('free')).toBe('free');
+  });
 });
 
 describe('fulfillSubscription', () => {
@@ -34,41 +69,98 @@ describe('fulfillSubscription', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('calls organizations.update with correct plan on active status', async () => {
-    const chain = setupMock(null);
+  it('writes organizations.plan and Pro gate entitlement on active Pro', async () => {
+    const { orgChain, gateChain } = setupMock();
     const result = await fulfillSubscription('org-1', 'pro', 'active');
+
     expect(result.ok).toBe(true);
-    expect(mockFrom).toHaveBeenCalledWith('organizations');
-    expect(chain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'pro' })
+    expect(orgChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: 'pro' }),
     );
-    expect(chain.eq).toHaveBeenCalledWith('id', 'org-1');
+    expect(orgChain.eq).toHaveBeenCalledWith('id', 'org-1');
+    expect(gateChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org_id: 'org-1',
+        tier: 'pro',
+        evals_per_month: 5000,
+      }),
+      { onConflict: 'org_id' },
+    );
   });
 
-  it('sets plan=free when status is canceled (via effectivePlan)', async () => {
-    const chain = setupMock(null);
+  it('grants the Pro gate tier during the 14-day Pro trial', async () => {
+    const { gateChain } = setupMock();
+    const result = await fulfillSubscription('org-1', 'pro', 'trialing');
+
+    expect(result.ok).toBe(true);
+    expect(gateChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tier: 'pro', evals_per_month: 5000 }),
+      { onConflict: 'org_id' },
+    );
+  });
+
+  it('maps active Business billing to Pro gate entitlement instead of Free', async () => {
+    const { orgChain, gateChain } = setupMock();
+    const result = await fulfillSubscription('org-1', 'business', 'active');
+
+    expect(result.ok).toBe(true);
+    expect(orgChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: 'business' }),
+    );
+    expect(gateChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tier: 'pro', evals_per_month: 5000 }),
+      { onConflict: 'org_id' },
+    );
+  });
+
+  it('writes Enterprise gate entitlement for active Enterprise', async () => {
+    const { gateChain } = setupMock();
+    const result = await fulfillSubscription('org-1', 'enterprise', 'active');
+
+    expect(result.ok).toBe(true);
+    expect(gateChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tier: 'enterprise', evals_per_month: 999999 }),
+      { onConflict: 'org_id' },
+    );
+  });
+
+  it('converges canceled status to free org and free gate tier', async () => {
+    const { orgChain, gateChain } = setupMock();
     const result = await fulfillSubscription('org-1', 'pro', 'canceled');
+
     expect(result.ok).toBe(true);
-    expect(chain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'free' })
+    expect(orgChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: 'free' }),
+    );
+    expect(gateChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tier: 'free', evals_per_month: 50 }),
+      { onConflict: 'org_id' },
     );
   });
 
-  it('returns ok:false when supabase returns error', async () => {
-    setupMock({ message: 'DB error' });
+  it('returns ok:false when organizations update fails', async () => {
+    setupMock({ orgError: { message: 'DB error' } });
     const result = await fulfillSubscription('org-1', 'pro', 'active');
     expect(result.ok).toBe(false);
     expect(result.error).toContain('DB error');
   });
 
-  it('is idempotent: calling twice produces same final state', async () => {
-    const chain = setupMock(null);
+  it('returns ok:false when gate entitlement synchronization fails', async () => {
+    setupMock({ gateError: { message: 'gate DB error' } });
+    const result = await fulfillSubscription('org-1', 'pro', 'active');
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('gate_entitlement_sync_failed');
+  });
+
+  it('is idempotent: repeated fulfillment writes the same final state', async () => {
+    const { orgChain, gateChain } = setupMock();
     await fulfillSubscription('org-1', 'pro', 'active');
     await fulfillSubscription('org-1', 'pro', 'active');
-    expect(chain.update).toHaveBeenCalledTimes(2);
-    // Both calls write the same value — final state is deterministic
-    const calls = chain.update.mock.calls;
-    expect(calls[0][0].plan).toBe(calls[1][0].plan);
+
+    expect(orgChain.update).toHaveBeenCalledTimes(2);
+    expect(gateChain.upsert).toHaveBeenCalledTimes(2);
+    expect(orgChain.update.mock.calls[0][0].plan).toBe(orgChain.update.mock.calls[1][0].plan);
+    expect(gateChain.upsert.mock.calls[0][0].tier).toBe(gateChain.upsert.mock.calls[1][0].tier);
   });
 });
 
@@ -78,17 +170,22 @@ describe('revokeSubscription', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('sets plan=free on organizations', async () => {
-    const chain = setupMock(null);
+  it('sets both organizations and gate entitlement to free', async () => {
+    const { orgChain, gateChain } = setupMock();
     const result = await revokeSubscription('org-1');
+
     expect(result.ok).toBe(true);
-    expect(chain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'free' })
+    expect(orgChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: 'free' }),
+    );
+    expect(gateChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tier: 'free', evals_per_month: 50 }),
+      { onConflict: 'org_id' },
     );
   });
 
-  it('returns ok:false on supabase error', async () => {
-    setupMock({ message: 'network timeout' });
+  it('returns ok:false on organizations error', async () => {
+    setupMock({ orgError: { message: 'network timeout' } });
     const result = await revokeSubscription('org-1');
     expect(result.ok).toBe(false);
   });

--- a/tests/unit/billing/fulfillment.test.ts
+++ b/tests/unit/billing/fulfillment.test.ts
@@ -138,18 +138,18 @@ describe('fulfillSubscription', () => {
     );
   });
 
-  it('returns ok:false when organizations update fails', async () => {
+  it('throws when organizations update fails so Stripe can retry the webhook event', async () => {
     setupMock({ orgError: { message: 'DB error' } });
-    const result = await fulfillSubscription('org-1', 'pro', 'active');
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('DB error');
+    await expect(fulfillSubscription('org-1', 'pro', 'active')).rejects.toThrow(
+      'organization_entitlement_sync_failed:DB error',
+    );
   });
 
-  it('returns ok:false when gate entitlement synchronization fails', async () => {
+  it('throws when gate entitlement synchronization fails so partial access is not acknowledged', async () => {
     setupMock({ gateError: { message: 'gate DB error' } });
-    const result = await fulfillSubscription('org-1', 'pro', 'active');
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('gate_entitlement_sync_failed');
+    await expect(fulfillSubscription('org-1', 'pro', 'active')).rejects.toThrow(
+      'gate_entitlement_sync_failed:gate DB error',
+    );
   });
 
   it('is idempotent: repeated fulfillment writes the same final state', async () => {
@@ -184,9 +184,10 @@ describe('revokeSubscription', () => {
     );
   });
 
-  it('returns ok:false on organizations error', async () => {
+  it('throws on organizations revoke error so Stripe can retry', async () => {
     setupMock({ orgError: { message: 'network timeout' } });
-    const result = await revokeSubscription('org-1');
-    expect(result.ok).toBe(false);
+    await expect(revokeSubscription('org-1')).rejects.toThrow(
+      'organization_entitlement_revoke_failed:network timeout',
+    );
   });
 });


### PR DESCRIPTION
## Goal
Turn the newly merged Encoding Proof Gate into a sellable Framer funnel without exposing an unmetered public proof endpoint or creating a second billing system.

## Changes
- protect `POST /api/dsg/v1/encoding/prove` with existing DSG auth
- enforce per-org 60 req/min rate limit
- enforce existing gate entitlement/quota before proof generation
- record encoding proof usage and DSG API audit events
- reject `encoding.kind` / `encodingType` mismatches
- add `/framer/encoding-proof/checkout` one-click handoff
  - unauthenticated users go to login and return automatically
  - authenticated users reuse `/api/billing/checkout`
  - Stripe secrets/session internals never enter Framer
- add tests for 401 / 402 / 429 and checkout redirects

## Revenue contract
Uses the existing `pro` plan from `lib/billing/pricing-catalog.ts`: $99/month, 14-day trial. No new Stripe SKU or duplicate entitlement pipeline is introduced.

## Truth boundary
Encoding Proof validates QUBO/Ising encoding structure, variable consistency, configured bounds, and deterministic hashes. It does not prove that the original natural-language problem was formalized semantically correctly, and it does not itself invoke Z3/QPU hardware.

## Deployment plan
1. CI green
2. merge
3. deploy merged commit to Render control-plane service
4. verify Render deployment commit/status
5. create/update `/encoding-proof` in Framer through Server API
6. publish and deploy to the existing Framer production domain
