### PR TITLE
feat: add revenue Command Center browser agent

### DIFF
--- a/app/api/github/revenue-autopilot-status/route.ts
+++ b/app/api/github/revenue-autopilot-status/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import {
+  REVENUE_AUTOPILOT_WORKFLOW,
+  resolveGitHubRepository,
+  summarizeWorkflowRun,
+  type GitHubWorkflowResponse,
+} from '../../../../lib/github/revenue-autopilot-status';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const repository = resolveGitHubRepository(process.env.GITHUB_REPOSITORY);
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'DSG-ONE-Command-Center',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) headers.authorization = 'Bearer ' + token;
+
+  try {
+    const response = await fetch(
+      'https://api.github.com/repos/' +
+        repository +
+        '/actions/workflows/' +
+        REVENUE_AUTOPILOT_WORKFLOW +
+        '/runs?per_page=1',
+      {
+        headers,
+        cache: 'no-store',
+        signal: AbortSignal.timeout(8_000),
+      },
+    );
+
+    if (!response.ok) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'GitHub workflow status is unavailable',
+          repository,
+          workflow: REVENUE_AUTOPILOT_WORKFLOW,
+          upstreamStatus: response.status,
+        },
+        { status: 502, headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const payload = (await response.json()) as GitHubWorkflowResponse;
+    return NextResponse.json(
+      {
+        ok: true,
+        repository,
+        workflow: REVENUE_AUTOPILOT_WORKFLOW,
+        run: summarizeWorkflowRun(payload),
+        checkedAt: new Date().toISOString(),
+      },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'GitHub workflow status is unavailable',
+        repository,
+        workflow: REVENUE_AUTOPILOT_WORKFLOW,
+      },
+      { status: 502, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/app/dashboard/command-center/command-center.module.css
+++ b/app/dashboard/command-center/command-center.module.css
@@ -1,0 +1,734 @@
+.shell {
+  min-height: 100vh;
+  padding: 8px 28px 28px;
+  color: #f6f7f9;
+}
+
+.frame {
+  width: min(1480px, 100%);
+  margin: 0 auto;
+  border: 1px solid rgba(151, 163, 184, 0.18);
+  background: #080b10;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.34);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(360px, 0.9fr);
+  gap: 32px;
+  padding: 20px 28px;
+  border-bottom: 1px solid rgba(151, 163, 184, 0.16);
+}
+
+.heroCopy {
+  padding: 4px 0 2px;
+}
+
+.eyebrow,
+.panelLabel {
+  margin: 0;
+  color: #8b929f;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: none;
+  margin: 10px 0 20px;
+  color: #f8f9fb;
+  font-size: clamp(28px, 1.95vw, 30px);
+  font-weight: 680;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+}
+
+.lede,
+.supportingCopy {
+  max-width: 920px;
+  margin: 0;
+  color: #a8afbb;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.supportingCopy {
+  margin-top: 6px;
+  color: #7f8794;
+}
+
+.statusRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.statusPass,
+.statusReview,
+.statusBlocked {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 13px;
+  border: 1px solid;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.statusPass {
+  border-color: rgba(212, 175, 55, 0.62);
+  color: #e8c45a;
+}
+
+.statusReview {
+  border-color: rgba(212, 175, 55, 0.44);
+  color: #d9b84f;
+}
+
+.statusBlocked {
+  border-color: rgba(255, 77, 77, 0.42);
+  color: #ff6262;
+}
+
+.truthPanel,
+.agentPanel,
+.briefPanel,
+.offerPanel {
+  border: 1px solid rgba(151, 163, 184, 0.17);
+  background: #0b0e14;
+}
+
+.truthPanel {
+  padding: 12px 16px;
+}
+
+.panelHeadingRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.iconButton {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid rgba(151, 163, 184, 0.22);
+  border-radius: 5px;
+  background: #0e1219;
+  color: #aeb5c1;
+}
+
+.iconButton:hover:not(:disabled) {
+  border-color: rgba(212, 175, 55, 0.62);
+  color: #e8c45a;
+}
+
+.iconButton:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.truthList {
+  margin: 8px 0 0;
+}
+
+.truthList > div {
+  display: grid;
+  grid-template-columns: minmax(145px, 0.9fr) minmax(0, 1.1fr);
+  gap: 16px;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(151, 163, 184, 0.16);
+}
+
+.truthList > div:last-child {
+  border-bottom: 0;
+}
+
+.truthList dt,
+.truthList dd {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.truthList dt {
+  color: #818996;
+}
+
+.truthList dd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: #d9dde4;
+  overflow-wrap: anywhere;
+}
+
+.truthList a {
+  display: inline-flex;
+  color: #d8b64f;
+}
+
+.journeySection {
+  padding: 18px 28px 24px;
+  border-bottom: 1px solid rgba(151, 163, 184, 0.16);
+}
+
+.journey {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 18px;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stepTop {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 10px;
+}
+
+.stepNumber {
+  display: inline-grid;
+  width: 29px;
+  height: 29px;
+  flex: 0 0 29px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.stepLabel {
+  font-size: 13px;
+  font-weight: 760;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.stepLine {
+  height: 1px;
+  min-width: 22px;
+  flex: 1;
+  background: currentColor;
+  opacity: 0.5;
+}
+
+.journey li > p {
+  margin: 7px 0 0 39px;
+  color: #777f8b;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.journeyComplete,
+.journeyActive {
+  color: #d9b74e;
+}
+
+.journeyActive .stepNumber {
+  background: rgba(212, 175, 55, 0.11);
+  box-shadow: 0 0 0 4px rgba(212, 175, 55, 0.05);
+}
+
+.journeyLocked {
+  color: #646b75;
+}
+
+.agentPanel {
+  display: grid;
+  grid-template-columns: minmax(340px, 0.75fr) minmax(0, 2fr);
+  align-items: center;
+  gap: 9px 18px;
+  margin: 12px 16px;
+  padding: 15px 18px;
+}
+
+.agentIntro {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+}
+
+.agentIcon {
+  display: inline-grid;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  place-items: center;
+  border: 1px solid rgba(212, 175, 55, 0.48);
+  border-radius: 7px;
+  color: #e3bd50;
+}
+
+.agentIntro h2 {
+  margin: 4px 0 5px;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+
+.agentIntro p:last-child {
+  max-width: 900px;
+  margin: 0;
+  color: #858d99;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.commandBox {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 10px;
+  margin-top: 0;
+}
+
+.commandBox textarea {
+  width: 100%;
+  min-height: 62px;
+  resize: vertical;
+  border: 1px solid rgba(151, 163, 184, 0.24);
+  border-radius: 6px;
+  background: #070a0f;
+  padding: 14px;
+  color: #f4f5f7;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.commandBox textarea:focus {
+  border-color: rgba(212, 175, 55, 0.72);
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(212, 175, 55, 0.08);
+}
+
+.commandButton,
+.checkoutButton,
+.evidenceLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  border-radius: 6px;
+  font-weight: 760;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.commandButton {
+  min-width: 225px;
+  border: 1px solid #d4af37;
+  background: #d4af37;
+  padding: 0 20px;
+  color: #090b0e;
+}
+
+.commandButton:hover:not(:disabled),
+.checkoutButton:hover:not(:disabled) {
+  background: #e5c454;
+}
+
+.commandButton:disabled,
+.checkoutButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.agentBoundary {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  grid-column: 2;
+  margin-top: 0;
+  color: #8b929f;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.agentBoundary svg {
+  flex: 0 0 auto;
+  color: #d4af37;
+}
+
+.agentOutput {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.7fr) minmax(0, 1.3fr);
+  gap: 16px;
+  grid-column: 1 / -1;
+  margin-top: 2px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(151, 163, 184, 0.16);
+}
+
+.eventList p,
+.agentReply {
+  margin: 0 0 7px;
+  color: #969eaa;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.agentReply {
+  margin: 0;
+  border-left: 2px solid rgba(212, 175, 55, 0.55);
+  padding-left: 14px;
+  color: #e6e8ec;
+  font-size: 13px;
+}
+
+.briefGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(330px, 1fr);
+  gap: 12px;
+  padding: 0 16px 16px;
+}
+
+.briefPanel,
+.offerPanel {
+  padding: 18px;
+}
+
+.briefColumns {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 14px;
+  border: 1px solid rgba(151, 163, 184, 0.18);
+}
+
+.briefColumns > div {
+  min-width: 0;
+  padding: 16px;
+  border-right: 1px solid rgba(151, 163, 184, 0.18);
+}
+
+.briefColumns > div:last-child {
+  border-right: 0;
+}
+
+.briefColumns h2 {
+  margin: 0 0 14px;
+  font-size: 12px;
+  font-weight: 780;
+  letter-spacing: 0.04em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.goldHeading {
+  color: #dab84f;
+}
+
+.redHeading {
+  color: #ff5b5b;
+}
+
+.briefColumns ul,
+.offerBenefits {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.briefColumns li,
+.offerBenefits li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: #c3c8d0;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.briefColumns li svg,
+.offerBenefits li svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.checkIcon,
+.offerBenefits svg {
+  color: #d9b74e;
+}
+
+.blockIcon {
+  color: #ff5b5b;
+}
+
+.failClosedNote {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+  border: 1px solid rgba(151, 163, 184, 0.16);
+  padding: 9px 12px;
+  color: #969da8;
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.failClosedNote svg {
+  flex: 0 0 auto;
+  color: #d4af37;
+}
+
+.priceRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 14px;
+}
+
+.priceRow h2 {
+  margin: 0;
+  font-size: 26px;
+  letter-spacing: -0.03em;
+}
+
+.priceRow p {
+  display: flex;
+  align-items: baseline;
+  margin: 0;
+  color: #e6c256;
+  white-space: nowrap;
+}
+
+.priceRow strong {
+  font-size: 30px;
+  letter-spacing: -0.04em;
+}
+
+.priceRow span {
+  margin-left: 2px;
+  font-size: 14px;
+}
+
+.offerCopy {
+  min-height: 44px;
+  margin: 9px 0 16px;
+  color: #9ba2ad;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.checkoutButton {
+  width: 100%;
+  min-height: 51px;
+  border: 1px solid #d4af37;
+  background: #d4af37;
+  padding: 0 15px;
+  color: #080a0d;
+}
+
+.evidenceLink {
+  width: 100%;
+  min-height: 45px;
+  margin-top: 10px;
+  border: 1px solid rgba(212, 175, 55, 0.62);
+  color: #dde0e5;
+  font-size: 13px;
+}
+
+.evidenceLink:hover {
+  border-color: #e4c353;
+  color: #e4c353;
+}
+
+.errorMessage {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  margin: 10px 0 0;
+  color: #ff7373;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.errorMessage svg {
+  flex: 0 0 auto;
+}
+
+.offerBenefits {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(151, 163, 184, 0.16);
+}
+
+.metricsSection {
+  padding: 18px 22px 22px;
+  border-top: 1px solid rgba(151, 163, 184, 0.16);
+}
+
+.metricsHeading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 14px;
+}
+
+.metricsHeading > div > p:last-child {
+  margin: 5px 0 0;
+  color: #767e8a;
+  font-size: 12px;
+}
+
+.usageBadge {
+  border: 1px solid rgba(151, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 7px 11px;
+  color: #aab1bc;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.metricGrid article {
+  display: grid;
+  min-height: 88px;
+  align-content: space-between;
+  border: 1px solid rgba(151, 163, 184, 0.2);
+  padding: 12px;
+  text-align: center;
+}
+
+.metricGrid p {
+  margin: 0;
+  color: #7f8793;
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.03em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.metricGrid strong {
+  color: #c4c9d1;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.spin {
+  animation: spin 800ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 1180px) {
+  .hero,
+  .briefGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .journey {
+    grid-template-columns: repeat(3, 1fr);
+    row-gap: 24px;
+  }
+
+  .metricGrid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 820px) {
+  .shell {
+    padding: 12px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 22px;
+    padding: 20px;
+  }
+
+  .briefColumns,
+  .agentOutput {
+    grid-template-columns: 1fr;
+  }
+
+  .agentPanel {
+    display: block;
+  }
+
+  .commandBox {
+    margin-top: 16px;
+  }
+
+  .agentBoundary {
+    margin-top: 10px;
+  }
+
+  .briefColumns > div {
+    border-right: 0;
+    border-bottom: 1px solid rgba(151, 163, 184, 0.18);
+  }
+
+  .briefColumns > div:last-child {
+    border-bottom: 0;
+  }
+
+  .commandBox {
+    grid-template-columns: 1fr;
+  }
+
+  .commandButton {
+    min-height: 50px;
+  }
+}
+
+@media (max-width: 620px) {
+  .journey {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stepLine {
+    display: none;
+  }
+
+  .truthList > div {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .truthList dd {
+    justify-content: flex-start;
+  }
+
+  .metricGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .metricsHeading,
+  .priceRow {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/app/dashboard/command-center/page.tsx
+++ b/app/dashboard/command-center/page.tsx
@@ -1,609 +1,856 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { parseSseData, formatAgentEventMessage } from '../../../lib/agent/chat-event';
+import {
+  ArrowRight,
+  Bot,
+  Check,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  LockKeyhole,
+  RefreshCw,
+  ShieldCheck,
+  Terminal,
+  X,
+  XCircle,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent } from 'react';
+import {
+  formatAgentEventMessage,
+  parseSseData,
+  type AgentChatEvent,
+} from '../../../lib/agent/chat-event';
+import styles from './command-center.module.css';
 
-type GateStatus = 'PASS' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED';
-type EvidenceState = 'present' | 'missing' | 'planned' | 'unsupported';
-type RuntimeStatus =
-  | 'GOAL_LOCKED'
-  | 'INSPECTING'
-  | 'GRAPH_BUILDING'
-  | 'GRAPH_READY'
-  | 'PLANNING'
-  | 'WAITING_APPROVAL'
-  | 'RUNNING'
-  | 'VERIFYING'
-  | 'BLOCKED'
-  | 'COMPLETED'
-  | 'RESET'
-  | 'CHECKING'
-  | 'DEGRADED';
-type ClaimStatus = 'BUILDABLE' | 'IMPLEMENTED' | 'VERIFIED' | 'DEPLOYABLE' | 'PRODUCTION' | 'BLOCKED' | 'REVIEW' | 'UNSUPPORTED';
+type EndpointStatus = 'loading' | 'ready' | 'unauthorized' | 'unavailable';
+type EndpointState<T> = { status: EndpointStatus; data?: T; error?: string };
 
-type HealthPayload = {
-  service?: string;
-  timestamp?: string;
-  core_ok?: boolean;
-  core?: {
-    status?: string;
-    version?: string;
-    error?: string;
+type RevenueReadinessPayload = {
+  ok: boolean;
+  stage: 'blocked' | 'configured-idle' | 'flowing';
+  env: {
+    required: Record<string, boolean>;
+    optional: Record<string, boolean>;
+    missingRequired: string[];
+  };
+  pipeline: {
+    billingCustomers: number;
+    outboxPending: number;
+    outboxFailed: number;
+    outboxSent: number;
+    reachable: boolean;
+    detail?: string;
+  };
+  blockers: string[];
+  timestamp: string;
+};
+
+type GitHubStatusPayload = {
+  ok: boolean;
+  repository: string;
+  workflow: string;
+  run: null | {
+    id: number;
+    number: number;
+    name: string;
+    status: string;
+    conclusion: string | null;
+    branch: string;
+    sha: string;
+    url: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+  checkedAt: string;
+};
+
+type ActivationProofPayload = {
+  ok: boolean;
+  activated: boolean;
+  message?: string;
+  proof: null | {
+    id: string;
+    tier: string;
+    subscription_status: string;
+    proof_version: string;
+    proof_hash: string;
+    created_at: string;
   };
 };
 
 type CapacityPayload = {
   ok?: boolean;
   plan_key?: string;
-  billing_interval?: string;
   subscription_status?: string;
-  billing_period?: string;
-  executions: number;
-  included_executions?: number;
-  remaining_executions: number;
-  utilization: number;
-  overage_executions?: number;
-  projected_amount_usd: number;
-};
-
-type UsagePayload = {
-  plan?: string;
-  subscription_status?: string;
-  billing_period?: string;
   executions?: number;
   included_executions?: number;
-  overage_executions?: number;
-  projected_amount_usd?: number;
+  remaining_executions?: number;
 };
 
-type AuditPayload = {
-  ok?: boolean;
-  error?: string | null;
-  items?: Array<{
-    id?: number;
-    gate_result?: string;
-    entropy?: number;
-    created_at?: string;
-    state_hash?: string;
-  }>;
-};
+type JourneyState = 'complete' | 'active' | 'locked';
+type AgentEventWithToken = AgentChatEvent & { text?: string; gateDecision?: string };
 
-type Blocker = {
-  status: GateStatus;
-  reason: string;
-  affected: string;
-  nextAction: string;
-  evidenceRequired: string;
-};
+const BROWSER_BOUNDARY =
+  'Open/read available; live click, type and submit are not enabled';
 
-type TimelineAction = {
-  name: string;
-  status: RuntimeStatus | GateStatus;
-  actor: string;
-  risk: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
-  evidence: string;
-};
-
-type EvidenceItem = {
-  label: string;
-  state: EvidenceState;
-  detail: string;
-  source: string;
-};
-
-type ClaimRow = {
-  claim: ClaimStatus;
-  status: GateStatus;
-  reason: string;
-  evidencePresent: string;
-  evidenceRequired: string;
-};
-
-type ApprovalItem = {
-  id: string;
-  requestedAction: string;
-  risk: 'HIGH' | 'CRITICAL';
-  approverRole: string;
-  reason: string;
-  evidence: string;
-  routeStatus: 'wired' | 'not_wired';
-};
-
-type OperatorControl = {
-  label: string;
-  status: 'wired' | 'not_wired';
-  reason: string;
-};
-
-function formatDate(value?: string) {
-  if (!value) return '-';
+async function readEndpoint<T>(
+  path: string,
+  acceptErrorBody = false,
+): Promise<EndpointState<T>> {
   try {
-    return new Date(value).toLocaleString();
-  } catch {
-    return value;
+    const response = await fetch(path, { cache: 'no-store' });
+    const body = (await response.json().catch(() => null)) as
+      | (T & { error?: string })
+      | null;
+
+    if (response.status === 401 || response.status === 403) {
+      return {
+        status: 'unauthorized',
+        error: response.status === 401 ? 'Sign in required' : 'Workspace access required',
+      };
+    }
+    if (response.ok || (acceptErrorBody && body)) {
+      return { status: 'ready', data: body || undefined };
+    }
+    return {
+      status: 'unavailable',
+      error: body?.error || 'Request failed (' + response.status + ')',
+    };
+  } catch (error) {
+    return {
+      status: 'unavailable',
+      error: error instanceof Error ? error.message : 'Request unavailable',
+    };
   }
 }
 
-function resultTone(result?: string) {
-  const normalized = (result || '').toUpperCase();
-  if (normalized.includes('BLOCK') || normalized.includes('FREEZE')) return 'border-red-400/25 bg-red-500/10 text-red-100';
-  if (normalized.includes('WARN') || normalized.includes('STABILIZE') || normalized.includes('REVIEW')) return 'border-amber-300/25 bg-amber-300/10 text-amber-100';
-  return 'border-emerald-400/25 bg-emerald-400/10 text-emerald-100';
+function displayEndpoint<T>(state: EndpointState<T>, value: string) {
+  if (state.status === 'loading') return 'Checking…';
+  if (state.status === 'unauthorized') return state.error || 'Sign in required';
+  if (state.status === 'unavailable') return 'Not available';
+  return value;
 }
 
-function statusTone(status: GateStatus | RuntimeStatus | ClaimStatus | EvidenceState) {
-  const normalized = status.toUpperCase();
-  if (['PASS', 'PRESENT', 'GRAPH_READY', 'COMPLETED', 'VERIFIED', 'IMPLEMENTED', 'BUILDABLE'].includes(normalized)) return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100';
-  if (['BLOCK', 'BLOCKED', 'MISSING', 'DEGRADED'].includes(normalized)) return 'border-red-400/30 bg-red-500/10 text-red-100';
-  if (['REVIEW', 'PLANNED', 'WAITING_APPROVAL', 'VERIFYING', 'PLANNING', 'GRAPH_BUILDING', 'CHECKING'].includes(normalized)) return 'border-amber-300/30 bg-amber-300/10 text-amber-100';
-  return 'border-slate-500/30 bg-slate-800/70 text-slate-200';
+function shortHash(value?: string | null) {
+  if (!value) return '—';
+  return value.replace(/^sha256:/, '').slice(0, 10);
 }
 
-function StatusPill({ status }: { status: GateStatus | RuntimeStatus | ClaimStatus | EvidenceState }) {
-  return <span className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${statusTone(status)}`}>{status}</span>;
+function journeyClass(state: JourneyState) {
+  if (state === 'complete') return styles.journeyComplete;
+  if (state === 'active') return styles.journeyActive;
+  return styles.journeyLocked;
 }
-
-function Panel({ eyebrow, title, children }: { eyebrow: string; title: string; children: ReactNode }) {
-  return (
-    <section className="border border-white/10 bg-[#0d0f12] p-6">
-      <p className="text-[11px] uppercase tracking-[0.24em] text-slate-500">{eyebrow}</p>
-      <h2 className="mt-2 text-2xl font-semibold text-white">{title}</h2>
-      <div className="mt-5">{children}</div>
-    </section>
-  );
-}
-
-const sampleBlockers: Blocker[] = [
-  {
-    status: 'BLOCK',
-    reason: 'Production claim is blocked because production flow proof is not present on this page.',
-    affected: 'production-claim-gate',
-    nextAction: 'Run and attach production flow proof before claiming PRODUCTION.',
-    evidenceRequired: 'deployment proof + production flow proof + auth/RBAC proof + audit/replay proof',
-  },
-  {
-    status: 'REVIEW',
-    reason: 'High-risk runtime actions require explicit human approval before execution.',
-    affected: 'approval-gate',
-    nextAction: 'Open approval queue and approve/reject with rationale.',
-    evidenceRequired: 'approval record with actor, decision, reason, and approvalHash',
-  },
-  {
-    status: 'UNSUPPORTED',
-    reason: 'Context graph build route is a proposed route unless backend API is verified.',
-    affected: 'context-graph-gate',
-    nextAction: 'Implement or connect context graph API before treating graph output as live state.',
-    evidenceRequired: 'graph.json + GRAPH_REPORT.md + graph hash + secret/privacy gate record',
-  },
-];
-
-const graphWorkflow: TimelineAction[] = [
-  { name: 'Goal lock', status: 'GOAL_LOCKED', actor: 'operator', risk: 'LOW', evidence: 'User goal frozen before planning.' },
-  { name: 'Repository inspection', status: 'INSPECTING', actor: 'context agent', risk: 'MEDIUM', evidence: 'Read repo files before planning.' },
-  { name: 'Privacy + secret gate', status: 'REVIEW', actor: 'policy gate', risk: 'HIGH', evidence: 'No external extraction without decision.' },
-  { name: 'Context graph build', status: 'GRAPH_BUILDING', actor: 'Graphify context layer', risk: 'MEDIUM', evidence: 'graph.json / GRAPH_REPORT.md required.' },
-  { name: 'Plan gate', status: 'PLANNING', actor: 'DSG planner', risk: 'HIGH', evidence: 'Plan must use graph-backed context only.' },
-  { name: 'Approval gate', status: 'WAITING_APPROVAL', actor: 'approver', risk: 'HIGH', evidence: 'Approval required before runtime handoff.' },
-  { name: 'Execution handoff', status: 'BLOCKED', actor: 'controlled executor', risk: 'CRITICAL', evidence: 'Blocked until Step 16 runtime evidence exists.' },
-];
-
-const proofFields: EvidenceItem[] = [
-  { label: 'policyVersion', state: 'present', detail: 'Observed scaffold field: 1.0.', source: 'live deterministic gate scaffold evidence' },
-  { label: 'inputHash', state: 'present', detail: 'Hash field present in scaffold response.', source: 'proof/gate scaffold' },
-  { label: 'constraintSetHash', state: 'present', detail: 'Constraint set hash field present.', source: 'proof/gate scaffold' },
-  { label: 'proofHash', state: 'present', detail: 'Proof hash field present.', source: 'proof/gate scaffold' },
-  { label: 'structured constraint results', state: 'present', detail: 'Per-constraint result shape is present.', source: 'proof/gate scaffold' },
-  { label: 'replayProtection.nonce', state: 'present', detail: 'Replay nonce field present.', source: 'replay-protection evidence' },
-  { label: 'replayProtection.idempotencyKey', state: 'present', detail: 'Idempotency key field present.', source: 'replay-protection evidence' },
-  { label: 'replayProtection.requestHash', state: 'present', detail: 'Request hash field present.', source: 'replay-protection evidence' },
-  { label: 'external Z3 production invocation', state: 'unsupported', detail: 'Not claimed. Current solver boundary is static_check.', source: 'truth boundary' },
-];
-
-const claimRows: ClaimRow[] = [
-  { claim: 'BUILDABLE', status: 'PASS', reason: 'Command Center and Graphify workflow are defined as an operator surface.', evidencePresent: 'route + UI contract', evidenceRequired: 'repo inspection and implementation plan' },
-  { claim: 'IMPLEMENTED', status: 'PASS', reason: 'This route exists in code and renders live health/capacity/audit surfaces.', evidencePresent: 'app/dashboard/command-center/page.tsx', evidenceRequired: 'merged code' },
-  { claim: 'VERIFIED', status: 'REVIEW', reason: 'Verification depends on test/build output and evidence manifests.', evidencePresent: 'deterministic scaffold fields are disclosed', evidenceRequired: 'test output + evidence manifest + replay proof' },
-  { claim: 'DEPLOYABLE', status: 'BLOCK', reason: 'Deployment proof is not shown as present on this page.', evidencePresent: 'none on this surface', evidenceRequired: 'Vercel ready state + deployment proof + build pass' },
-  { claim: 'PRODUCTION', status: 'BLOCK', reason: 'Production user-flow proof is missing.', evidencePresent: 'none on this surface', evidenceRequired: 'production flow proof + auth/RBAC proof + audit/replay/evidence proof' },
-];
-
-const approvalItems: ApprovalItem[] = [
-  {
-    id: 'sample-high-risk-approval',
-    requestedAction: 'Runtime handoff for graph-backed implementation plan',
-    risk: 'HIGH',
-    approverRole: 'approver / owner',
-    reason: 'High-risk code/runtime changes require human approval before controlled execution.',
-    evidence: 'graph report + plan gate result + approval record required',
-    routeStatus: 'not_wired',
-  },
-  {
-    id: 'sample-production-claim-review',
-    requestedAction: 'Upgrade claim from REVIEW to PRODUCTION',
-    risk: 'CRITICAL',
-    approverRole: 'owner + compliance reviewer',
-    reason: 'Production claim requires real production-flow proof and cannot be auto-approved.',
-    evidence: 'deployment proof + production flow proof + audit/replay/evidence proof required',
-    routeStatus: 'not_wired',
-  },
-];
-
-const operatorControls: OperatorControl[] = [
-  { label: 'Pause runtime', status: 'not_wired', reason: 'Runtime control route not wired on this page.' },
-  { label: 'Resume runtime', status: 'not_wired', reason: 'Runtime control route not wired on this page.' },
-  { label: 'Kill runtime', status: 'not_wired', reason: 'Runtime control route not wired on this page.' },
-  { label: 'Approve action', status: 'not_wired', reason: 'Approval mutation route is not invoked from this surface.' },
-  { label: 'Reject action', status: 'not_wired', reason: 'Approval mutation route is not invoked from this surface.' },
-  { label: 'Request changes', status: 'not_wired', reason: 'Reviewer feedback route is not wired on this page.' },
-];
 
 export default function CommandCenterPage() {
-  const [health, setHealth] = useState<HealthPayload | null>(null);
-  const [capacity, setCapacity] = useState<CapacityPayload | null>(null);
-  const [usage, setUsage] = useState<UsagePayload | null>(null);
-  const [audit, setAudit] = useState<AuditPayload | null>(null);
-  const [command, setCommand] = useState('');
-  const [chatBusy, setChatBusy] = useState(false);
-  const [chatOutput, setChatOutput] = useState<string[]>([]);
-  const [error, setError] = useState('');
+  const [readiness, setReadiness] =
+    useState<EndpointState<RevenueReadinessPayload>>({ status: 'loading' });
+  const [github, setGithub] =
+    useState<EndpointState<GitHubStatusPayload>>({ status: 'loading' });
+  const [activation, setActivation] =
+    useState<EndpointState<ActivationProofPayload>>({ status: 'loading' });
+  const [capacity, setCapacity] =
+    useState<EndpointState<CapacityPayload>>({ status: 'loading' });
+  const [refreshing, setRefreshing] = useState(false);
+  const [checkoutBusy, setCheckoutBusy] = useState(false);
+  const [checkoutError, setCheckoutError] = useState('');
+  const [goal, setGoal] = useState('');
+  const [agentBusy, setAgentBusy] = useState(false);
+  const [agentEvents, setAgentEvents] = useState<string[]>([]);
+  const [agentReply, setAgentReply] = useState('');
 
-  useEffect(() => {
-    let alive = true;
-
-    Promise.allSettled([
-      fetch('/api/health', { cache: 'no-store' }).then(async (response) => {
-        const json = await response.json().catch(() => ({}));
-        if (!response.ok) throw new Error(json.error || 'Failed to load health');
-        return json;
-      }),
-      fetch('/api/capacity', { cache: 'no-store' }).then(async (response) => {
-        const json = await response.json().catch(() => ({}));
-        if (!response.ok) throw new Error(json.error || 'Failed to load capacity');
-        return json;
-      }),
-      fetch('/api/usage', { cache: 'no-store' }).then(async (response) => {
-        const json = await response.json().catch(() => ({}));
-        if (!response.ok) throw new Error(json.error || 'Failed to load usage');
-        return json;
-      }),
-      fetch('/api/audit?limit=8', { cache: 'no-store' }).then(async (response) => {
-        const json = await response.json().catch(() => ({}));
-        if (!response.ok) throw new Error(json.error || 'Failed to load audit');
-        return json;
-      }),
-    ])
-      .then(([healthRes, capacityRes, usageRes, auditRes]) => {
-        if (!alive) return;
-
-        const errors: string[] = [];
-
-        if (healthRes.status === 'fulfilled') setHealth(healthRes.value);
-        else errors.push(healthRes.reason?.message || 'Failed to load health');
-
-        if (capacityRes.status === 'fulfilled') setCapacity(capacityRes.value);
-        else errors.push(capacityRes.reason?.message || 'Failed to load capacity');
-
-        if (usageRes.status === 'fulfilled') setUsage(usageRes.value);
-        else errors.push(usageRes.reason?.message || 'Failed to load usage');
-
-        if (auditRes.status === 'fulfilled') setAudit(auditRes.value);
-        else errors.push(auditRes.reason?.message || 'Failed to load audit');
-
-        if (errors.length > 0) setError(errors.join(' • '));
-      })
-      .catch((err) => {
-        if (!alive) return;
-        setError(err instanceof Error ? err.message : 'Failed to load command center');
-      });
-
-    return () => {
-      alive = false;
-    };
+  const loadTruth = useCallback(async () => {
+    setRefreshing(true);
+    const [nextReadiness, nextGithub, nextActivation, nextCapacity] =
+      await Promise.all([
+        readEndpoint<RevenueReadinessPayload>('/api/revenue-readiness', true),
+        readEndpoint<GitHubStatusPayload>('/api/github/revenue-autopilot-status'),
+        readEndpoint<ActivationProofPayload>('/api/billing/activation-proof'),
+        readEndpoint<CapacityPayload>('/api/capacity'),
+      ]);
+    setReadiness(nextReadiness);
+    setGithub(nextGithub);
+    setActivation(nextActivation);
+    setCapacity(nextCapacity);
+    setRefreshing(false);
   }, []);
 
-  const overallStatus = useMemo<RuntimeStatus>(() => {
-    if (!health) return 'CHECKING';
-    return health.core_ok ? 'GRAPH_READY' : 'DEGRADED';
-  }, [health]);
+  useEffect(() => {
+    void loadTruth();
+  }, [loadTruth]);
 
-  const alerts = useMemo(() => {
-    const events = audit?.items || [];
-    return events.filter((item) => ['BLOCK', 'FREEZE'].includes((item.gate_result || '').toUpperCase()));
-  }, [audit]);
+  const paidEntitlement =
+    activation.status === 'ready' && activation.data?.activated === true;
+  const truthLoaded = [readiness, github, activation, capacity].every(
+    (item) => item.status !== 'loading',
+  );
+  const verificationLoaded =
+    readiness.status === 'ready' && github.status === 'ready';
+  const executionReady =
+    paidEntitlement &&
+    readiness.status === 'ready' &&
+    readiness.data?.ok === true;
 
-  const evidenceItems = useMemo<EvidenceItem[]>(
+  const blockers = useMemo(() => {
+    const items: string[] = [];
+    const run = github.data?.run;
+    if (
+      github.status === 'ready' &&
+      run?.conclusion &&
+      run.conclusion !== 'success'
+    ) {
+      items.push(
+        'GitHub scheduled run #' + run.number + ': ' + run.conclusion,
+      );
+    }
+    if (readiness.status === 'ready') {
+      items.push(...(readiness.data?.blockers || []));
+    }
+    if (activation.status === 'ready' && !activation.data?.activated) {
+      items.push('No Stripe-backed activation proof for this workspace');
+    }
+    items.push('Live browser click/type/submit executor is not enabled');
+    return Array.from(new Set(items));
+  }, [activation, github, readiness]);
+
+  const recommendations = useMemo(() => {
+    const items = [
+      'Type the outcome once; DSG plans and runs supported actions inside that scope.',
+    ];
+    if (!paidEntitlement) {
+      items.push(
+        'Start Pro verification to create a paid entitlement through Stripe Checkout.',
+      );
+    }
+    const missing = readiness.data?.env.missingRequired || [];
+    if (readiness.status === 'ready' && missing.length) {
+      items.push(
+        'Configure ' +
+          missing.join(', ') +
+          ' before the revenue loop can run.',
+      );
+    }
+    items.push(
+      'Enable a verified browser mutation executor before delegating click, type or submit actions.',
+    );
+    return items;
+  }, [paidEntitlement, readiness]);
+
+  const verified = useMemo(() => {
+    const items: string[] = [];
+    const run = github.data?.run;
+    if (github.status === 'ready') {
+      items.push(
+        run
+          ? 'GitHub workflow run #' +
+              run.number +
+              ': ' +
+              (run.conclusion || run.status)
+          : 'GitHub workflow returned no runs',
+      );
+    }
+    if (readiness.status === 'ready') {
+      const required = Object.keys(readiness.data?.env.required || {}).length;
+      const missing = readiness.data?.env.missingRequired.length || 0;
+      items.push(
+        'Revenue configuration: ' +
+          (required - missing) +
+          '/' +
+          required +
+          ' required variables present',
+      );
+    }
+    if (activation.status === 'ready') {
+      items.push(
+        paidEntitlement
+          ? 'Activation proof present: ' +
+              shortHash(activation.data?.proof?.proof_hash)
+          : 'Activation proof query returned no proof',
+      );
+    }
+    items.push('Production verifier boundary: static_check');
+    items.push('Browser boundary: ' + BROWSER_BOUNDARY);
+    return items;
+  }, [activation, github, paidEntitlement, readiness]);
+
+  const journey = useMemo<
+    Array<{
+      number: number;
+      label: string;
+      detail: string;
+      state: JourneyState;
+    }>
+  >(
     () => [
-      { label: 'Context graph JSON', state: 'planned', detail: 'Required by Graphify skill. Not treated as live until generated.', source: 'proposed /api/dsg/context-graph/build' },
-      { label: 'GRAPH_REPORT.md', state: 'planned', detail: 'Must list inspected files, inferred edges, missing evidence, and risks.', source: 'Graphify context evidence layer' },
-      { label: 'Evidence manifest', state: 'missing', detail: 'Required before upgrading claim beyond review surface.', source: 'evidence gate' },
-      { label: 'Audit ledger entries', state: audit?.items?.length ? 'present' : 'missing', detail: audit?.items?.length ? `${audit.items.length} latest audit item(s) loaded.` : 'No audit items loaded for this page.', source: '/api/audit?limit=8' },
-      { label: 'Replay proof', state: 'missing', detail: 'Required for VERIFIED/DEPLOYABLE claim upgrades.', source: 'replay gate' },
-      { label: 'Deployment proof', state: 'missing', detail: 'Required before DEPLOYABLE claim.', source: 'deployment gate' },
-      { label: 'Production flow proof', state: 'missing', detail: 'Required before PRODUCTION claim.', source: 'production claim gate' },
+      {
+        number: 1,
+        label: 'Evaluate',
+        detail: 'Choose use case & assess',
+        state: truthLoaded ? 'complete' : 'active',
+      },
+      {
+        number: 2,
+        label: 'Verify',
+        detail: 'DSG evaluates readiness',
+        state: verificationLoaded
+          ? 'complete'
+          : truthLoaded
+            ? 'active'
+            : 'locked',
+      },
+      {
+        number: 3,
+        label: 'Buy',
+        detail: 'Select Pro package',
+        state: paidEntitlement
+          ? 'complete'
+          : verificationLoaded
+            ? 'active'
+            : 'locked',
+      },
+      {
+        number: 4,
+        label: 'Activate',
+        detail: 'Secure activation',
+        state: paidEntitlement ? 'complete' : 'locked',
+      },
+      {
+        number: 5,
+        label: 'Execute',
+        detail: 'Run with DSG guardrails',
+        state: executionReady ? 'active' : 'locked',
+      },
+      {
+        number: 6,
+        label: 'Evidence',
+        detail: 'Measured ROI report',
+        state:
+          executionReady && Number(capacity.data?.executions || 0) > 0
+            ? 'active'
+            : 'locked',
+      },
     ],
-    [audit?.items],
+    [
+      capacity.data?.executions,
+      executionReady,
+      paidEntitlement,
+      truthLoaded,
+      verificationLoaded,
+    ],
   );
 
-  const auditUnavailableInInternalMode = useMemo(() => {
-    const message = (audit?.error || '').toLowerCase();
-    return message.includes('internal dsg core mode');
-  }, [audit?.error]);
-
-  const suggestedActions = useMemo(() => {
-    const actions: string[] = [];
-    if (!health?.core_ok) actions.push('Verify DSG core connectivity and runtime credentials.');
-    if ((capacity?.utilization ?? 0) > 0.8) actions.push('Reduce execution load or expand plan capacity before quota pressure becomes operational risk.');
-    if (alerts.length > 0) actions.push('Review the latest BLOCK or FREEZE events before releasing more approvals.');
-    actions.push('Build or attach a context graph before planning risky repository changes.');
-    actions.push('Keep production claim BLOCKED until deployment and production-flow proofs exist.');
-    return actions;
-  }, [alerts.length, capacity?.utilization, health?.core_ok]);
-
-  const metrics = useMemo(
-    () => [
-      { label: 'Runtime status', value: overallStatus, helper: health?.core?.version || 'Graph-backed review surface' },
-      { label: 'Current claim', value: 'REVIEW', helper: 'Verification evidence still required' },
-      { label: 'Production claim', value: 'BLOCKED', helper: 'No production flow proof on this surface' },
-      { label: 'Active blockers', value: String(sampleBlockers.length + alerts.length), helper: `${alerts.length} live audit alert(s)` },
-    ],
-    [alerts.length, health?.core?.version, overallStatus],
-  );
-
-  const hasNoRuntimeJobs = !audit?.items?.length && (capacity?.executions ?? 0) === 0;
-
-  async function submitCommand() {
-    const value = command.trim();
-    if (!value || chatBusy) return;
-    setChatBusy(true);
-    setChatOutput((prev) => [...prev, `> ${value}`]);
-
+  const startCheckout = async () => {
+    setCheckoutBusy(true);
+    setCheckoutError('');
     try {
-      const res = await fetch('/api/agent-chat', {
+      const response = await fetch('/api/billing/checkout', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ message: value }),
+        body: JSON.stringify({ plan: 'pro', interval: 'monthly' }),
       });
-      if (!res.ok) {
-        const json = await res.json().catch(() => ({}));
-        throw new Error(json.error || 'Agent chat failed');
+      const body = (await response.json().catch(() => ({}))) as {
+        url?: string;
+        error?: string;
+      };
+      if (response.status === 401) {
+        window.location.assign('/login?next=/dashboard/command-center');
+        return;
+      }
+      if (!response.ok || !body.url) {
+        throw new Error(body.error || 'Stripe Checkout is not available');
+      }
+      window.location.assign(body.url);
+    } catch (error) {
+      setCheckoutError(
+        error instanceof Error
+          ? error.message
+          : 'Stripe Checkout is not available',
+      );
+      setCheckoutBusy(false);
+    }
+  };
+
+  const submitGoal = async () => {
+    const message = goal.trim();
+    if (!message || agentBusy) return;
+    setAgentBusy(true);
+    setAgentEvents([
+      'Goal accepted as the current plan scope. Checking policy and available tools…',
+    ]);
+    setAgentReply('');
+
+    try {
+      const response = await fetch('/api/agent-chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          message,
+          pageContext: '/dashboard/command-center',
+          sessionId: 'command-center-revenue-agent',
+        }),
+      });
+      if (response.status === 401 || response.status === 403) {
+        setAgentEvents((current) => [
+          ...current,
+          'Sign in with an active operator workspace to run this governed plan.',
+        ]);
+        return;
+      }
+      if (!response.ok || !response.body) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+          reason?: string;
+        };
+        throw new Error(
+          body.reason ||
+            body.error ||
+            'Agent request failed (' + response.status + ')',
+        );
       }
 
-      const reader = res.body?.getReader();
-      if (!reader) throw new Error('No stream body returned');
-
+      const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
       while (true) {
-        const { done, value: chunk } = await reader.read();
+        const { done, value } = await reader.read();
         if (done) break;
-        buffer += decoder.decode(chunk, { stream: true });
-        const events = buffer.split('\n\n');
-        buffer = events.pop() || '';
+        buffer += decoder.decode(value, { stream: true });
+        const frames = buffer.split('\n\n');
+        buffer = frames.pop() || '';
 
-        for (const raw of events) {
-          if (!raw.startsWith('data: ')) continue;
-          const event = parseSseData(raw);
+        for (const frame of frames) {
+          const line = frame
+            .split('\n')
+            .find((candidate) => candidate.startsWith('data: '));
+          if (!line) continue;
+          const event = parseSseData(line) as AgentEventWithToken | null;
           if (!event) continue;
-          const message = formatAgentEventMessage(event);
-          if (!message) continue;
-          setChatOutput((prev) => [...prev, message]);
+          if (event.type === 'token' && event.text) {
+            setAgentReply((current) => current + event.text);
+            continue;
+          }
+          if (event.type === 'synthesis_done' && event.reply) {
+            setAgentReply(event.reply);
+            continue;
+          }
+          const formatted = formatAgentEventMessage(event);
+          if (formatted) {
+            setAgentEvents((current) =>
+              current[current.length - 1] === formatted
+                ? current
+                : [...current, formatted],
+            );
+          }
         }
       }
-
-      setCommand('');
-    } catch (err) {
-      setChatOutput((prev) => [...prev, err instanceof Error ? err.message : 'Agent chat failed']);
+    } catch (error) {
+      setAgentEvents((current) => [
+        ...current,
+        'Agent stopped: ' +
+          (error instanceof Error ? error.message : 'request unavailable'),
+      ]);
     } finally {
-      setChatBusy(false);
+      setAgentBusy(false);
     }
-  }
+  };
+
+  const handleGoalKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      void submitGoal();
+    }
+  };
+
+  const githubRun = github.data?.run;
+  const githubLabel = githubRun
+    ? githubRun.branch + '@' + shortHash(githubRun.sha)
+    : 'No workflow run found';
+  const runLabel = githubRun?.conclusion || githubRun?.status || 'No run';
+  const activationLabel = paidEntitlement
+    ? (activation.data?.proof?.tier || 'paid') +
+      ' / ' +
+      (activation.data?.proof?.subscription_status || 'active')
+    : 'No activation proof';
+  const workspacePlan =
+    capacity.status === 'ready'
+      ? (capacity.data?.plan_key || 'trial') +
+        ' / ' +
+        (capacity.data?.subscription_status || 'unknown')
+      : 'Workspace plan unavailable';
+  const metrics = [
+    'Actions proposed',
+    'Actions verified',
+    'Invalid actions rejected',
+    'Replay match %',
+    'Successful executions',
+    'Time saved',
+    'Solver latency',
+    'Cost / action',
+  ];
 
   return (
-    <main className="min-h-screen bg-[#090a0d] px-6 pb-12 pt-8 text-slate-100">
-      <div className="mx-auto max-w-7xl space-y-6">
-        <section className="border border-white/10 bg-[linear-gradient(135deg,rgba(120,14,21,0.2),rgba(10,11,14,0.92)_35%,rgba(245,197,92,0.08)_120%)] p-8">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-4xl">
-              <p className="text-[11px] uppercase tracking-[0.32em] text-slate-500">DSG ONE Command Center</p>
-              <h1 className="mt-3 text-4xl font-semibold leading-tight text-white md:text-5xl">Runtime control surface with Graphify context evidence.</h1>
-              <p className="mt-4 text-sm leading-7 text-slate-300">
-                Command Center shows what DSG ONE is doing, what it blocked, what needs approval, and what evidence supports each claim. The Graphify context layer reduces blind code navigation by requiring repo inspection, privacy gates, extracted/inferred edge labels, graph evidence, and claim gates before runtime execution.
+    <main className={styles.shell}>
+      <section className={styles.frame}>
+        <div className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <p className={styles.eyebrow}>DSG ONE Command Center</p>
+            <h1>Runtime control surface with Graphify context evidence.</h1>
+            <p className={styles.lede}>
+            Command Center shows what DSG ONE is doing, what it blocked, what
+            needs approval, and what evidence supports each claim.
+            </p>
+            <p className={styles.supportingCopy}>
+              The typed agent uses the same workspace context as the operator.
+              Supported actions continue inside the stated goal; verified
+              constraint, permission, billing and executor boundaries remain
+              fail-closed.
+            </p>
+            <div className={styles.statusRow}>
+              <span
+                className={
+                  verificationLoaded
+                    ? styles.statusPass
+                    : styles.statusReview
+                }
+              >
+                {verificationLoaded ? 'Truth loaded' : 'Review'}
+              </span>
+              <span
+                className={
+                  paidEntitlement ? styles.statusPass : styles.statusReview
+                }
+              >
+                {paidEntitlement ? 'Paid active' : 'Activation needed'}
+              </span>
+              <span
+                className={
+                  blockers.length ? styles.statusBlocked : styles.statusPass
+                }
+              >
+                {blockers.length
+                  ? blockers.length + ' boundaries'
+                  : 'No verified blocker'}
+              </span>
+            </div>
+          </div>
+
+          <aside className={styles.truthPanel} aria-label="Current truth">
+            <div className={styles.panelHeadingRow}>
+              <p className={styles.panelLabel}>Current truth</p>
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => void loadTruth()}
+                disabled={refreshing}
+                aria-label="Refresh current truth"
+                title="Refresh current truth"
+              >
+                <RefreshCw
+                  size={15}
+                  className={refreshing ? styles.spin : undefined}
+                />
+              </button>
+            </div>
+            <dl className={styles.truthList}>
+              <div>
+                <dt>GitHub deployment</dt>
+                <dd>{displayEndpoint(github, githubLabel)}</dd>
+              </div>
+              <div>
+                <dt>Latest scheduled run</dt>
+                <dd>
+                  {displayEndpoint(github, runLabel)}
+                  {githubRun?.url ? (
+                    <a
+                      href={githubRun.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label="Open GitHub workflow run"
+                    >
+                      <ExternalLink size={13} />
+                    </a>
+                  ) : null}
+                </dd>
+              </div>
+              <div>
+                <dt>Revenue readiness</dt>
+                <dd>
+                  {displayEndpoint(
+                    readiness,
+                    readiness.data?.stage || 'unknown',
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt>Workspace entitlement</dt>
+                <dd>{displayEndpoint(activation, activationLabel)}</dd>
+              </div>
+              <div>
+                <dt>Workspace plan</dt>
+                <dd>{displayEndpoint(capacity, workspacePlan)}</dd>
+              </div>
+              <div>
+                <dt>Production verifier</dt>
+                <dd>static_check</dd>
+              </div>
+              <div>
+                <dt>External Z3 (production)</dt>
+                <dd>Unsupported</dd>
+              </div>
+              <div>
+                <dt>Activation proof</dt>
+                <dd>
+                  {displayEndpoint(
+                    activation,
+                    paidEntitlement
+                      ? shortHash(activation.data?.proof?.proof_hash)
+                      : 'None',
+                  )}
+                </dd>
+              </div>
+            </dl>
+          </aside>
+        </div>
+
+        <section
+          className={styles.journeySection}
+          aria-labelledby="journey-title"
+        >
+          <p id="journey-title" className={styles.panelLabel}>
+            Deployment journey
+          </p>
+          <ol className={styles.journey}>
+            {journey.map((step, index) => (
+              <li key={step.label} className={journeyClass(step.state)}>
+                <div className={styles.stepTop}>
+                  <span className={styles.stepNumber}>
+                    {step.state === 'complete' ? (
+                      <Check size={15} />
+                    ) : (
+                      step.number
+                    )}
+                  </span>
+                  <span className={styles.stepLabel}>{step.label}</span>
+                  {index < journey.length - 1 ? (
+                    <span className={styles.stepLine} />
+                  ) : null}
+                </div>
+                <p>{step.detail}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className={styles.agentPanel} aria-labelledby="agent-title">
+          <div className={styles.agentIntro}>
+            <span className={styles.agentIcon}>
+              <Bot size={20} />
+            </span>
+            <div>
+              <p className={styles.panelLabel}>Typed browser agent</p>
+              <h2 id="agent-title">One goal defines the working scope.</h2>
+              <p>
+                Press Enter once. DSG plans and runs supported in-scope tools
+                without asking you to click through every step. Shift+Enter adds
+                a new line.
               </p>
             </div>
-            <div className="flex flex-wrap gap-2 lg:justify-end">
-              <StatusPill status={overallStatus} />
-              <StatusPill status="REVIEW" />
-              <StatusPill status="BLOCKED" />
-            </div>
           </div>
+          <div className={styles.commandBox}>
+            <textarea
+              value={goal}
+              onChange={(event) => setGoal(event.target.value)}
+              onKeyDown={handleGoalKeyDown}
+              placeholder="Example: Inspect the failed Revenue Autopilot run, explain the verified blocker, and prepare the safest in-scope next action."
+              rows={2}
+              disabled={agentBusy}
+              aria-label="Agent goal"
+            />
+            <button
+              type="button"
+              className={styles.commandButton}
+              onClick={() => void submitGoal()}
+              disabled={!goal.trim() || agentBusy}
+            >
+              {agentBusy ? (
+                <Loader2 size={17} className={styles.spin} />
+              ) : (
+                <Terminal size={17} />
+              )}
+              {agentBusy ? 'Running governed plan…' : 'Run governed plan'}
+              {!agentBusy ? <ArrowRight size={17} /> : null}
+            </button>
+          </div>
+          <div className={styles.agentBoundary}>
+            <ShieldCheck size={16} />
+            <span>
+              {BROWSER_BOUNDARY}. High-risk, destructive, payment and
+              out-of-scope changes still require explicit approval.
+            </span>
+          </div>
+          {agentEvents.length > 0 || agentReply ? (
+            <div className={styles.agentOutput} aria-live="polite">
+              <div className={styles.eventList}>
+                {agentEvents.map((event, index) => (
+                  <p key={event + '-' + index}>{event}</p>
+                ))}
+              </div>
+              {agentReply ? (
+                <div className={styles.agentReply}>{agentReply}</div>
+              ) : null}
+            </div>
+          ) : null}
         </section>
 
-        <section className="grid gap-4 md:grid-cols-4">
-          {metrics.map((item) => (
-            <div key={item.label} className="border border-white/10 bg-white/[0.03] p-5">
-              <p className="text-[11px] uppercase tracking-[0.24em] text-slate-500">{item.label}</p>
-              <p className="mt-4 text-3xl font-semibold text-white">{item.value}</p>
-              <p className="mt-2 text-sm text-slate-400">{item.helper}</p>
-            </div>
-          ))}
-        </section>
-
-        {hasNoRuntimeJobs ? (
-          <Panel eyebrow="Empty state" title="No active runtime job found">
-            <p className="text-sm leading-7 text-slate-300">No live job or audit stream is available on this page yet. Start from a safe planning surface or inspect public evidence before claiming runtime completion.</p>
-            <div className="mt-4 flex flex-wrap gap-3">
-              <Link className="rounded-xl bg-amber-300 px-4 py-3 text-sm font-semibold text-slate-950" href="/automation">Create governed draft in Auto Mode</Link>
-              <Link className="rounded-xl border border-white/15 px-4 py-3 text-sm font-semibold text-slate-100" href="/enterprise-proof/demo">View live gate evidence</Link>
-              <Link className="rounded-xl border border-white/15 px-4 py-3 text-sm font-semibold text-slate-100" href="/evidence-pack">Open evidence pack</Link>
-            </div>
-          </Panel>
-        ) : null}
-
-        <section className="grid gap-6 xl:grid-cols-[0.82fr_1.18fr]">
-          <div className="space-y-6">
-            <Panel eyebrow="Claim gate summary" title="What can be claimed now">
-              <div className="space-y-3">
-                <div className="border border-amber-300/20 bg-amber-300/10 p-4">
-                  <div className="flex items-center justify-between gap-3"><span className="font-semibold text-amber-100">Current Claim</span><StatusPill status="REVIEW" /></div>
-                  <p className="mt-2 text-sm leading-6 text-slate-300">Runtime UI and deterministic scaffold evidence exist, but VERIFIED requires current test/build evidence, evidence manifest, and replay proof.</p>
-                </div>
-                <div className="border border-red-400/20 bg-red-500/10 p-4">
-                  <div className="flex items-center justify-between gap-3"><span className="font-semibold text-red-100">Production Claim</span><StatusPill status="BLOCKED" /></div>
-                  <p className="mt-2 text-sm leading-6 text-slate-300">Production claim is blocked until real production user-flow proof, deployment proof, auth/RBAC proof, audit proof, evidence proof, and replay proof are present.</p>
-                </div>
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Gate & blockers" title="Why execution/claims are stopped">
-              <div className="mb-3 rounded-xl border border-slate-700 bg-slate-950 p-3 text-xs leading-5 text-slate-400">Sample blocker model — replace with live job blockers when backend data is available. Sample state is not production truth.</div>
-              <div className="space-y-3">
-                {sampleBlockers.map((blocker) => (
-                  <article key={blocker.affected} className="border border-white/10 bg-black/20 p-4">
-                    <div className="flex items-start justify-between gap-3"><h3 className="font-semibold text-white">{blocker.affected}</h3><StatusPill status={blocker.status} /></div>
-                    <p className="mt-2 text-sm leading-6 text-slate-300">{blocker.reason}</p>
-                    <p className="mt-2 text-xs text-amber-100">Next action: {blocker.nextAction}</p>
-                    <p className="mt-1 text-xs text-slate-500">Evidence required: {blocker.evidenceRequired}</p>
-                  </article>
-                ))}
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Approval queue" title="High-risk actions need human review">
-              <div className="mb-3 rounded-xl border border-slate-700 bg-slate-950 p-3 text-xs leading-5 text-slate-400">Sample approval queue — buttons stay disabled until approval routes are wired into this page.</div>
-              <div className="space-y-3">
-                {approvalItems.map((item) => (
-                  <article key={item.id} className="border border-white/10 bg-black/20 p-4">
-                    <div className="flex items-start justify-between gap-3"><h3 className="font-semibold text-white">{item.requestedAction}</h3><StatusPill status="REVIEW" /></div>
-                    <p className="mt-2 text-sm leading-6 text-slate-300">{item.reason}</p>
-                    <p className="mt-2 text-xs text-slate-500">Risk: {item.risk} · Required role: {item.approverRole}</p>
-                    <p className="mt-1 text-xs text-slate-500">Evidence: {item.evidence}</p>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {['Approve', 'Reject', 'Request changes'].map((label) => (
-                        <button key={label} type="button" disabled className="rounded-xl border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-400 disabled:cursor-not-allowed disabled:opacity-60">{label} — route not wired</button>
-                      ))}
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Runtime controls" title="Control routes are explicit">
-              <div className="grid gap-3 sm:grid-cols-2">
-                {operatorControls.map((control) => (
-                  <button key={control.label} type="button" disabled className="rounded-xl border border-slate-700 bg-black/20 p-4 text-left disabled:cursor-not-allowed disabled:opacity-70">
-                    <span className="block text-sm font-semibold text-slate-200">{control.label}</span>
-                    <span className="mt-2 block text-xs leading-5 text-slate-500">{control.reason}</span>
-                  </button>
-                ))}
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Operator next actions" title="Do the next useful thing">
-              <div className="grid gap-3">
-                <Link className="rounded-xl bg-amber-300 px-4 py-3 text-sm font-semibold text-slate-950" href="/automation">Open Auto Mode</Link>
-                <Link className="rounded-xl border border-white/15 px-4 py-3 text-sm font-semibold text-slate-100" href="/evidence-pack">Export evidence pack</Link>
-                <Link className="rounded-xl border border-white/15 px-4 py-3 text-sm font-semibold text-slate-100" href="/docs">Read deterministic gate docs</Link>
-                <Link className="rounded-xl border border-white/15 px-4 py-3 text-sm font-semibold text-slate-100" href="/dashboard/policies">Review policies</Link>
-              </div>
-            </Panel>
-          </div>
-
-          <div className="grid gap-6">
-            <Panel eyebrow="Graphify context evidence layer" title="Inspect → graph → plan → gate">
-              <div className="grid gap-3 md:grid-cols-2">
-                {graphWorkflow.map((step, index) => (
-                  <div key={step.name} className="border border-white/10 bg-black/20 p-4">
-                    <div className="flex items-start justify-between gap-3"><p className="text-xs uppercase tracking-[0.22em] text-slate-500">Step {index + 1}</p><StatusPill status={step.status} /></div>
-                    <h3 className="mt-3 font-semibold text-white">{step.name}</h3>
-                    <p className="mt-2 text-xs text-slate-400">Actor: {step.actor} · Risk: {step.risk}</p>
-                    <p className="mt-2 text-sm leading-6 text-slate-300">{step.evidence}</p>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-4 rounded-xl border border-amber-300/20 bg-amber-300/10 p-4 text-sm leading-6 text-amber-50">
-                Graphify-style context graphs are a context evidence layer. They do not replace tests, audits, permissions, deployment proof, or production flow proof.
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Evidence / audit / replay" title="Evidence availability">
-              <div className="grid gap-3 md:grid-cols-2">
-                {evidenceItems.map((item) => (
-                  <div key={item.label} className="border border-white/10 bg-black/20 p-4">
-                    <div className="flex items-start justify-between gap-3"><h3 className="font-semibold text-white">{item.label}</h3><StatusPill status={item.state} /></div>
-                    <p className="mt-2 text-sm leading-6 text-slate-300">{item.detail}</p>
-                    <p className="mt-2 text-xs text-slate-500">Source: {item.source}</p>
-                  </div>
-                ))}
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Deterministic proof / gate" title="Verified scaffold fields">
-              <div className="grid gap-3 md:grid-cols-3">
-                {proofFields.map((item) => (
-                  <div key={item.label} className="border border-white/10 bg-black/20 p-4">
-                    <div className="flex items-start justify-between gap-3"><h3 className="text-sm font-semibold text-white">{item.label}</h3><StatusPill status={item.state} /></div>
-                    <p className="mt-2 text-xs leading-5 text-slate-400">{item.detail}</p>
-                  </div>
-                ))}
-              </div>
-              <p className="mt-4 rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm leading-6 text-slate-300">Boundary: this is a deterministic TypeScript static_check scaffold. This page does not claim external Z3 production invocation.</p>
-            </Panel>
-
-            <Panel eyebrow="Live action monitor" title="Monitor / Control Panel">
-              <div className="grid gap-6 lg:grid-cols-2">
-                <div>
-                  <div className="flex items-center justify-between gap-3">
-                    <h3 className="font-semibold text-white">Chat / Agent Console</h3>
-                    <button type="button" onClick={submitCommand} disabled={chatBusy} className="rounded-xl bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300">{chatBusy ? 'Running…' : 'Run'}</button>
-                  </div>
-                  <textarea value={command} onChange={(e) => setCommand(e.target.value)} placeholder="Ask readiness, audit, graph, capacity, or recovery questions..." className="mt-4 h-32 w-full border border-white/10 bg-black/30 p-4 text-sm text-slate-100 outline-none transition focus:border-amber-300/40" />
-                  {error ? <p className="mt-3 text-sm text-red-200">{error}</p> : null}
-                  <div className="mt-4 max-h-64 space-y-3 overflow-y-auto pr-1">
-                    {chatOutput.length === 0 ? <p className="text-sm text-slate-500">No output yet.</p> : null}
-                    {chatOutput.map((line, index) => (<pre key={`${index}-${line.slice(0, 8)}`} className="overflow-x-auto border border-white/10 bg-black/20 p-3 text-xs leading-6 text-slate-200">{line}</pre>))}
-                  </div>
-                </div>
-
-                <div>
-                  <div className="flex items-center justify-between gap-3"><h3 className="font-semibold text-white">Latest audit</h3><span className="text-xs text-slate-500">{formatDate(health?.timestamp)}</span></div>
-                  <div className="mt-4 max-h-80 space-y-3 overflow-y-auto pr-1">
-                    {(audit?.items || []).map((item) => (
-                      <div key={`${item.id}-${item.created_at}`} className={`border p-4 ${resultTone(item.gate_result)}`}>
-                        <div className="flex items-center justify-between gap-3"><p className="text-sm font-semibold uppercase tracking-[0.18em]">{item.gate_result || '-'}</p><p className="text-xs text-slate-400">{formatDate(item.created_at)}</p></div>
-                        <p className="mt-3 text-xs text-slate-300">Entropy: {typeof item.entropy === 'number' ? item.entropy.toFixed(4) : '-'}</p>
-                        <p className="mt-2 break-all text-xs text-slate-500">State hash: {item.state_hash || '-'}</p>
-                      </div>
-                    ))}
-                    {auditUnavailableInInternalMode ? <p className="text-sm text-slate-500">Audit unavailable in internal mode.</p> : null}
-                    {!auditUnavailableInInternalMode && audit?.items?.length === 0 ? <p className="text-sm text-slate-500">No audit events found.</p> : null}
-                  </div>
-                </div>
-              </div>
-            </Panel>
-
-            <Panel eyebrow="Claim gate matrix" title="Allowed claim status">
-              <div className="overflow-x-auto">
-                <div className="min-w-[760px] divide-y divide-white/10 border border-white/10">
-                  {claimRows.map((row) => (
-                    <div key={row.claim} className="grid grid-cols-[140px_130px_1fr_1fr] gap-3 p-4 text-sm">
-                      <div className="font-semibold text-white">{row.claim}</div>
-                      <div><StatusPill status={row.status} /></div>
-                      <div className="text-slate-300">{row.reason}</div>
-                      <div className="text-slate-400">Need: {row.evidenceRequired}<br />Have: {row.evidencePresent}</div>
-                    </div>
+        <section
+          className={styles.briefGrid}
+          aria-label="Verified deployment brief and offer"
+        >
+          <div className={styles.briefPanel}>
+            <p className={styles.panelLabel}>Verified deployment brief</p>
+            <div className={styles.briefColumns}>
+              <div>
+                <h2 className={styles.goldHeading}>What DSG recommends</h2>
+                <ul>
+                  {recommendations.map((item) => (
+                    <li key={item}>
+                      <ArrowRight size={15} /> <span>{item}</span>
+                    </li>
                   ))}
-                </div>
+                </ul>
               </div>
-            </Panel>
+              <div>
+                <h2 className={styles.goldHeading}>What is verified</h2>
+                <ul>
+                  {verified.map((item) => (
+                    <li key={item}>
+                      <CheckCircle2
+                        size={16}
+                        className={styles.checkIcon}
+                      />{' '}
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h2 className={styles.redHeading}>What blocks execution</h2>
+                <ul>
+                  {blockers.slice(0, 6).map((item) => (
+                    <li key={item}>
+                      <XCircle size={16} className={styles.blockIcon} />{' '}
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                  {blockers.length === 0 ? (
+                    <li>
+                      <CheckCircle2
+                        size={16}
+                        className={styles.checkIcon}
+                      />{' '}
+                      <span>No verified blocker from loaded sources.</span>
+                    </li>
+                  ) : null}
+                </ul>
+              </div>
+            </div>
+            <div className={styles.failClosedNote}>
+              <LockKeyhole size={15} />
+              <span>
+                DSG continues supported, plan-authorized actions. It pauses
+                only when a verified constraint, permission, billing, risk or
+                executor boundary is reached.
+              </span>
+            </div>
           </div>
+
+          <aside className={styles.offerPanel}>
+            <p className={styles.panelLabel}>Recommended Pro package</p>
+            <div className={styles.priceRow}>
+              <h2>Pro Verification</h2>
+              <p>
+                <strong>$99</strong>
+                <span>/month</span>
+              </p>
+            </div>
+            <p className={styles.offerCopy}>
+              Production verification entitlement, DSG verifier access and
+              audit-grade evidence reports.
+            </p>
+            <button
+              type="button"
+              className={styles.checkoutButton}
+              onClick={() => void startCheckout()}
+              disabled={checkoutBusy || paidEntitlement}
+            >
+              {checkoutBusy ? (
+                <Loader2 size={18} className={styles.spin} />
+              ) : null}
+              {paidEntitlement
+                ? 'Pro verification active'
+                : checkoutBusy
+                  ? 'Opening Stripe Checkout…'
+                  : 'Start Pro verification — $99/month'}
+            </button>
+            <Link href="/evidence-pack" className={styles.evidenceLink}>
+              View technical evidence <ExternalLink size={14} />
+            </Link>
+            {checkoutError ? (
+              <p className={styles.errorMessage}>
+                <X size={14} /> {checkoutError}
+              </p>
+            ) : null}
+            <ul className={styles.offerBenefits}>
+              <li>
+                <CheckCircle2 size={16} /> Stripe-hosted subscription checkout
+              </li>
+              <li>
+                <CheckCircle2 size={16} /> 14-day Pro trial from the shared
+                catalog
+              </li>
+              <li>
+                <CheckCircle2 size={16} /> Append-only entitlement activation
+                proof
+              </li>
+              <li>
+                <CheckCircle2 size={16} /> Cancel any time
+              </li>
+            </ul>
+          </aside>
         </section>
 
-        <section className="border border-amber-300/25 bg-amber-300/10 p-5 text-sm leading-7 text-amber-50">
-          <p className="font-semibold">Command Center boundary</p>
-          <p className="mt-2">Command Center is an operator review surface. It shows live state when backend data is available and clearly labeled sample/planned state otherwise. It does not execute production actions by itself and does not prove production readiness without deployment and production-flow evidence.</p>
+        <section
+          className={styles.metricsSection}
+          aria-labelledby="metrics-title"
+        >
+          <div className={styles.metricsHeading}>
+            <div>
+              <p id="metrics-title" className={styles.panelLabel}>
+                Outcome contract — measured after real usage
+              </p>
+              <p>
+                No inferred ROI. Values remain unmeasured until a verified
+                production event supplies evidence.
+              </p>
+            </div>
+            {capacity.status === 'ready' ? (
+              <span className={styles.usageBadge}>
+                Usage counter: {Number(capacity.data?.executions || 0)} /{' '}
+                {Number(capacity.data?.included_executions || 0)}
+              </span>
+            ) : null}
+          </div>
+          <div className={styles.metricGrid}>
+            {metrics.map((metric) => (
+              <article key={metric}>
+                <p>{metric}</p>
+                <strong>Not measured</strong>
+              </article>
+            ))}
+          </div>
         </section>
-      </div>
+      </section>
     </main>
   );
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -18,7 +18,10 @@ export default async function DashboardLayout({ children }: { children: React.Re
   return (
     <div className="min-h-screen bg-slate-950 text-white">
       <div className="border-b border-slate-800 bg-slate-950/80">
-        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-3">
+        <div
+          className="mx-auto flex items-center justify-between gap-4 px-6 py-3"
+          style={{ maxWidth: 1480 }}
+        >
           <Link href="/dashboard" className="flex shrink-0 flex-col">
             <p className="text-xs uppercase tracking-[0.2em] text-slate-400">DSG ONE</p>
             <p className="text-base font-semibold leading-tight">Command Center</p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,8 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const enableVercelTelemetry = process.env.VERCEL === '1';
+
   return (
     <html lang="en">
       <body className="min-h-screen bg-slate-950 text-slate-100 antialiased">
@@ -23,8 +25,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <GlobalNav />
             {children}
             <PublicChatWidget />
-            <Analytics />
-            <SpeedInsights />
+            {enableVercelTelemetry ? (
+              <>
+                <Analytics />
+                <SpeedInsights />
+              </>
+            ) : null}
           </ToastProvider>
         </LanguageProvider>
       </body>

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,55 @@
+# Design QA — DSG ONE Command Center
+
+final result: passed
+
+## Visual comparison
+
+- Reference: `/workspace/scratch/980e2e78a7a8/upload/01-file_00000000b6dc820ba080b1155dba372d.png`
+- Implementation viewport: `artifacts/design-qa/command-center-viewport.png`
+- Side-by-side comparison: `artifacts/design-qa/command-center-comparison.png`
+- Full-page implementation: `artifacts/design-qa/command-center-final.png`
+- Viewport and device scale: `1536 × 1093`, DPR `1`
+
+The reference and implementation were compared together at the same viewport and loaded state. The implementation retains the reference's black cockpit, thin cool-gray borders, gold conversion accents, red blocker states, compact journey, evidence brief, and right-hand paid offer. The typed browser-agent strip is an intentional product addition requested for this build; it shifts the lower evidence section without changing the source hierarchy.
+
+### Severity review
+
+- P0: none
+- P1: none
+- P2: none after reducing the hero title to one line, compacting Current Truth, aligning the frame width, and reducing the agent input height
+
+## Interaction verification
+
+Playwright production-browser QA: 8/8 passed.
+
+1. Command Center route returned HTTP 200.
+2. Buyer cockpit and Current Truth rendered.
+3. Empty command remained disabled.
+4. A typed goal enabled `Run governed plan`.
+5. An unsigned operator received the explicit sign-in boundary.
+6. Technical evidence linked to `/evidence-pack`.
+7. Current Truth refreshed without a page exception.
+8. Stripe checkout failed closed locally because production distributed rate limiting is not configured.
+
+## Runtime and console review
+
+- Uncaught page exceptions: 0
+- Vercel telemetry CSP failures: 0
+- Handled API status messages: expected `401` for unsigned workspace resources, `503` for unconfigured readiness dependencies, `502` when the GitHub upstream was unavailable in the sandbox, and `429` for the production fail-closed rate-limit boundary.
+- Browser request aborts: two canceled Next.js RSC navigation requests; neither produced a page exception or changed the tested state.
+- Machine-readable report: `artifacts/design-qa/command-center-qa.json`
+
+## Truth boundary
+
+- No revenue, ROI, replay, time-saved, latency, or cost metric is inferred.
+- GitHub state is shown only when the public workflow source responds; otherwise the UI says it is unavailable.
+- The browser agent can plan and use the existing open/read boundary. Live click, type, and submit execution remains explicitly disabled until a verified mutation executor exists.
+- Payment, destructive, high-risk, unsupported, and out-of-scope changes remain approval- or capability-gated.
+
+## Build verification
+
+- TypeScript: passed
+- ESLint: passed
+- Targeted command-center and GitHub status tests: passed
+- Next.js production build: passed; 195 static pages generated
+- Existing Turbopack NFT tracing warning remains in the unrelated Hermes execution import path.

--- a/lib/github/revenue-autopilot-status.ts
+++ b/lib/github/revenue-autopilot-status.ts
@@ -1,0 +1,48 @@
+export const DEFAULT_REVENUE_AUTOPILOT_REPOSITORY =
+  'tdealer01-crypto/tdealer01-crypto-dsg-control-plane';
+
+export const REVENUE_AUTOPILOT_WORKFLOW = 'revenue-autopilot.yml';
+
+export type GitHubWorkflowRun = {
+  id?: number;
+  run_number?: number;
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+  head_branch?: string;
+  head_sha?: string;
+  html_url?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type GitHubWorkflowResponse = {
+  workflow_runs?: GitHubWorkflowRun[];
+};
+
+export function resolveGitHubRepository(value?: string | null) {
+  const candidate = String(value || '').trim();
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(candidate)
+    ? candidate
+    : DEFAULT_REVENUE_AUTOPILOT_REPOSITORY;
+}
+
+export function summarizeWorkflowRun(payload: GitHubWorkflowResponse) {
+  const run = Array.isArray(payload.workflow_runs)
+    ? payload.workflow_runs[0]
+    : undefined;
+  if (!run || !run.id || !run.run_number) return null;
+
+  return {
+    id: run.id,
+    number: run.run_number,
+    name: run.name || 'Revenue Autopilot',
+    status: run.status || 'unknown',
+    conclusion: run.conclusion || null,
+    branch: run.head_branch || 'unknown',
+    sha: run.head_sha || '',
+    url: run.html_url || '',
+    createdAt: run.created_at || '',
+    updatedAt: run.updated_at || '',
+  };
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dsg-one-mcp-server"
   ],
   "scripts": {
-    "dev": "next dev -p 3000",
+    "dev": "node scripts/next-dev-compatible.mjs",
     "build": "next build",
     "start": "next start -p 3000",
     "lint": "eslint app/ lib/ components/ --ext .ts,.tsx,.js,.jsx",

--- a/scripts/next-dev-compatible.mjs
+++ b/scripts/next-dev-compatible.mjs
@@ -1,0 +1,45 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+const input = process.argv.slice(2);
+const forwarded = [];
+let hasPort = false;
+
+for (let index = 0; index < input.length; index += 1) {
+  const argument = input[index];
+  if (argument === '--strictPort') continue;
+  if (argument === '--host') {
+    forwarded.push('--hostname');
+    if (input[index + 1] && !input[index + 1].startsWith('-')) {
+      forwarded.push(input[index + 1]);
+      index += 1;
+    }
+    continue;
+  }
+  if (argument === '--port' || argument === '-p') hasPort = true;
+  forwarded.push(argument);
+}
+
+if (!hasPort) forwarded.push('--port', '3000');
+
+const nextBin = path.join(
+  process.cwd(),
+  'node_modules',
+  'next',
+  'dist',
+  'bin',
+  'next',
+);
+const child = spawn(process.execPath, [nextBin, 'dev', ...forwarded], {
+  env: process.env,
+  stdio: 'inherit',
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => child.kill(signal));
+}
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 1);
+});

--- a/scripts/qa-command-center.mjs
+++ b/scripts/qa-command-center.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+import { chromium } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const baseUrl =
+  process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:4173';
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+const outputDir = path.resolve(
+  process.env.DSG_QA_OUTPUT_DIR || 'artifacts/design-qa',
+);
+
+if (!executablePath) {
+  throw new Error('PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH is required');
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const browser = await chromium.launch({
+  executablePath,
+  headless: true,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
+});
+
+const page = await browser.newPage({
+  viewport: { width: 1536, height: 1093 },
+  deviceScaleFactor: 1,
+});
+const consoleErrors = [];
+const pageErrors = [];
+const failedRequests = [];
+
+page.on('console', (message) => {
+  if (message.type() === 'error') consoleErrors.push(message.text());
+});
+page.on('pageerror', (error) => pageErrors.push(error.message));
+page.on('requestfailed', (request) => {
+  failedRequests.push({
+    url: request.url(),
+    error: request.failure()?.errorText || 'request failed',
+  });
+});
+
+const interactions = [];
+
+try {
+  const response = await page.goto(
+    baseUrl + '/dashboard/command-center',
+    { waitUntil: 'domcontentloaded', timeout: 60_000 },
+  );
+  interactions.push({
+    name: 'command center route',
+    result: response?.ok() ? 'passed' : 'failed',
+    detail: 'HTTP ' + (response?.status() ?? 'unknown'),
+  });
+
+  await page.getByRole('heading', {
+    name: 'Runtime control surface with Graphify context evidence.',
+  }).waitFor();
+  await page.waitForFunction(() => {
+    const button = document.querySelector(
+      'button[aria-label="Refresh current truth"]',
+    );
+    return button instanceof HTMLButtonElement && !button.disabled;
+  });
+  await page.waitForFunction(
+    () =>
+      !document.body.innerText.includes('Checking…') &&
+      !document.body.innerText.includes('Checking...'),
+    undefined,
+    { timeout: 30_000 },
+  );
+  interactions.push({
+    name: 'primary buyer cockpit',
+    result: 'passed',
+    detail: 'hero and current-truth surface rendered',
+  });
+
+  await page.screenshot({
+    path: path.join(outputDir, 'command-center-viewport.png'),
+    fullPage: false,
+  });
+
+  const commandButton = page.getByRole('button', {
+    name: 'Run governed plan',
+  });
+  interactions.push({
+    name: 'empty command guard',
+    result: (await commandButton.isDisabled()) ? 'passed' : 'failed',
+    detail: 'run action is disabled until the user supplies a goal',
+  });
+
+  await page.getByLabel('Agent goal').fill(
+    'Inspect the Revenue Autopilot blocker and explain the safest next action.',
+  );
+  interactions.push({
+    name: 'typed goal',
+    result: (await commandButton.isEnabled()) ? 'passed' : 'failed',
+    detail: 'one typed goal enabled the governed plan action',
+  });
+
+  await commandButton.click();
+  await page
+    .getByText(
+      'Sign in with an active operator workspace to run this governed plan.',
+    )
+    .waitFor();
+  interactions.push({
+    name: 'agent authorization boundary',
+    result: 'passed',
+    detail: 'unsigned operator is told exactly what is required',
+  });
+
+  const evidenceHref = await page
+    .getByRole('link', { name: /View technical evidence/ })
+    .getAttribute('href');
+  interactions.push({
+    name: 'technical evidence route',
+    result: evidenceHref === '/evidence-pack' ? 'passed' : 'failed',
+    detail: evidenceHref || 'missing href',
+  });
+
+  const refreshButton = page.getByRole('button', {
+    name: 'Refresh current truth',
+  });
+  await refreshButton.click();
+  await page.waitForFunction(() => {
+    const button = document.querySelector(
+      'button[aria-label="Refresh current truth"]',
+    );
+    return button instanceof HTMLButtonElement && !button.disabled;
+  });
+  interactions.push({
+    name: 'truth refresh',
+    result: 'passed',
+    detail: 'refresh completed without a page exception',
+  });
+
+  await page.screenshot({
+    path: path.join(outputDir, 'command-center-final.png'),
+    fullPage: true,
+  });
+
+  const checkoutResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith('/api/billing/checkout') &&
+      response.request().method() === 'POST',
+    { timeout: 30_000 },
+  );
+  await page
+    .getByRole('button', { name: 'Start Pro verification — $99/month' })
+    .click();
+  const checkoutResponse = await checkoutResponsePromise;
+  const checkoutStatus = checkoutResponse.status();
+  let checkoutDetail = `checkout boundary returned HTTP ${checkoutStatus}`;
+  let checkoutPassed = false;
+
+  if (checkoutStatus === 401) {
+    await page.waitForURL(
+      /\/login\?next=%2Fdashboard%2Fcommand-center|\/login\?next=\/dashboard\/command-center/,
+      { timeout: 20_000 },
+    );
+    checkoutPassed = true;
+    checkoutDetail = 'unsigned buyer is routed to sign in before Stripe Checkout';
+  } else if (checkoutStatus === 429) {
+    await page.getByText('Too many requests').waitFor();
+    checkoutPassed = true;
+    checkoutDetail =
+      'production checkout failed closed because distributed rate limiting is not configured locally';
+  }
+
+  interactions.push({
+    name: 'Stripe checkout boundary',
+    result: checkoutPassed ? 'passed' : 'failed',
+    detail: checkoutDetail,
+  });
+} finally {
+  await browser.close();
+}
+
+const report = {
+  viewport: { width: 1536, height: 1093 },
+  baseUrl,
+  screenshot: path.join(outputDir, 'command-center-final.png'),
+  interactions,
+  consoleErrors,
+  pageErrors,
+  failedRequests,
+};
+
+await writeFile(
+  path.join(outputDir, 'command-center-qa.json'),
+  JSON.stringify(report, null, 2) + '\n',
+  'utf8',
+);
+
+console.log(JSON.stringify(report, null, 2));

--- a/tests/integration/ui/command-center-capabilities.test.tsx
+++ b/tests/integration/ui/command-center-capabilities.test.tsx
@@ -6,16 +6,21 @@ function read(relativePath: string) {
 }
 
 describe('command center capabilities surface', () => {
-  it('exposes clickable chat submit action and monitor panel in dashboard command center', () => {
+  it('exposes a typed governed agent, live truth sources, and Stripe checkout', () => {
     const source = read('app/dashboard/command-center/page.tsx');
 
-    expect(source).toContain('Chat / Agent Console');
-    expect(source).toContain('Monitor / Control Panel');
-    expect(source).toContain('onClick={submitCommand}');
-    expect(source).toContain('disabled={chatBusy}');
+    expect(source).toContain('Typed browser agent');
+    expect(source).toContain('Current truth');
+    expect(source).toContain('onClick={() => void submitGoal()}');
+    expect(source).toContain('disabled={!goal.trim() || agentBusy}');
     expect(source).toContain("fetch('/api/agent-chat'");
-    expect(source).toContain("fetch('/api/health'");
-    expect(source).toContain("fetch('/api/audit?limit=8'");
+    expect(source).toContain("'/api/revenue-readiness'");
+    expect(source).toContain("'/api/github/revenue-autopilot-status'");
+    expect(source).toContain("'/api/billing/activation-proof'");
+    expect(source).toContain("fetch('/api/billing/checkout'");
+    expect(source).toContain(
+      'Live browser click/type/submit executor is not enabled',
+    );
   });
 
   it('shows live monitor + chat workflow in app shell', () => {

--- a/tests/unit/github/revenue-autopilot-status.test.ts
+++ b/tests/unit/github/revenue-autopilot-status.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_REVENUE_AUTOPILOT_REPOSITORY,
+  resolveGitHubRepository,
+  summarizeWorkflowRun,
+} from '../../../lib/github/revenue-autopilot-status';
+
+describe('revenue autopilot GitHub status', () => {
+  it('accepts a valid owner/repository and fails closed to the verified default', () => {
+    expect(resolveGitHubRepository('owner/repository')).toBe(
+      'owner/repository',
+    );
+    expect(
+      resolveGitHubRepository('https://github.com/owner/repository'),
+    ).toBe(DEFAULT_REVENUE_AUTOPILOT_REPOSITORY);
+  });
+
+  it('returns only fields used by the buyer cockpit', () => {
+    expect(
+      summarizeWorkflowRun({
+        workflow_runs: [
+          {
+            id: 123,
+            run_number: 7,
+            name: 'Revenue Autopilot',
+            status: 'completed',
+            conclusion: 'failure',
+            head_branch: 'main',
+            head_sha: 'abcdef1234567890',
+            html_url: 'https://github.com/owner/repo/actions/runs/123',
+            created_at: '2026-08-13T00:00:00Z',
+            updated_at: '2026-08-13T00:01:00Z',
+          },
+        ],
+      }),
+    ).toEqual({
+      id: 123,
+      number: 7,
+      name: 'Revenue Autopilot',
+      status: 'completed',
+      conclusion: 'failure',
+      branch: 'main',
+      sha: 'abcdef1234567890',
+      url: 'https://github.com/owner/repo/actions/runs/123',
+      createdAt: '2026-08-13T00:00:00Z',
+      updatedAt: '2026-08-13T00:01:00Z',
+    });
+  });
+
+  it('returns null when GitHub has no complete run identity', () => {
+    expect(summarizeWorkflowRun({ workflow_runs: [] })).toBeNull();
+    expect(
+      summarizeWorkflowRun({ workflow_runs: [{ status: 'queued' }] }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Outcome

Turns DSG ONE Command Center into a truthful revenue/deployment control surface with a typed browser-agent command entry point, live GitHub Revenue Autopilot status, Stripe purchase CTA, execution constraints, and evidence-first ROI fields.

## Why

Enterprise buyers need a visible flow from recommended action to verification, approval, controlled execution, and replayable evidence. This change packages existing DSG capabilities as a purchasable, auditable product without inventing production metrics.

## User impact

- One UI for users and the browser agent
- Natural-language command input
- Live, fail-closed GitHub deployment truth
- Real Stripe checkout CTA
- Explicit supported/blocked action boundaries
- Evidence and ROI metrics remain truthful until measured
- Existing plan-authorized actions are not given a redundant approval gate

## Scope

- 12 files
- 2,007 additions / 541 deletions
- Base: `69c6204e04363ea9a5c4f20721c2757907180337`
- Head: `06f22cbe635102e64b242b418ae656c9758a34f6`
- Tree: `18faaf44538394942d4fc7d19fc940039d159341`

## Verification completed locally

- TypeScript typecheck: passed
- ESLint: passed
- Targeted unit/integration tests: 11/11 passed
- Next.js production build: passed (195 static pages)
- Playwright production QA: 8/8 interactions passed
- Browser page exceptions: 0
- `git diff --check`: passed

## Truthful boundaries

- Current browser runtime supports open/read navigation only; click/type/submit mutation is intentionally not claimed.
- Local checkout returned 429 because the production fail-closed limiter has no Redis in the sandbox; no checkout success is claimed from local QA.
- ROI fields show unmeasured baselines until verified production executions exist.
- Existing unrelated Turbopack NFT tracing warning in the Hermes route remains unchanged.
