### PR TITLE
feat: refresh production DSG Agent Skill for Render + AWS readiness

### DIFF
--- a/docs/AWS_MARKETPLACE_PRIVATE_OFFER_READINESS_2026-08-12.md
+++ b/docs/AWS_MARKETPLACE_PRIVATE_OFFER_READINESS_2026-08-12.md
@@ -1,0 +1,136 @@
+# DSG ONE — AWS Marketplace / Private Offer Readiness
+
+**Assessment date:** 2026-08-12  
+**Repository assessed:** `tdealer01-crypto/tdealer01-crypto-dsg-control-plane` (`main`)  
+**Decision:** **NO-GO for paid AWS Marketplace launch/private offer today.**
+
+This document separates repository evidence from AWS-side prerequisites. It does not mark seller registration, tax, banking, KYC, legal-entity eligibility, listing status, or live AWS integration as PASS unless directly verified.
+
+## 1. Current repository evidence
+
+| Area | Status | Evidence / boundary |
+|---|---|---|
+| Authenticated DSG gate API | PASS (code) | `POST /api/dsg/v1/gates/evaluate` uses `requireDsgAuth`, org-scoped rate limiting, entitlement checks, deterministic evaluation, audit logging, and usage recording. |
+| Authenticated DSG proof API | PASS (code) | `POST /api/dsg/v1/proofs/prove` uses `requireDsgAuth`, entitlement checks, replay-protection inputs, deterministic proof generation, and usage recording. |
+| Internal entitlement/usage model | PASS (code) | DSG has an internal entitlement and usage path. This is not AWS Marketplace entitlement. |
+| Stripe billing path | PASS as a separate provider path | Existing Stripe logic must not be treated as AWS Marketplace fulfillment. |
+| AWS `ResolveCustomer` implementation | BLOCKER | No current repository implementation was found in the 2026-08-12 code search. |
+| AWS `GetEntitlements` integration | BLOCKER | No current repository implementation was found in the 2026-08-12 code search. |
+| AWS Marketplace metering integration | BLOCKER for consumption pricing | No current `BatchMeterUsage` / equivalent Marketplace metering implementation was found in the 2026-08-12 code search. |
+| Concurrent-agreement-safe Marketplace model | BLOCKER | No verified implementation currently establishes agreement/license-aware AWS buyer state. |
+
+## 2. Current AWS requirements that matter
+
+Official AWS Marketplace documentation checked on 2026-08-12 states:
+
+- New SaaS products must support the updated Concurrent Agreements integration requirements starting June 1, 2026.
+- SaaS onboarding uses a seller-managed registration landing page that receives `x-amzn-marketplace-token`, then resolves the customer through AWS Marketplace rather than trusting buyer-supplied identity fields.
+- SaaS contract products use AWS Marketplace Entitlement Service (`GetEntitlements`) to verify purchased capacity.
+- Sellers must have at least one active public listing before they are eligible to issue private offers.
+
+Reference pages:
+
+- https://docs.aws.amazon.com/marketplace/latest/userguide/saas-product-customer-setup.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/saas-integrate-contract.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/checking-entitlements.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/creating-private-offer.html
+
+## 3. Required DSG architecture
+
+Do not merge AWS buyers into the Stripe identity or metering path. Add an explicit provider boundary:
+
+```text
+DSG canonical entitlement / usage decision
+                 |
+                 v
+          billing_provider
+          /              \
+      stripe         aws_marketplace
+        |                 |
+        v                 v
+ Stripe outbox      AWS MP adapter
+ Stripe Meter       entitlement / metering
+```
+
+Recommended identity boundary:
+
+```text
+billing_provider = stripe | aws_marketplace
+```
+
+For `aws_marketplace` customers:
+
+- do not create or charge a Stripe subscription for the Marketplace purchase;
+- do not send Marketplace usage into Stripe Meter Events;
+- resolve and persist AWS buyer/product/agreement identity idempotently;
+- verify entitlement before granting paid DSG access;
+- fail closed if entitlement cannot be verified;
+- send consumption usage only through the AWS Marketplace metering path when the selected listing model requires it.
+
+## 4. P0 implementation blockers
+
+1. **Marketplace registration endpoint**
+   - accept the AWS registration token;
+   - call `ResolveCustomer` server-side;
+   - never trust buyer-supplied AWS account/customer identifiers without resolution;
+   - link resolved AWS identity to exactly one DSG workspace/org idempotently.
+
+2. **AWS entitlement adapter**
+   - call `GetEntitlements` for contract entitlement state;
+   - persist the relevant product, account/customer, license/agreement, dimension, status, and expiry data;
+   - deny paid access when entitlement is absent, expired, or unverifiable.
+
+3. **Concurrent-agreement-safe data model**
+   - do not key Marketplace state only by `org_id`;
+   - preserve AWS product and agreement/license identity;
+   - add unique constraints for idempotent registration and event processing.
+
+4. **Agreement / entitlement change processing**
+   - ingest the current AWS event mechanism selected for the listing;
+   - re-check entitlement on changes;
+   - deterministically downgrade or revoke access when entitlement ends;
+   - retain audit evidence for every transition.
+
+5. **Marketplace metering adapter** — if using consumption
+   - use a provider-neutral or AWS-specific durable outbox;
+   - preserve idempotency/retry evidence;
+   - never double-send the same DSG usage to Stripe and AWS Marketplace.
+
+6. **Provider-isolation tests**
+   - prove an AWS Marketplace org cannot enter the Stripe billing path;
+   - prove a Stripe org cannot enter the AWS Marketplace metering path.
+
+## 5. Minimum GO evidence
+
+```text
+[ ] registration token resolved by AWS
+[ ] resolved AWS identity linked idempotently to one DSG org
+[ ] entitled agreement grants the expected DSG entitlement
+[ ] missing/expired entitlement denies paid access
+[ ] duplicate registration/event delivery is idempotent
+[ ] concurrent agreements do not overwrite each other
+[ ] AWS Marketplace customer never enters Stripe charge/meter path
+[ ] Stripe customer never enters AWS Marketplace meter path
+[ ] AWS metering retry is idempotent when consumption is enabled
+[ ] cancellation/update changes DSG access deterministically
+[ ] customer can see Marketplace subscription/entitlement status
+[ ] audit evidence identifies product/agreement/event/decision/result
+[ ] seller registration/tax/bank/KYC/legal-entity state verified outside the repo
+[ ] at least one active public listing exists before private-offer GO
+```
+
+## 6. Current conclusion
+
+The shortest valid path is:
+
+```text
+verify seller eligibility/account
+→ create limited SaaS product
+→ implement registration + entitlement + agreement-safe state
+→ add AWS metering only if the pricing model needs consumption
+→ run AWS integration tests
+→ obtain active public listing
+→ enable private offers
+```
+
+Until those items are evidenced, the correct status remains **NO-GO**, not “Marketplace integrated” or “private-offer ready.”

