### PR TITLE
fix(revenue): close automatic billing loop on current main

### DIFF
--- a/app/api/billing/activation-proof/route.ts
+++ b/app/api/billing/activation-proof/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { requireActiveProfile } from '../../../../lib/auth/require-active-profile';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '../../../../lib/security/rate-limit';
+import { handleApiError } from '../../../../lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+const RATE_LIMIT = 60;
+const WINDOW_MS = 60_000;
+
+/**
+ * GET /api/billing/activation-proof
+ *
+ * Returns the newest append-only proof that the authenticated workspace has a
+ * paid Stripe subscription reflected in DSG's entitlement state.
+ *
+ * This is an entitlement activation proof. It is not a Stripe payment receipt
+ * and it does not claim regulatory compliance by itself.
+ */
+export async function GET(request: Request) {
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, 'billing-activation-proof'),
+    limit: RATE_LIMIT,
+    windowMs: WINDOW_MS,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, RATE_LIMIT);
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'Too many requests' },
+      { status: 429, headers },
+    );
+  }
+
+  try {
+    const access = await requireActiveProfile();
+    if (!access.ok) {
+      return NextResponse.json(
+        { ok: false, error: access.error },
+        { status: access.status, headers },
+      );
+    }
+
+    const supabase = getSupabaseAdmin() as any;
+    const { data, error } = await supabase
+      .from('billing_activation_proofs')
+      .select(
+        'id,org_id,tier,subscription_status,stripe_customer_id,stripe_subscription_id,current_period_start,current_period_end,proof_version,proof_hash,created_at',
+      )
+      .eq('org_id', access.orgId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    if (!data) {
+      return NextResponse.json(
+        {
+          ok: true,
+          activated: false,
+          proof: null,
+          message:
+            'No paid subscription activation proof exists for this workspace yet.',
+        },
+        { headers },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        activated: true,
+        proof: {
+          id: data.id,
+          tier: data.tier,
+          subscription_status: data.subscription_status,
+          stripe_customer_id: data.stripe_customer_id,
+          stripe_subscription_id: data.stripe_subscription_id,
+          current_period_start: data.current_period_start,
+          current_period_end: data.current_period_end,
+          proof_version: data.proof_version,
+          proof_hash: data.proof_hash,
+          created_at: data.created_at,
+        },
+        meaning:
+          'Stripe-backed paid entitlement is active and has an append-only deterministic proof record.',
+      },
+      { headers },
+    );
+  } catch (error) {
+    return handleApiError('api/billing/activation-proof', error, { headers });
+  }
+}

--- a/app/api/dsg/v1/encoding/prove/route.ts
+++ b/app/api/dsg/v1/encoding/prove/route.ts
@@ -59,6 +59,28 @@ function responseHeaders(req: Request, base?: HeadersInit): Headers {
   return buildCorsHeaders(req, base);
 }
 
+function usageFailure(error?: string) {
+  const accessMode = error?.startsWith('delivery_blocked:')
+    ? error.slice('delivery_blocked:'.length)
+    : 'billing_unavailable';
+  const requiresUpgrade =
+    accessMode === 'quota_exceeded' || accessMode === 'subscription_inactive';
+
+  return {
+    status: requiresUpgrade ? 402 : 503,
+    body: {
+      ok: false,
+      error: 'usage_evidence_unavailable',
+      accessMode,
+      requiresUpgrade,
+      message: requiresUpgrade
+        ? 'Encoding proof withheld because the current subscription does not authorize this usage slot.'
+        : 'Encoding proof withheld because usage evidence could not be completed safely.',
+      upgradeUrl: '/pricing#dsg-gate',
+    },
+  };
+}
+
 function validateRequest(data: unknown):
   | {
       valid: true;
@@ -171,11 +193,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       {
         ok: false,
         error: entitlement.message,
-        requiresUpgrade: true,
+        requiresUpgrade: entitlement.requiresPayment,
         tier: entitlement.tier,
+        accessMode: entitlement.accessMode,
         upgradeUrl: entitlement.upgradeUrl,
       },
-      { status: 402, headers: responseHeaders(req, rateLimitHeaders) },
+      {
+        status: entitlement.requiresPayment ? 402 : 503,
+        headers: responseHeaders(req, rateLimitHeaders),
+      },
     );
   }
 
@@ -244,6 +270,22 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           { status: 500, headers: responseHeaders(req, rateLimitHeaders) },
         );
       }
+
+      const replayUsage = await recordGateEvaluation(
+        data.idempotencyKey,
+        caller.orgId,
+        'encoding/prove',
+        replay.proof.status,
+        Date.now() - startMs,
+      );
+      if (!replayUsage.recorded) {
+        const failure = usageFailure(replayUsage.error);
+        return NextResponse.json(failure.body, {
+          status: failure.status,
+          headers: responseHeaders(req, rateLimitHeaders),
+        });
+      }
+
       return proofResponse(req, replay.proof, rateLimitHeaders, true);
     }
 
@@ -281,6 +323,22 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       proof,
     });
 
+    const durationMs = Date.now() - startMs;
+    const usage = await recordGateEvaluation(
+      data.idempotencyKey,
+      caller.orgId,
+      'encoding/prove',
+      proof.status,
+      durationMs,
+    );
+    if (!usage.recorded) {
+      const failure = usageFailure(usage.error);
+      return NextResponse.json(failure.body, {
+        status: failure.status,
+        headers: responseHeaders(req, rateLimitHeaders),
+      });
+    }
+
     const statusCode = proof.status === 'BLOCK' ? 422 : 200;
     void logDsgApiCall({
       orgId: caller.orgId,
@@ -291,16 +349,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       statusCode,
       gateStatus: proof.status,
       proofId: proof.proofId,
-      durationMs: Date.now() - startMs,
+      durationMs,
     });
