### PR TITLE
fix(billing): fail closed until Pro overage is fully billable

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -7,6 +7,7 @@ import { ensureUserWorkspace, isWorkspaceFailure } from '../../../../lib/auth/en
 import { applyRateLimit, buildRateLimitHeaders, getRateLimitKey } from '../../../../lib/security/rate-limit';
 import { handleApiError } from '../../../../lib/security/api-error';
 import { captureEvent } from '../../../../lib/telemetry/capture-event';
+import { getMeteredBillingConfiguration } from '../../../../lib/billing/metered';
 // Pricing/plan definitions live in the shared catalog — the single source
 // of truth for every price shown or charged (lib/billing/pricing-catalog.ts).
 import {
@@ -252,7 +253,18 @@ export async function POST(request: Request) {
         return handleApiError('api/billing/checkout', new Error('Missing Stripe price configuration'), { details: { plan, interval, stage: 'price-config' } });
       }
       metadata.plan_key = plan;
-      lineItems = [{ price: priceId, quantity: 1 }];
+
+      const planLineItems: NonNullable<Stripe.Checkout.SessionCreateParams['line_items']> = [
+        { price: priceId, quantity: 1 },
+      ];
+      const metering = getMeteredBillingConfiguration();
+      if (plan === 'pro' && metering.configured) {
+        // Metered Stripe Prices must not receive a fixed quantity. Stripe bills
+        // usage reported to the linked Billing Meter during the invoice period.
+        planLineItems.push({ price: metering.priceId });
+      }
+      lineItems = planLineItems;
+
       trialDays = PLAN_CONFIG[plan].trialDays;
       successUrl = `${appUrl}/dashboard/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}`;
       cancelUrl = `${appUrl}/pricing?checkout=cancelled&plan=${plan}&interval=${interval}`;

--- a/app/api/billing/meter-health/route.ts
+++ b/app/api/billing/meter-health/route.ts
@@ -2,11 +2,13 @@
  * GET /api/billing/meter-health
  *
  * Returns real-time billing meter health for admin dashboard.
- * Returns per-org stats and dead-letter events.
+ * Returns per-org stats and dead-letter events without exposing Stripe ids or
+ * secrets. A false `configured` value includes only the missing env names so
+ * operators can distinguish safe fail-closed mode from a provider outage.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { reconcileMeterOutbox, getOrgBillingStats } from '../../../../lib/billing/reconciliation';
-import { isMeteredBillingConfigured } from '../../../../lib/billing/metered';
+import { getMeteredBillingConfiguration } from '../../../../lib/billing/metered';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,6 +31,8 @@ export async function GET(request: NextRequest) {
   const windowHours = Math.min(Number(searchParams.get('hours') ?? '24'), 168);
 
   try {
+    const metering = getMeteredBillingConfiguration();
+
     // Overall health
     const report = await reconcileMeterOutbox(windowHours, 500);
 
@@ -38,7 +42,13 @@ export async function GET(request: NextRequest) {
       : null;
 
     return NextResponse.json({
-      configured: isMeteredBillingConfigured(),
+      configured: metering.configured,
+      missingConfiguration: metering.configured ? [] : metering.missing,
+      meterContract: {
+        eventNameConfigured: Boolean(metering.eventName),
+        meterIdConfigured: Boolean(metering.meterId),
+        proOveragePriceConfigured: Boolean(metering.priceId),
+      },
       health: {
         windowStart: report.windowStart,
         windowEnd: report.windowEnd,

--- a/docs/revenue/PRO_OVERAGE_ACTIVATION.md
+++ b/docs/revenue/PRO_OVERAGE_ACTIVATION.md
@@ -1,0 +1,49 @@
+# DSG Pro Overage Activation Contract
+
+## Current production rule
+
+DSG Pro is a fixed **$99/month** subscription with **5,000 included evaluations**. Evaluation 5,001 and later must not be delivered as billable overage unless the complete Stripe usage-billing contract has been verified.
+
+The repository-defined overage rate is **USD 0.001 per execution** and the meter event name is `dsg_execution_overage`.
+
+## Required production configuration
+
+All four values must exist before overage is considered active:
+
+```env
+STRIPE_SECRET_KEY=<live-secret-in-secret-store>
+STRIPE_METER_EVENT_NAME=dsg_execution_overage
+STRIPE_METER_ID=<verified Stripe Billing Meter id>
+STRIPE_PRICE_PRO_OVERAGE=<verified recurring metered Price id>
+```
+
+`STRIPE_PRICE_PRO_MONTHLY` remains the fixed $99/month base price.
+
+## Checkout contract
+
+When the full meter contract is configured, a new Pro Checkout subscription contains:
+
+1. the fixed Pro monthly Price with quantity `1`; and
+2. the metered overage Price with **no fixed quantity**.
+
+Enterprise remains unlimited and does not receive the Pro overage item.
+
+If any required meter setting is missing, Checkout can still sell the fixed Pro subscription, but DSG reports metered billing as not configured and the entitlement layer must fail closed once the included quota is exhausted.
+
+## Meter-event contract
+
+For authorized Pro overage, DSG first persists an idempotent `billing_meter_outbox` row and then sends a Stripe Billing Meter event using the configured event name. The execution id is the meter-event idempotency key.
+
+A Stripe API delivery failure can be retried from the durable outbox. If DSG cannot create durable billing evidence, the paid output must be withheld.
+
+## Truth boundary
+
+Do not claim Pro overage is live merely because `STRIPE_METER_EVENT_NAME` is set or because the application can call Stripe's Meter Event API. Overage is live only after:
+
+- a real Stripe Billing Meter exists;
+- a real metered recurring Price linked to that meter exists;
+- `STRIPE_METER_ID` and `STRIPE_PRICE_PRO_OVERAGE` are configured in production;
+- Pro Checkout is verified to contain both subscription items; and
+- a controlled real usage event is observed on a real Stripe invoice/subscription.
+
+Until then, the correct status is **fixed subscription live; overage fail-closed**.

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -5,9 +5,16 @@
  * A durable outbox row is always created before Stripe delivery so temporary
  * provider failures can be retried without losing revenue evidence.
  *
- * Required env vars:
- *   STRIPE_METER_EVENT_NAME  – e.g. "dsg_execution"
- *   STRIPE_SECRET_KEY
+ * Production overage is considered configured only when the complete billing
+ * contract exists:
+ *   STRIPE_SECRET_KEY         – live Stripe key
+ *   STRIPE_METER_EVENT_NAME   – e.g. "dsg_execution_overage"
+ *   STRIPE_METER_ID           – verified Stripe Billing Meter id
+ *   STRIPE_PRICE_PRO_OVERAGE  – verified recurring metered Price id
+ *
+ * Requiring the Meter and Price ids prevents a dangerous half-configured state
+ * where DSG can emit usage events but Stripe has no subscription billing item
+ * capable of turning those events into invoice revenue.
  */
 
 import Stripe from 'stripe';
@@ -30,6 +37,21 @@ export type MeterOutboxFlushResult = {
   errors: string[];
 };
 
+export type MeteredBillingConfiguration =
+  | {
+      configured: true;
+      eventName: string;
+      meterId: string;
+      priceId: string;
+    }
+  | {
+      configured: false;
+      eventName: string | null;
+      meterId: string | null;
+      priceId: string | null;
+      missing: string[];
+    };
+
 type OutboxRow = {
   id: string;
   execution_id: string;
@@ -49,10 +71,6 @@ function getStripe(): Stripe | null {
   return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
-function getMeterEventName(): string | null {
-  return process.env.STRIPE_METER_EVENT_NAME ?? null;
-}
-
 function normalizeExecutionId(executionId: string): string | null {
   const normalized = executionId.trim();
   return normalized.length > 0 ? normalized : null;
@@ -64,6 +82,28 @@ function positiveQuantity(quantity: number): number {
 
 function idempotencyKeyForExecution(executionId: string): string {
   return `dsg-meter-${executionId}`;
+}
+
+/**
+ * Return the complete metered-billing contract without exposing secret values.
+ * The Stripe key is checked only for presence and is never returned.
+ */
+export function getMeteredBillingConfiguration(): MeteredBillingConfiguration {
+  const eventName = process.env.STRIPE_METER_EVENT_NAME?.trim() || null;
+  const meterId = process.env.STRIPE_METER_ID?.trim() || null;
+  const priceId = process.env.STRIPE_PRICE_PRO_OVERAGE?.trim() || null;
+  const missing: string[] = [];
+
+  if (!process.env.STRIPE_SECRET_KEY) missing.push('STRIPE_SECRET_KEY');
+  if (!eventName) missing.push('STRIPE_METER_EVENT_NAME');
+  if (!meterId) missing.push('STRIPE_METER_ID');
+  if (!priceId) missing.push('STRIPE_PRICE_PRO_OVERAGE');
+
+  if (missing.length === 0 && eventName && meterId && priceId) {
+    return { configured: true, eventName, meterId, priceId };
+  }
+
+  return { configured: false, eventName, meterId, priceId, missing };
 }
 
 async function getOutboxClient() {
@@ -192,8 +232,6 @@ export async function reportMeterEvent(
   quantity: number,
   executionId: string,
 ): Promise<MeterEventResult> {
-  const stripe = getStripe();
-  const eventName = getMeterEventName();
   const normalizedExecutionId = normalizeExecutionId(executionId);
   const meteredQuantity = positiveQuantity(quantity);
 
@@ -205,7 +243,18 @@ export async function reportMeterEvent(
     };
   }
 
-  if (!stripe || !eventName) {
+  const config = getMeteredBillingConfiguration();
+  if (!config.configured) {
+    return {
+      ok: false,
+      error: `Stripe metering not fully configured: ${config.missing.join(', ')}`,
+      skipped: true,
+      durable: false,
+    };
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
     return {
       ok: false,
       error: 'Stripe metering not configured',
@@ -218,7 +267,7 @@ export async function reportMeterEvent(
     executionId: normalizedExecutionId,
     orgId,
     stripeCustomerId,
-    eventName,
+    eventName: config.eventName,
     quantity: meteredQuantity,
   });
 
@@ -238,7 +287,7 @@ export async function reportMeterEvent(
     const result = await deliverMeterEvent({
       stripe,
       stripeCustomerId,
-      eventName,
+      eventName: config.eventName,
       quantity: meteredQuantity,
       executionId: normalizedExecutionId,
     });
@@ -356,7 +405,5 @@ export async function meterExecution(
 }
 
 export function isMeteredBillingConfigured(): boolean {
-  return !!(
-    process.env.STRIPE_SECRET_KEY && process.env.STRIPE_METER_EVENT_NAME
-  );
+  return getMeteredBillingConfiguration().configured;
 }

--- a/lib/billing/metered.ts
+++ b/lib/billing/metered.ts
@@ -43,6 +43,7 @@ export type MeteredBillingConfiguration =
       eventName: string;
       meterId: string;
       priceId: string;
+      missing: string[];
     }
   | {
       configured: false;
@@ -100,7 +101,7 @@ export function getMeteredBillingConfiguration(): MeteredBillingConfiguration {
   if (!priceId) missing.push('STRIPE_PRICE_PRO_OVERAGE');
 
   if (missing.length === 0 && eventName && meterId && priceId) {
-    return { configured: true, eventName, meterId, priceId };
+    return { configured: true, eventName, meterId, priceId, missing: [] };
   }
 
   return { configured: false, eventName, meterId, priceId, missing };

--- a/scripts/verify-stripe-setup.sh
+++ b/scripts/verify-stripe-setup.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-# Phase 1 Verification Script: Check Stripe Setup
-# Run this to verify Stripe account is configured correctly before launch
+# Production verification script: Stripe + DSG ONE billing setup
 # Usage: bash scripts/verify-stripe-setup.sh
 
 set -e
 
 echo "=========================================="
-echo "DSG ONE Phase 1: Stripe Setup Verification"
+echo "DSG ONE: Stripe Production Verification"
 echo "=========================================="
 echo ""
 
@@ -18,12 +17,16 @@ if [ -z "$STRIPE_SECRET_KEY" ]; then
   MISSING_VARS+=("STRIPE_SECRET_KEY")
 fi
 
-if [ -z "$STRIPE_PUBLISHABLE_KEY" ]; then
-  MISSING_VARS+=("STRIPE_PUBLISHABLE_KEY")
-fi
-
 if [ -z "$STRIPE_WEBHOOK_SECRET" ]; then
   MISSING_VARS+=("STRIPE_WEBHOOK_SECRET")
+fi
+
+if [ -z "$STRIPE_PRICE_PRO_MONTHLY" ]; then
+  MISSING_VARS+=("STRIPE_PRICE_PRO_MONTHLY")
+fi
+
+if [ -z "$STRIPE_PRICE_ENTERPRISE_MONTHLY" ]; then
+  MISSING_VARS+=("STRIPE_PRICE_ENTERPRISE_MONTHLY")
 fi
 
 if [ -z "$STRIPE_METER_ID" ]; then
@@ -34,85 +37,90 @@ if [ -z "$STRIPE_METER_EVENT_NAME" ]; then
   MISSING_VARS+=("STRIPE_METER_EVENT_NAME")
 fi
 
+if [ -z "$STRIPE_PRICE_PRO_OVERAGE" ]; then
+  MISSING_VARS+=("STRIPE_PRICE_PRO_OVERAGE")
+fi
+
 if [ -z "$CRON_SECRET" ]; then
   MISSING_VARS+=("CRON_SECRET")
 fi
 
 if [ ${#MISSING_VARS[@]} -gt 0 ]; then
-  echo "❌ Missing environment variables:"
+  echo "❌ Full automatic billing is not configured. Missing:"
   for var in "${MISSING_VARS[@]}"; do
     echo "   - $var"
   done
   echo ""
-  echo "Set these variables in Vercel or .env.production before proceeding."
+  echo "Fixed subscription checkout may still be live, but Pro overage must remain fail-closed."
+  echo "Set verified values in Render before declaring overage active."
   exit 1
 fi
 
-echo "✅ All required environment variables present"
+echo "✅ All required fixed + usage billing variables present"
 echo ""
+
+if [ "$STRIPE_METER_EVENT_NAME" != "dsg_execution_overage" ]; then
+  echo "❌ STRIPE_METER_EVENT_NAME must match repository billing contract: dsg_execution_overage"
+  exit 1
+fi
 
 # Check if Stripe CLI is installed
 if ! command -v stripe &> /dev/null; then
-  echo "⚠️  Stripe CLI not found. Install from https://stripe.com/docs/stripe-cli"
-  echo "   Skipping Stripe API verification (can be done manually)"
+  echo "⚠️  Stripe CLI not found."
+  echo "   Skipping provider-object verification; environment checks above still apply."
   echo ""
 else
   echo "✓ Stripe CLI found"
   echo ""
 
-  # Verify Stripe API access
   echo "Testing Stripe API connectivity..."
   if stripe products list --limit 1 > /dev/null 2>&1; then
     echo "✅ Stripe API connectivity OK"
   else
     echo "❌ Stripe API connectivity failed"
-    echo "   Check STRIPE_SECRET_KEY is correct and Stripe CLI is authenticated"
     exit 1
   fi
   echo ""
 
-  # Check products exist
-  echo "Checking Stripe products..."
-  PRODUCTS=$(stripe products list --limit 100 --format=json 2>/dev/null | grep -c '"name"' || true)
-  if [ "$PRODUCTS" -ge 3 ]; then
-    echo "✅ Found $PRODUCTS products (expected: Pro, Business, Enterprise, + skills bundles)"
-  else
-    echo "⚠️  Only found $PRODUCTS products (expected: 8+)"
-    echo "   Make sure Pro, Business, Enterprise, and Skills bundles are created in Stripe"
-  fi
+  echo "Checking configured fixed prices..."
+  stripe prices retrieve "$STRIPE_PRICE_PRO_MONTHLY" > /dev/null
+  stripe prices retrieve "$STRIPE_PRICE_ENTERPRISE_MONTHLY" > /dev/null
+  echo "✅ Pro and Enterprise fixed prices resolve"
   echo ""
 
-  # Check prices exist
-  echo "Checking Stripe prices..."
-  PRICES=$(stripe prices list --limit 100 --format=json 2>/dev/null | grep -c '"object": "price"' || true)
-  if [ "$PRICES" -ge 6 ]; then
-    echo "✅ Found $PRICES prices (expected: Pro month/year, Business month/year, Enterprise month/year, + bundles)"
-  else
-    echo "⚠️  Only found $PRICES prices (expected: 12+)"
-    echo "   Make sure monthly + yearly prices are created for each plan"
-  fi
-  echo ""
-
-  # Check meters
-  echo "Checking Stripe billing meters..."
-  METERS=$(stripe billing meters list --limit 10 --format=json 2>/dev/null | grep -c '"event_name"' || true)
-  if [ "$METERS" -ge 1 ]; then
-    echo "✅ Found $METERS meter(s)"
-  else
-    echo "❌ No billing meters found!"
-    echo "   Create a meter named 'dsg_execution' in Stripe Dashboard → Billing → Meters"
+  echo "Checking configured Billing Meter..."
+  METER_JSON=$(stripe billing meters retrieve "$STRIPE_METER_ID" --format=json 2>/dev/null || true)
+  if [ -z "$METER_JSON" ]; then
+    echo "❌ STRIPE_METER_ID does not resolve"
     exit 1
   fi
+  if ! printf '%s' "$METER_JSON" | grep -q 'dsg_execution_overage'; then
+    echo "❌ Billing Meter event name does not match dsg_execution_overage"
+    exit 1
+  fi
+  echo "✅ Billing Meter resolves with expected event name"
   echo ""
 
-  # Check webhook endpoints
-  echo "Checking Stripe webhook endpoints..."
-  WEBHOOKS=$(stripe webhook_endpoints list --format=json 2>/dev/null | grep -c '"url"' || true)
-  if [ "$WEBHOOKS" -ge 1 ]; then
-    echo "✅ Found $WEBHOOKS webhook endpoint(s)"
+  echo "Checking configured Pro overage price..."
+  OVERAGE_JSON=$(stripe prices retrieve "$STRIPE_PRICE_PRO_OVERAGE" --format=json 2>/dev/null || true)
+  if [ -z "$OVERAGE_JSON" ]; then
+    echo "❌ STRIPE_PRICE_PRO_OVERAGE does not resolve"
+    exit 1
+  fi
+  if ! printf '%s' "$OVERAGE_JSON" | grep -q "$STRIPE_METER_ID"; then
+    echo "❌ Pro overage price is not linked to the configured Billing Meter"
+    exit 1
+  fi
+  echo "✅ Pro overage price resolves and references the configured meter"
+  echo ""
+
+  echo "Checking canonical Render billing webhook..."
+  WEBHOOKS_JSON=$(stripe webhook_endpoints list --limit 100 --format=json 2>/dev/null || true)
+  if printf '%s' "$WEBHOOKS_JSON" | grep -q 'tdealer01-crypto-dsg-control-plane.onrender.com/api/billing/webhook'; then
+    echo "✅ Canonical Render billing webhook found"
   else
-    echo "⚠️  No webhook endpoints configured"
-    echo "   Configure: https://your-production-url/api/billing/webhook"
+    echo "❌ Canonical Render billing webhook not found"
+    exit 1
   fi
   echo ""
 fi
@@ -121,30 +129,22 @@ fi
 echo "Checking API routes..."
 ROUTES_OK=true
 
-if [ ! -f "app/api/billing/checkout/route.ts" ]; then
-  echo "❌ /api/billing/checkout not found"
-  ROUTES_OK=false
-fi
-
-if [ ! -f "app/api/billing/webhook/route.ts" ]; then
-  echo "❌ /api/billing/webhook not found"
-  ROUTES_OK=false
-fi
-
-if [ ! -f "app/api/revenue/events/route.ts" ]; then
-  echo "❌ /api/revenue/events not found"
-  ROUTES_OK=false
-fi
-
-if [ ! -f "app/api/cron/flush-meter-outbox/route.ts" ]; then
-  echo "❌ /api/cron/flush-meter-outbox not found"
-  ROUTES_OK=false
-fi
+for route in \
+  "app/api/billing/checkout/route.ts" \
+  "app/api/billing/webhook/route.ts" \
+  "app/api/billing/meter-health/route.ts" \
+  "app/api/revenue/events/route.ts" \
+  "app/api/cron/flush-meter-outbox/route.ts"
+do
+  if [ ! -f "$route" ]; then
+    echo "❌ Missing $route"
+    ROUTES_OK=false
+  fi
+done
 
 if [ "$ROUTES_OK" = true ]; then
   echo "✅ All required API routes present"
 else
-  echo "❌ Some API routes missing"
   exit 1
 fi
 echo ""
@@ -152,82 +152,41 @@ echo ""
 # Check database migrations
 echo "Checking database migrations..."
 MIGRATIONS_OK=true
-
-if ! grep -q "billing_customers" supabase/migrations/*.sql; then
-  echo "❌ billing_customers migration not found"
-  MIGRATIONS_OK=false
-fi
-
-if ! grep -q "billing_subscriptions" supabase/migrations/*.sql; then
-  echo "❌ billing_subscriptions migration not found"
-  MIGRATIONS_OK=false
-fi
-
-if ! grep -q "billing_meter_outbox" supabase/migrations/*.sql; then
-  echo "❌ billing_meter_outbox migration not found"
-  MIGRATIONS_OK=false
-fi
-
-if ! grep -q "revenue_events" supabase/migrations/*.sql; then
-  echo "❌ revenue_events migration not found"
-  MIGRATIONS_OK=false
-fi
+for marker in billing_customers billing_subscriptions billing_meter_outbox revenue_events dsg_gate_usage
+do
+  if ! grep -q "$marker" supabase/migrations/*.sql; then
+    echo "❌ Migration marker not found: $marker"
+    MIGRATIONS_OK=false
+  fi
+done
 
 if [ "$MIGRATIONS_OK" = true ]; then
-  echo "✅ All required database migrations present"
+  echo "✅ Required database migrations present"
 else
-  echo "❌ Some migrations missing"
   exit 1
 fi
 echo ""
 
 # Check libraries
 echo "Checking billing libraries..."
-LIBS_OK=true
-
-if [ ! -f "lib/billing/metered.ts" ]; then
-  echo "❌ lib/billing/metered.ts not found"
-  LIBS_OK=false
-fi
-
-if [ ! -f "lib/billing/pricing-catalog.ts" ]; then
-  echo "❌ lib/billing/pricing-catalog.ts not found"
-  LIBS_OK=false
-fi
-
-if [ ! -f "lib/revenue/events.ts" ]; then
-  echo "❌ lib/revenue/events.ts not found"
-  LIBS_OK=false
-fi
-
-if [ "$LIBS_OK" = true ]; then
-  echo "✅ All required billing libraries present"
-else
-  echo "❌ Some libraries missing"
-  exit 1
-fi
+for lib in lib/billing/metered.ts lib/billing/pricing-catalog.ts lib/billing/fulfillment.ts lib/revenue/events.ts
+do
+  if [ ! -f "$lib" ]; then
+    echo "❌ Missing $lib"
+    exit 1
+  fi
+done
+echo "✅ Required billing libraries present"
 echo ""
 
-# Summary
 echo "=========================================="
-echo "✅ Phase 1 Verification Complete!"
+echo "✅ Stripe billing configuration is evidence-ready"
 echo "=========================================="
 echo ""
-echo "Next steps:"
-echo "1. Set environment variables in Vercel:"
-echo "   - STRIPE_SECRET_KEY"
-echo "   - STRIPE_PUBLISHABLE_KEY"
-echo "   - STRIPE_WEBHOOK_SECRET"
-echo "   - STRIPE_METER_ID"
-echo "   - STRIPE_METER_EVENT_NAME"
-echo "   - CRON_SECRET"
+echo "Final production proof still requires a controlled real customer flow:"
+echo "1. authenticated Pro Checkout on Render"
+echo "2. Stripe checkout/subscription webhook received by Render"
+echo "3. atomic entitlement + Activation Proof persisted"
+echo "4. usage beyond included quota appears on the linked Stripe meter/invoice"
 echo ""
-echo "2. Deploy to production:"
-echo "   git push origin main"
-echo ""
-echo "3. Verify deployment:"
-echo "   curl https://your-production-url/api/billing/meter-health"
-echo ""
-echo "4. Test first checkout:"
-echo "   bash scripts/test-checkout.sh"
-echo ""
+echo "Do not create fake production billing events merely to make this check pass."

--- a/tests/unit/billing/checkout-route.test.ts
+++ b/tests/unit/billing/checkout-route.test.ts
@@ -68,6 +68,9 @@ beforeEach(() => {
   process.env.STRIPE_PRICE_PRO_MONTHLY = 'price_pro_monthly';
   process.env.STRIPE_PRICE_BUSINESS_MONTHLY = 'price_biz_monthly';
   process.env.STRIPE_PRICE_ENTERPRISE_MONTHLY = 'price_ent_monthly';
+  delete process.env.STRIPE_METER_EVENT_NAME;
+  delete process.env.STRIPE_METER_ID;
+  delete process.env.STRIPE_PRICE_PRO_OVERAGE;
   mockApplyRateLimit.mockResolvedValue(ALLOWED_RATE as any);
 });
 
@@ -109,7 +112,7 @@ describe('POST /api/billing/checkout', () => {
     expect(res.status).toBe(403);
   });
 
-  it('creates Stripe session for pro plan with correct price ID', async () => {
+  it('creates Stripe session for pro plan with correct fixed price ID', async () => {
     mockCreateClient.mockResolvedValue(
       makeSupabaseClient(
         { id: 'user-1' },
@@ -124,9 +127,49 @@ describe('POST /api/billing/checkout', () => {
     expect(body.plan).toBe('pro');
 
     const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
-    expect(createCall.line_items[0].price).toBe('price_pro_monthly');
+    expect(createCall.line_items).toEqual([
+      { price: 'price_pro_monthly', quantity: 1 },
+    ]);
     expect(createCall.subscription_data.trial_period_days).toBe(14);
     expect(createCall.payment_method_types).toBeUndefined();
+  });
+
+  it('attaches the metered overage price to Pro only when the complete meter contract is configured', async () => {
+    process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution_overage';
+    process.env.STRIPE_METER_ID = 'mtr_live_verified';
+    process.env.STRIPE_PRICE_PRO_OVERAGE = 'price_pro_overage';
+    mockCreateClient.mockResolvedValue(
+      makeSupabaseClient(
+        { id: 'user-1' },
+        { org_id: 'org-1', is_active: true, email: 'test@example.com' }
+      ) as any
+    );
+
+    const res = await POST(makeRequest({ plan: 'pro', interval: 'monthly' }));
+    expect(res.status).toBe(200);
+
+    const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+    expect(createCall.line_items).toEqual([
+      { price: 'price_pro_monthly', quantity: 1 },
+      { price: 'price_pro_overage' },
+    ]);
+  });
+
+  it('does not attach an overage price when only part of the meter contract exists', async () => {
+    process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution_overage';
+    process.env.STRIPE_METER_ID = 'mtr_live_verified';
+    mockCreateClient.mockResolvedValue(
+      makeSupabaseClient(
+        { id: 'user-1' },
+        { org_id: 'org-1', is_active: true, email: 'test@example.com' }
+      ) as any
+    );
+
+    await POST(makeRequest({ plan: 'pro', interval: 'monthly' }));
+    const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
+    expect(createCall.line_items).toEqual([
+      { price: 'price_pro_monthly', quantity: 1 },
+    ]);
   });
 
   it('normalizes unknown plan to pro', async () => {
@@ -144,7 +187,10 @@ describe('POST /api/billing/checkout', () => {
     expect(createCall.line_items[0].price).toBe('price_pro_monthly');
   });
 
-  it('uses enterprise trial of 30 days', async () => {
+  it('uses enterprise trial of 30 days and never attaches Pro overage', async () => {
+    process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution_overage';
+    process.env.STRIPE_METER_ID = 'mtr_live_verified';
+    process.env.STRIPE_PRICE_PRO_OVERAGE = 'price_pro_overage';
     mockCreateClient.mockResolvedValue(
       makeSupabaseClient(
         { id: 'user-1' },
@@ -154,6 +200,9 @@ describe('POST /api/billing/checkout', () => {
     await POST(makeRequest({ plan: 'enterprise', interval: 'monthly' }));
     const createCall = mockStripeInstance.checkout.sessions.create.mock.calls[0][0];
     expect(createCall.subscription_data.trial_period_days).toBe(30);
+    expect(createCall.line_items).toEqual([
+      { price: 'price_ent_monthly', quantity: 1 },
+    ]);
   });
 
   it('uses inline price_data for skills bundle', async () => {

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -327,6 +327,7 @@ describe('Stripe metered billing', () => {
       eventName: 'dsg_execution',
       meterId: 'mtr_test_123',
       priceId: 'price_overage_test',
+      missing: [],
     });
   });
 

--- a/tests/unit/billing/metered.test.ts
+++ b/tests/unit/billing/metered.test.ts
@@ -72,6 +72,7 @@ vi.mock('../../../lib/supabase-server', () => ({
 
 import {
   flushMeterOutbox,
+  getMeteredBillingConfiguration,
   isMeteredBillingConfigured,
   reportMeterEvent,
 } from '../../../lib/billing/metered';
@@ -81,6 +82,8 @@ describe('Stripe metered billing', () => {
     vi.clearAllMocks();
     process.env.STRIPE_SECRET_KEY = 'sk_test_xxx';
     process.env.STRIPE_METER_EVENT_NAME = 'dsg_execution';
+    process.env.STRIPE_METER_ID = 'mtr_test_123';
+    process.env.STRIPE_PRICE_PRO_OVERAGE = 'price_overage_test';
     mockOutboxInsertMaybeSingle.mockResolvedValue({
       data: { id: 'outbox-001', status: 'pending', stripe_event_id: null },
       error: null,
@@ -179,7 +182,7 @@ describe('Stripe metered billing', () => {
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
-  it('fails without durable evidence when meter configuration is missing', async () => {
+  it('fails without durable evidence when meter event name is missing', async () => {
     delete process.env.STRIPE_METER_EVENT_NAME;
 
     const result = await reportMeterEvent(
@@ -192,6 +195,7 @@ describe('Stripe metered billing', () => {
     if (result.ok === false) {
       expect(result.skipped).toBe(true);
       expect(result.durable).toBe(false);
+      expect(result.error).toContain('STRIPE_METER_EVENT_NAME');
     }
     expect(mockOutboxInsertCall).not.toHaveBeenCalled();
     expect(mockMeterEventsCreate).not.toHaveBeenCalled();
@@ -210,7 +214,34 @@ describe('Stripe metered billing', () => {
     if (result.ok === false) {
       expect(result.skipped).toBe(true);
       expect(result.durable).toBe(false);
+      expect(result.error).toContain('STRIPE_SECRET_KEY');
     }
+  });
+
+  it('fails closed when the verified Billing Meter id is missing', async () => {
+    delete process.env.STRIPE_METER_ID;
+
+    const result = await reportMeterEvent('cus_test', 'org-meter', 1, 'exec-meter');
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.durable).toBe(false);
+      expect(result.error).toContain('STRIPE_METER_ID');
+    }
+    expect(mockOutboxInsertCall).not.toHaveBeenCalled();
+    expect(mockMeterEventsCreate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the Pro metered Price id is missing', async () => {
+    delete process.env.STRIPE_PRICE_PRO_OVERAGE;
+
+    const result = await reportMeterEvent('cus_test', 'org-price', 1, 'exec-price');
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.durable).toBe(false);
+      expect(result.error).toContain('STRIPE_PRICE_PRO_OVERAGE');
+    }
+    expect(mockOutboxInsertCall).not.toHaveBeenCalled();
+    expect(mockMeterEventsCreate).not.toHaveBeenCalled();
   });
 
   it('fails closed when the outbox row cannot be created or recovered', async () => {
@@ -290,12 +321,23 @@ describe('Stripe metered billing', () => {
     );
   });
 
-  it('isMeteredBillingConfigured returns true when both env vars are set', () => {
-    expect(isMeteredBillingConfigured()).toBe(true);
+  it('returns a complete non-secret configuration contract', () => {
+    expect(getMeteredBillingConfiguration()).toEqual({
+      configured: true,
+      eventName: 'dsg_execution',
+      meterId: 'mtr_test_123',
+      priceId: 'price_overage_test',
+    });
   });
 
-  it('isMeteredBillingConfigured returns false when meter name missing', () => {
-    delete process.env.STRIPE_METER_EVENT_NAME;
+  it('isMeteredBillingConfigured returns true only when all required env vars are set', () => {
+    expect(isMeteredBillingConfigured()).toBe(true);
+
+    delete process.env.STRIPE_METER_ID;
+    expect(isMeteredBillingConfigured()).toBe(false);
+
+    process.env.STRIPE_METER_ID = 'mtr_test_123';
+    delete process.env.STRIPE_PRICE_PRO_OVERAGE;
     expect(isMeteredBillingConfigured()).toBe(false);
   });
 });


### PR DESCRIPTION
## Goal
Prevent DSG Pro from entering a half-configured state where usage events can be emitted but Stripe has no verified Meter + metered subscription Price capable of turning those events into invoice revenue.

## Current verified production state
- Pro fixed subscription: $99/month live Price exists
- Enterprise fixed subscription: $499/month live Price exists
- canonical subscription webhook points to Render and is enabled
- zero live subscriptions currently exist, so there is no existing-customer migration risk
- no verified Billing Meter / metered Pro overage Price exists through the connected Stripe surface

## Changes
- `isMeteredBillingConfigured()` now requires all four pieces:
  - `STRIPE_SECRET_KEY`
  - `STRIPE_METER_EVENT_NAME`
  - `STRIPE_METER_ID`
  - `STRIPE_PRICE_PRO_OVERAGE`
- `reportMeterEvent()` returns fail-closed/no-durable-evidence when any part is missing
- Pro Checkout automatically appends the metered overage Price (without a fixed quantity) only when the full meter contract is configured
- Enterprise never receives the Pro overage item
- `/api/billing/meter-health` exposes only non-secret readiness booleans + missing env names
- tests cover complete, partial, missing-meter, missing-price, Pro attach, and Enterprise no-attach behavior
- added `docs/revenue/PRO_OVERAGE_ACTIVATION.md`

## Billing contract
Repository source-of-truth: Pro includes 5,000 evaluations and defines overage at USD 0.001/execution with event `dsg_execution_overage`.

Until a real Stripe Billing Meter and real metered Price are created and configured, the expected production state is:

**fixed subscription live; overage fail-closed**

This means evaluation 5,001 must not be delivered as an unbilled overage.

## Truth boundary
This PR does not create Stripe Meter objects because the connected Stripe MCP does not expose a Billing Meter create operation. It does not invent a Meter ID or Price ID. No existing or new customer is charged by this PR.