--- a/skills/dsg-production-gate/SKILL.md
+++ b/skills/dsg-production-gate/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: dsg-production-gate
+compatibility: >
+  Requires Node.js 18+ and a DSG API key. Defaults to the DSG ONE Render
+  production control-plane URL and never falls back to mock data.
+description: >-
+  Call DSG ONE's real /api/dsg/v1/gates/evaluate or /api/dsg/v1/proofs/prove
+  production API before an agent action. Return PASS, REVIEW, BLOCK, or
+  UNSUPPORTED with proof identifiers and fail closed when production evidence
+  cannot be obtained.
+---
+
+# DSG Production Gate
+
+Use this skill when an agent must obtain a real DSG ONE governance decision or deterministic proof from the deployed control plane before acting.
+
+## User outcome
+
+The user should see five things immediately:
+
+1. **Use** — set one API key and run one command.
+2. **Result** — `PASS`, `REVIEW`, `BLOCK`, or `UNSUPPORTED` is printed as JSON.
+3. **Evidence** — when supplied by the API, include `proofId`, `proofHash`, and `productionReadyClaim`.
+4. **Fix** — authentication, entitlement, quota, rate-limit, malformed-response, and network failures return a concrete next action.
+5. **Truth boundary** — no successful production claim is allowed unless the remote API actually returns the evidence for that request.
+
+## Production endpoint
+
+Default base URL:
+
+```text
+https://tdealer01-crypto-dsg-control-plane.onrender.com
+```
+
+Routes used by this skill:
+
+```text
+POST /api/dsg/v1/gates/evaluate
+POST /api/dsg/v1/proofs/prove
+```
+
+The current repository implementation for these routes requires authenticated DSG callers, applies org-scoped rate limiting, checks entitlement, and records governed usage. Do not replace these calls with a local mock when the task asks for a production decision.
+
+## Authentication
+
+Create a DSG API key with only the scopes needed by the caller:
+
+- `gates:evaluate` for gate evaluation
+- `proofs:prove` for proof generation
+
+Set it in the environment:
+
+```bash
+export DSG_API_KEY='...'
+```
+
+Never print, persist, commit, or place the raw key in logs, issue bodies, evidence bundles, or agent responses.
+
+Optional override for staging or an explicitly approved alternate deployment:
+
+```bash
+export DSG_CONTROL_PLANE_URL='https://approved-host.example'
+```
+
+Outside localhost, the client rejects non-HTTPS URLs.
+
+## Evaluate an action
+
+```bash
+node skills/dsg-production-gate/scripts/dsg-production-gate.mjs evaluate \
+  --risk high \
+  --action deploy_production \
+  --context '{"target":"production","change":"release-2026-08"}'
+```
+
+For larger context, pass a JSON file:
+
+```bash
+node skills/dsg-production-gate/scripts/dsg-production-gate.mjs evaluate \
+  --risk medium \
+  --context-file ./context.json
+```
+
+Optional fields:
+
+```text
+--plan-id <id>
+--policy-ref <ref>
+--policy-version <version>
+--previous-proof-hash <hex>
+--timeout <milliseconds>
+--raw
+```
+
+The client generates a fresh replay-protection `nonce` and `idempotencyKey` for each call.
+
+## Generate a proof
+
+```bash
+node skills/dsg-production-gate/scripts/dsg-production-gate.mjs prove \
+  --risk medium \
+  --plan-id plan_123 \
+  --context-file ./context.json
+```
+
+## Decision contract
+
+| Remote result | Agent behavior |
+|---|---|
+| `PASS` | May continue only when the API response itself is successful; preserve returned proof evidence. |
+| `REVIEW` | Stop automated execution and surface the required review. |
+| `BLOCK` | Stop. Do not execute the action. |
+| `UNSUPPORTED` | Stop. Never convert to PASS. |
+| Network/API/malformed response | Stop. Production decision is unverified. |
+
+CLI exit codes:
+
+```text
+0   PASS / successful proof
+2   local configuration or input error
+3   remote/API/auth/quota/rate-limit/network error
+10  REVIEW
+11  BLOCK
+12  UNSUPPORTED or non-passing proof
+```
+
+## Required agent response
+
+After a production call, report only evidence actually returned by the API:
+
+```text
+Result: PASS | REVIEW | BLOCK | UNSUPPORTED
+Can proceed: yes | no
+Reason: <remote reason or explicit unavailable>
+Proof ID: <remote proofId or unavailable>
+Proof hash: <remote proofHash or unavailable>
+Production-ready claim: true | false
+Next action: <execute / obtain review / fix blocker / verify API>
+```
+
+Do not invent a proof hash, solver result, latency, entitlement tier, or production status.
+
+## Failure handling
+
+- `401/403`: check API key status and scopes.
+- `402`: entitlement or quota blocked the request; fix entitlement before retrying.
+- `429`: rate limit exceeded; retry only after the limit window.
+- non-JSON or unexpected gate status: treat the response as malformed and do not execute.
+- timeout/DNS/network error: production is unverified; do not fall back to a mock.
+
+## Verification boundary
+
+This skill is wired to the repository's current production API contract and defaults to Render. A successful live production invocation still depends on deployment reachability, a valid API key, active backing services, and current entitlements. If those are not directly verified in the current run, state that limitation rather than claiming the production call succeeded.