-
-    void recordGateEvaluation(
-      proof.proofId,
-      caller.orgId,
-      'encoding/prove',
-      proof.status,
-      Date.now() - startMs,
-    );
 
     return proofResponse(req, proof, rateLimitHeaders);
   } catch (error) {

--- a/app/api/dsg/v1/entitlement/route.ts
+++ b/app/api/dsg/v1/entitlement/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import {
+  dsgAuthError,
+  requireDsgAuth,
+} from '@/lib/dsg/auth/require-dsg-auth';
+import { checkGateEntitlement } from '@/lib/dsg/gate-entitlement';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dsg/v1/entitlement
+ *
+ * Client contract for web, Android, and MCP clients. It exposes only the
+ * caller's effective tier and usage state; Stripe identifiers remain server-side.
+ */
+export async function GET(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-entitlement:${caller.orgId}`),
+    limit: 60,
+    windowMs: 60_000,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, 60);
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limit_exceeded' },
+      { status: 429, headers },
+    );
+  }
+
+  const entitlement = await checkGateEntitlement(caller.orgId);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      entitlement: {
+        allowed: entitlement.allowed,
+        tier: entitlement.tier,
+        evalsRemaining: entitlement.evalsRemaining,
+        accessMode: entitlement.accessMode,
+        requiresPayment: entitlement.requiresPayment,
+        message: entitlement.message,
+        upgradeUrl: entitlement.upgradeUrl,
+      },
+    },
+    { headers },
+  );
+}

--- a/app/api/dsg/v1/gates/evaluate/route.ts
+++ b/app/api/dsg/v1/gates/evaluate/route.ts
@@ -38,14 +38,35 @@ function validationErrorCode(details: { field: string; message: string }[]) {
   return "validation_failed";
 }
 
+function usageFailure(error?: string) {
+  const accessMode = error?.startsWith("delivery_blocked:")
+    ? error.slice("delivery_blocked:".length)
+    : "billing_unavailable";
+  const requiresUpgrade =
+    accessMode === "quota_exceeded" || accessMode === "subscription_inactive";
+
+  return {
+    status: requiresUpgrade ? 402 : 503,
+    body: {
+      ok: false,
+      error: "usage_evidence_unavailable",
+      accessMode,
+      requiresUpgrade,
+      message:
+        requiresUpgrade
+          ? "Execution result withheld because the current subscription does not authorize this usage slot."
+          : "Execution result withheld because usage evidence could not be completed safely.",
+      upgradeUrl: "/pricing#dsg-gate",
+    },
+  };
+}
+
 export async function POST(request: Request) {
-  // ── Auth ─────────────────────────────────────────────────────────────────
   const caller = await requireDsgAuth(request);
   if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
 
   const startMs = Date.now();
 
-  // ── Rate limit (keyed to org) ─────────────────────────────────────────────
   const rateLimitResult = await applyRateLimit({
     key: getRateLimitKey(request, `dsg-gate:${caller.orgId}`),
     limit: 60,
@@ -59,18 +80,21 @@ export async function POST(request: Request) {
     );
   }
 
-  // ── Entitlement check (metered billing gate) ─────────────────────────────
   const entitlement = await checkGateEntitlement(caller.orgId);
   if (!entitlement.allowed) {
     return NextResponse.json(
       {
         ok: false,
         error: entitlement.message,
-        requiresUpgrade: true,
+        requiresUpgrade: entitlement.requiresPayment,
         tier: entitlement.tier,
+        accessMode: entitlement.accessMode,
         upgradeUrl: entitlement.upgradeUrl,
       },
-      { status: 402, headers: rateLimitHeaders },
+      {
+        status: entitlement.requiresPayment ? 402 : 503,
+        headers: rateLimitHeaders,
+      },
     );
   }
 
@@ -99,6 +123,23 @@ export async function POST(request: Request) {
     verifyFresh: false,
     recordResult: true,
   });
+  const durationMs = Date.now() - startMs;
+
+  const usage = await recordGateEvaluation(
+    validated.value.idempotencyKey,
+    caller.orgId,
+    "gates/evaluate",
+    result.gateStatus,
+    durationMs,
+  );
+
+  if (!usage.recorded) {
+    const failure = usageFailure(usage.error);
+    return NextResponse.json(failure.body, {
+      status: failure.status,
+      headers: rateLimitHeaders,
+    });
+  }
 
   const response = NextResponse.json(
     {
@@ -109,6 +150,11 @@ export async function POST(request: Request) {
       riskLevel: result.riskLevel,
       reason: result.reason ?? null,
       proof: result.proof,
+      entitlement: {
+        tier: entitlement.tier,
+        evalsRemaining: entitlement.evalsRemaining,
+        accessMode: entitlement.accessMode,
+      },
       caller: { orgId: caller.orgId, actorType: caller.actorType },
       boundary: {
         statement:
@@ -122,28 +168,18 @@ export async function POST(request: Request) {
     { headers: rateLimitHeaders },
   );
 
-  // Audit log (fire-and-forget — never delays response)
   void logDsgApiCall({
-    orgId:      caller.orgId,
-    actorType:  caller.actorType,
-    apiKeyId:   caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
-    userId:     caller.actorType === 'user'    ? caller.userId    : undefined,
-    route:      'gates/evaluate',
+    orgId: caller.orgId,
+    actorType: caller.actorType,
+    apiKeyId: caller.actorType === "api_key" ? caller.apiKeyId : undefined,
+    userId: caller.actorType === "user" ? caller.userId : undefined,
+    route: "gates/evaluate",
     statusCode: 200,
     gateStatus: result.gateStatus,
-    proofId:    result.proof.proofId,
+    proofId: result.proof.proofId,
     proofSource: result.source,
-    durationMs: Date.now() - startMs,
+    durationMs,
   });
-
-  // Usage recording for metered billing (fire-and-forget)
-  void recordGateEvaluation(
-    result.proof.proofId,
-    caller.orgId,
-    'gates/evaluate',
-    result.gateStatus,
-    Date.now() - startMs,
-  );
 
   return response;
 }

--- a/app/api/dsg/v1/pricing/route.ts
+++ b/app/api/dsg/v1/pricing/route.ts
@@ -1,17 +1,9 @@
 /**
  * GET /api/dsg/v1/pricing
  *
- * Public endpoint — no authentication required.
- * Returns DSG Gate API pricing tiers for use on /pricing page,
- * upgrade modals, and SDK documentation.
- *
- * Response (200 OK):
- * {
- *   ok: true,
- *   product: "DSG Gate API",
- *   tiers: [{ id, name, description, price, billingPeriod, features, cta, checkoutLink }],
- *   description: string
- * }
+ * Public, single-purpose pricing contract for web and client applications.
+ * Paid calls enter the authenticated direct-checkout handoff, which delegates
+ * price resolution and Stripe session creation to /api/billing/checkout.
  */
 
 import { NextResponse } from 'next/server';
@@ -50,8 +42,8 @@ const GATE_PRICING_TIERS: PricingTier[] = [
     price: `$${GATE_PLANS.pro.displayMonthlyUsd}`,
     billingPeriod: 'monthly',
     features: DSG_GATE_TIERS.pro.features,
-    cta: 'Upgrade to Pro',
-    checkoutLink: '/dashboard/billing?plan=pro',
+    cta: 'Start Pro Checkout',
+    checkoutLink: '/checkout/pro',
     highlight: true,
   },
   {
@@ -61,17 +53,17 @@ const GATE_PRICING_TIERS: PricingTier[] = [
     price: `$${GATE_PLANS.enterprise.displayMonthlyUsd}`,
     billingPeriod: 'monthly',
     features: DSG_GATE_TIERS.enterprise.features,
-    cta: 'Contact Sales',
-    checkoutLink: '/dashboard/billing?plan=enterprise',
+    cta: 'Start Enterprise Checkout',
+    checkoutLink: '/checkout/enterprise',
   },
 ];
 
 export async function GET() {
   return NextResponse.json({
     ok: true,
-    product: 'DSG Gate API',
+    product: 'DSG Compliance Verification & Gate API',
     tiers: GATE_PRICING_TIERS,
     description:
-      'DSG Gate API — Deterministic AI governance with cryptographic proof. Same input → same decision, always.',
+      'Automated compliance and AI-governance verification with persisted entitlement, idempotent usage evidence, and Stripe-backed billing.',
   });
 }

--- a/app/api/dsg/v1/proofs/prove/route.ts
+++ b/app/api/dsg/v1/proofs/prove/route.ts
@@ -19,8 +19,30 @@ function text(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function usageFailure(error?: string) {
+  const accessMode = error?.startsWith("delivery_blocked:")
+    ? error.slice("delivery_blocked:".length)
+    : "billing_unavailable";
+  const requiresUpgrade =
+    accessMode === "quota_exceeded" || accessMode === "subscription_inactive";
+
+  return {
+    status: requiresUpgrade ? 402 : 503,
+    body: {
+      ok: false,
+      error: "usage_evidence_unavailable",
+      accessMode,
+      requiresUpgrade,
+      message:
+        requiresUpgrade
+          ? "Proof withheld because the current subscription does not authorize this usage slot."
+          : "Proof withheld because usage evidence could not be completed safely.",
+      upgradeUrl: "/pricing#dsg-gate",
+    },
+  };
+}
+
 export async function POST(request: Request) {
-  // ── Auth ─────────────────────────────────────────────────────────────────
   const caller = await requireDsgAuth(request);
   if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
 
@@ -37,18 +59,21 @@ export async function POST(request: Request) {
     );
   }
 
-  // ── Entitlement check (metered billing gate) ─────────────────────────────
   const entitlement = await checkGateEntitlement(caller.orgId);
   if (!entitlement.allowed) {
     return NextResponse.json(
       {
         ok: false,
         error: entitlement.message,
-        requiresUpgrade: true,
+        requiresUpgrade: entitlement.requiresPayment,
         tier: entitlement.tier,
+        accessMode: entitlement.accessMode,
         upgradeUrl: entitlement.upgradeUrl,
       },
-      { status: 402, headers: rateLimitHeaders },
+      {
+        status: entitlement.requiresPayment ? 402 : 503,
+        headers: rateLimitHeaders,
+      },
     );
   }
 
@@ -61,7 +86,7 @@ export async function POST(request: Request) {
   if (!body || !body.context || typeof body.context !== "object") {
     return NextResponse.json(
       { ok: false, error: "missing_context" },
-      { status: 400 },
+      { status: 400, headers: rateLimitHeaders },
     );
   }
 
@@ -72,14 +97,14 @@ export async function POST(request: Request) {
   if (!nonce) {
     return NextResponse.json(
       { ok: false, error: "missing_nonce" },
-      { status: 400 },
+      { status: 400, headers: rateLimitHeaders },
     );
   }
 
   if (!idempotencyKey) {
     return NextResponse.json(
       { ok: false, error: "missing_idempotency_key" },
-      { status: 400 },
+      { status: 400, headers: rateLimitHeaders },
     );
   }
 
@@ -93,30 +118,41 @@ export async function POST(request: Request) {
     idempotencyKey,
     context: body.context,
   });
+  const durationMs = Date.now() - startMs;
 
-  // Usage recording for metered billing (fire-and-forget)
-  void recordGateEvaluation(
-    proof.proofId,
+  const usage = await recordGateEvaluation(
+    idempotencyKey,
     caller.orgId,
-    'proofs/prove',
+    "proofs/prove",
     proof.status,
-    Date.now() - startMs,
+    durationMs,
   );
 
-  // Capture proof_verified event
-  void captureEvent('proof_verified', {
-    userId: caller.userId || 'unknown',
-    organizationId: caller.orgId,
-  }, {
-    organization_id: caller.orgId,
-    proof_status: proof.status,
-    proof_hash: proof.proofHash || null,
-    production_ready: proof.evidenceBoundary.productionReadyClaim,
-    external_solver_invoked: proof.evidenceBoundary.externalSolverInvoked,
-    verification_time_ms: Date.now() - startMs,
-    verified_by_user_id: caller.userId || 'unknown',
-  }).catch((error) => {
-    console.error('[dsg-proof-verify] Failed to capture event:', error);
+  if (!usage.recorded) {
+    const failure = usageFailure(usage.error);
+    return NextResponse.json(failure.body, {
+      status: failure.status,
+      headers: rateLimitHeaders,
+    });
+  }
+
+  void captureEvent(
+    "proof_verified",
+    {
+      userId: caller.userId || "unknown",
+      organizationId: caller.orgId,
+    },
+    {
+      organization_id: caller.orgId,
+      proof_status: proof.status,
+      proof_hash: proof.proofHash || null,
+      production_ready: proof.evidenceBoundary.productionReadyClaim,
+      external_solver_invoked: proof.evidenceBoundary.externalSolverInvoked,
+      verification_time_ms: durationMs,
+      verified_by_user_id: caller.userId || "unknown",
+    },
+  ).catch((error) => {
+    console.error("[dsg-proof-verify] Failed to capture event:", error);
   });
 
   return NextResponse.json(
@@ -124,6 +160,11 @@ export async function POST(request: Request) {
       ok: proof.status === "PASS",
       type: "dsg-deterministic-proof",
       proof,
+      entitlement: {
+        tier: entitlement.tier,
+        evalsRemaining: entitlement.evalsRemaining,
+        accessMode: entitlement.accessMode,
+      },
       boundary: {
         statement:
           "DSG-native deterministic proof adapter. productionReadyClaim is true only when all policy constraints pass and replay-protection evidence is present for this request.",

--- a/app/checkout/[plan]/page.tsx
+++ b/app/checkout/[plan]/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+
+type CheckoutPlan = 'pro' | 'enterprise';
+
+function isCheckoutPlan(value: string): value is CheckoutPlan {
+  return value === 'pro' || value === 'enterprise';
+}
+
+const PLAN_COPY: Record<CheckoutPlan, { name: string; price: string; included: string }> = {
+  pro: {
+    name: 'DSG Gate Pro',
+    price: '$99/month',
+    included: '5,000 compliance and governance evaluations included',
+  },
+  enterprise: {
+    name: 'DSG Gate Enterprise',
+    price: '$499/month',
+    included: 'Unlimited governed evaluations while the subscription is active',
+  },
+};
+
+export default function DirectCheckoutPage() {
+  const params = useParams<{ plan: string }>();
+  const rawPlan = String(params?.plan || '').toLowerCase();
+  const plan = useMemo(
+    () => (isCheckoutPlan(rawPlan) ? rawPlan : null),
+    [rawPlan],
+  );
+  const [status, setStatus] = useState<'starting' | 'error' | 'invalid'>('starting');
+  const [message, setMessage] = useState('Preparing secure checkout…');
+
+  useEffect(() => {
+    if (!plan) {
+      setStatus('invalid');
+      setMessage('This plan is not available for automatic checkout.');
+      return;
+    }
+
+    let cancelled = false;
+
+    async function beginCheckout() {
+      try {
+        const response = await fetch('/api/billing/checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ plan, interval: 'monthly' }),
+          cache: 'no-store',
+        });
+
+        if (cancelled) return;
+
+        if (response.status === 401) {
+          window.location.href = `/login?next=${encodeURIComponent(`/checkout/${plan}`)}`;
+          return;
+        }
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || !data?.url) {
+          setStatus('error');
+          setMessage(data?.error || 'Checkout is temporarily unavailable.');
+          return;
+        }
+
+        window.location.href = data.url;
+      } catch {
+        if (!cancelled) {
+          setStatus('error');
+          setMessage('Checkout is temporarily unavailable.');
+        }
+      }
+    }
+
+    void beginCheckout();
+    return () => {
+      cancelled = true;
+    };
+  }, [plan]);
+
+  const copy = plan ? PLAN_COPY[plan] : null;
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-16 text-slate-100">
+      <div className="mx-auto max-w-lg rounded-2xl border border-slate-800 bg-slate-900 p-8 shadow-2xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-300">
+          Secure subscription
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">
+          {copy?.name || 'DSG Gate Checkout'}
+        </h1>
+        {copy && (
+          <div className="mt-5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4">
+            <p className="text-2xl font-bold text-white">{copy.price}</p>
+            <p className="mt-1 text-sm text-slate-300">{copy.included}</p>
+          </div>
+        )}
+
+        <div className="mt-8 flex items-center gap-3 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+          {status === 'starting' && (
+            <span className="h-5 w-5 animate-spin rounded-full border-2 border-slate-700 border-t-emerald-400" />
+          )}
+          <p className={status === 'error' || status === 'invalid' ? 'text-amber-300' : 'text-slate-300'}>
+            {message}
+          </p>
+        </div>
+
+        {(status === 'error' || status === 'invalid') && (
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/pricing#dsg-gate"
+              className="rounded-xl bg-emerald-500 px-4 py-2.5 font-semibold text-emerald-950 hover:bg-emerald-400"
+            >
+              Back to pricing
+            </Link>
+            <Link
+              href="/dashboard/billing"
+              className="rounded-xl border border-slate-700 px-4 py-2.5 font-semibold text-slate-200 hover:border-slate-500"
+            >
+              Open billing
+            </Link>
+          </div>
+        )}
+
+        <p className="mt-8 text-xs text-slate-500">
+          Subscription access is granted only after a verified Stripe webhook updates the workspace entitlement.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/dashboard/billing/activation-proof/page.tsx
+++ b/app/dashboard/billing/activation-proof/page.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+type ActivationProof = {
+  id: string;
+  tier: string;
+  subscription_status: string;
+  stripe_customer_id: string;
+  stripe_subscription_id: string;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  proof_version: string;
+  proof_hash: string;
+  created_at: string;
+};
+
+type ProofResponse = {
+  ok: boolean;
+  activated?: boolean;
+  proof?: ActivationProof | null;
+  message?: string;
+  meaning?: string;
+  error?: string;
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+export default function BillingActivationProofPage() {
+  const [result, setResult] = useState<ProofResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let attempts = 0;
+
+    async function loadProof() {
+      attempts += 1;
+      try {
+        const response = await fetch('/api/billing/activation-proof', {
+          cache: 'no-store',
+        });
+        const data = (await response.json().catch(() => ({}))) as ProofResponse;
+        if (cancelled) return;
+
+        if (!response.ok) {
+          setResult({ ok: false, error: data.error || 'Activation proof unavailable' });
+          setLoading(false);
+          return;
+        }
+
+        setResult(data);
+        setLoading(false);
+
+        // Stripe webhooks can arrive just after Checkout redirects back. Poll for
+        // a short bounded window so the customer sees the result without having
+        // to refresh manually. We stop as soon as a proof exists.
+        if (!data.activated && attempts < 8) {
+          timer = setTimeout(loadProof, 1500);
+        }
+      } catch {
+        if (!cancelled) {
+          setResult({ ok: false, error: 'Activation proof unavailable' });
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadProof();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  const proof = result?.proof ?? null;
+
+  async function copyHash() {
+    if (!proof?.proof_hash) return;
+    try {
+      await navigator.clipboard.writeText(proof.proof_hash);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-10 text-slate-100">
+      <div className="mx-auto max-w-4xl">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-300">
+              Billing Evidence
+            </p>
+            <h1 className="mt-2 text-3xl font-bold">Subscription Activation Proof</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-400">
+              ดูว่าการสมัครแบบชำระเงินถูก Stripe ยืนยันและถูกสะท้อนเป็นสิทธิ์ใช้งานใน DSG แล้วหรือยัง โดยไม่ต้องไล่ดู log หรือฐานข้อมูลเอง
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Link
+              href="/dashboard/billing"
+              className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-slate-500"
+            >
+              Billing
+            </Link>
+            <Link
+              href="/pricing#dsg-gate"
+              className="rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-slate-500"
+            >
+              Pricing
+            </Link>
+          </div>
+        </div>
+
+        <section className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          {loading ? (
+            <div className="flex items-center gap-3 text-slate-300">
+              <span className="h-5 w-5 animate-spin rounded-full border-2 border-slate-700 border-t-emerald-400" />
+              กำลังตรวจหลักฐานการเปิดใช้งาน…
+            </div>
+          ) : result?.activated && proof ? (
+            <>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-emerald-300">✓ VERIFIED ACTIVATION</p>
+                  <h2 className="mt-1 text-2xl font-bold">{proof.tier.toUpperCase()} is active</h2>
+                </div>
+                <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 text-xs font-bold text-emerald-200">
+                  {proof.subscription_status}
+                </span>
+              </div>
+
+              <dl className="mt-6 grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                  <dt className="text-xs uppercase tracking-wider text-slate-500">Stripe Subscription</dt>
+                  <dd className="mt-1 break-all font-mono text-sm text-slate-200">{proof.stripe_subscription_id}</dd>
+                </div>
+                <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                  <dt className="text-xs uppercase tracking-wider text-slate-500">Stripe Customer</dt>
+                  <dd className="mt-1 break-all font-mono text-sm text-slate-200">{proof.stripe_customer_id}</dd>
+                </div>
+                <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                  <dt className="text-xs uppercase tracking-wider text-slate-500">Billing Period</dt>
+                  <dd className="mt-1 text-sm text-slate-200">
+                    {formatDate(proof.current_period_start)} → {formatDate(proof.current_period_end)}
+                  </dd>
+                </div>
+                <div className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                  <dt className="text-xs uppercase tracking-wider text-slate-500">Proof Created</dt>
+                  <dd className="mt-1 text-sm text-slate-200">{formatDate(proof.created_at)}</dd>
+                </div>
+              </dl>
+
+              <div className="mt-4 rounded-xl border border-violet-400/20 bg-violet-400/5 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-wider text-violet-300">Deterministic Proof Hash</p>
+                    <p className="mt-2 break-all font-mono text-xs text-slate-300">{proof.proof_hash}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={copyHash}
+                    className="rounded-lg border border-violet-400/30 px-3 py-2 text-xs font-semibold text-violet-200 hover:bg-violet-400/10"
+                  >
+                    {copied ? 'Copied' : 'Copy hash'}
+                  </button>
+                </div>
+              </div>
+            </>
+          ) : result?.ok ? (
+            <div>
+              <p className="text-sm font-semibold text-amber-300">NOT VERIFIED YET</p>
+              <h2 className="mt-1 text-xl font-bold">ยังไม่มี Activation Proof สำหรับ workspace นี้</h2>
+              <p className="mt-2 text-sm text-slate-400">
+                {result.message || 'ระบบยังไม่พบ paid entitlement ที่มี Stripe customer และ subscription IDs ครบ'}
+              </p>
+              <p className="mt-3 text-xs text-slate-500">
+                ถ้าเพิ่งกลับจาก Checkout หน้านี้จะตรวจซ้ำอัตโนมัติช่วงสั้น ๆ เพื่อรอ webhook โดยไม่สร้างข้อมูลปลอมขึ้นมาเอง
+              </p>
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm font-semibold text-red-300">CHECK FAILED</p>
+              <p className="mt-2 text-sm text-slate-300">{result?.error || 'Activation proof unavailable'}</p>
+            </div>
+          )}
+        </section>
+
+        <section className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/5 p-5">
+            <h2 className="font-bold text-emerald-200">หลักฐานนี้ยืนยันอะไร</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              ยืนยันว่า DSG มี paid entitlement สถานะ active/trialing ที่ผูกกับ Stripe customer และ subscription จริง และบันทึกหลักฐานแบบ append-only พร้อม SHA-256 hash แล้ว
+            </p>
+          </div>
+          <div className="rounded-2xl border border-amber-400/20 bg-amber-400/5 p-5">
+            <h2 className="font-bold text-amber-200">หลักฐานนี้ไม่ใช่อะไร</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              ไม่ใช่ใบเสร็จรับเงินจาก Stripe และไม่ใช่ใบรับรองว่าลูกค้าหรือระบบผ่านกฎหมาย/มาตรฐานใดโดยอัตโนมัติ หลักฐาน compliance ต้องมาจากการตรวจ DSG แยกต่างหาก
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/revenue/COMPLIANCE_AUTOMATIC_REVENUE_FLOW.md
+++ b/docs/revenue/COMPLIANCE_AUTOMATIC_REVENUE_FLOW.md
@@ -1,0 +1,93 @@
+# Compliance Verification — Automatic Revenue Flow
+
+Status: development branch implementation; not production-approved.
+
+## Customer journey
+
+1. The customer reviews `/pricing#dsg-gate`.
+2. Pro and Enterprise actions open `/checkout/pro` or `/checkout/enterprise`.
+3. The checkout handoff authenticates the user and requests a Stripe Checkout Session from `POST /api/billing/checkout`.
+4. Stripe sends a signed event to `POST /api/billing/webhook`.
+5. The webhook claims the event idempotently, persists the subscription, and calls `sync_dsg_paid_entitlement`.
+6. The database transaction updates both `organizations.plan` and `dsg_gate_entitlements`.
+7. Web, Android, or MCP clients read `GET /api/dsg/v1/entitlement` before execution.
+8. The client submits a governed verification to `POST /api/dsg/v1/solver/hybrid/evaluate` with a unique `idempotencyKey`.
+9. The server checks entitlement, executes the solver, and persists a unique usage row keyed by `(org_id, eval_id)` before returning the result.
+10. Pro evaluations above the included quota enter the durable Stripe meter outbox. Stripe failures remain retryable instead of losing revenue evidence.
+
+## Client contract
+
+### Read entitlement
+
+```http
+GET /api/dsg/v1/entitlement
+Authorization: Bearer <DSG credential>
+```
+
+Important response fields:
+
+```json
+{
+  "ok": true,
+  "entitlement": {
+    "allowed": true,
+    "tier": "pro",
+    "evalsRemaining": 42,
+    "accessMode": "included_quota",
+    "requiresPayment": false,
+    "upgradeUrl": "/pricing#dsg-gate"
+  }
+}
+```
+
+`accessMode` values:
+
+- `included_quota`: execute without an overage event.
+- `metered_overage`: execute and create one idempotent Stripe meter event.
+- `quota_exceeded`: upgrade required.
+- `subscription_inactive`: paid access revoked.
+- `billing_unavailable`: fail closed because billing evidence cannot be trusted.
+
+### Submit verification
+
+```http
+POST /api/dsg/v1/solver/hybrid/evaluate
+Authorization: Bearer <DSG credential>
+Content-Type: application/json
+
+{
+  "planId": "customer-policy-v1",
+  "riskLevel": "medium",
+  "context": {
+    "approval_present": true,
+    "audit_complete": true
+  },
+  "nonce": "client-generated-nonce",
+  "idempotencyKey": "stable-id-for-this-logical-evaluation"
+}
+```
+
+The same logical request must reuse the same `idempotencyKey`. A retry cannot create a second `dsg_gate_usage` row or a second Stripe meter event.
+
+## Revenue invariants
+
+- Evaluation 5,000 is included in Pro; evaluation 5,001 is the first possible overage.
+- Paid access requires Stripe status `active` or `trialing`.
+- Missing entitlement storage fails closed for authenticated organizations.
+- Solver output is withheld when usage evidence cannot be persisted.
+- Subscription fulfillment and revocation update organization and gate entitlement in one database transaction.
+- SECURITY DEFINER revenue functions are executable only by `service_role` and the database owner.
+
+## Verified development evidence
+
+- Both revenue migrations were applied successfully to Supabase project `dsg-control-plane-dev`.
+- The entitlement RPC was executed inside a transaction and returned Pro / 5,000 / overage enabled; rollback restored the original Free state.
+- Routine privileges were queried after hardening: only `postgres` and `service_role` retained `EXECUTE`.
+
+## Known production blockers
+
+- Production Supabase project identity and readiness are not confirmed; the suspected project is inactive.
+- Vercel native Git previews report `Resource provisioning failed`; repository release policy intentionally requires governed CI promotion.
+- The repository contains conflicting legacy plan displays in `/dashboard/billing`; the public DSG Gate pricing flow now bypasses those cards, but the legacy billing UI still needs catalog consolidation.
+- The connected Stripe account currently exposes monthly Pro and Enterprise prices; Business and yearly prices were not created because no verified commercial decision exists.
+- Stripe meter configuration and production environment variables must be verified during governed promotion.

--- a/lib/billing/fulfillment.ts
+++ b/lib/billing/fulfillment.ts
@@ -1,107 +1,60 @@
 /**
- * Idempotent subscription fulfillment.
+ * Idempotent, atomic entitlement fulfillment.
  *
- * Invariants:
- *   I1: repeated fulfillment converges on the same org + gate entitlement state
- *   I2: revoked subscriptions always converge to the free plan/tier
- *   I3: a paid DSG plan never leaves the deterministic gate quota at free
- *   I4: persistence failures throw so the canonical Stripe webhook releases
- *       its event claim and Stripe can retry instead of acknowledging partial
- *       entitlement state
+ * The database RPC updates organizations.plan and dsg_gate_entitlements in
+ * one transaction. A webhook retry therefore produces the same final state,
+ * while a database failure produces no partial entitlement grant.
  */
 
 import { getSupabaseAdmin } from '../supabase-server';
-import { effectivePlan } from './entitlements';
-import { DSG_GATE_TIERS } from '../dsg/gate-entitlement';
 
 export type FulfillResult = {
   ok: boolean;
   error?: string;
 };
 
-type GateTier = 'free' | 'pro' | 'enterprise';
-
-/**
- * Billing has a Business plan while the deterministic Gate currently exposes
- * Free / Pro / Enterprise tiers. Business receives the verified Pro gate tier;
- * Enterprise receives Enterprise. Unknown/non-gate products remain Free.
- */
-export function gateTierForBillingPlan(plan: string): GateTier {
-  if (plan === 'enterprise') return 'enterprise';
-  if (plan === 'pro' || plan === 'business') return 'pro';
-  return 'free';
-}
-
-async function syncGateEntitlement(
+async function syncPaidEntitlement(
   orgId: string,
-  effectiveBillingPlan: string,
-): Promise<void> {
-  const tier = gateTierForBillingPlan(effectiveBillingPlan);
-  const tierSpec = DSG_GATE_TIERS[tier];
-  const supabase = getSupabaseAdmin();
-  const { error } = await (supabase as any)
-    .from('dsg_gate_entitlements')
-    .upsert(
-      {
-        org_id: orgId,
-        tier,
-        evals_per_month: tierSpec.evalsPerMonth,
-      },
-      { onConflict: 'org_id' },
-    );
+  planKey: string,
+  status: string,
+): Promise<FulfillResult> {
+  const supabase = getSupabaseAdmin() as any;
+  const { error } = await supabase.rpc('sync_dsg_paid_entitlement', {
+    p_org_id: orgId,
+    p_plan_key: planKey,
+    p_status: status,
+  });
 
   if (error) {
-    throw new Error(`gate_entitlement_sync_failed:${error.message}`);
+    return { ok: false, error: error.message };
   }
+
+  return { ok: true };
 }
 
 /**
- * Update organizations.plan and the deterministic gate entitlement for an
- * active/trialing subscription. Called by the canonical Stripe webhook.
+ * Grant or update an active/trialing subscription.
+ * Non-active statuses are normalized to free by the database function.
  */
 export async function fulfillSubscription(
   orgId: string,
   planKey: string,
   status: string,
 ): Promise<FulfillResult> {
-  if (!orgId || !planKey) {
-    return { ok: false, error: 'orgId and planKey are required' };
+  if (!orgId || !planKey || !status) {
+    return { ok: false, error: 'orgId, planKey, and status are required' };
   }
 
-  const plan = effectivePlan(status, planKey);
-  const supabase = getSupabaseAdmin();
-  const { error } = await supabase
-    .from('organizations')
-    .update({ plan, updated_at: new Date().toISOString() })
-    .eq('id', orgId);
-
-  if (error) {
-    throw new Error(`organization_entitlement_sync_failed:${error.message}`);
-  }
-
-  await syncGateEntitlement(orgId, plan);
-  return { ok: true };
+  return syncPaidEntitlement(orgId, planKey, status);
 }
 
 /**
- * Downgrade both organizations.plan and the deterministic gate entitlement
- * when a subscription is canceled, unpaid, or permanently failed.
+ * Revoke paid access atomically when Stripe cancels or stops collection.
  */
 export async function revokeSubscription(orgId: string): Promise<FulfillResult> {
   if (!orgId) {
     return { ok: false, error: 'orgId is required' };
   }
 
-  const supabase = getSupabaseAdmin();
-  const { error } = await supabase
-    .from('organizations')
-    .update({ plan: 'free', updated_at: new Date().toISOString() })
-    .eq('id', orgId);
-
-  if (error) {
-    throw new Error(`organization_entitlement_revoke_failed:${error.message}`);
-  }
-
-  await syncGateEntitlement(orgId, 'free');
-  return { ok: true };
+  return syncPaidEntitlement(orgId, 'free', 'canceled');
 }

--- a/lib/billing/fulfillment.ts
+++ b/lib/billing/fulfillment.ts
@@ -2,8 +2,10 @@
  * Idempotent, atomic entitlement fulfillment.
  *
  * The database RPC updates organizations.plan and dsg_gate_entitlements in
- * one transaction. A webhook retry therefore produces the same final state,
- * while a database failure produces no partial entitlement grant.
+ * one transaction. A webhook retry therefore produces the same final state.
+ * Persistence failures throw so the canonical Stripe webhook can release its
+ * event claim and return a non-2xx response, allowing Stripe to retry instead
+ * of acknowledging a paid event whose entitlement was not persisted.
  */
 
 import { getSupabaseAdmin } from '../supabase-server';
@@ -26,7 +28,7 @@ async function syncPaidEntitlement(
   });
 
   if (error) {
-    return { ok: false, error: error.message };
+    throw new Error(`paid_entitlement_sync_failed:${error.message}`);
   }
 
   return { ok: true };

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -1,25 +1,26 @@
 /**
  * Stripe Metered Billing — Usage-Based Overage Charges
  *
- * Implements Stripe's Billing Meter API (2026) to report per-execution
- * usage events. This enables hybrid pricing: flat subscription +
- * metered overage for high-volume orgs.
+ * Implements Stripe's Billing Meter API to report per-execution usage events.
+ * A durable outbox row is always created before Stripe delivery so temporary
+ * provider failures can be retried without losing revenue evidence.
  *
- * Market context: Stripe Metering for AI agents (tokens, tasks, workflows)
- * became the industry standard in Q1 2026. This positions DSG ONE at the
- * frontier of enterprise AI billing.
- *
- * Required env vars (add to Vercel when enabling metered billing):
- *   STRIPE_METER_EVENT_NAME  – e.g., "dsg_execution"
- *   STRIPE_SECRET_KEY        – already configured
+ * Required env vars:
+ *   STRIPE_METER_EVENT_NAME  – e.g. "dsg_execution"
+ *   STRIPE_SECRET_KEY
  */
 
 import Stripe from 'stripe';
 import { STRIPE_API_VERSION } from '@/lib/stripe-api-version';
 
-type MeterEventResult =
-  | { ok: true; eventId: string }
-  | { ok: false; error: string; skipped?: boolean };
+export type MeterEventResult =
+  | { ok: true; eventId: string; durable: true }
+  | {
+      ok: false;
+      error: string;
+      durable: boolean;
+      skipped?: boolean;
+    };
 
 export type MeterOutboxFlushResult = {
   scanned: number;
@@ -67,8 +68,6 @@ function idempotencyKeyForExecution(executionId: string): string {
 
 async function getOutboxClient() {
   const { getSupabaseAdmin } = await import('../supabase-server');
-  // billing_meter_outbox is introduced by a new migration in this branch.
-  // Cast to any until lib/database.types.ts is regenerated from Supabase.
   return getSupabaseAdmin() as any;
 }
 
@@ -78,7 +77,10 @@ async function createOutboxRow(input: {
   stripeCustomerId: string;
   eventName: string;
   quantity: number;
-}): Promise<{ ok: true; rowId: string; alreadySentEventId?: string } | { ok: false; error: string }> {
+}): Promise<
+  | { ok: true; rowId: string; alreadySentEventId?: string }
+  | { ok: false; error: string }
+> {
   const supabase = await getOutboxClient();
 
   const { data, error } = await supabase
@@ -106,14 +108,21 @@ async function createOutboxRow(input: {
 
   if (existing?.id) {
     if (existing.status === 'sent' && existing.stripe_event_id) {
-      return { ok: true, rowId: existing.id, alreadySentEventId: existing.stripe_event_id };
+      return {
+        ok: true,
+        rowId: existing.id,
+        alreadySentEventId: existing.stripe_event_id,
+      };
     }
     return { ok: true, rowId: existing.id };
   }
 
   return {
     ok: false,
-    error: existingError?.message ?? error?.message ?? 'failed to create billing meter outbox row',
+    error:
+      existingError?.message ??
+      error?.message ??
+      'failed to create billing meter outbox row',
   };
 }
 
@@ -164,32 +173,24 @@ async function deliverMeterEvent(input: {
 
   const event = await input.stripe.billing.meterEvents.create(
     meterEventPayload,
-    { idempotencyKey }
+    { idempotencyKey },
   );
 
-  return { ok: true, eventId: event.identifier };
+  return { ok: true, eventId: event.identifier, durable: true };
 }
 
 /**
  * Report a single execution event to Stripe Metering.
  *
- * Called after a successful /api/execute response.
- * Execution-level idempotency prevents same-second org activity from being
- * silently deduped by Stripe while still making retries of the same execution safe.
- *
- * A durable outbox row is written before Stripe delivery. If Stripe fails,
- * the failed row remains retryable by /api/cron/flush-meter-outbox.
- *
- * @param stripeCustomerId  The org's Stripe customer ID (from billing_customers table)
- * @param orgId             DSG org ID
- * @param quantity          Number of executions to meter
- * @param executionId       Canonical execution/audit row ID for idempotency
+ * `durable: true` means a retryable outbox row exists, even when immediate
+ * Stripe delivery failed. `durable: false` means no trustworthy billing
+ * evidence exists and callers that deliver paid work must fail closed.
  */
 export async function reportMeterEvent(
   stripeCustomerId: string,
   orgId: string,
   quantity: number,
-  executionId: string
+  executionId: string,
 ): Promise<MeterEventResult> {
   const stripe = getStripe();
   const eventName = getMeterEventName();
@@ -197,11 +198,20 @@ export async function reportMeterEvent(
   const meteredQuantity = positiveQuantity(quantity);
 
   if (!normalizedExecutionId) {
-    return { ok: false, error: 'executionId is required for Stripe meter idempotency' };
+    return {
+      ok: false,
+      error: 'executionId is required for Stripe meter idempotency',
+      durable: false,
+    };
   }
 
   if (!stripe || !eventName) {
-    return { ok: false, error: 'Stripe metering not configured', skipped: true };
+    return {
+      ok: false,
+      error: 'Stripe metering not configured',
+      skipped: true,
+      durable: false,
+    };
   }
 
   const outbox = await createOutboxRow({
@@ -212,12 +222,16 @@ export async function reportMeterEvent(
     quantity: meteredQuantity,
   });
 
-  if ('error' in outbox) {
-    return { ok: false, error: outbox.error };
+  if (outbox.ok === false) {
+    return { ok: false, error: outbox.error, durable: false };
   }
 
   if (outbox.alreadySentEventId) {
-    return { ok: true, eventId: outbox.alreadySentEventId };
+    return {
+      ok: true,
+      eventId: outbox.alreadySentEventId,
+      durable: true,
+    };
   }
 
   try {
@@ -229,7 +243,7 @@ export async function reportMeterEvent(
       executionId: normalizedExecutionId,
     });
 
-    if (result.ok) {
+    if (result.ok === true) {
       await markOutboxSent(outbox.rowId, result.eventId);
     }
 
@@ -238,14 +252,16 @@ export async function reportMeterEvent(
     const message = err instanceof Error ? err.message : String(err);
     console.error('[metered] Stripe meter event failed:', message);
     await markOutboxFailed(outbox.rowId, message);
-    return { ok: false, error: message };
+    return { ok: false, error: message, durable: true };
   }
 }
 
 /**
  * Retry pending and failed billing meter outbox rows.
  */
-export async function flushMeterOutbox(limit = 100): Promise<MeterOutboxFlushResult> {
+export async function flushMeterOutbox(
+  limit = 100,
+): Promise<MeterOutboxFlushResult> {
   const stripe = getStripe();
   const result: MeterOutboxFlushResult = {
     scanned: 0,
@@ -271,7 +287,10 @@ export async function flushMeterOutbox(limit = 100): Promise<MeterOutboxFlushRes
     .limit(limit);
 
   if (error) {
-    return { ...result, errors: [error.message ?? 'failed to load billing meter outbox'] };
+    return {
+      ...result,
+      errors: [error.message ?? 'failed to load billing meter outbox'],
+    };
   }
 
   const rows = (data ?? []) as OutboxRow[];
@@ -292,7 +311,7 @@ export async function flushMeterOutbox(limit = 100): Promise<MeterOutboxFlushRes
         executionId: row.execution_id,
       });
 
-      if (delivered.ok) {
+      if (delivered.ok === true) {
         await markOutboxSent(row.id, delivered.eventId);
         result.sent++;
       }
@@ -307,11 +326,9 @@ export async function flushMeterOutbox(limit = 100): Promise<MeterOutboxFlushRes
   return result;
 }
 
-/**
- * Lookup the Stripe customer ID for an org from the billing_customers table.
- * Returns null if no customer record exists (org not yet on Stripe).
- */
-export async function getStripeCustomerIdForOrg(orgId: string): Promise<string | null> {
+export async function getStripeCustomerIdForOrg(
+  orgId: string,
+): Promise<string | null> {
   const { getSupabaseAdmin } = await import('../supabase-server');
   const supabase = getSupabaseAdmin();
 
@@ -325,18 +342,21 @@ export async function getStripeCustomerIdForOrg(orgId: string): Promise<string |
 }
 
 /**
- * Combined: report meter event for an org if they have a Stripe customer.
- * Safe to call from /api/execute — never throws, skips gracefully if unconfigured.
+ * Legacy convenience path. Callers that must guarantee paid-delivery evidence
+ * should call reportMeterEvent directly and inspect `durable`.
  */
-export async function meterExecution(orgId: string, quantity: number, executionId: string): Promise<void> {
+export async function meterExecution(
+  orgId: string,
+  quantity: number,
+  executionId: string,
+): Promise<void> {
   const customerId = await getStripeCustomerIdForOrg(orgId);
   if (!customerId) return;
   await reportMeterEvent(customerId, orgId, quantity, executionId);
 }
 
-/**
- * Check if Stripe metered billing is configured.
- */
 export function isMeteredBillingConfigured(): boolean {
-  return !!(process.env.STRIPE_SECRET_KEY && process.env.STRIPE_METER_EVENT_NAME);
+  return !!(
+    process.env.STRIPE_SECRET_KEY && process.env.STRIPE_METER_EVENT_NAME
+  );
 }

--- a/lib/billing/pricing-catalog.ts
+++ b/lib/billing/pricing-catalog.ts
@@ -1,14 +1,11 @@
 /**
- * Pricing catalog — single source of truth for every price shown or charged.
+ * Pricing catalog — single source of truth for prices shown by DSG surfaces.
  *
- * Consumers:
- *   app/api/billing/checkout/route.ts        (charges — env-first price IDs)
- *   app/api/dsg/v1/pricing/route.ts          (public gate pricing display)
- *   app/api/delivery-proof/pricing/route.ts  (public delivery-proof display)
- *
- * Rule: display prices here MUST match the Stripe prices behind
- * DEFAULT_PRICE_IDS / STRIPE_PRICE_* envs. Change prices here first,
- * then reconcile Stripe, never the other way around.
+ * Charging rule:
+ *   Checkout may use only an explicitly configured STRIPE_PRICE_* environment
+ *   value. We intentionally do not fall back to hardcoded Price IDs because
+ *   Price IDs are scoped to one Stripe account; a cross-account fallback can
+ *   make a correct-looking UI attempt to charge through the wrong account.
  */
 
 export type PlanKey = 'pro' | 'business' | 'enterprise';
@@ -23,7 +20,7 @@ export type BillingInterval = 'monthly' | 'yearly';
 
 export interface GatePlan {
   trialDays: number;
-  /** Display price per month in USD (what the public pricing endpoints show). */
+  /** Display price per month in USD (what public pricing endpoints show). */
   displayMonthlyUsd: number;
   priceEnv: Record<BillingInterval, string>;
 }
@@ -32,34 +29,74 @@ export const GATE_PLANS: Record<PlanKey, GatePlan> = {
   pro: {
     trialDays: 14,
     displayMonthlyUsd: 99,
-    priceEnv: { monthly: 'STRIPE_PRICE_PRO_MONTHLY', yearly: 'STRIPE_PRICE_PRO_YEARLY' },
+    priceEnv: {
+      monthly: 'STRIPE_PRICE_PRO_MONTHLY',
+      yearly: 'STRIPE_PRICE_PRO_YEARLY',
+    },
   },
   business: {
     trialDays: 14,
     displayMonthlyUsd: 199,
-    priceEnv: { monthly: 'STRIPE_PRICE_BUSINESS_MONTHLY', yearly: 'STRIPE_PRICE_BUSINESS_YEARLY' },
+    priceEnv: {
+      monthly: 'STRIPE_PRICE_BUSINESS_MONTHLY',
+      yearly: 'STRIPE_PRICE_BUSINESS_YEARLY',
+    },
   },
   enterprise: {
     trialDays: 30,
     displayMonthlyUsd: 499,
-    priceEnv: { monthly: 'STRIPE_PRICE_ENTERPRISE_MONTHLY', yearly: 'STRIPE_PRICE_ENTERPRISE_YEARLY' },
+    priceEnv: {
+      monthly: 'STRIPE_PRICE_ENTERPRISE_MONTHLY',
+      yearly: 'STRIPE_PRICE_ENTERPRISE_YEARLY',
+    },
   },
 };
 
 // Skills bundles use inline price_data (no pre-created Stripe price IDs needed).
 // Amounts are in USD cents.
-export const SKILLS_BUNDLES: Record<SkillsBundleKey, { name: string; amountMonthly: number; amountYearly: number }> = {
-  finance_skills:    { name: 'DSG Finance Governance Pack',  amountMonthly: 19900, amountYearly: 179100 },
-  dev_skills:        { name: 'DSG Dev Automation Pack',      amountMonthly:  9900, amountYearly:  89100 },
-  compliance_skills: { name: 'DSG Compliance & Legal Pack',  amountMonthly: 24900, amountYearly: 224100 },
-  ops_skills:        { name: 'DSG Operations Pack',          amountMonthly: 14900, amountYearly: 134100 },
-  enterprise_skills: { name: 'DSG Enterprise Bundle',        amountMonthly: 59900, amountYearly: 539100 },
+export const SKILLS_BUNDLES: Record<
+  SkillsBundleKey,
+  { name: string; amountMonthly: number; amountYearly: number }
+> = {
+  finance_skills: {
+    name: 'DSG Finance Governance Pack',
+    amountMonthly: 19900,
+    amountYearly: 179100,
+  },
+  dev_skills: {
+    name: 'DSG Dev Automation Pack',
+    amountMonthly: 9900,
+    amountYearly: 89100,
+  },
+  compliance_skills: {
+    name: 'DSG Compliance & Legal Pack',
+    amountMonthly: 24900,
+    amountYearly: 224100,
+  },
+  ops_skills: {
+    name: 'DSG Operations Pack',
+    amountMonthly: 14900,
+    amountYearly: 134100,
+  },
+  enterprise_skills: {
+    name: 'DSG Enterprise Bundle',
+    amountMonthly: 59900,
+    amountYearly: 539100,
+  },
 };
 
 // MCP API subscription — monthly only, env-driven price ID.
-// ฿490/month corresponds to ~$14 USD (exchange rate context only; actual charged in USD via Stripe).
-export const MCP_SUBSCRIPTION: Record<MCPSubscriptionKey, { name: string; callsPerMonth: number; priceEnv: string }> = {
-  mcp_api: { name: 'MCP API Subscription', callsPerMonth: 10000, priceEnv: 'STRIPE_PRICE_MCP_MONTHLY' },
+// ฿490/month corresponds to ~$14 USD (exchange rate context only; actual
+// charged currency is determined by the configured Stripe Price object).
+export const MCP_SUBSCRIPTION: Record<
+  MCPSubscriptionKey,
+  { name: string; callsPerMonth: number; priceEnv: string }
+> = {
+  mcp_api: {
+    name: 'MCP API Subscription',
+    callsPerMonth: 10000,
+    priceEnv: 'STRIPE_PRICE_MCP_MONTHLY',
+  },
 };
 
 export function isSkillsBundle(plan: string): plan is SkillsBundleKey {
@@ -77,22 +114,21 @@ export const DELIVERY_PROOF_PRICING = {
   unlimited: { displayUsd: 199, label: '$199', planKey: 'business' as PlanKey },
 } as const;
 
-// Live price IDs in Stripe account acct_1Tnbl5CVpjxFKlKT (dsg-one, Inc.), created 2026-07-02.
-// Price IDs are public identifiers (visible in Checkout URLs), not secrets.
-// STRIPE_PRICE_* env vars always take precedence when set.
-export const DEFAULT_PRICE_IDS: Record<PlanKey, Record<BillingInterval, string>> = {
-  pro:        { monthly: 'price_1TopmZCVpjxFKlKT18ljNI84', yearly: 'price_1TopmiCVpjxFKlKT0EVZwCps' },
-  business:   { monthly: 'price_1TopmsCVpjxFKlKTdpm128OG', yearly: 'price_1Topn0CVpjxFKlKTvxKJUsff' },
-  enterprise: { monthly: 'price_1TopnACVpjxFKlKT36Pe7Zmu', yearly: 'price_1TopnICVpjxFKlKTqHhjKzhR' },
-};
-
 function getLegacyMonthlyPriceId(plan: PlanKey): string {
   if (plan === 'pro') return process.env.STRIPE_PRICE_PRO || '';
   if (plan === 'business') return process.env.STRIPE_PRICE_BUSINESS || '';
   return '';
 }
 
-/** Env-first Stripe price resolution: STRIPE_PRICE_* → legacy monthly envs → hardcoded fallback. */
+/**
+ * Env-first and fail-closed Stripe price resolution.
+ *
+ * Resolution order:
+ * 1. Interval-specific STRIPE_PRICE_* environment variable.
+ * 2. Legacy monthly env for Pro/Business only.
+ * 3. Empty string, causing checkout to return a configuration error instead
+ *    of attempting a Price ID from another Stripe account.
+ */
 export function getPriceId(plan: PlanKey, interval: BillingInterval): string {
   const envName = GATE_PLANS[plan].priceEnv[interval];
   const configured = process.env[envName] || '';
@@ -103,5 +139,5 @@ export function getPriceId(plan: PlanKey, interval: BillingInterval): string {
     if (legacy) return legacy;
   }
 
-  return DEFAULT_PRICE_IDS[plan][interval];
+  return '';
 }

--- a/lib/dsg/gate-entitlement.ts
+++ b/lib/dsg/gate-entitlement.ts
@@ -1,28 +1,32 @@
 /**
- * DSG Gate API — Pricing & Entitlement Logic
- *
- * Controls access to DSG deterministic gate/proof APIs based on org tier.
- * Current metered routes:
- * - POST /api/dsg/v1/gates/evaluate
- * - POST /api/dsg/v1/proofs/prove
- * - POST /api/dsg/v1/encoding/prove
+ * DSG Gate API — persisted entitlement and usage-based revenue control.
  *
  * Revenue model:
- *   Free        — 50 evaluations / month
- *   Pro         — $99/month  — 5 000 evals / month + compliance bundle access
- *   Enterprise  — $499/month — high-limit evals + SLA + Hermes executor access
+ *   Free        — 50 gate evaluations / month
+ *   Pro         — $99/month, 5 000 included, metered overage when configured
+ *   Enterprise  — $499/month, active subscription treated as unlimited
  */
 
-import { reportMeterEvent } from '@/lib/billing/metered';
+import {
+  isMeteredBillingConfigured,
+  reportMeterEvent,
+} from '@/lib/billing/metered';
 import { insertRevenueEvent } from '@/lib/revenue/events';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  decideGateRevenueAccess,
+  GATE_INCLUDED_EVALS,
+  type GateAccessMode,
+  type GateTier,
+} from './gate-revenue-policy';
 
-export type DsgMeteredGateRoute = 'gates/evaluate' | 'proofs/prove' | 'encoding/prove';
-
-// ─── Tier definitions ────────────────────────────────────────────────────────
+export type DsgMeteredGateRoute =
+  | 'gates/evaluate'
+  | 'proofs/prove'
+  | 'encoding/prove';
 
 export interface DsgGateTier {
-  tier: 'free' | 'pro' | 'enterprise';
+  tier: GateTier;
   evalsPerMonth: number;
   priceUsdCents: number;
   billingPeriod: 'monthly' | 'none';
@@ -30,10 +34,10 @@ export interface DsgGateTier {
   features: string[];
 }
 
-export const DSG_GATE_TIERS: Record<string, DsgGateTier> = {
+export const DSG_GATE_TIERS: Record<GateTier, DsgGateTier> = {
   free: {
     tier: 'free',
-    evalsPerMonth: 50,
+    evalsPerMonth: GATE_INCLUDED_EVALS.free,
     priceUsdCents: 0,
     billingPeriod: 'none',
     description: 'Free — 50 gate evaluations/month',
@@ -41,49 +45,39 @@ export const DSG_GATE_TIERS: Record<string, DsgGateTier> = {
       '50 gate evaluations / month',
       'Deterministic PASS / REVIEW / BLOCK decision',
       'proofHash + constraintSetHash + inputHash',
-      'Replay-protection (nonce + idempotency-key)',
-      'Public policy manifest access',
+      'Replay protection',
       'JSON audit log per evaluation',
     ],
   },
   pro: {
     tier: 'pro',
-    evalsPerMonth: 5_000,
+    evalsPerMonth: GATE_INCLUDED_EVALS.pro,
     priceUsdCents: 99_00,
     billingPeriod: 'monthly',
-    description: 'Pro — $99/month — 5 000 gate evaluations/month',
+    description: 'Pro — $99/month — 5 000 included evaluations',
     features: [
-      '5 000 gate evaluations / month',
-      'All Free features',
-      'proofHash chain (hash-linked audit trail)',
-      'Compliance bundle export (JSON + hashes)',
-      'SBOM + CodeQL evidence access via API',
+      '5 000 included evaluations / month',
+      'Metered overage when billing meter is configured',
+      'Compliance bundle export',
+      'Hash-linked audit trail',
       'Multi-policy versioning',
-      'Priority rate-limit (600 req/min)',
-      'Email alerts on BLOCK decisions',
     ],
   },
   enterprise: {
     tier: 'enterprise',
-    evalsPerMonth: 999_999,
+    evalsPerMonth: GATE_INCLUDED_EVALS.enterprise,
     priceUsdCents: 499_00,
     billingPeriod: 'monthly',
-    description: 'Enterprise — $499/month — Unlimited evaluations',
+    description: 'Enterprise — $499/month — unlimited evaluations',
     features: [
-      'Unlimited gate evaluations',
-      'All Pro features',
+      'Unlimited gate evaluations while subscription is active',
       'Hermes Controlled Executor access',
-      'Credential broker (Supabase-backed secret leases)',
-      'SLA — 99.9% uptime guarantee',
-      'Dedicated support + Slack connect',
-      'Custom policy set deployment',
-      'Org-level RBAC + audit export (CSV/JSON)',
-      'White-label report branding',
+      'Credential broker',
+      'Audit export and white-label reports',
+      'Enterprise support',
     ],
   },
 };
-
-// ─── Entitlement check ────────────────────────────────────────────────────────
 
 export interface GateEntitlementCheck {
   allowed: boolean;
@@ -92,13 +86,25 @@ export interface GateEntitlementCheck {
   message: string;
   requiresPayment: boolean;
   upgradeUrl: string;
+  accessMode: GateAccessMode;
 }
 
 type GateEntitlementRow = {
   org_id: string;
-  tier: 'free' | 'pro' | 'enterprise' | string;
+  tier: GateTier | string;
   evals_per_month: number | null;
-  stripe_customer_id?: string | null;
+  subscription_status: string | null;
+  overage_enabled: boolean | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+};
+
+type GateUsageRecord = {
+  id: string;
+  created: boolean;
+  billed: boolean;
+  meterEventId?: string;
+  usagePosition: number | null;
 };
 
 function monthBoundsUtc(now = new Date()) {
@@ -107,8 +113,8 @@ function monthBoundsUtc(now = new Date()) {
   return { startIso: start.toISOString(), endIso: end.toISOString() };
 }
 
-function tierSpec(tier: string | null | undefined) {
-  const key = String(tier || 'free').toLowerCase();
+function tierSpec(tier: string | null | undefined): DsgGateTier {
+  const key = String(tier || 'free').toLowerCase() as GateTier;
   return DSG_GATE_TIERS[key] || DSG_GATE_TIERS.free;
 }
 
@@ -117,7 +123,9 @@ async function getOrCreateEntitlement(orgId: string): Promise<GateEntitlementRow
 
   const existing = await supabase
     .from('dsg_gate_entitlements')
-    .select('org_id,tier,evals_per_month,stripe_customer_id')
+    .select(
+      'org_id,tier,evals_per_month,subscription_status,overage_enabled,stripe_customer_id,stripe_subscription_id',
+    )
     .eq('org_id', orgId)
     .maybeSingle();
 
@@ -134,13 +142,19 @@ async function getOrCreateEntitlement(orgId: string): Promise<GateEntitlementRow
     .insert({
       org_id: orgId,
       tier: 'free',
-      evals_per_month: DSG_GATE_TIERS.free.evalsPerMonth,
+      evals_per_month: GATE_INCLUDED_EVALS.free,
+      subscription_status: 'free',
+      overage_enabled: false,
     })
-    .select('org_id,tier,evals_per_month,stripe_customer_id')
+    .select(
+      'org_id,tier,evals_per_month,subscription_status,overage_enabled,stripe_customer_id,stripe_subscription_id',
+    )
     .maybeSingle();
 
   if (created.error || !created.data) {
-    throw new Error(created.error?.message || 'failed_to_create_dsg_gate_entitlement');
+    throw new Error(
+      created.error?.message || 'failed_to_create_dsg_gate_entitlement',
+    );
   }
 
   return created.data as GateEntitlementRow;
@@ -148,8 +162,10 @@ async function getOrCreateEntitlement(orgId: string): Promise<GateEntitlementRow
 
 async function countEvalsThisPeriod(orgId: string): Promise<number> {
   const supabase = getSupabaseAdmin() as any;
+  const rpcResult = await supabase.rpc('dsg_gate_evals_this_period', {
+    p_org_id: orgId,
+  });
 
-  const rpcResult = await supabase.rpc('dsg_gate_evals_this_period', { p_org_id: orgId });
   if (!rpcResult.error && typeof rpcResult.data === 'number') {
     return rpcResult.data;
   }
@@ -169,7 +185,26 @@ async function countEvalsThisPeriod(orgId: string): Promise<number> {
   return countResult.count || 0;
 }
 
-/** Check whether an org is allowed to call a metered DSG gate/proof API. */
+function messageForAccessMode(
+  mode: GateAccessMode,
+  tier: string,
+  remaining: number,
+): string {
+  switch (mode) {
+    case 'included_quota':
+      return `${tier.toUpperCase()} tier — ${remaining} included evaluations remaining`;
+    case 'metered_overage':
+      return 'PRO tier — included quota used; metered overage billing is active';
+    case 'subscription_inactive':
+      return 'Paid subscription is not active';
+    case 'billing_unavailable':
+      return 'Included quota used; metered billing is not fully configured';
+    case 'quota_exceeded':
+    default:
+      return 'Quota exceeded — upgrade to DSG Gate Pro';
+  }
+}
+
 export async function checkGateEntitlement(
   orgId: string | null,
 ): Promise<GateEntitlementCheck> {
@@ -177,46 +212,97 @@ export async function checkGateEntitlement(
     return {
       allowed: true,
       tier: 'free',
-      evalsRemaining: 50,
-      message: 'Free tier — authenticate to unlock higher limits',
+      evalsRemaining: GATE_INCLUDED_EVALS.free,
+      message:
+        'Free tier — authenticate to persist usage and unlock paid plans',
       requiresPayment: false,
       upgradeUrl: '/pricing#dsg-gate',
+      accessMode: 'included_quota',
     };
   }
 
   try {
     const entitlement = await getOrCreateEntitlement(orgId);
     const plan = tierSpec(entitlement.tier);
-    const evalsPerMonth = Number(entitlement.evals_per_month || plan.evalsPerMonth);
+    const evalsPerMonth = Number(
+      entitlement.evals_per_month || plan.evalsPerMonth,
+    );
     const used = await countEvalsThisPeriod(orgId);
-    const remaining = Math.max(0, evalsPerMonth - used);
-    const allowed = remaining > 0;
+    const decision = decideGateRevenueAccess({
+      tier: plan.tier,
+      subscriptionStatus: entitlement.subscription_status,
+      includedLimit: evalsPerMonth,
+      used,
+      overageEnabled: entitlement.overage_enabled === true,
+      hasStripeCustomer: Boolean(entitlement.stripe_customer_id),
+      hasStripeSubscription: Boolean(entitlement.stripe_subscription_id),
+      meteringConfigured: isMeteredBillingConfigured(),
+    });
 
     return {
-      allowed,
+      allowed: decision.allowed,
       tier: plan.tier,
-      evalsRemaining: remaining,
-      message: allowed
-        ? `${plan.tier.toUpperCase()} tier — ${remaining} evaluations remaining this period`
-        : 'Quota exceeded — upgrade to DSG Gate Pro',
-      requiresPayment: !allowed,
+      evalsRemaining: decision.remaining,
+      message: messageForAccessMode(
+        decision.accessMode,
+        plan.tier,
+        decision.remaining,
+      ),
+      requiresPayment: decision.requiresPayment,
       upgradeUrl: '/pricing#dsg-gate',
+      accessMode: decision.accessMode,
     };
   } catch (error) {
-    console.error('[dsg-gate-entitlement] fallback to free tier:', error);
+    console.error('[dsg-gate-entitlement] entitlement check failed:', error);
+    return {
+      allowed: false,
+      tier: 'unknown',
+      evalsRemaining: 0,
+      message:
+        'Billing entitlement is temporarily unavailable; execution blocked to prevent unmetered usage',
+      requiresPayment: false,
+      upgradeUrl: '/pricing#dsg-gate',
+      accessMode: 'billing_unavailable',
+    };
+  }
+}
+
+async function recordUsageAtomically(
+  supabase: any,
+  orgId: string,
+  evalId: string,
+  route: DsgMeteredGateRoute,
+  gateStatus: string,
+  durationMs: number,
+): Promise<GateUsageRecord> {
+  const result = await supabase
+    .rpc('record_dsg_gate_usage', {
+      p_org_id: orgId,
+      p_eval_id: evalId,
+      p_route: route,
+      p_gate_status: gateStatus,
+      p_duration_ms: durationMs,
+    })
+    .maybeSingle();
+
+  if (result.error || !result.data?.usage_id) {
+    throw new Error(
+      result.error?.message || 'failed_to_record_dsg_gate_usage',
+    );
   }
 
   return {
-    allowed: true,
-    tier: 'free',
-    evalsRemaining: 50,
-    message: 'Free tier — 50 evaluations/month',
-    requiresPayment: false,
-    upgradeUrl: '/pricing#dsg-gate',
+    id: String(result.data.usage_id),
+    created: result.data.created === true,
+    billed: result.data.billed === true,
+    meterEventId: result.data.meter_event_id || undefined,
+    usagePosition:
+      typeof result.data.usage_position === 'number'
+        ? result.data.usage_position
+        : null,
   };
 }
 
-/** Record one metered deterministic evaluation/proof call. */
 export async function recordGateEvaluation(
   evalId: string,
   orgId: string | null,
@@ -225,30 +311,48 @@ export async function recordGateEvaluation(
   durationMs: number,
 ): Promise<{ recorded: boolean; meterEventId?: string; error?: string }> {
   try {
-    console.log(
-      `[dsg-gate-usage] evalId=${evalId} org=${orgId ?? 'anonymous'} route=${route} status=${gateStatus} ms=${durationMs}`,
-    );
-
     if (!orgId) {
       return { recorded: true };
     }
 
     const supabase = getSupabaseAdmin() as any;
-    const usageInsert = await supabase
-      .from('dsg_gate_usage')
-      .insert({
-        org_id: orgId,
-        eval_id: evalId,
-        route,
-        gate_status: gateStatus,
-        duration_ms: durationMs,
-        billed: false,
-      })
-      .select('id')
-      .maybeSingle();
+    const usage = await recordUsageAtomically(
+      supabase,
+      orgId,
+      evalId,
+      route,
+      gateStatus,
+      durationMs,
+    );
 
-    if (usageInsert.error || !usageInsert.data?.id) {
-      throw new Error(usageInsert.error?.message || 'failed_to_insert_dsg_gate_usage');
+    const entitlement = await getOrCreateEntitlement(orgId);
+    const plan = tierSpec(entitlement.tier);
+    const limit = Number(
+      entitlement.evals_per_month || plan.evalsPerMonth,
+    );
+    const usagePosition =
+      usage.usagePosition ?? (await countEvalsThisPeriod(orgId));
+
+    const deliveryDecision = decideGateRevenueAccess({
+      tier: plan.tier,
+      subscriptionStatus: entitlement.subscription_status,
+      includedLimit: limit,
+      used: Math.max(0, usagePosition - 1),
+      overageEnabled: entitlement.overage_enabled === true,
+      hasStripeCustomer: Boolean(entitlement.stripe_customer_id),
+      hasStripeSubscription: Boolean(entitlement.stripe_subscription_id),
+      meteringConfigured: isMeteredBillingConfigured(),
+    });
+
+    if (!deliveryDecision.allowed) {
+      return {
+        recorded: false,
+        error: `delivery_blocked:${deliveryDecision.accessMode}`,
+      };
+    }
+
+    if (!usage.created && usage.billed) {
+      return { recorded: true, meterEventId: usage.meterEventId };
     }
 
     await insertRevenueEvent({
@@ -258,34 +362,51 @@ export async function recordGateEvaluation(
       currency: 'USD',
       source: `dsg_gate:${route}`,
       metadata: {
+        idempotency_key: `dsg-gate-usage-${orgId}-${evalId}`,
         evalId,
         gateStatus,
         durationMs,
+        usagePosition,
+        accessMode: deliveryDecision.accessMode,
       },
     });
 
-    const entitlement = await getOrCreateEntitlement(orgId);
-    const limit = Number(entitlement.evals_per_month || tierSpec(entitlement.tier).evalsPerMonth);
-    const used = await countEvalsThisPeriod(orgId);
-    const overage = used > limit;
+    if (
+      deliveryDecision.accessMode === 'metered_overage' &&
+      entitlement.stripe_customer_id
+    ) {
+      const meter = await reportMeterEvent(
+        entitlement.stripe_customer_id,
+        orgId,
+        1,
+        `dsg-gate-${evalId}`,
+      );
 
-    if (overage && entitlement.stripe_customer_id) {
-      const meter = await reportMeterEvent(entitlement.stripe_customer_id, orgId, 1, `dsg-gate-${evalId}`);
-      if (meter.ok) {
+      if (meter.ok === true) {
         await supabase
           .from('dsg_gate_usage')
           .update({ billed: true, meter_event_id: meter.eventId })
-          .eq('id', usageInsert.data.id);
+          .eq('id', usage.id);
         return { recorded: true, meterEventId: meter.eventId };
       }
+
+      const meterError = meter.error;
+      if (meter.durable === false) {
+        return {
+          recorded: false,
+          error: `meter_outbox_unavailable:${meterError}`,
+        };
+      }
+
+      return { recorded: true, error: meterError };
     }
 
     return { recorded: true };
-  } catch (err) {
-    console.error('[dsg-gate-record] Error recording evaluation:', err);
+  } catch (error) {
+    console.error('[dsg-gate-record] usage recording failed:', error);
     return {
       recorded: false,
-      error: `Failed to record evaluation: ${String(err).slice(0, 120)}`,
+      error: `Failed to record evaluation: ${String(error).slice(0, 160)}`,
     };
   }
 }
@@ -294,5 +415,8 @@ export async function resetMonthlyGateCounters(): Promise<{
   reset: number;
   error?: string;
 }> {
-  return { reset: 0, error: 'Not yet implemented in Phase 1' };
+  return {
+    reset: 0,
+    error: 'No reset required: usage is counted by Stripe subscription period',
+  };
 }

--- a/lib/dsg/gate-revenue-policy.ts
+++ b/lib/dsg/gate-revenue-policy.ts
@@ -1,0 +1,143 @@
+export type GateTier = 'free' | 'pro' | 'enterprise';
+
+export type GateAccessMode =
+  | 'included_quota'
+  | 'metered_overage'
+  | 'quota_exceeded'
+  | 'subscription_inactive'
+  | 'billing_unavailable';
+
+export const GATE_INCLUDED_EVALS: Readonly<Record<GateTier, number>> = {
+  free: 50,
+  pro: 5_000,
+  enterprise: 999_999,
+} as const;
+
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing']);
+
+export function normalizeGateTier(planKey: string | null | undefined): GateTier {
+  const normalized = String(planKey || 'free').toLowerCase();
+  if (normalized === 'enterprise') return 'enterprise';
+  if (normalized === 'pro' || normalized === 'business') return 'pro';
+  return 'free';
+}
+
+export function isPaidSubscriptionActive(status: string | null | undefined): boolean {
+  return ACTIVE_SUBSCRIPTION_STATUSES.has(String(status || '').toLowerCase());
+}
+
+export type GateRevenuePolicyInput = {
+  tier: GateTier;
+  subscriptionStatus: string | null | undefined;
+  includedLimit: number;
+  used: number;
+  overageEnabled: boolean;
+  hasStripeCustomer: boolean;
+  hasStripeSubscription: boolean;
+  meteringConfigured: boolean;
+};
+
+export type GateRevenueDecision = {
+  allowed: boolean;
+  remaining: number;
+  accessMode: GateAccessMode;
+  requiresPayment: boolean;
+};
+
+function overageBillingReady(input: GateRevenuePolicyInput): boolean {
+  return (
+    input.tier === 'pro' &&
+    isPaidSubscriptionActive(input.subscriptionStatus) &&
+    input.overageEnabled &&
+    input.hasStripeCustomer &&
+    input.hasStripeSubscription &&
+    input.meteringConfigured
+  );
+}
+
+/**
+ * Pure, deterministic pre-execution revenue gate.
+ *
+ * Invariants:
+ * - Paid tiers never execute while the subscription is inactive.
+ * - Free tier never exceeds its included quota.
+ * - Pro overage executes only when the Stripe customer, subscription,
+ *   overage flag, and meter configuration are all present.
+ * - Enterprise is treated as unlimited only while active/trialing.
+ */
+export function decideGateRevenueAccess(
+  input: GateRevenuePolicyInput,
+): GateRevenueDecision {
+  const includedLimit = Math.max(0, Math.floor(input.includedLimit));
+  const used = Math.max(0, Math.floor(input.used));
+  const remaining = Math.max(0, includedLimit - used);
+  const paidTier = input.tier !== 'free';
+  const paidActive = paidTier && isPaidSubscriptionActive(input.subscriptionStatus);
+
+  if (paidTier && !paidActive) {
+    return {
+      allowed: false,
+      remaining: 0,
+      accessMode: 'subscription_inactive',
+      requiresPayment: true,
+    };
+  }
+
+  if (input.tier === 'enterprise' && paidActive) {
+    return {
+      allowed: true,
+      remaining,
+      accessMode: 'included_quota',
+      requiresPayment: false,
+    };
+  }
+
+  if (remaining > 0) {
+    return {
+      allowed: true,
+      remaining,
+      accessMode: 'included_quota',
+      requiresPayment: false,
+    };
+  }
+
+  if (input.tier === 'pro' && paidActive) {
+    if (overageBillingReady(input)) {
+      return {
+        allowed: true,
+        remaining: 0,
+        accessMode: 'metered_overage',
+        requiresPayment: false,
+      };
+    }
+
+    return {
+      allowed: false,
+      remaining: 0,
+      accessMode: 'billing_unavailable',
+      requiresPayment: false,
+    };
+  }
+
+  return {
+    allowed: false,
+    remaining: 0,
+    accessMode: 'quota_exceeded',
+    requiresPayment: true,
+  };
+}
+
+/**
+ * Post-insert billing decision for the evaluation that was just recorded.
+ * `usedAfterInsert === includedLimit` is still included. Only usage strictly
+ * above the limit is an overage, preventing the last included call from being
+ * charged.
+ */
+export function shouldMeterRecordedEvaluation(
+  input: GateRevenuePolicyInput & { usedAfterInsert: number },
+): boolean {
+  const includedLimit = Math.max(0, Math.floor(input.includedLimit));
+  const usedAfterInsert = Math.max(0, Math.floor(input.usedAfterInsert));
+
+  return usedAfterInsert > includedLimit && overageBillingReady(input);
+}

--- a/lib/revenue/events.ts
+++ b/lib/revenue/events.ts
@@ -65,38 +65,74 @@ function toRecord(row: RevenueEventRow): RevenueEventRecord {
   };
 }
 
-export async function insertRevenueEvent(event: RevenueEventInput): Promise<RevenueEventRecord> {
-  const supabase = getSupabaseAdmin();
-  const eventId = typeof event.metadata?.stripe_event_id === 'string'
-    ? String(event.metadata.stripe_event_id)
-    : null;
-
-  if (eventId) {
-    const duplicate = await (supabase as any)
-      .from('revenue_events')
-      .select('id, created_at, org_id, user_id, event_type, plan_id, amount, currency, source, metadata')
-      .eq('org_id', event.orgId)
-      .contains('metadata', { stripe_event_id: eventId })
-      .maybeSingle();
-
-    if (duplicate?.data) {
-      return toRecord(duplicate.data as RevenueEventRow);
-    }
+function eventIdempotencyKey(
+  metadata: Record<string, unknown> | null | undefined,
+): string | null {
+  if (typeof metadata?.idempotency_key === 'string' && metadata.idempotency_key) {
+    return metadata.idempotency_key;
   }
 
-  const insertResult = await (supabase as any)
+  if (typeof metadata?.stripe_event_id === 'string' && metadata.stripe_event_id) {
+    return `stripe:${metadata.stripe_event_id}`;
+  }
+
+  return null;
+}
+
+const EVENT_SELECT =
+  'id, created_at, org_id, user_id, event_type, plan_id, amount, currency, source, metadata';
+
+export async function insertRevenueEvent(event: RevenueEventInput): Promise<RevenueEventRecord> {
+  const supabase = getSupabaseAdmin() as any;
+  const idempotencyKey = eventIdempotencyKey(event.metadata);
+  const payload = {
+    org_id: event.orgId,
+    user_id: event.userId ?? null,
+    event_type: event.eventType,
+    plan_id: event.planId ?? null,
+    amount: event.amount ?? null,
+    currency: event.currency || 'USD',
+    source: event.source,
+    metadata: event.metadata ?? null,
+    idempotency_key: idempotencyKey,
+  };
+
+  if (idempotencyKey) {
+    const upsertResult = await supabase
+      .from('revenue_events')
+      .upsert(payload, {
+        onConflict: 'org_id,idempotency_key',
+        ignoreDuplicates: true,
+      })
+      .select(EVENT_SELECT)
+      .maybeSingle();
+
+    if (upsertResult.error) {
+      throw new Error(upsertResult.error.message);
+    }
+
+    if (upsertResult.data) {
+      return toRecord(upsertResult.data as RevenueEventRow);
+    }
+
+    const existing = await supabase
+      .from('revenue_events')
+      .select(EVENT_SELECT)
+      .eq('org_id', event.orgId)
+      .eq('idempotency_key', idempotencyKey)
+      .maybeSingle();
+
+    if (existing.error || !existing.data) {
+      throw new Error(existing.error?.message || 'failed_to_resolve_revenue_event');
+    }
+
+    return toRecord(existing.data as RevenueEventRow);
+  }
+
+  const insertResult = await supabase
     .from('revenue_events')
-    .insert({
-      org_id: event.orgId,
-      user_id: event.userId ?? null,
-      event_type: event.eventType,
-      plan_id: event.planId ?? null,
-      amount: event.amount ?? null,
-      currency: event.currency || 'USD',
-      source: event.source,
-      metadata: event.metadata ?? null,
-    })
-    .select('id, created_at, org_id, user_id, event_type, plan_id, amount, currency, source, metadata')
+    .insert(payload)
+    .select(EVENT_SELECT)
     .single();
 
   if (insertResult.error) {
@@ -108,14 +144,14 @@ export async function insertRevenueEvent(event: RevenueEventInput): Promise<Reve
 
 export async function listRevenueEvents(
   orgId: string,
-  options?: { limit?: number }
+  options?: { limit?: number },
 ): Promise<RevenueEventRecord[]> {
-  const supabase = getSupabaseAdmin();
+  const supabase = getSupabaseAdmin() as any;
   const limit = Math.min(Math.max(options?.limit ?? 50, 1), 500);
 
-  const query = (supabase as any)
+  const query = supabase
     .from('revenue_events')
-    .select('id, created_at, org_id, user_id, event_type, plan_id, amount, currency, source, metadata')
+    .select(EVENT_SELECT)
     .eq('org_id', orgId)
     .order('created_at', { ascending: false })
     .limit(limit);

--- a/supabase/migrations/20260806133000_dsg_gate_revenue_hardening.sql
+++ b/supabase/migrations/20260806133000_dsg_gate_revenue_hardening.sql
@@ -1,0 +1,245 @@
+-- DSG Gate automatic-revenue hardening
+--
+-- Creates the missing entitlement/usage schema when an environment skipped the
+-- historical migration, makes usage idempotent, aligns counts to the Stripe
+-- subscription period, and atomically syncs organization + gate entitlements.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.dsg_gate_entitlements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL UNIQUE,
+  tier TEXT NOT NULL DEFAULT 'free'
+    CHECK (tier IN ('free', 'pro', 'enterprise')),
+  evals_per_month INTEGER NOT NULL DEFAULT 50
+    CHECK (evals_per_month > 0),
+  subscription_status TEXT NOT NULL DEFAULT 'free',
+  overage_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT,
+  stripe_meter_event_name TEXT,
+  current_period_start TIMESTAMPTZ,
+  current_period_end TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.dsg_gate_entitlements
+  ADD COLUMN IF NOT EXISTS subscription_status TEXT NOT NULL DEFAULT 'free',
+  ADD COLUMN IF NOT EXISTS overage_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS dsg_gate_entitlements_subscription_uidx
+  ON public.dsg_gate_entitlements (stripe_subscription_id)
+  WHERE stripe_subscription_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.dsg_gate_usage (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL,
+  eval_id TEXT NOT NULL,
+  route TEXT NOT NULL
+    CHECK (route IN ('gates/evaluate', 'proofs/prove')),
+  gate_status TEXT NOT NULL,
+  duration_ms INTEGER,
+  billed BOOLEAN NOT NULL DEFAULT FALSE,
+  meter_event_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dsg_gate_usage_org_created_idx
+  ON public.dsg_gate_usage (org_id, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dsg_gate_usage_org_eval_uidx
+  ON public.dsg_gate_usage (org_id, eval_id);
+
+ALTER TABLE public.dsg_gate_entitlements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.dsg_gate_usage ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'dsg_gate_entitlements'
+      AND policyname = 'dsg_gate_entitlements_org_read'
+  ) THEN
+    CREATE POLICY dsg_gate_entitlements_org_read
+      ON public.dsg_gate_entitlements
+      FOR SELECT
+      USING (org_id = auth.jwt() ->> 'org_id');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'dsg_gate_usage'
+      AND policyname = 'dsg_gate_usage_org_read'
+  ) THEN
+    CREATE POLICY dsg_gate_usage_org_read
+      ON public.dsg_gate_usage
+      FOR SELECT
+      USING (org_id = auth.jwt() ->> 'org_id');
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.dsg_gate_evals_this_period(p_org_id TEXT)
+RETURNS INTEGER
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH entitlement AS (
+    SELECT current_period_start, current_period_end
+    FROM public.dsg_gate_entitlements
+    WHERE org_id = p_org_id
+  ), bounds AS (
+    SELECT
+      COALESCE(current_period_start, date_trunc('month', now())) AS period_start,
+      COALESCE(current_period_end, date_trunc('month', now()) + INTERVAL '1 month') AS period_end
+    FROM entitlement
+    UNION ALL
+    SELECT date_trunc('month', now()), date_trunc('month', now()) + INTERVAL '1 month'
+    WHERE NOT EXISTS (SELECT 1 FROM entitlement)
+    LIMIT 1
+  )
+  SELECT COUNT(*)::INTEGER
+  FROM public.dsg_gate_usage usage
+  CROSS JOIN bounds
+  WHERE usage.org_id = p_org_id
+    AND usage.created_at >= bounds.period_start
+    AND usage.created_at < bounds.period_end;
+$$;
+
+REVOKE ALL ON FUNCTION public.dsg_gate_evals_this_period(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dsg_gate_evals_this_period(TEXT) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.sync_dsg_paid_entitlement(
+  p_org_id TEXT,
+  p_plan_key TEXT,
+  p_status TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_plan TEXT := 'free';
+  v_tier TEXT := 'free';
+  v_limit INTEGER := 50;
+  v_overage BOOLEAN := FALSE;
+  v_customer_id TEXT;
+  v_subscription_id TEXT;
+  v_period_start TIMESTAMPTZ;
+  v_period_end TIMESTAMPTZ;
+  v_status TEXT := lower(COALESCE(p_status, 'unknown'));
+  v_plan_key TEXT := lower(COALESCE(p_plan_key, 'free'));
+BEGIN
+  IF p_org_id IS NULL OR btrim(p_org_id) = '' THEN
+    RAISE EXCEPTION 'org_id is required';
+  END IF;
+
+  SELECT
+    subscription.stripe_customer_id,
+    subscription.stripe_subscription_id,
+    subscription.current_period_start,
+    subscription.current_period_end
+  INTO
+    v_customer_id,
+    v_subscription_id,
+    v_period_start,
+    v_period_end
+  FROM public.billing_subscriptions subscription
+  WHERE subscription.org_id::TEXT = p_org_id
+  ORDER BY subscription.updated_at DESC NULLS LAST
+  LIMIT 1;
+
+  IF v_customer_id IS NULL THEN
+    SELECT customer.stripe_customer_id
+    INTO v_customer_id
+    FROM public.billing_customers customer
+    WHERE customer.org_id::TEXT = p_org_id
+    ORDER BY customer.updated_at DESC NULLS LAST
+    LIMIT 1;
+  END IF;
+
+  IF v_status IN ('active', 'trialing') THEN
+    CASE v_plan_key
+      WHEN 'enterprise' THEN
+        v_plan := 'enterprise';
+        v_tier := 'enterprise';
+        v_limit := 999999;
+        v_overage := FALSE;
+      WHEN 'business' THEN
+        v_plan := 'business';
+        v_tier := 'pro';
+        v_limit := 5000;
+        v_overage := TRUE;
+      WHEN 'pro' THEN
+        v_plan := 'pro';
+        v_tier := 'pro';
+        v_limit := 5000;
+        v_overage := TRUE;
+      ELSE
+        v_plan := 'free';
+        v_tier := 'free';
+        v_limit := 50;
+        v_overage := FALSE;
+    END CASE;
+  END IF;
+
+  UPDATE public.organizations
+  SET plan = v_plan,
+      updated_at = now()
+  WHERE id::TEXT = p_org_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'organization % not found', p_org_id;
+  END IF;
+
+  INSERT INTO public.dsg_gate_entitlements (
+    org_id,
+    tier,
+    evals_per_month,
+    subscription_status,
+    overage_enabled,
+    stripe_customer_id,
+    stripe_subscription_id,
+    stripe_meter_event_name,
+    current_period_start,
+    current_period_end,
+    updated_at
+  ) VALUES (
+    p_org_id,
+    v_tier,
+    v_limit,
+    v_status,
+    v_overage,
+    v_customer_id,
+    v_subscription_id,
+    current_setting('app.settings.stripe_meter_event_name', TRUE),
+    v_period_start,
+    v_period_end,
+    now()
+  )
+  ON CONFLICT (org_id) DO UPDATE SET
+    tier = EXCLUDED.tier,
+    evals_per_month = EXCLUDED.evals_per_month,
+    subscription_status = EXCLUDED.subscription_status,
+    overage_enabled = EXCLUDED.overage_enabled,
+    stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, public.dsg_gate_entitlements.stripe_customer_id),
+    stripe_subscription_id = COALESCE(EXCLUDED.stripe_subscription_id, public.dsg_gate_entitlements.stripe_subscription_id),
+    stripe_meter_event_name = COALESCE(EXCLUDED.stripe_meter_event_name, public.dsg_gate_entitlements.stripe_meter_event_name),
+    current_period_start = COALESCE(EXCLUDED.current_period_start, public.dsg_gate_entitlements.current_period_start),
+    current_period_end = COALESCE(EXCLUDED.current_period_end, public.dsg_gate_entitlements.current_period_end),
+    updated_at = now();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sync_dsg_paid_entitlement(TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.sync_dsg_paid_entitlement(TEXT, TEXT, TEXT) TO service_role;
+
+COMMENT ON FUNCTION public.sync_dsg_paid_entitlement(TEXT, TEXT, TEXT) IS
+  'Atomically synchronizes organizations.plan and DSG Gate entitlement from Stripe subscription state.';
+
+COMMIT;

--- a/supabase/migrations/20260806134500_dsg_gate_function_grants.sql
+++ b/supabase/migrations/20260806134500_dsg_gate_function_grants.sql
@@ -1,0 +1,14 @@
+-- Restrict automatic-revenue SECURITY DEFINER functions to the server-side
+-- service role. Supabase may apply explicit default EXECUTE grants to anon and
+-- authenticated when a function is created, so revoking PUBLIC alone is not
+-- sufficient in every project.
+
+REVOKE ALL ON FUNCTION public.dsg_gate_evals_this_period(TEXT)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.sync_dsg_paid_entitlement(TEXT, TEXT, TEXT)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.dsg_gate_evals_this_period(TEXT)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.sync_dsg_paid_entitlement(TEXT, TEXT, TEXT)
+  TO service_role;

--- a/supabase/migrations/20260806140000_dsg_gate_atomic_usage_position.sql
+++ b/supabase/migrations/20260806140000_dsg_gate_atomic_usage_position.sql
@@ -1,0 +1,116 @@
+-- Serialize DSG Gate usage assignment per organization so concurrent requests
+-- cannot both claim the final included quota slot.
+
+ALTER TABLE public.dsg_gate_usage
+  ADD COLUMN IF NOT EXISTS usage_position INTEGER;
+
+CREATE OR REPLACE FUNCTION public.record_dsg_gate_usage(
+  p_org_id TEXT,
+  p_eval_id TEXT,
+  p_route TEXT,
+  p_gate_status TEXT,
+  p_duration_ms INTEGER
+)
+RETURNS TABLE (
+  usage_id UUID,
+  created BOOLEAN,
+  billed BOOLEAN,
+  meter_event_id TEXT,
+  usage_position INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing public.dsg_gate_usage%ROWTYPE;
+  v_period_start TIMESTAMPTZ;
+  v_period_end TIMESTAMPTZ;
+  v_position INTEGER;
+  v_inserted public.dsg_gate_usage%ROWTYPE;
+BEGIN
+  IF p_org_id IS NULL OR btrim(p_org_id) = '' THEN
+    RAISE EXCEPTION 'org_id is required';
+  END IF;
+  IF p_eval_id IS NULL OR btrim(p_eval_id) = '' THEN
+    RAISE EXCEPTION 'eval_id is required';
+  END IF;
+  IF p_route NOT IN ('gates/evaluate', 'proofs/prove') THEN
+    RAISE EXCEPTION 'unsupported route: %', p_route;
+  END IF;
+
+  -- One organization is serialized only for the short usage-assignment
+  -- transaction. Different organizations remain concurrent.
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_org_id, 0));
+
+  SELECT *
+  INTO v_existing
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.eval_id = p_eval_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN QUERY SELECT
+      v_existing.id,
+      FALSE,
+      v_existing.billed,
+      v_existing.meter_event_id,
+      v_existing.usage_position;
+    RETURN;
+  END IF;
+
+  SELECT
+    COALESCE(entitlement.current_period_start, date_trunc('month', now())),
+    COALESCE(entitlement.current_period_end, date_trunc('month', now()) + INTERVAL '1 month')
+  INTO v_period_start, v_period_end
+  FROM public.dsg_gate_entitlements entitlement
+  WHERE entitlement.org_id = p_org_id;
+
+  IF NOT FOUND THEN
+    v_period_start := date_trunc('month', now());
+    v_period_end := v_period_start + INTERVAL '1 month';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER + 1
+  INTO v_position
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.created_at >= v_period_start
+    AND usage.created_at < v_period_end;
+
+  INSERT INTO public.dsg_gate_usage (
+    org_id,
+    eval_id,
+    route,
+    gate_status,
+    duration_ms,
+    billed,
+    usage_position
+  ) VALUES (
+    p_org_id,
+    p_eval_id,
+    p_route,
+    p_gate_status,
+    p_duration_ms,
+    FALSE,
+    v_position
+  )
+  RETURNING * INTO v_inserted;
+
+  RETURN QUERY SELECT
+    v_inserted.id,
+    TRUE,
+    v_inserted.billed,
+    v_inserted.meter_event_id,
+    v_inserted.usage_position;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  TO service_role;
+
+COMMENT ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER) IS
+  'Idempotently records one DSG Gate evaluation and assigns a serialized subscription-period usage position.';

--- a/supabase/migrations/20260806141500_revenue_event_idempotency.sql
+++ b/supabase/migrations/20260806141500_revenue_event_idempotency.sql
@@ -1,0 +1,16 @@
+-- Revenue events participate in billing evidence. Metadata lookups alone are
+-- not concurrency-safe, so persist a first-class idempotency key and enforce it
+-- per organization.
+
+ALTER TABLE public.revenue_events
+  ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+
+UPDATE public.revenue_events
+SET idempotency_key = metadata ->> 'idempotency_key'
+WHERE idempotency_key IS NULL
+  AND jsonb_typeof(metadata) = 'object'
+  AND NULLIF(metadata ->> 'idempotency_key', '') IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS revenue_events_org_idempotency_uidx
+  ON public.revenue_events (org_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/supabase/migrations/20260806142000_revenue_event_stripe_idempotency_backfill.sql
+++ b/supabase/migrations/20260806142000_revenue_event_stripe_idempotency_backfill.sql
@@ -1,0 +1,24 @@
+-- Preserve deduplication for historical Stripe revenue events after moving
+-- idempotency from JSON metadata to a first-class unique column. If historical
+-- duplicates exist, only the oldest row receives the canonical key so the
+-- unique index remains valid without deleting audit evidence.
+
+WITH ranked AS (
+  SELECT
+    id,
+    org_id,
+    metadata ->> 'stripe_event_id' AS stripe_event_id,
+    row_number() OVER (
+      PARTITION BY org_id, metadata ->> 'stripe_event_id'
+      ORDER BY created_at ASC, id ASC
+    ) AS occurrence
+  FROM public.revenue_events
+  WHERE idempotency_key IS NULL
+    AND jsonb_typeof(metadata) = 'object'
+    AND NULLIF(metadata ->> 'stripe_event_id', '') IS NOT NULL
+)
+UPDATE public.revenue_events event
+SET idempotency_key = 'stripe:' || ranked.stripe_event_id
+FROM ranked
+WHERE event.id = ranked.id
+  AND ranked.occurrence = 1;

--- a/supabase/migrations/20260806142500_revenue_event_idempotency_conflict_target.sql
+++ b/supabase/migrations/20260806142500_revenue_event_idempotency_conflict_target.sql
@@ -1,0 +1,9 @@
+-- A partial unique index cannot be inferred by PostgREST's
+-- ON CONFLICT (org_id, idempotency_key) target. A normal PostgreSQL unique
+-- index still permits multiple NULL idempotency keys while supporting atomic
+-- upsert for non-NULL keys.
+
+DROP INDEX IF EXISTS public.revenue_events_org_idempotency_uidx;
+
+CREATE UNIQUE INDEX revenue_events_org_idempotency_uidx
+  ON public.revenue_events (org_id, idempotency_key);

--- a/supabase/migrations/20260808133000_billing_activation_proofs.sql
+++ b/supabase/migrations/20260808133000_billing_activation_proofs.sql
@@ -1,0 +1,129 @@
+-- Billing activation proofs
+--
+-- Purpose: create a deterministic, append-only evidence record whenever
+-- dsg_gate_entitlements reaches a paid + active state with real Stripe IDs.
+-- This is an entitlement activation proof, not a payment receipt and not a
+-- regulatory-compliance certificate.
+
+create table if not exists public.billing_activation_proofs (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null,
+  tier text not null check (tier in ('pro', 'enterprise')),
+  subscription_status text not null check (subscription_status in ('active', 'trialing')),
+  stripe_customer_id text not null,
+  stripe_subscription_id text not null,
+  current_period_start timestamptz,
+  current_period_end timestamptz,
+  proof_version text not null default 'billing-activation-v1',
+  evidence jsonb not null,
+  proof_hash text not null unique,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists billing_activation_proofs_org_created_idx
+  on public.billing_activation_proofs (org_id, created_at desc);
+
+alter table public.billing_activation_proofs enable row level security;
+
+revoke all on public.billing_activation_proofs from anon;
+revoke insert, update, delete on public.billing_activation_proofs from authenticated;
+grant select on public.billing_activation_proofs to authenticated;
+
+drop policy if exists billing_activation_proofs_select_org on public.billing_activation_proofs;
+create policy billing_activation_proofs_select_org
+  on public.billing_activation_proofs
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.users u
+      where u.auth_user_id = auth.uid()
+        and u.is_active is true
+        and u.org_id::text = billing_activation_proofs.org_id
+    )
+  );
+
+create or replace function public.reject_billing_activation_proof_mutation()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  raise exception 'billing_activation_proofs is append-only';
+end;
+$$;
+
+drop trigger if exists billing_activation_proofs_append_only on public.billing_activation_proofs;
+create trigger billing_activation_proofs_append_only
+before update or delete on public.billing_activation_proofs
+for each row execute function public.reject_billing_activation_proof_mutation();
+
+create or replace function public.capture_billing_activation_proof()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, extensions, pg_temp
+as $$
+declare
+  v_evidence jsonb;
+  v_hash text;
+begin
+  if new.tier not in ('pro', 'enterprise')
+     or new.subscription_status not in ('active', 'trialing')
+     or new.stripe_customer_id is null
+     or new.stripe_subscription_id is null then
+    return new;
+  end if;
+
+  v_evidence := jsonb_build_object(
+    'proof_type', 'billing_activation',
+    'proof_version', 'billing-activation-v1',
+    'org_id', new.org_id,
+    'tier', new.tier,
+    'subscription_status', new.subscription_status,
+    'stripe_customer_id', new.stripe_customer_id,
+    'stripe_subscription_id', new.stripe_subscription_id,
+    'current_period_start', new.current_period_start,
+    'current_period_end', new.current_period_end
+  );
+
+  v_hash := 'sha256:' || encode(
+    digest(convert_to(v_evidence::text, 'UTF8'), 'sha256'),
+    'hex'
+  );
+
+  insert into public.billing_activation_proofs (
+    org_id,
+    tier,
+    subscription_status,
+    stripe_customer_id,
+    stripe_subscription_id,
+    current_period_start,
+    current_period_end,
+    proof_version,
+    evidence,
+    proof_hash
+  ) values (
+    new.org_id,
+    new.tier,
+    new.subscription_status,
+    new.stripe_customer_id,
+    new.stripe_subscription_id,
+    new.current_period_start,
+    new.current_period_end,
+    'billing-activation-v1',
+    v_evidence,
+    v_hash
+  )
+  on conflict (proof_hash) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists dsg_gate_entitlement_capture_activation_proof on public.dsg_gate_entitlements;
+create trigger dsg_gate_entitlement_capture_activation_proof
+after insert or update of tier, subscription_status, stripe_customer_id, stripe_subscription_id, current_period_start, current_period_end
+on public.dsg_gate_entitlements
+for each row execute function public.capture_billing_activation_proof();

--- a/supabase/migrations/20260808133500_billing_activation_proofs_hardening.sql
+++ b/supabase/migrations/20260808133500_billing_activation_proofs_hardening.sql
@@ -1,0 +1,12 @@
+-- Tighten billing activation proof privileges after table creation.
+-- Supabase default privileges can leave authenticated/service_role with
+-- TRUNCATE/TRIGGER/REFERENCES even when INSERT/UPDATE/DELETE are revoked.
+-- The proof ledger must be append-only: only the owner trigger function writes.
+
+revoke all on public.billing_activation_proofs from anon, authenticated, service_role;
+grant select on public.billing_activation_proofs to authenticated, service_role;
+
+revoke all on function public.capture_billing_activation_proof()
+  from public, anon, authenticated, service_role;
+revoke all on function public.reject_billing_activation_proof_mutation()
+  from public, anon, authenticated, service_role;

--- a/supabase/migrations/20260812232000_dsg_gate_encoding_usage_route.sql
+++ b/supabase/migrations/20260812232000_dsg_gate_encoding_usage_route.sql
@@ -1,0 +1,141 @@
+-- Extend the atomic DSG Gate usage ledger to the Encoding Proof product that
+-- was merged after the original automatic-revenue branch was created.
+--
+-- This migration is additive and safe after the historical revenue migrations:
+-- it preserves their tested behavior while adding encoding/prove as a metered
+-- route. The usage RPC remains serialized and idempotent per organization.
+
+BEGIN;
+
+DO $$
+DECLARE
+  constraint_name TEXT;
+BEGIN
+  FOR constraint_name IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.dsg_gate_usage'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%route%'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.dsg_gate_usage DROP CONSTRAINT IF EXISTS %I',
+      constraint_name
+    );
+  END LOOP;
+END $$;
+
+ALTER TABLE public.dsg_gate_usage
+  ADD CONSTRAINT dsg_gate_usage_route_check
+  CHECK (route IN ('gates/evaluate', 'proofs/prove', 'encoding/prove'));
+
+CREATE OR REPLACE FUNCTION public.record_dsg_gate_usage(
+  p_org_id TEXT,
+  p_eval_id TEXT,
+  p_route TEXT,
+  p_gate_status TEXT,
+  p_duration_ms INTEGER
+)
+RETURNS TABLE (
+  usage_id UUID,
+  created BOOLEAN,
+  billed BOOLEAN,
+  meter_event_id TEXT,
+  usage_position INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing public.dsg_gate_usage%ROWTYPE;
+  v_period_start TIMESTAMPTZ;
+  v_period_end TIMESTAMPTZ;
+  v_position INTEGER;
+  v_inserted public.dsg_gate_usage%ROWTYPE;
+BEGIN
+  IF p_org_id IS NULL OR btrim(p_org_id) = '' THEN
+    RAISE EXCEPTION 'org_id is required';
+  END IF;
+  IF p_eval_id IS NULL OR btrim(p_eval_id) = '' THEN
+    RAISE EXCEPTION 'eval_id is required';
+  END IF;
+  IF p_route NOT IN ('gates/evaluate', 'proofs/prove', 'encoding/prove') THEN
+    RAISE EXCEPTION 'unsupported route: %', p_route;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_org_id, 0));
+
+  SELECT *
+  INTO v_existing
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.eval_id = p_eval_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN QUERY SELECT
+      v_existing.id,
+      FALSE,
+      v_existing.billed,
+      v_existing.meter_event_id,
+      v_existing.usage_position;
+    RETURN;
+  END IF;
+
+  SELECT
+    COALESCE(entitlement.current_period_start, date_trunc('month', now())),
+    COALESCE(entitlement.current_period_end, date_trunc('month', now()) + INTERVAL '1 month')
+  INTO v_period_start, v_period_end
+  FROM public.dsg_gate_entitlements entitlement
+  WHERE entitlement.org_id = p_org_id;
+
+  IF NOT FOUND THEN
+    v_period_start := date_trunc('month', now());
+    v_period_end := v_period_start + INTERVAL '1 month';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER + 1
+  INTO v_position
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.created_at >= v_period_start
+    AND usage.created_at < v_period_end;
+
+  INSERT INTO public.dsg_gate_usage (
+    org_id,
+    eval_id,
+    route,
+    gate_status,
+    duration_ms,
+    billed,
+    usage_position
+  ) VALUES (
+    p_org_id,
+    p_eval_id,
+    p_route,
+    p_gate_status,
+    p_duration_ms,
+    FALSE,
+    v_position
+  )
+  RETURNING * INTO v_inserted;
+
+  RETURN QUERY SELECT
+    v_inserted.id,
+    TRUE,
+    v_inserted.billed,
+    v_inserted.meter_event_id,
+    v_inserted.usage_position;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  TO service_role;
+
+COMMENT ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER) IS
+  'Idempotently records one DSG Gate/Proof/Encoding evaluation and assigns a serialized subscription-period usage position.';
+
+COMMIT;

--- a/tests/integration/encoding-proof-api.test.ts
+++ b/tests/integration/encoding-proof-api.test.ts
@@ -86,10 +86,15 @@ describe('Encoding Proof API Route', () => {
     accessMocks.checkGateEntitlement.mockReset().mockResolvedValue({
       allowed: true,
       tier: 'pro',
+      evalsRemaining: 4999,
       message: 'Allowed',
+      requiresPayment: false,
       upgradeUrl: '/pricing',
+      accessMode: 'included_quota',
     });
-    accessMocks.recordGateEvaluation.mockReset().mockResolvedValue(undefined);
+    accessMocks.recordGateEvaluation.mockReset().mockResolvedValue({
+      recorded: true,
+    });
     accessMocks.applyRateLimit.mockReset().mockResolvedValue({ allowed: true });
     proofStoreMocks.inspectEncodingProofRequest.mockReset().mockResolvedValue({
       kind: 'new',
@@ -114,14 +119,36 @@ describe('Encoding Proof API Route', () => {
       accessMocks.checkGateEntitlement.mockResolvedValueOnce({
         allowed: false,
         tier: 'free',
+        evalsRemaining: 0,
         message: 'Monthly quota exceeded',
+        requiresPayment: true,
         upgradeUrl: '/pricing',
+        accessMode: 'quota_exceeded',
       });
 
       const res = await POST(createRequest(validQuboBody()));
       expect(res.status).toBe(402);
       const data = await res.json();
       expect(data.requiresUpgrade).toBe(true);
+      expect(data.accessMode).toBe('quota_exceeded');
+    });
+
+    it('fails closed with 503 when entitlement evidence is unavailable', async () => {
+      accessMocks.checkGateEntitlement.mockResolvedValueOnce({
+        allowed: false,
+        tier: 'unknown',
+        evalsRemaining: 0,
+        message: 'Billing entitlement is unavailable',
+        requiresPayment: false,
+        upgradeUrl: '/pricing',
+        accessMode: 'billing_unavailable',
+      });
+
+      const res = await POST(createRequest(validQuboBody()));
+      expect(res.status).toBe(503);
+      const data = await res.json();
+      expect(data.requiresUpgrade).toBe(false);
+      expect(data.accessMode).toBe('billing_unavailable');
     });
 
     it('enforces the per-org rate limit', async () => {
@@ -146,8 +173,27 @@ describe('Encoding Proof API Route', () => {
       expect(data.proof.checks.quadratic_terms_valid).toBe(true);
       expect(proofStoreMocks.inspectEncodingProofRequest).toHaveBeenCalled();
       expect(proofStoreMocks.persistEncodingProof).toHaveBeenCalled();
-      expect(accessMocks.recordGateEvaluation).toHaveBeenCalled();
+      expect(accessMocks.recordGateEvaluation).toHaveBeenCalledWith(
+        'idem_key_123',
+        'org_test',
+        'encoding/prove',
+        'PASS',
+        expect.any(Number),
+      );
       expect(accessMocks.logDsgApiCall).toHaveBeenCalled();
+    });
+
+    it('withholds a new proof when durable usage evidence cannot be recorded', async () => {
+      accessMocks.recordGateEvaluation.mockResolvedValueOnce({
+        recorded: false,
+        error: 'meter_outbox_unavailable:db unavailable',
+      });
+
+      const res = await POST(createRequest(validQuboBody()));
+      expect(res.status).toBe(503);
+      const data = await res.json();
+      expect(data.error).toBe('usage_evidence_unavailable');
+      expect(proofStoreMocks.persistEncodingProof).toHaveBeenCalled();
     });
 
     it('should accept valid Ising encoding and return PASS', async () => {
@@ -364,6 +410,48 @@ describe('Encoding Proof API Route', () => {
       const data = await res.json();
       expect(data.ok).toBe(true);
       expect(data.status).toBe('PASS');
+    });
+
+    it('re-establishes idempotent usage evidence before returning a replayed proof', async () => {
+      const first = await POST(createRequest(validQuboBody()));
+      expect(first.status).toBe(200);
+      const firstData = await first.json();
+
+      accessMocks.recordGateEvaluation.mockClear();
+      proofStoreMocks.inspectEncodingProofRequest.mockResolvedValueOnce({
+        kind: 'replay',
+        proof: firstData.proof,
+      });
+
+      const replay = await POST(createRequest(validQuboBody()));
+      expect(replay.status).toBe(200);
+      expect(replay.headers.get('X-Idempotent-Replay')).toBe('true');
+      expect(accessMocks.recordGateEvaluation).toHaveBeenCalledWith(
+        'idem_key_123',
+        'org_test',
+        'encoding/prove',
+        'PASS',
+        expect.any(Number),
+      );
+    });
+
+    it('withholds a replayed proof when usage evidence is unavailable', async () => {
+      const first = await POST(createRequest(validQuboBody()));
+      const firstData = await first.json();
+
+      proofStoreMocks.inspectEncodingProofRequest.mockResolvedValueOnce({
+        kind: 'replay',
+        proof: firstData.proof,
+      });
+      accessMocks.recordGateEvaluation.mockResolvedValueOnce({
+        recorded: false,
+        error: 'meter_outbox_unavailable:db unavailable',
+      });
+
+      const replay = await POST(createRequest(validQuboBody()));
+      expect(replay.status).toBe(503);
+      const data = await replay.json();
+      expect(data.error).toBe('usage_evidence_unavailable');
     });
 
     it('binds proofId to the canonical request while preserving encodingHash', async () => {

--- a/tests/unit/billing/fulfillment.test.ts
+++ b/tests/unit/billing/fulfillment.test.ts
@@ -1,193 +1,79 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockFrom = vi.fn();
+const mockRpc = vi.fn();
 
 vi.mock('../../../lib/supabase-server', () => ({
-  getSupabaseAdmin: vi.fn(() => ({ from: mockFrom })),
-}));
-
-vi.mock('../../../lib/billing/metered', () => ({
-  reportMeterEvent: vi.fn(),
-}));
-
-vi.mock('../../../lib/revenue/events', () => ({
-  insertRevenueEvent: vi.fn(),
+  getSupabaseAdmin: vi.fn(() => ({ rpc: mockRpc })),
 }));
 
 import {
   fulfillSubscription,
   revokeSubscription,
-  gateTierForBillingPlan,
 } from '../../../lib/billing/fulfillment';
-
-function setupMock(options: { orgError?: any; gateError?: any } = {}) {
-  const orgChain: any = {
-    update: vi.fn(),
-    eq: vi.fn(),
-  };
-  orgChain.update.mockReturnValue(orgChain);
-  orgChain.eq.mockResolvedValue({ error: options.orgError ?? null });
-
-  const gateChain: any = {
-    upsert: vi.fn().mockResolvedValue({ error: options.gateError ?? null }),
-  };
-
-  mockFrom.mockImplementation((table: string) => {
-    if (table === 'organizations') return orgChain;
-    if (table === 'dsg_gate_entitlements') return gateChain;
-    throw new Error(`unexpected table ${table}`);
-  });
-
-  return { orgChain, gateChain };
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
-});
-
-describe('gateTierForBillingPlan', () => {
-  it('maps Pro and Business to the verified Pro gate tier', () => {
-    expect(gateTierForBillingPlan('pro')).toBe('pro');
-    expect(gateTierForBillingPlan('business')).toBe('pro');
-  });
-
-  it('maps Enterprise to Enterprise and unknown products to Free', () => {
-    expect(gateTierForBillingPlan('enterprise')).toBe('enterprise');
-    expect(gateTierForBillingPlan('finance_skills')).toBe('free');
-    expect(gateTierForBillingPlan('free')).toBe('free');
-  });
+  mockRpc.mockResolvedValue({ error: null });
 });
 
 describe('fulfillSubscription', () => {
-  it('returns ok:false for empty orgId', async () => {
-    const result = await fulfillSubscription('', 'pro', 'active');
-    expect(result.ok).toBe(false);
+  it('rejects incomplete input', async () => {
+    await expect(fulfillSubscription('', 'pro', 'active')).resolves.toEqual(
+      expect.objectContaining({ ok: false }),
+    );
+    await expect(fulfillSubscription('org-1', '', 'active')).resolves.toEqual(
+      expect.objectContaining({ ok: false }),
+    );
+    await expect(fulfillSubscription('org-1', 'pro', '')).resolves.toEqual(
+      expect.objectContaining({ ok: false }),
+    );
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  it('returns ok:false for empty planKey', async () => {
-    const result = await fulfillSubscription('org-1', '', 'active');
-    expect(result.ok).toBe(false);
-  });
-
-  it('writes organizations.plan and Pro gate entitlement on active Pro', async () => {
-    const { orgChain, gateChain } = setupMock();
+  it('calls the atomic database entitlement RPC', async () => {
     const result = await fulfillSubscription('org-1', 'pro', 'active');
 
-    expect(result.ok).toBe(true);
-    expect(orgChain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'pro' }),
-    );
-    expect(orgChain.eq).toHaveBeenCalledWith('id', 'org-1');
-    expect(gateChain.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        org_id: 'org-1',
-        tier: 'pro',
-        evals_per_month: 5000,
-      }),
-      { onConflict: 'org_id' },
-    );
+    expect(result).toEqual({ ok: true });
+    expect(mockRpc).toHaveBeenCalledWith('sync_dsg_paid_entitlement', {
+      p_org_id: 'org-1',
+      p_plan_key: 'pro',
+      p_status: 'active',
+    });
   });
 
-  it('grants the Pro gate tier during the 14-day Pro trial', async () => {
-    const { gateChain } = setupMock();
-    const result = await fulfillSubscription('org-1', 'pro', 'trialing');
+  it('is retry-safe because every call writes the same target state', async () => {
+    await fulfillSubscription('org-1', 'enterprise', 'trialing');
+    await fulfillSubscription('org-1', 'enterprise', 'trialing');
 
-    expect(result.ok).toBe(true);
-    expect(gateChain.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ tier: 'pro', evals_per_month: 5000 }),
-      { onConflict: 'org_id' },
-    );
+    expect(mockRpc).toHaveBeenCalledTimes(2);
+    expect(mockRpc.mock.calls[0]).toEqual(mockRpc.mock.calls[1]);
   });
 
-  it('maps active Business billing to Pro gate entitlement instead of Free', async () => {
-    const { orgChain, gateChain } = setupMock();
-    const result = await fulfillSubscription('org-1', 'business', 'active');
+  it('returns the database error and does not claim fulfillment', async () => {
+    mockRpc.mockResolvedValue({ error: { message: 'transaction failed' } });
 
-    expect(result.ok).toBe(true);
-    expect(orgChain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'business' }),
-    );
-    expect(gateChain.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ tier: 'pro', evals_per_month: 5000 }),
-      { onConflict: 'org_id' },
-    );
-  });
-
-  it('writes Enterprise gate entitlement for active Enterprise', async () => {
-    const { gateChain } = setupMock();
-    const result = await fulfillSubscription('org-1', 'enterprise', 'active');
-
-    expect(result.ok).toBe(true);
-    expect(gateChain.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ tier: 'enterprise', evals_per_month: 999999 }),
-      { onConflict: 'org_id' },
-    );
-  });
-
-  it('converges canceled status to free org and free gate tier', async () => {
-    const { orgChain, gateChain } = setupMock();
-    const result = await fulfillSubscription('org-1', 'pro', 'canceled');
-
-    expect(result.ok).toBe(true);
-    expect(orgChain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'free' }),
-    );
-    expect(gateChain.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ tier: 'free', evals_per_month: 50 }),
-      { onConflict: 'org_id' },
-    );
-  });
-
-  it('throws when organizations update fails so Stripe can retry the webhook event', async () => {
-    setupMock({ orgError: { message: 'DB error' } });
-    await expect(fulfillSubscription('org-1', 'pro', 'active')).rejects.toThrow(
-      'organization_entitlement_sync_failed:DB error',
-    );
-  });
-
-  it('throws when gate entitlement synchronization fails so partial access is not acknowledged', async () => {
-    setupMock({ gateError: { message: 'gate DB error' } });
-    await expect(fulfillSubscription('org-1', 'pro', 'active')).rejects.toThrow(
-      'gate_entitlement_sync_failed:gate DB error',
-    );
-  });
-
-  it('is idempotent: repeated fulfillment writes the same final state', async () => {
-    const { orgChain, gateChain } = setupMock();
-    await fulfillSubscription('org-1', 'pro', 'active');
-    await fulfillSubscription('org-1', 'pro', 'active');
-
-    expect(orgChain.update).toHaveBeenCalledTimes(2);
-    expect(gateChain.upsert).toHaveBeenCalledTimes(2);
-    expect(orgChain.update.mock.calls[0][0].plan).toBe(orgChain.update.mock.calls[1][0].plan);
-    expect(gateChain.upsert.mock.calls[0][0].tier).toBe(gateChain.upsert.mock.calls[1][0].tier);
+    await expect(
+      fulfillSubscription('org-1', 'pro', 'active'),
+    ).resolves.toEqual({ ok: false, error: 'transaction failed' });
   });
 });
 
 describe('revokeSubscription', () => {
-  it('returns ok:false for empty orgId', async () => {
-    const result = await revokeSubscription('');
-    expect(result.ok).toBe(false);
+  it('rejects an empty organization', async () => {
+    await expect(revokeSubscription('')).resolves.toEqual(
+      expect.objectContaining({ ok: false }),
+    );
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 
-  it('sets both organizations and gate entitlement to free', async () => {
-    const { orgChain, gateChain } = setupMock();
+  it('revokes organization and gate access through the same RPC', async () => {
     const result = await revokeSubscription('org-1');
 
-    expect(result.ok).toBe(true);
-    expect(orgChain.update).toHaveBeenCalledWith(
-      expect.objectContaining({ plan: 'free' }),
-    );
-    expect(gateChain.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ tier: 'free', evals_per_month: 50 }),
-      { onConflict: 'org_id' },
-    );
-  });
-
-  it('throws on organizations revoke error so Stripe can retry', async () => {
-    setupMock({ orgError: { message: 'network timeout' } });
-    await expect(revokeSubscription('org-1')).rejects.toThrow(
-      'organization_entitlement_revoke_failed:network timeout',
-    );
+    expect(result).toEqual({ ok: true });
+    expect(mockRpc).toHaveBeenCalledWith('sync_dsg_paid_entitlement', {
+      p_org_id: 'org-1',
+      p_plan_key: 'free',
+      p_status: 'canceled',
+    });
   });
 });

--- a/tests/unit/billing/fulfillment.test.ts
+++ b/tests/unit/billing/fulfillment.test.ts
@@ -49,12 +49,12 @@ describe('fulfillSubscription', () => {
     expect(mockRpc.mock.calls[0]).toEqual(mockRpc.mock.calls[1]);
   });
 
-  it('returns the database error and does not claim fulfillment', async () => {
+  it('throws on database failure so the Stripe webhook can release its event claim and retry', async () => {
     mockRpc.mockResolvedValue({ error: { message: 'transaction failed' } });
 
     await expect(
       fulfillSubscription('org-1', 'pro', 'active'),
-    ).resolves.toEqual({ ok: false, error: 'transaction failed' });
+    ).rejects.toThrow('paid_entitlement_sync_failed:transaction failed');
   });
 });
 

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock stripe before imports
 const mockMeterEventsCreate = vi.fn();
 vi.mock('stripe', () => ({
   default: vi.fn().mockImplementation(() => ({
@@ -71,12 +70,16 @@ vi.mock('../../../lib/supabase-server', () => ({
   }),
 }));
 
-import { reportMeterEvent, isMeteredBillingConfigured, flushMeterOutbox } from '../../../lib/billing/metered';
+import {
+  flushMeterOutbox,
+  isMeteredBillingConfigured,
+  reportMeterEvent,
+} from '../../../lib/billing/metered';
 
 describe('Stripe metered billing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.STRIPE_SECRET_KEY       = 'sk_test_xxx';
+    process.env.STRIPE_SECRET_KEY = 'sk_test_xxx';
     process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution';
     mockOutboxInsertMaybeSingle.mockResolvedValue({
       data: { id: 'outbox-001', status: 'pending', stripe_event_id: null },
@@ -85,15 +88,26 @@ describe('Stripe metered billing', () => {
     mockOutboxExistingMaybeSingle.mockResolvedValue({ data: null, error: null });
     mockOutboxUpdateEq.mockResolvedValue({ data: null, error: null });
     mockOutboxSelectAll.mockResolvedValue({ data: [], error: null });
-    mockCustomerMaybeSingle.mockResolvedValue({ data: { stripe_customer_id: 'cus_test123' }, error: null });
+    mockCustomerMaybeSingle.mockResolvedValue({
+      data: { stripe_customer_id: 'cus_test123' },
+      error: null,
+    });
   });
 
-  it('reports meter event successfully', async () => {
+  it('reports meter event successfully with durable evidence', async () => {
     mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_001' });
 
-    const result = await reportMeterEvent('cus_test123', 'org-1', 1, 'exec-001');
+    const result = await reportMeterEvent(
+      'cus_test123',
+      'org-1',
+      1,
+      'exec-001',
+    );
     expect(result.ok).toBe(true);
-    if (result.ok) expect((result as any).eventId).toBe('mtr_evt_001');
+    if (result.ok === true) {
+      expect(result.eventId).toBe('mtr_evt_001');
+      expect(result.durable).toBe(true);
+    }
     expect(mockMeterEventsCreate).toHaveBeenCalledOnce();
   });
 
@@ -110,11 +124,13 @@ describe('Stripe metered billing', () => {
       quantity: 1,
       status: 'pending',
     });
-    expect(mockOutboxUpdateCall).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'sent',
-      stripe_event_id: 'mtr_evt_001',
-      error: null,
-    }));
+    expect(mockOutboxUpdateCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'sent',
+        stripe_event_id: 'mtr_evt_001',
+        error: null,
+      }),
+    );
   });
 
   it('passes correct payload and execution idempotency key to Stripe', async () => {
@@ -131,68 +147,135 @@ describe('Stripe metered billing', () => {
   });
 
   it('uses distinct idempotency keys for same-second executions from the same org', async () => {
-    mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_same_second' });
+    mockMeterEventsCreate.mockResolvedValue({
+      identifier: 'mtr_evt_same_second',
+    });
     const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(1_777_000_000_000);
 
     await reportMeterEvent('cus_abc', 'org-same', 1, 'exec-same-1');
     await reportMeterEvent('cus_abc', 'org-same', 1, 'exec-same-2');
 
-    expect(mockMeterEventsCreate.mock.calls[0][1].idempotencyKey).toBe('dsg-meter-exec-same-1');
-    expect(mockMeterEventsCreate.mock.calls[1][1].idempotencyKey).toBe('dsg-meter-exec-same-2');
+    expect(mockMeterEventsCreate.mock.calls[0][1].idempotencyKey).toBe(
+      'dsg-meter-exec-same-1',
+    );
+    expect(mockMeterEventsCreate.mock.calls[1][1].idempotencyKey).toBe(
+      'dsg-meter-exec-same-2',
+    );
     dateSpy.mockRestore();
   });
 
-  it('requires executionId to prevent unsafe timestamp-only metering', async () => {
-    const result = await reportMeterEvent('cus_test', 'org-missing-exec', 1, '   ');
+  it('requires executionId and reports that no durable evidence exists', async () => {
+    const result = await reportMeterEvent(
+      'cus_test',
+      'org-missing-exec',
+      1,
+      '   ',
+    );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result as any).error).toContain('executionId is required');
+    if (result.ok === false) {
+      expect(result.error).toContain('executionId is required');
+      expect(result.durable).toBe(false);
+    }
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
-  it('skips gracefully when STRIPE_METER_EVENT_NAME is not set', async () => {
+  it('fails without durable evidence when meter configuration is missing', async () => {
     delete process.env.STRIPE_METER_EVENT_NAME;
 
-    const result = await reportMeterEvent('cus_test', 'org-3', 1, 'exec-003');
+    const result = await reportMeterEvent(
+      'cus_test',
+      'org-3',
+      1,
+      'exec-003',
+    );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result as any).skipped).toBe(true);
+    if (result.ok === false) {
+      expect(result.skipped).toBe(true);
+      expect(result.durable).toBe(false);
+    }
     expect(mockOutboxInsertCall).not.toHaveBeenCalled();
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
-  it('skips gracefully when STRIPE_SECRET_KEY is not set', async () => {
+  it('fails without durable evidence when the Stripe key is missing', async () => {
     delete process.env.STRIPE_SECRET_KEY;
 
-    const result = await reportMeterEvent('cus_test', 'org-4', 1, 'exec-004');
+    const result = await reportMeterEvent(
+      'cus_test',
+      'org-4',
+      1,
+      'exec-004',
+    );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result as any).skipped).toBe(true);
+    if (result.ok === false) {
+      expect(result.skipped).toBe(true);
+      expect(result.durable).toBe(false);
+    }
   });
 
-  it('returns error and marks outbox failed when Stripe call fails', async () => {
+  it('fails closed when the outbox row cannot be created or recovered', async () => {
+    mockOutboxInsertMaybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: 'outbox insert failed' },
+    });
+    mockOutboxExistingMaybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: 'outbox lookup failed' },
+    });
+
+    const result = await reportMeterEvent(
+      'cus_test',
+      'org-outbox-down',
+      1,
+      'exec-outbox-down',
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.durable).toBe(false);
+      expect(result.error).toContain('outbox lookup failed');
+    }
+    expect(mockMeterEventsCreate).not.toHaveBeenCalled();
+  });
+
+  it('keeps durable retry evidence when the Stripe call fails', async () => {
     mockMeterEventsCreate.mockRejectedValue(new Error('Stripe API error'));
 
-    const result = await reportMeterEvent('cus_test', 'org-5', 1, 'exec-005');
+    const result = await reportMeterEvent(
+      'cus_test',
+      'org-5',
+      1,
+      'exec-005',
+    );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result as any).error).toContain('Stripe API error');
-    expect(mockOutboxUpdateCall).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'failed',
-      error: 'Stripe API error',
-    }));
+    if (result.ok === false) {
+      expect(result.error).toContain('Stripe API error');
+      expect(result.durable).toBe(true);
+    }
+    expect(mockOutboxUpdateCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        error: 'Stripe API error',
+      }),
+    );
   });
 
   it('flushMeterOutbox retries pending rows', async () => {
     mockOutboxSelectAll.mockResolvedValue({
-      data: [{
-        id: 'outbox-retry-1',
-        execution_id: 'exec-retry-1',
-        org_id: 'org-retry',
-        stripe_customer_id: 'cus_retry',
-        event_name: 'dsg_execution',
-        quantity: 1,
-        status: 'pending',
-        stripe_event_id: null,
-        error: null,
-        created_at: '2026-05-01T00:00:00.000Z',
-      }],
+      data: [
+        {
+          id: 'outbox-retry-1',
+          execution_id: 'exec-retry-1',
+          org_id: 'org-retry',
+          stripe_customer_id: 'cus_retry',
+          event_name: 'dsg_execution',
+          quantity: 1,
+          status: 'pending',
+          stripe_event_id: null,
+          error: null,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
       error: null,
     });
     mockMeterEventsCreate.mockResolvedValue({ identifier: 'mtr_evt_retry' });
@@ -203,7 +286,7 @@ describe('Stripe metered billing', () => {
     expect(result.sent).toBe(1);
     expect(mockMeterEventsCreate).toHaveBeenCalledWith(
       expect.objectContaining({ identifier: 'dsg-meter-exec-retry-1' }),
-      { idempotencyKey: 'dsg-meter-exec-retry-1' }
+      { idempotencyKey: 'dsg-meter-exec-retry-1' },
     );
   });
 

--- a/tests/unit/billing/pricing-catalog.test.ts
+++ b/tests/unit/billing/pricing-catalog.test.ts
@@ -3,14 +3,16 @@ import {
   GATE_PLANS,
   SKILLS_BUNDLES,
   DELIVERY_PROOF_PRICING,
-  DEFAULT_PRICE_IDS,
   getPriceId,
   isSkillsBundle,
 } from '../../../lib/billing/pricing-catalog';
 
 const ENV_KEYS = [
   'STRIPE_PRICE_PRO_MONTHLY',
+  'STRIPE_PRICE_PRO_YEARLY',
   'STRIPE_PRICE_PRO',
+  'STRIPE_PRICE_ENTERPRISE_MONTHLY',
+  'STRIPE_PRICE_ENTERPRISE_YEARLY',
 ] as const;
 const saved: Record<string, string | undefined> = {};
 for (const k of ENV_KEYS) saved[k] = process.env[k];
@@ -54,22 +56,28 @@ describe('pricing catalog — single source of truth', () => {
     expect(DELIVERY_PROOF_PRICING.unlimited.planKey).toBe('business');
   });
 
-  it('getPriceId: env var wins over legacy and defaults', () => {
+  it('getPriceId: interval-specific env var wins over legacy monthly env', () => {
     process.env.STRIPE_PRICE_PRO_MONTHLY = 'price_env_first';
     process.env.STRIPE_PRICE_PRO = 'price_legacy';
     expect(getPriceId('pro', 'monthly')).toBe('price_env_first');
   });
 
-  it('getPriceId: legacy monthly env wins over hardcoded default', () => {
+  it('getPriceId: legacy monthly env remains compatible for Pro', () => {
     delete process.env.STRIPE_PRICE_PRO_MONTHLY;
     process.env.STRIPE_PRICE_PRO = 'price_legacy';
     expect(getPriceId('pro', 'monthly')).toBe('price_legacy');
   });
 
-  it('getPriceId: falls back to hardcoded live price IDs when no env set', () => {
+  it('getPriceId: missing config fails closed instead of using a hardcoded cross-account Price ID', () => {
     delete process.env.STRIPE_PRICE_PRO_MONTHLY;
+    delete process.env.STRIPE_PRICE_PRO_YEARLY;
     delete process.env.STRIPE_PRICE_PRO;
-    expect(getPriceId('pro', 'monthly')).toBe(DEFAULT_PRICE_IDS.pro.monthly);
-    expect(getPriceId('enterprise', 'yearly')).toBe(DEFAULT_PRICE_IDS.enterprise.yearly);
+    delete process.env.STRIPE_PRICE_ENTERPRISE_MONTHLY;
+    delete process.env.STRIPE_PRICE_ENTERPRISE_YEARLY;
+
+    expect(getPriceId('pro', 'monthly')).toBe('');
+    expect(getPriceId('pro', 'yearly')).toBe('');
+    expect(getPriceId('enterprise', 'monthly')).toBe('');
+    expect(getPriceId('enterprise', 'yearly')).toBe('');
   });
 });

--- a/tests/unit/dsg/gate-entitlement-metering.test.ts
+++ b/tests/unit/dsg/gate-entitlement-metering.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUsageMaybeSingle = vi.fn();
+const mockEntitlementMaybeSingle = vi.fn();
+const mockUsageUpdateEq = vi.fn();
+const mockUsageUpdate = vi.fn((payload: Record<string, unknown>) => ({
+  eq: (...args: unknown[]) => {
+    mockUsageUpdateEq(payload, ...args);
+    return Promise.resolve({ error: null });
+  },
+}));
+const mockInsertRevenueEvent = vi.fn();
+const mockReportMeterEvent = vi.fn();
+
+vi.mock('../../../lib/supabase-server', () => ({
+  getSupabaseAdmin: () => ({
+    rpc: () => ({ maybeSingle: mockUsageMaybeSingle }),
+    from: (table: string) => {
+      if (table === 'dsg_gate_entitlements') {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: mockEntitlementMaybeSingle }),
+          }),
+        };
+      }
+
+      if (table === 'dsg_gate_usage') {
+        return { update: mockUsageUpdate };
+      }
+
+      throw new Error(`unexpected table: ${table}`);
+    },
+  }),
+}));
+
+vi.mock('../../../lib/revenue/events', () => ({
+  insertRevenueEvent: (...args: unknown[]) => mockInsertRevenueEvent(...args),
+}));
+
+vi.mock('../../../lib/billing/metered', () => ({
+  isMeteredBillingConfigured: () => true,
+  reportMeterEvent: (...args: unknown[]) => mockReportMeterEvent(...args),
+}));
+
+import { recordGateEvaluation } from '../../../lib/dsg/gate-entitlement';
+
+function usage(position: number, overrides?: Record<string, unknown>) {
+  return {
+    data: {
+      usage_id: `usage-${position}`,
+      created: true,
+      billed: false,
+      meter_event_id: null,
+      usage_position: position,
+      ...overrides,
+    },
+    error: null,
+  };
+}
+
+function activeProEntitlement() {
+  return {
+    data: {
+      org_id: 'org-pro',
+      tier: 'pro',
+      evals_per_month: 5_000,
+      subscription_status: 'active',
+      overage_enabled: true,
+      stripe_customer_id: 'cus_pro',
+      stripe_subscription_id: 'sub_pro',
+    },
+    error: null,
+  };
+}
+
+describe('recordGateEvaluation durable revenue orchestration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEntitlementMaybeSingle.mockResolvedValue(activeProEntitlement());
+    mockInsertRevenueEvent.mockResolvedValue({ id: 'revenue-1' });
+    mockUsageUpdateEq.mockResolvedValue({ error: null });
+  });
+
+  it('keeps evaluation 5,000 inside the included Pro quota', async () => {
+    mockUsageMaybeSingle.mockResolvedValue(usage(5_000));
+
+    const result = await recordGateEvaluation(
+      'eval-5000',
+      'org-pro',
+      'gates/evaluate',
+      'PASS',
+      12,
+    );
+
+    expect(result).toEqual({ recorded: true });
+    expect(mockInsertRevenueEvent).toHaveBeenCalledOnce();
+    expect(mockReportMeterEvent).not.toHaveBeenCalled();
+  });
+
+  it('meters evaluation 5,001 and marks the usage billed on Stripe success', async () => {
+    mockUsageMaybeSingle.mockResolvedValue(usage(5_001));
+    mockReportMeterEvent.mockResolvedValue({
+      ok: true,
+      eventId: 'meter-5001',
+      durable: true,
+    });
+
+    const result = await recordGateEvaluation(
+      'eval-5001',
+      'org-pro',
+      'gates/evaluate',
+      'PASS',
+      13,
+    );
+
+    expect(result).toEqual({ recorded: true, meterEventId: 'meter-5001' });
+    expect(mockReportMeterEvent).toHaveBeenCalledWith(
+      'cus_pro',
+      'org-pro',
+      1,
+      'dsg-gate-eval-5001',
+    );
+    expect(mockUsageUpdateEq).toHaveBeenCalledWith(
+      { billed: true, meter_event_id: 'meter-5001' },
+      'id',
+      'usage-5001',
+    );
+  });
+
+  it('withholds paid delivery when no durable meter outbox exists', async () => {
+    mockUsageMaybeSingle.mockResolvedValue(usage(5_001));
+    mockReportMeterEvent.mockResolvedValue({
+      ok: false,
+      error: 'outbox unavailable',
+      durable: false,
+    });
+
+    const result = await recordGateEvaluation(
+      'eval-no-outbox',
+      'org-pro',
+      'gates/evaluate',
+      'PASS',
+      14,
+    );
+
+    expect(result.recorded).toBe(false);
+    expect(result.error).toContain('meter_outbox_unavailable');
+    expect(mockUsageUpdateEq).not.toHaveBeenCalled();
+  });
+
+  it('allows delivery when Stripe fails after durable outbox persistence', async () => {
+    mockUsageMaybeSingle.mockResolvedValue(usage(5_001));
+    mockReportMeterEvent.mockResolvedValue({
+      ok: false,
+      error: 'Stripe temporarily unavailable',
+      durable: true,
+    });
+
+    const result = await recordGateEvaluation(
+      'eval-retryable',
+      'org-pro',
+      'gates/evaluate',
+      'PASS',
+      15,
+    );
+
+    expect(result).toEqual({
+      recorded: true,
+      error: 'Stripe temporarily unavailable',
+    });
+    expect(mockUsageUpdateEq).not.toHaveBeenCalled();
+  });
+
+  it('does not create a second revenue or meter event for an already billed retry', async () => {
+    mockUsageMaybeSingle.mockResolvedValue(
+      usage(5_001, {
+        created: false,
+        billed: true,
+        meter_event_id: 'meter-existing',
+      }),
+    );
+
+    const result = await recordGateEvaluation(
+      'eval-existing',
+      'org-pro',
+      'gates/evaluate',
+      'PASS',
+      16,
+    );
+
+    expect(result).toEqual({
+      recorded: true,
+      meterEventId: 'meter-existing',
+    });
+    expect(mockInsertRevenueEvent).not.toHaveBeenCalled();
+    expect(mockReportMeterEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dsg/gate-entitlement.test.ts
+++ b/tests/unit/dsg/gate-entitlement.test.ts
@@ -11,7 +11,13 @@ vi.mock('../../../lib/revenue/events', () => ({
 }));
 
 vi.mock('../../../lib/billing/metered', () => ({
-  reportMeterEvent: vi.fn(async () => ({ ok: false, error: 'not_configured', skipped: true })),
+  isMeteredBillingConfigured: vi.fn(() => false),
+  reportMeterEvent: vi.fn(async () => ({
+    ok: false,
+    error: 'not_configured',
+    skipped: true,
+    durable: false,
+  })),
 }));
 
 describe('dsg gate entitlement', () => {
@@ -30,7 +36,15 @@ describe('dsg gate entitlement', () => {
 
   it('uses db-backed entitlement + usage when available', async () => {
     const maybeSingle = vi.fn().mockResolvedValue({
-      data: { org_id: 'org_1', tier: 'pro', evals_per_month: 5000, stripe_customer_id: null },
+      data: {
+        org_id: 'org_1',
+        tier: 'pro',
+        evals_per_month: 5000,
+        subscription_status: 'active',
+        overage_enabled: false,
+        stripe_customer_id: null,
+        stripe_subscription_id: null,
+      },
       error: null,
     });
 

--- a/tests/unit/dsg/gate-revenue-policy.test.ts
+++ b/tests/unit/dsg/gate-revenue-policy.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decideGateRevenueAccess,
+  normalizeGateTier,
+  shouldMeterRecordedEvaluation,
+} from '../../../lib/dsg/gate-revenue-policy';
+
+describe('normalizeGateTier', () => {
+  it('maps only supported paid plans to gate tiers', () => {
+    expect(normalizeGateTier('pro')).toBe('pro');
+    expect(normalizeGateTier('business')).toBe('pro');
+    expect(normalizeGateTier('enterprise')).toBe('enterprise');
+    expect(normalizeGateTier('unknown')).toBe('free');
+  });
+});
+
+describe('decideGateRevenueAccess', () => {
+  it('allows free usage only while included quota remains', () => {
+    expect(
+      decideGateRevenueAccess({
+        tier: 'free',
+        subscriptionStatus: 'free',
+        includedLimit: 50,
+        used: 49,
+        overageEnabled: false,
+        hasStripeCustomer: false,
+        hasStripeSubscription: false,
+        meteringConfigured: false,
+      }),
+    ).toEqual({
+      allowed: true,
+      remaining: 1,
+      accessMode: 'included_quota',
+      requiresPayment: false,
+    });
+
+    expect(
+      decideGateRevenueAccess({
+        tier: 'free',
+        subscriptionStatus: 'free',
+        includedLimit: 50,
+        used: 50,
+        overageEnabled: false,
+        hasStripeCustomer: false,
+        hasStripeSubscription: false,
+        meteringConfigured: false,
+      }).accessMode,
+    ).toBe('quota_exceeded');
+  });
+
+  it('never grants a paid tier when Stripe says the subscription is inactive', () => {
+    const result = decideGateRevenueAccess({
+      tier: 'pro',
+      subscriptionStatus: 'past_due',
+      includedLimit: 5_000,
+      used: 0,
+      overageEnabled: true,
+      hasStripeCustomer: true,
+      hasStripeSubscription: true,
+      meteringConfigured: true,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.accessMode).toBe('subscription_inactive');
+  });
+
+  it('allows Pro overage only when every billing dependency is present', () => {
+    const ready = decideGateRevenueAccess({
+      tier: 'pro',
+      subscriptionStatus: 'active',
+      includedLimit: 5_000,
+      used: 5_000,
+      overageEnabled: true,
+      hasStripeCustomer: true,
+      hasStripeSubscription: true,
+      meteringConfigured: true,
+    });
+
+    expect(ready.allowed).toBe(true);
+    expect(ready.accessMode).toBe('metered_overage');
+
+    const missingMeter = decideGateRevenueAccess({
+      tier: 'pro',
+      subscriptionStatus: 'active',
+      includedLimit: 5_000,
+      used: 5_000,
+      overageEnabled: true,
+      hasStripeCustomer: true,
+      hasStripeSubscription: true,
+      meteringConfigured: false,
+    });
+
+    expect(missingMeter.allowed).toBe(false);
+    expect(missingMeter.accessMode).toBe('billing_unavailable');
+  });
+
+  it('treats active Enterprise as unlimited but blocks canceled Enterprise', () => {
+    const active = decideGateRevenueAccess({
+      tier: 'enterprise',
+      subscriptionStatus: 'active',
+      includedLimit: 999_999,
+      used: 1_500_000,
+      overageEnabled: false,
+      hasStripeCustomer: true,
+      hasStripeSubscription: true,
+      meteringConfigured: false,
+    });
+    expect(active.allowed).toBe(true);
+
+    const canceled = decideGateRevenueAccess({
+      tier: 'enterprise',
+      subscriptionStatus: 'canceled',
+      includedLimit: 999_999,
+      used: 0,
+      overageEnabled: false,
+      hasStripeCustomer: true,
+      hasStripeSubscription: true,
+      meteringConfigured: false,
+    });
+    expect(canceled.allowed).toBe(false);
+  });
+});
+
+describe('shouldMeterRecordedEvaluation', () => {
+  const proBilling = {
+    tier: 'pro' as const,
+    subscriptionStatus: 'active',
+    includedLimit: 5_000,
+    used: 5_000,
+    overageEnabled: true,
+    hasStripeCustomer: true,
+    hasStripeSubscription: true,
+    meteringConfigured: true,
+  };
+
+  it('does not charge evaluation 5,000 because it is included', () => {
+    expect(
+      shouldMeterRecordedEvaluation({
+        ...proBilling,
+        usedAfterInsert: 5_000,
+      }),
+    ).toBe(false);
+  });
+
+  it('charges evaluation 5,001 when all billing dependencies exist', () => {
+    expect(
+      shouldMeterRecordedEvaluation({
+        ...proBilling,
+        usedAfterInsert: 5_001,
+      }),
+    ).toBe(true);
+  });
+
+  it('never charges an overage when metering is unavailable', () => {
+    expect(
+      shouldMeterRecordedEvaluation({
+        ...proBilling,
+        meteringConfigured: false,
+        usedAfterInsert: 5_001,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Goal
Move the proven automatic-revenue controls from stale PR #1058 onto the current `main` without importing its diverged 58-commit history, while preserving the merged Encoding Proof product.

## Why this is a new PR
PR #1058 is 75 commits behind current `main`, 58 commits ahead, draft, and non-mergeable. This branch starts directly from current `main` and ports only the revenue-critical implementation.

## Revenue path
Customer → `/pricing` or Framer Encoding Proof → authenticated checkout → Stripe → canonical webhook → atomic paid entitlement → persisted usage slot → optional durable Stripe meter outbox → Activation Proof.

## Changes
- remove hardcoded cross-account Stripe Price ID fallback; checkout is env-only/fail-closed
- atomic `organizations.plan` + `dsg_gate_entitlements` sync through `sync_dsg_paid_entitlement`
- deterministic revenue policy for Free / Pro / Enterprise
- fail closed when entitlement storage is unavailable
- serialized/idempotent usage positions per organization
- durable Stripe meter outbox semantics (`durable` result)
- first-class revenue-event idempotency
- authenticated entitlement API
- direct `/checkout/pro` and `/checkout/enterprise` handoff
- append-only billing Activation Proof API/UI + hardening migrations
- gate/proof API responses are withheld until usage evidence is durable
- Encoding Proof is integrated into the same atomic usage ledger
- Encoding Proof replay also re-verifies/records usage evidence, preventing retry-based unmetered delivery
- public pricing CTAs route to direct checkout

## Compatibility with current main
The original #1058 usage schema supported only `gates/evaluate` and `proofs/prove`. Current main also sells `encoding/prove`. A new additive migration `20260812232000_dsg_gate_encoding_usage_route.sql` extends the route constraint and atomic RPC without rewriting historical migrations.

## Stripe truth boundary
Connected Stripe account verified in this session: `acct_1Tft0OAZNzhgTUPV` (`DSG Governance Gate`). Live recurring prices observed:
- Pro monthly: $99
- Enterprise monthly: $499

This PR deliberately does not hardcode those Price IDs. Production Render must receive the verified Price IDs through `STRIPE_PRICE_PRO_MONTHLY` and `STRIPE_PRICE_ENTERPRISE_MONTHLY`.

## Safety / claims
- No claim that production revenue is closed until CI is green, migrations are verified, Render is deployed, and live runtime smoke checks pass.
- No automatic real customer charge is initiated by this PR.
- Activation Proof proves Stripe-backed entitlement activation; it is not a payment receipt or compliance certificate.
- If usage evidence cannot be persisted safely, paid output is withheld rather than delivered unmetered.

## Source evidence
Revenue core is ported from PR #1058 implementation head `018ceb176a69ebd36f975951e85add04e2267309`, whose implementation CI had previously passed security, typecheck, unit/integration/migration, full suite, formal proof, E2E, and governance gates. This PR requires fresh CI because it is rebased/ported onto current main and includes Encoding Proof compatibility work.