### PR TITLE
Install GA4 measurement tag G-ZG5DY1HXRJ

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import './dsg-brand.css';
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import type { ReactNode } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -8,6 +9,8 @@ import GlobalNav from '../components/GlobalNav';
 import PublicChatWidget from '../components/PublicChatWidget';
 import { ToastProvider } from '../components/ToastProvider';
 import { LanguageProvider } from '@/lib/i18n/language-context';
+
+const GA_MEASUREMENT_ID = 'G-ZG5DY1HXRJ';
 
 export const metadata: Metadata = {
   title: 'DSG ONE — ProofGate Runtime Control Plane',
@@ -27,6 +30,18 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <SpeedInsights />
           </ToastProvider>
         </LanguageProvider>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
       </body>
     </html>
   );

--- a/next.config.js
+++ b/next.config.js
@@ -54,11 +54,24 @@ function buildConnectSrc() {
   const coreOrigin = parseOrigin(process.env.DSG_CORE_URL);
   const remoteApiOrigin = resolveRemoteApiOrigin();
 
-  return unique(["'self'", 'https://*.supabase.co', 'https://api.stripe.com', coreOrigin, remoteApiOrigin]).join(' ');
+  return unique([
+    "'self'",
+    'https://*.supabase.co',
+    'https://api.stripe.com',
+    'https://www.google-analytics.com',
+    'https://*.google-analytics.com',
+    coreOrigin,
+    remoteApiOrigin,
+  ]).join(' ');
 }
 
 function buildScriptSrc() {
-  const base = ["'self'", "'unsafe-inline'", 'https://js.stripe.com'];
+  const base = [
+    "'self'",
+    "'unsafe-inline'",
+    'https://js.stripe.com',
+    'https://www.googletagmanager.com',
+  ];
   if (process.env.NODE_ENV !== 'production') {
     base.push("'unsafe-eval'");
   }
@@ -146,7 +159,7 @@ const nextConfig = {
               "default-src 'self'",
               `script-src ${buildScriptSrc()}`,
               "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data:",
+              "img-src 'self' data: https://www.google-analytics.com https://*.google-analytics.com",
               `connect-src ${buildConnectSrc()}`,
               'frame-src https://js.stripe.com',
               "frame-ancestors 'none'",


### PR DESCRIPTION
Closed without merge after verifying the active public storefront uses Jimdo's native Google Analytics integration. Installing the GA4 tag in the Render control-plane code would not connect analytics for the Jimdo storefront. No production change was applied.