--- a/skills/dsg-production-gate/scripts/dsg-production-gate.mjs
+++ b/skills/dsg-production-gate/scripts/dsg-production-gate.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { randomBytes } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+const PROD_URL = 'https://tdealer01-crypto-dsg-control-plane.onrender.com';
+const VALID_RISKS = new Set(['low', 'medium', 'high', 'critical']);
+const VALID_COMMANDS = new Set(['evaluate', 'prove']);
+
+function fail(message, code = 2, details = undefined) {
+  const payload = { ok: false, error: message };
+  if (details !== undefined) payload.details = details;
+  console.error(JSON.stringify(payload, null, 2));
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const out = { command: 'evaluate' };
+  const args = [...argv];
+  if (args[0] && !args[0].startsWith('--')) out.command = args.shift();
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) fail(`Unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    if (key === 'raw') {
+      out.raw = true;
+      continue;
+    }
+    const value = args[i + 1];
+    if (!value || value.startsWith('--')) fail(`Missing value for --${key}`);
+    out[key] = value;
+    i += 1;
+  }
+  return out;
+}
+
+async function loadContext(args) {
+  if (args['context-file']) {
+    const text = await readFile(args['context-file'], 'utf8');
+    return JSON.parse(text);
+  }
+  if (args.context) return JSON.parse(args.context);
+  return {};
+}
+
+function token(prefix, bytes = 18) {
+  return `${prefix}_${randomBytes(bytes).toString('base64url')}`;
+}
+
+function safeUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail('DSG_CONTROL_PLANE_URL must be a valid URL');
+  }
+
+  const isLoopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+  if (url.protocol !== 'https:' && !isLoopback) {
+    fail('DSG_CONTROL_PLANE_URL must use HTTPS outside localhost');
+  }
+  return url.origin;
+}
+
+function exitForGate(gateStatus) {
+  if (gateStatus === 'PASS') return 0;
+  if (gateStatus === 'REVIEW') return 10;
+  if (gateStatus === 'BLOCK') return 11;
+  return 12;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!VALID_COMMANDS.has(args.command)) fail('Command must be evaluate or prove');
+
+const apiKey = process.env.DSG_API_KEY?.trim();
+if (!apiKey) {
+  fail('DSG_API_KEY is required. Create a key with gates:evaluate and/or proofs:prove scope.');
+}
+
+const baseUrl = safeUrl(process.env.DSG_CONTROL_PLANE_URL?.trim() || PROD_URL);
+const riskLevel = args.risk || 'medium';
+if (!VALID_RISKS.has(riskLevel)) fail('--risk must be low, medium, high, or critical');
+
+let context;
+try {
+  context = await loadContext(args);
+} catch (error) {
+  fail('Context must be valid JSON', 2, error instanceof Error ? error.message : String(error));
+}
+if (!context || typeof context !== 'object' || Array.isArray(context)) {
+  fail('Context must be a JSON object');
+}
+if (args.action) context = { action: args.action, ...context };
+
+const payload = {
+  riskLevel,
+  nonce: token('nonce'),
+  idempotencyKey: token('idem', 24),
+  context,
+};
+if (args['plan-id']) payload.planId = args['plan-id'];
+if (args['policy-ref']) payload.policyRef = args['policy-ref'];
+if (args['policy-version']) payload.policyVersion = args['policy-version'];
+if (args['previous-proof-hash']) payload.previousProofHash = args['previous-proof-hash'];
+
+const path = args.command === 'prove'
+  ? '/api/dsg/v1/proofs/prove'
+  : '/api/dsg/v1/gates/evaluate';
+
+const requestedTimeout = Number(args.timeout || 20000);
+if (!Number.isFinite(requestedTimeout) || requestedTimeout < 1000 || requestedTimeout > 120000) {
+  fail('--timeout must be between 1000 and 120000 milliseconds');
+}
+
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), requestedTimeout);
+let response;
+let body;
+try {
+  response = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+      accept: 'application/json',
+      'user-agent': 'dsg-production-agent-skill/1.1',
+    },
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+  });
+
+  const text = await response.text();
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    fail('DSG API returned non-JSON response', 3, { status: response.status });
+  }
+} catch (error) {
+  fail('DSG production API request failed', 3, error instanceof Error ? error.message : String(error));
+} finally {
+  clearTimeout(timeout);
+}
+
+if (!response.ok) {
+  const error = body?.error || `HTTP ${response.status}`;
+  const action = response.status === 401 || response.status === 403
+    ? 'Check DSG_API_KEY and its scopes/status.'
+    : response.status === 402
+      ? 'Entitlement or quota blocked this call; correct entitlement before retrying.'
+      : response.status === 429
+        ? 'Rate limit exceeded; retry after the limit window.'
+        : 'Inspect the API response and server evidence before retrying.';
+
+  console.error(JSON.stringify({ ok: false, httpStatus: response.status, error, action }, null, 2));
+  process.exit(3);
+}
+
+if (args.raw) {
+  console.log(JSON.stringify(body, null, 2));
+  if (args.command === 'evaluate') process.exit(exitForGate(body.gateStatus));
+  process.exit(body.ok === true ? 0 : 12);
+}
+
+if (args.command === 'evaluate') {
+  const gateStatus = body?.gateStatus;
+  if (!['PASS', 'REVIEW', 'BLOCK', 'UNSUPPORTED'].includes(gateStatus)) {
+    fail('Malformed DSG gate response: missing/invalid gateStatus', 3);
+  }
+
+  const proof = body?.proof || {};
+  const result = {
+    ok: body.ok === true,
+    gateStatus,
+    canProceed: body.ok === true && gateStatus === 'PASS',
+    riskLevel: body.riskLevel || riskLevel,
+    reason: body.reason ?? null,
+    proofId: proof.proofId ?? null,
+    proofHash: proof.proofHash ?? null,
+    productionReadyClaim: body?.boundary?.productionReadyClaim === true,
+    endpoint: `${baseUrl}${path}`,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(exitForGate(gateStatus));
+}
+
+const proof = body?.proof || {};
+console.log(JSON.stringify({
+  ok: body.ok === true,
+  proofStatus: proof.status ?? null,
+  proofId: proof.proofId ?? null,
+  proofHash: proof.proofHash ?? null,
+  productionReadyClaim: body?.boundary?.productionReadyClaim === true,
+  endpoint: `${baseUrl}${path}`,
+}, null, 2));
+process.exit(body.ok === true ? 0 : 12);


### PR DESCRIPTION
## Purpose
Clean replacement for stale PR #1062, rebuilt from the current `main` instead of rebasing the old 65-commit-behind branch.

## Changes
- add `skills/dsg-production-gate/SKILL.md`
- add `skills/dsg-production-gate/scripts/dsg-production-gate.mjs`
- default production control-plane URL is Render:
  `https://tdealer01-crypto-dsg-control-plane.onrender.com`
- preserve fail-closed auth/entitlement/rate-limit/network behavior
- validate alternate production URL and timeout bounds
- add refreshed AWS Marketplace/private-offer readiness document dated 2026-08-12

## Current repository evidence
The current `main` still exposes authenticated:
- `POST /api/dsg/v1/gates/evaluate`
- `POST /api/dsg/v1/proofs/prove`

Both current routes require DSG auth and entitlement before governed delivery.

Repository search on current `main` found no `ResolveCustomer`, `GetEntitlements`, or `BatchMeterUsage` implementation, so AWS Marketplace status remains NO-GO rather than claiming integration.

## Truth boundary
- no mock fallback
- no live authenticated production API smoke is claimed by this PR yet
- no AWS seller/KYC/tax/bank/listing status is claimed from repository evidence
- private-offer readiness remains blocked until AWS-side and integration evidence exists

## Merge gate
Use the active `dsg` ruleset on `main`. Do not bypass required status checks. This branch was created from current `main` and is 0 commits behind at PR creation.

Supersedes: #1062