### PR TITLE
feat: add verified Vercel account migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,10 @@ permissions:
 
 env:
   VERCEL_CLI_VERSION: 58.0.0
-  VERCEL_ORG_ID: team_n189mlAdVHR6cGGiaAwsKzQ0
-  VERCEL_PROJECT_ID: prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  VERCEL_USE_NEW_ACCOUNT: ${{ vars.VERCEL_USE_NEW_ACCOUNT || 'false' }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_USE_NEW_ACCOUNT == 'true' && vars.VERCEL_ORG_ID || 'team_n189mlAdVHR6cGGiaAwsKzQ0' }}
+  VERCEL_PROJECT_ID: ${{ vars.VERCEL_USE_NEW_ACCOUNT == 'true' && vars.VERCEL_PROJECT_ID || 'prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW' }}
+  VERCEL_TOKEN: ${{ vars.VERCEL_USE_NEW_ACCOUNT == 'true' && secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -87,8 +88,12 @@ jobs:
         shell: bash
         run: |
           test -n "$VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN"; exit 1; }
-          test "$VERCEL_ORG_ID" = "team_n189mlAdVHR6cGGiaAwsKzQ0" || { echo "Unexpected Vercel team"; exit 1; }
-          test "$VERCEL_PROJECT_ID" = "prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW" || { echo "Unexpected Vercel project"; exit 1; }
+          [[ "$VERCEL_ORG_ID" =~ ^[A-Za-z0-9_-]{3,128}$ ]] || { echo "Invalid Vercel account ID"; exit 1; }
+          [[ "$VERCEL_PROJECT_ID" =~ ^prj_[A-Za-z0-9]+$ ]] || { echo "Invalid Vercel project ID"; exit 1; }
+          if test "$VERCEL_USE_NEW_ACCOUNT" = "true"; then
+            test "$VERCEL_ORG_ID" != "team_n189mlAdVHR6cGGiaAwsKzQ0" || { echo "New-account routing has the legacy account ID"; exit 1; }
+            test "$VERCEL_PROJECT_ID" != "prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW" || { echo "New-account routing has the legacy project ID"; exit 1; }
+          fi
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Pull preview configuration

--- a/.github/workflows/promoted-production-deploy.yml
+++ b/.github/workflows/promoted-production-deploy.yml
@@ -26,9 +26,10 @@ permissions:
 
 env:
   VERCEL_CLI_VERSION: 58.0.0
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-  VERCEL_ORG_ID: team_n189mlAdVHR6cGGiaAwsKzQ0
-  VERCEL_PROJECT_ID: prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW
+  VERCEL_USE_NEW_ACCOUNT: ${{ vars.VERCEL_USE_NEW_ACCOUNT || 'false' }}
+  VERCEL_TOKEN: ${{ vars.VERCEL_USE_NEW_ACCOUNT == 'true' && secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_USE_NEW_ACCOUNT == 'true' && vars.VERCEL_ORG_ID || 'team_n189mlAdVHR6cGGiaAwsKzQ0' }}
+  VERCEL_PROJECT_ID: ${{ vars.VERCEL_USE_NEW_ACCOUNT == 'true' && vars.VERCEL_PROJECT_ID || 'prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW' }}
   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -84,8 +85,12 @@ jobs:
             AGENT_WORKSPACE_RELEASE_AGENT_ID; do
             test -n "${!name}" || { echo "Missing required configuration: $name"; exit 1; }
           done
-          test "$VERCEL_ORG_ID" = "team_n189mlAdVHR6cGGiaAwsKzQ0" || { echo "Unexpected Vercel team"; exit 1; }
-          test "$VERCEL_PROJECT_ID" = "prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW" || { echo "Unexpected Vercel project"; exit 1; }
+          [[ "$VERCEL_ORG_ID" =~ ^[A-Za-z0-9_-]{3,128}$ ]] || { echo "Invalid Vercel account ID"; exit 1; }
+          [[ "$VERCEL_PROJECT_ID" =~ ^prj_[A-Za-z0-9]+$ ]] || { echo "Invalid Vercel project ID"; exit 1; }
+          if test "$VERCEL_USE_NEW_ACCOUNT" = "true"; then
+            test "$VERCEL_ORG_ID" != "team_n189mlAdVHR6cGGiaAwsKzQ0" || { echo "New-account routing has the legacy account ID"; exit 1; }
+            test "$VERCEL_PROJECT_ID" != "prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW" || { echo "New-account routing has the legacy project ID"; exit 1; }
+          fi
 
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/sync-vercel-envs.yml
+++ b/.github/workflows/sync-vercel-envs.yml
@@ -1,0 +1,189 @@
+name: Sync Vercel ENV to New Account
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Exact current main commit to authorize
+        required: true
+        type: string
+      new_team_id:
+        description: New Vercel team ID; leave blank for the token default scope
+        required: false
+        default: ''
+        type: string
+      new_project_id:
+        description: Existing new Vercel project ID; leave blank to resolve or create by name
+        required: false
+        default: ''
+        type: string
+      new_project_name:
+        description: Destination Vercel project name
+        required: true
+        default: tdealer01-crypto-dsg-control-plane
+        type: string
+      dry_run:
+        description: Inspect and prove copyability without changing Vercel
+        required: true
+        default: true
+        type: boolean
+      include_integration_managed:
+        description: Copy integration-managed values as detached ENV entries
+        required: true
+        default: false
+        type: boolean
+      acknowledge_rotated_protected:
+        description: Confirm sensitive values were rotated into the existing destination project
+        required: true
+        default: false
+        type: boolean
+      deploy_preview:
+        description: Verify a preview before activating new GitHub routing
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: vercel-account-env-migration
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+env:
+  VERCEL_CLI_VERSION: 58.0.0
+
+jobs:
+  migrate-verify-activate:
+    name: Preflight, Sync, Verify, and Activate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: "Production – dsg-qubo-api"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.expected_main_sha }}
+          fetch-depth: 0
+
+      - name: Require exact current main commit
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+        shell: bash
+        run: |
+          [[ "$EXPECTED_MAIN_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "expected_main_sha must be a full commit SHA"; exit 1; }
+          git fetch origin main --depth=1
+          CHECKED_OUT=$(git rev-parse HEAD)
+          MAIN_HEAD=$(git rev-parse origin/main)
+          test "${CHECKED_OUT,,}" = "${EXPECTED_MAIN_SHA,,}" || { echo "Checked-out commit mismatch"; exit 1; }
+          test "$CHECKED_OUT" = "$MAIN_HEAD" || { echo "Commit is not current main head"; exit 1; }
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Validate migration configuration
+        env:
+          OLD_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TEAM_ID: ${{ inputs.new_team_id }}
+          NEW_VERCEL_PROJECT_ID: ${{ inputs.new_project_id }}
+          NEW_VERCEL_PROJECT_NAME: ${{ inputs.new_project_name }}
+        shell: bash
+        run: |
+          test -n "$OLD_VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN"; exit 1; }
+          test -n "$NEW_VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN_NEW"; exit 1; }
+          test -n "$NEW_VERCEL_PROJECT_NAME" || { echo "Missing destination project name"; exit 1; }
+          [[ "$NEW_VERCEL_PROJECT_NAME" =~ ^[a-z0-9][a-z0-9._-]{0,99}$ ]] || { echo "Invalid destination project name"; exit 1; }
+          if test -n "$NEW_VERCEL_TEAM_ID"; then
+            [[ "$NEW_VERCEL_TEAM_ID" =~ ^[A-Za-z0-9_-]{3,128}$ ]] || { echo "Invalid new team ID"; exit 1; }
+          fi
+          if test -n "$NEW_VERCEL_PROJECT_ID"; then
+            [[ "$NEW_VERCEL_PROJECT_ID" =~ ^prj_[A-Za-z0-9]+$ ]] || { echo "Invalid new project ID"; exit 1; }
+          fi
+
+      - name: Check migration scripts
+        run: |
+          node --check scripts/lib/vercel-env-sync.mjs
+          node --check scripts/sync-vercel-envs.mjs
+
+      - name: Reconfirm main immediately before migration
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+        shell: bash
+        run: |
+          git fetch origin main --depth=1
+          test "$(git rev-parse origin/main)" = "$EXPECTED_MAIN_SHA" || { echo "Main advanced after authorization; dispatch again"; exit 1; }
+
+      - name: Preflight and sync environment variables
+        id: sync
+        env:
+          OLD_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          OLD_VERCEL_TEAM_ID: team_n189mlAdVHR6cGGiaAwsKzQ0
+          OLD_VERCEL_PROJECT_ID: prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TEAM_ID: ${{ inputs.new_team_id }}
+          NEW_VERCEL_PROJECT_ID: ${{ inputs.new_project_id }}
+          NEW_VERCEL_PROJECT_NAME: ${{ inputs.new_project_name }}
+          NEW_VERCEL_GIT_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          INCLUDE_INTEGRATION_MANAGED: ${{ inputs.include_integration_managed }}
+          ACKNOWLEDGE_ROTATED_PROTECTED: ${{ inputs.acknowledge_rotated_protected }}
+        run: node scripts/sync-vercel-envs.mjs
+
+      - name: Pull verified destination preview configuration
+        if: inputs.dry_run == false && inputs.deploy_preview && steps.sync.outputs.verification_status == 'verified'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          VERCEL_ORG_ID: ${{ steps.sync.outputs.new_team_id }}
+          VERCEL_PROJECT_ID: ${{ steps.sync.outputs.new_project_id }}
+        run: npx --yes "vercel@$VERCEL_CLI_VERSION" pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Deploy destination preview
+        id: preview
+        if: inputs.dry_run == false && inputs.deploy_preview && steps.sync.outputs.verification_status == 'verified'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          VERCEL_ORG_ID: ${{ steps.sync.outputs.new_team_id }}
+          VERCEL_PROJECT_ID: ${{ steps.sync.outputs.new_project_id }}
+        shell: bash
+        run: |
+          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" deploy --yes --token="$VERCEL_TOKEN" \
+            --meta=migration_run="${{ github.run_id }}" \
+            --meta=commit="${{ github.sha }}")
+          test -n "$PREVIEW_URL"
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify destination preview health
+        if: inputs.dry_run == false && inputs.deploy_preview && steps.sync.outputs.verification_status == 'verified'
+        run: curl --fail --retry 8 --retry-delay 5 "${{ steps.preview.outputs.preview_url }}/api/health"
+
+      - name: Activate new Vercel routing for GitHub Actions
+        if: inputs.dry_run == false && inputs.deploy_preview && steps.sync.outputs.verification_status == 'verified'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERCEL_TEAM_ID: ${{ steps.sync.outputs.new_team_id }}
+          NEW_VERCEL_PROJECT_ID: ${{ steps.sync.outputs.new_project_id }}
+          NEW_VERCEL_PROJECT_NAME: ${{ steps.sync.outputs.new_project_name }}
+        shell: bash
+        run: |
+          test -n "$NEW_VERCEL_TEAM_ID" && test -n "$NEW_VERCEL_PROJECT_ID"
+          gh variable set VERCEL_USE_NEW_ACCOUNT --body "false"
+          gh variable set VERCEL_ORG_ID --body "$NEW_VERCEL_TEAM_ID"
+          gh variable set VERCEL_PROJECT_ID --body "$NEW_VERCEL_PROJECT_ID"
+          gh variable set VERCEL_PROJECT_NAME --body "$NEW_VERCEL_PROJECT_NAME"
+          gh variable set VERCEL_USE_NEW_ACCOUNT --body "true"
+
+      - name: Record preview activation evidence
+        if: inputs.dry_run == false && inputs.deploy_preview && steps.sync.outputs.verification_status == 'verified'
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
+        run: |
+          {
+            echo "## Destination activation"
+            echo ""
+            echo "- Preview health: **verified**"
+            echo "- Preview URL: $PREVIEW_URL"
+            echo "- GitHub deployment variables: **activated**"
+            echo "- Production deployment: **not performed**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deploy/vercel-account-env-migration.md
+++ b/docs/deploy/vercel-account-env-migration.md
@@ -1,0 +1,70 @@
+# Vercel account and ENV migration
+
+This runbook moves decryptable application environment variables from the legacy DSG ONE Vercel project to a project in the new account. It verifies exact values in memory, deploys a preview, checks `/api/health`, and only then updates the GitHub repository variables used by deployment workflows.
+
+Production is not deployed by this migration. Production remains behind the `Promoted Production Deployment` evidence, approval, health, and rollback workflow.
+
+## Safety contract
+
+- No environment value is written to GitHub outputs, artifacts, summaries, or repository files.
+- `VERCEL_*`, `NOW_*`, GitHub CI credentials, and Vercel system variables are never copied.
+- Marketplace/integration-managed values are excluded by default and must be reconnected in the destination account.
+- Custom Environment IDs are not portable between projects and are excluded.
+- `plain` and `encrypted` values are copied only when Vercel returns a decryptable value.
+- `sensitive` and legacy `secret` values cannot be read back from Vercel. They must be rotated directly into the destination project and verified there as `sensitive` metadata.
+- Any hidden production value, unreadable value, scope collision, type conflict, or parity mismatch blocks activation.
+- GitHub deployment routing changes only after the destination preview passes its health check.
+
+## One-time configuration
+
+1. Ensure the Vercel GitHub App for the new account can access `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`.
+2. Create a Vercel access token in the new account with access to the destination scope.
+3. Add that token as the GitHub Actions secret `VERCEL_TOKEN_NEW`. Prefer a repository secret so both the `preview` and `Production – dsg-qubo-api` environments can use it. If environment-scoped secrets are required, add the same secret name to both environments.
+4. Keep the existing `VERCEL_TOKEN` secret during migration; it is used only to read the legacy project.
+5. Never paste either token into a PR, issue, workflow input, log, or chat.
+
+## Run the migration
+
+Open **Actions → Sync Vercel ENV to New Account → Run workflow** and use the full current `main` commit SHA.
+
+First run:
+
+- `dry_run`: `true`
+- `include_integration_managed`: `false`
+- `acknowledge_rotated_protected`: `false`
+- `deploy_preview`: `true`
+
+If the dry-run reports protected keys:
+
+1. Create or open the destination project using the same project name.
+2. Rotate each reported key directly into the destination as a `sensitive` value with the same Production/Preview/Development and branch scope.
+3. Reconnect Supabase, storage, Redis, or other Vercel Marketplace integrations for every integration-managed entry.
+4. Re-run the dry-run with `acknowledge_rotated_protected: true`. The workflow verifies the destination key, target, branch, and `sensitive` type; it does not claim the old and new secret values match because the new value is intentionally rotated.
+
+After the dry-run passes, run again with:
+
+- `dry_run`: `false`
+- `acknowledge_rotated_protected`: `true` only when the previous step required it
+- `deploy_preview`: `true`
+
+The live run performs this sequence:
+
+1. Verify the dispatched SHA is the exact current `main` head.
+2. Read and classify legacy project environment metadata.
+3. Stop before mutation if any value cannot be migrated or acknowledged safely.
+4. Resolve or create the destination Next.js project.
+5. Upsert decryptable values while preserving type, target, and preview branch.
+6. Read the destination back and compare exact values in memory.
+7. Deploy and health-check a destination preview.
+8. Set repository variables `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, and `VERCEL_PROJECT_NAME`, then set `VERCEL_USE_NEW_ACCOUNT=true` to activate the new destination for later workflows. Merely adding `VERCEL_TOKEN_NEW` does not switch deployment traffic.
+
+## Recovery
+
+The legacy IDs remain as workflow fallbacks. If destination activation must be reversed, set `VERCEL_USE_NEW_ACCOUNT=false`. The workflows will use the legacy token and IDs. The legacy values are:
+
+| Variable | Legacy value |
+| --- | --- |
+| `VERCEL_ORG_ID` | `team_n189mlAdVHR6cGGiaAwsKzQ0` |
+| `VERCEL_PROJECT_ID` | `prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW` |
+
+Do not remove the legacy project or `VERCEL_TOKEN` until a promoted production deployment on the new project is healthy and its rollback evidence has been retained.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "deploy": "npx vercel deploy --target=preview --yes",
     "deploy:preview": "npx vercel deploy --target=preview --yes",
     "deploy:prod": "npx vercel deploy --prod --yes",
+    "vercel:env:sync": "node scripts/sync-vercel-envs.mjs",
     "go:no-go": "./scripts/go-no-go-gate.sh",
     "benchmark": "node scripts/benchmark-dsg.mjs",
     "benchmark:gateway": "node scripts/benchmark-gateway-production.mjs",

--- a/scripts/lib/vercel-env-sync.mjs
+++ b/scripts/lib/vercel-env-sync.mjs
@@ -1,0 +1,709 @@
+const VERCEL_API_ORIGIN = 'https://api.vercel.com';
+const TARGET_ORDER = new Map([
+  ['development', 0],
+  ['preview', 1],
+  ['production', 2],
+]);
+const COPYABLE_TYPES = new Set(['plain', 'encrypted']);
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const CONTROL_ENV_KEYS = new Set([
+  'ACTIONS_ID_TOKEN_REQUEST_TOKEN',
+  'ACTIONS_RUNTIME_TOKEN',
+  'CI',
+  'GITHUB_TOKEN',
+  'NODE_AUTH_TOKEN',
+  'NPM_TOKEN',
+]);
+
+export class VercelApiError extends Error {
+  constructor(message, { status, code } = {}) {
+    super(message);
+    this.name = 'VercelApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export class VercelEnvMigrationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'VercelEnvMigrationError';
+    this.details = details;
+  }
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function redactText(value, secrets = []) {
+  let redacted = typeof value === 'string' ? value : '';
+  for (const secret of secrets) {
+    if (typeof secret === 'string' && secret.length > 0) {
+      redacted = redacted.split(secret).join('[REDACTED]');
+    }
+  }
+  return redacted;
+}
+
+function apiErrorMessage(payload, secrets) {
+  const code = payload?.error?.code;
+  const message = payload?.error?.message;
+  return {
+    code: typeof code === 'string' ? code : undefined,
+    message: redactText(
+      typeof message === 'string' ? message : 'Vercel rejected the request',
+      secrets,
+    ),
+  };
+}
+
+function requestSecrets(body) {
+  const entries = Array.isArray(body) ? body : body ? [body] : [];
+  return entries
+    .map((entry) => entry?.value)
+    .filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+function retryDelay(response, attempt) {
+  const retryAfter = response.headers?.get?.('retry-after');
+  const parsed = Number.parseInt(retryAfter ?? '', 10);
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return Math.min(parsed * 1_000, 10_000);
+  }
+  return Math.min(500 * 2 ** attempt, 4_000);
+}
+
+function appendScope(url, teamId) {
+  if (teamId) {
+    url.searchParams.set('teamId', teamId);
+  }
+  return url;
+}
+
+export function createVercelApiClient({ token, teamId = '', fetchImpl = fetch }) {
+  if (!token) {
+    throw new VercelEnvMigrationError('A Vercel token is required');
+  }
+
+  async function request(path, { method = 'GET', body, allowNotFound = false } = {}) {
+    const secrets = requestSecrets(body);
+    const url = appendScope(new URL(path, VERCEL_API_ORIGIN), teamId);
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      let response;
+      try {
+        response = await fetchImpl(url, {
+          method,
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+            ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+          },
+          ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+          signal: AbortSignal.timeout(30_000),
+        });
+      } catch (error) {
+        if (attempt < 3) {
+          await sleep(Math.min(500 * 2 ** attempt, 4_000));
+          continue;
+        }
+        throw new VercelApiError(
+          `Vercel API ${method} request failed before a response was received`,
+        );
+      }
+
+      let payload = {};
+      try {
+        payload = await response.json();
+      } catch {
+        payload = {};
+      }
+
+      if (response.status === 404 && allowNotFound) {
+        return null;
+      }
+
+      if (!response.ok && RETRYABLE_STATUS_CODES.has(response.status) && attempt < 3) {
+        await sleep(retryDelay(response, attempt));
+        continue;
+      }
+
+      if (!response.ok) {
+        const error = apiErrorMessage(payload, secrets);
+        throw new VercelApiError(
+          `Vercel API ${method} failed (${response.status})${error.code ? ` [${error.code}]` : ''}: ${error.message}`,
+          { status: response.status, code: error.code },
+        );
+      }
+
+      return payload;
+    }
+
+    throw new VercelApiError(`Vercel API ${method} exhausted its retry budget`);
+  }
+
+  return {
+    teamId,
+    getProject(idOrName, options = {}) {
+      return request(`/v9/projects/${encodeURIComponent(idOrName)}`, options);
+    },
+    createProject({ name, gitRepository }) {
+      return request('/v11/projects', {
+        method: 'POST',
+        body: {
+          name,
+          framework: 'nextjs',
+          ...(gitRepository
+            ? { gitRepository: { type: 'github', repo: gitRepository } }
+            : {}),
+        },
+      });
+    },
+    listEnvironmentVariables(projectId) {
+      return request(
+        `/v10/projects/${encodeURIComponent(projectId)}/env?decrypt=true`,
+      );
+    },
+    getEnvironmentVariable(projectId, envId) {
+      return request(
+        `/v1/projects/${encodeURIComponent(projectId)}/env/${encodeURIComponent(envId)}`,
+      );
+    },
+    upsertEnvironmentVariables(projectId, entries) {
+      return request(
+        `/v10/projects/${encodeURIComponent(projectId)}/env?upsert=true`,
+        { method: 'POST', body: entries },
+      );
+    },
+  };
+}
+
+export function normalizeTargets(target) {
+  const values = Array.isArray(target) ? target : target ? [target] : [];
+  const normalized = [...new Set(values.map((value) => String(value).toLowerCase()))];
+  const invalid = normalized.filter((value) => !TARGET_ORDER.has(value));
+  if (invalid.length > 0 || normalized.length === 0) {
+    throw new VercelEnvMigrationError(
+      `Unsupported or missing Vercel target: ${invalid.join(', ') || '(missing)'}`,
+    );
+  }
+  return normalized.sort((left, right) => TARGET_ORDER.get(left) - TARGET_ORDER.get(right));
+}
+
+export function isSystemEnvironmentVariable(record) {
+  const key = typeof record?.key === 'string' ? record.key : '';
+  return (
+    record?.type === 'system' ||
+    record?.system === true ||
+    key.startsWith('VERCEL_') ||
+    key.startsWith('NOW_') ||
+    CONTROL_ENV_KEYS.has(key)
+  );
+}
+
+export function isIntegrationManagedEnvironmentVariable(record) {
+  const hint = record?.contentHint;
+  return Boolean(
+    record?.configurationId ||
+      record?.edgeConfigId ||
+      record?.edgeConfigTokenId ||
+      hint?.storeId ||
+      hint?.integrationConfigurationId ||
+      hint?.projectId,
+  );
+}
+
+function safeKey(record) {
+  return typeof record?.key === 'string' && record.key.length > 0
+    ? record.key
+    : '(invalid key)';
+}
+
+export function classifyEnvironmentVariables(
+  records,
+  { includeIntegrationManaged = false } = {},
+) {
+  const candidates = [];
+  const excluded = {
+    system: [],
+    integrationManaged: [],
+    customEnvironment: [],
+  };
+
+  for (const record of Array.isArray(records) ? records : []) {
+    if (isSystemEnvironmentVariable(record)) {
+      excluded.system.push(safeKey(record));
+    } else if (
+      isIntegrationManagedEnvironmentVariable(record) &&
+      !includeIntegrationManaged
+    ) {
+      excluded.integrationManaged.push(safeKey(record));
+    } else if (Array.isArray(record?.customEnvironmentIds) && record.customEnvironmentIds.length > 0) {
+      excluded.customEnvironment.push(safeKey(record));
+    } else {
+      candidates.push(record);
+    }
+  }
+
+  for (const keys of Object.values(excluded)) {
+    keys.sort();
+  }
+
+  return { candidates, excluded };
+}
+
+function normalizeScope(record) {
+  const key = safeKey(record);
+  if (key === '(invalid key)') {
+    throw new VercelEnvMigrationError('Environment variable has an invalid key');
+  }
+  const target = normalizeTargets(record.target);
+  const gitBranch = typeof record.gitBranch === 'string' && record.gitBranch.length > 0
+    ? record.gitBranch
+    : undefined;
+  if (gitBranch && !target.includes('preview')) {
+    throw new VercelEnvMigrationError(
+      `${key}: gitBranch is only valid for the preview target`,
+    );
+  }
+
+  return {
+    id: typeof record.id === 'string' ? record.id : undefined,
+    key,
+    target,
+    ...(gitBranch ? { gitBranch } : {}),
+  };
+}
+
+function normalizeMetadata(record) {
+  const scope = normalizeScope(record);
+  const sourceType = typeof record?.type === 'string' ? record.type.toLowerCase() : '';
+  if (!COPYABLE_TYPES.has(sourceType)) {
+    const reason = sourceType === 'sensitive' || sourceType === 'secret'
+      ? 'protected values must be rotated because Vercel cannot return them after creation'
+      : `type ${sourceType || '(missing)'} is unsupported`;
+    throw new VercelEnvMigrationError(`${scope.key}: ${reason}`);
+  }
+  return { ...scope, type: sourceType };
+}
+
+function readableListValue(record) {
+  if (record?.type === 'plain' && typeof record.value === 'string') {
+    return record.value;
+  }
+  if (record?.decrypted === true && typeof record.value === 'string') {
+    return record.value;
+  }
+  return undefined;
+}
+
+function readableDetailedValue(record) {
+  if (record?.decrypted === false || typeof record?.value !== 'string') {
+    return undefined;
+  }
+  return record.value;
+}
+
+export function environmentIdentity(record) {
+  const target = normalizeTargets(record.target);
+  const branch = typeof record.gitBranch === 'string' ? record.gitBranch : '';
+  return `${record.key}\u0000${target.join(',')}\u0000${branch}`;
+}
+
+function stableEnvironmentSort(left, right) {
+  return environmentIdentity(left).localeCompare(environmentIdentity(right)) ||
+    left.type.localeCompare(right.type);
+}
+
+function duplicateIdentities(records) {
+  const seen = new Set();
+  const duplicates = [];
+  for (const record of records) {
+    const identity = environmentIdentity(record);
+    if (seen.has(identity)) {
+      duplicates.push(record.key);
+    }
+    seen.add(identity);
+  }
+  return [...new Set(duplicates)].sort();
+}
+
+function formatKeys(keys) {
+  const visible = keys.slice(0, 40);
+  return `${visible.join(', ')}${keys.length > visible.length ? ` (+${keys.length - visible.length} more)` : ''}`;
+}
+
+export async function prepareMigrationPlan({
+  records,
+  sourceClient,
+  sourceProjectId,
+  includeIntegrationManaged = false,
+  acknowledgeRotatedProtected = false,
+}) {
+  const { candidates, excluded } = classifyEnvironmentVariables(records, {
+    includeIntegrationManaged,
+  });
+  const entries = [];
+  const protectedEntries = [];
+  const protectedOrUnsupported = [];
+  const unreadable = [];
+
+  for (const candidate of candidates) {
+    const sourceType = typeof candidate?.type === 'string'
+      ? candidate.type.toLowerCase()
+      : '';
+    if (sourceType === 'sensitive' || sourceType === 'secret') {
+      if (!acknowledgeRotatedProtected) {
+        protectedOrUnsupported.push(safeKey(candidate));
+        continue;
+      }
+      try {
+        protectedEntries.push({
+          ...normalizeScope(candidate),
+          type: 'sensitive',
+        });
+      } catch {
+        protectedOrUnsupported.push(safeKey(candidate));
+      }
+      continue;
+    }
+
+    let metadata;
+    try {
+      metadata = normalizeMetadata(candidate);
+    } catch (error) {
+      protectedOrUnsupported.push(safeKey(candidate));
+      continue;
+    }
+
+    let value = readableListValue(candidate);
+    if (value === undefined && metadata.id) {
+      const detailed = await sourceClient.getEnvironmentVariable(
+        sourceProjectId,
+        metadata.id,
+      );
+      value = readableDetailedValue(detailed);
+    }
+
+    if (value === undefined) {
+      unreadable.push(metadata.key);
+      continue;
+    }
+
+    entries.push({
+      key: metadata.key,
+      value,
+      type: metadata.type,
+      target: metadata.target,
+      ...(metadata.gitBranch ? { gitBranch: metadata.gitBranch } : {}),
+    });
+  }
+
+  entries.sort(stableEnvironmentSort);
+  protectedEntries.sort(stableEnvironmentSort);
+  protectedOrUnsupported.sort();
+  unreadable.sort();
+  const duplicates = duplicateIdentities([...entries, ...protectedEntries]);
+
+  if (protectedOrUnsupported.length > 0 || unreadable.length > 0 || duplicates.length > 0) {
+    const reasons = [];
+    if (protectedOrUnsupported.length > 0) {
+      reasons.push(`protected/unsupported: ${formatKeys(protectedOrUnsupported)}`);
+    }
+    if (unreadable.length > 0) {
+      reasons.push(`unreadable: ${formatKeys(unreadable)}`);
+    }
+    if (duplicates.length > 0) {
+      reasons.push(`duplicate scopes: ${formatKeys(duplicates)}`);
+    }
+    throw new VercelEnvMigrationError(
+      `ENV migration preflight failed; no destination values were changed. ${reasons.join('; ')}`,
+      { protectedOrUnsupported, unreadable, duplicates, excluded },
+    );
+  }
+
+  return {
+    entries,
+    protectedEntries,
+    excluded: {
+      ...excluded,
+      protectedRotated: protectedEntries.map((entry) => entry.key).sort(),
+    },
+  };
+}
+
+function destinationMetadataConflicts(sourceEntries, destinationRecords) {
+  const destinationByIdentity = new Map();
+  for (const record of destinationRecords) {
+    try {
+      destinationByIdentity.set(environmentIdentity(record), record);
+    } catch {
+      // Unrelated malformed destination entries are outside this migration's scope.
+    }
+  }
+
+  return sourceEntries
+    .filter((source) => {
+      const destination = destinationByIdentity.get(environmentIdentity(source));
+      return destination && destination.type !== source.type;
+    })
+    .map((source) => source.key)
+    .sort();
+}
+
+async function loadDestinationEntries({ destinationClient, destinationProjectId, sourceEntries }) {
+  const response = await destinationClient.listEnvironmentVariables(destinationProjectId);
+  const records = Array.isArray(response?.envs) ? response.envs : [];
+  const sourceIdentities = new Set(sourceEntries.map(environmentIdentity));
+  const hydrated = [];
+
+  for (const record of records) {
+    let identity;
+    try {
+      identity = environmentIdentity(record);
+    } catch {
+      continue;
+    }
+    if (!sourceIdentities.has(identity)) {
+      continue;
+    }
+
+    let value = readableListValue(record);
+    if (value === undefined && typeof record.id === 'string') {
+      const detailed = await destinationClient.getEnvironmentVariable(
+        destinationProjectId,
+        record.id,
+      );
+      value = readableDetailedValue(detailed);
+    }
+
+    hydrated.push({
+      key: record.key,
+      type: record.type,
+      target: normalizeTargets(record.target),
+      ...(record.gitBranch ? { gitBranch: record.gitBranch } : {}),
+      ...(value === undefined ? {} : { value }),
+    });
+  }
+
+  return { records, hydrated };
+}
+
+export function verifyEnvironmentParity(sourceEntries, destinationEntries) {
+  const destinationByIdentity = new Map(
+    destinationEntries.map((entry) => [environmentIdentity(entry), entry]),
+  );
+  const missing = [];
+  const unreadable = [];
+  const mismatched = [];
+
+  for (const source of sourceEntries) {
+    const destination = destinationByIdentity.get(environmentIdentity(source));
+    if (!destination) {
+      missing.push(source.key);
+    } else if (typeof destination.value !== 'string') {
+      unreadable.push(source.key);
+    } else if (destination.type !== source.type || destination.value !== source.value) {
+      mismatched.push(source.key);
+    }
+  }
+
+  return {
+    ok: missing.length === 0 && unreadable.length === 0 && mismatched.length === 0,
+    missing: [...new Set(missing)].sort(),
+    unreadable: [...new Set(unreadable)].sort(),
+    mismatched: [...new Set(mismatched)].sort(),
+  };
+}
+
+async function resolveDestinationProject({
+  destinationClient,
+  destinationProjectId,
+  destinationProjectName,
+  gitRepository,
+  dryRun,
+  requireExisting = false,
+}) {
+  const idOrName = destinationProjectId || destinationProjectName;
+  const existing = await destinationClient.getProject(idOrName, { allowNotFound: true });
+  if (existing) {
+    return { project: existing, created: false };
+  }
+  if (requireExisting) {
+    throw new VercelEnvMigrationError(
+      'Destination project must already exist with manually rotated sensitive values; no project or ENV values were changed',
+    );
+  }
+  if (dryRun) {
+    return { project: null, created: false };
+  }
+  const created = await destinationClient.createProject({
+    name: destinationProjectName,
+    gitRepository,
+  });
+  return { project: created, created: true };
+}
+
+function verifyRotatedProtectedMetadata(protectedEntries, destinationRecords) {
+  const destinationByIdentity = new Map();
+  for (const record of destinationRecords) {
+    try {
+      destinationByIdentity.set(environmentIdentity(record), record);
+    } catch {
+      // Ignore destination records unrelated to the authorized source scopes.
+    }
+  }
+  const missing = [];
+  const incompatible = [];
+  for (const source of protectedEntries) {
+    const destination = destinationByIdentity.get(environmentIdentity(source));
+    if (!destination) {
+      missing.push(source.key);
+    } else if (destination.type !== 'sensitive') {
+      incompatible.push(source.key);
+    }
+  }
+  return {
+    ok: missing.length === 0 && incompatible.length === 0,
+    missing: [...new Set(missing)].sort(),
+    incompatible: [...new Set(incompatible)].sort(),
+  };
+}
+
+export async function runVercelEnvMigration({
+  sourceClient,
+  sourceProjectId,
+  destinationClient,
+  destinationProjectId = '',
+  destinationProjectName,
+  gitRepository = '',
+  includeIntegrationManaged = false,
+  acknowledgeRotatedProtected = false,
+  dryRun = true,
+}) {
+  if (!sourceProjectId || !destinationProjectName) {
+    throw new VercelEnvMigrationError('Source project ID and destination project name are required');
+  }
+  if (
+    sourceClient.teamId &&
+    destinationClient.teamId &&
+    sourceClient.teamId === destinationClient.teamId
+  ) {
+    throw new VercelEnvMigrationError(
+      'Source and destination Vercel account IDs are identical; migration was not started',
+    );
+  }
+
+  const sourceResponse = await sourceClient.listEnvironmentVariables(sourceProjectId);
+  const sourceRecords = Array.isArray(sourceResponse?.envs) ? sourceResponse.envs : [];
+  const hiddenProductionEnvCount = Number(sourceResponse?.hiddenProductionEnvCount ?? 0);
+  if (hiddenProductionEnvCount > 0) {
+    throw new VercelEnvMigrationError(
+      `ENV migration preflight failed; Vercel withheld ${hiddenProductionEnvCount} protected production value(s). Rotate those values into the destination before retrying. No destination values were changed.`,
+      { hiddenProductionEnvCount },
+    );
+  }
+  const plan = await prepareMigrationPlan({
+    records: sourceRecords,
+    sourceClient,
+    sourceProjectId,
+    includeIntegrationManaged,
+    acknowledgeRotatedProtected,
+  });
+
+  const resolved = await resolveDestinationProject({
+    destinationClient,
+    destinationProjectId,
+    destinationProjectName,
+    gitRepository,
+    dryRun,
+    requireExisting: plan.protectedEntries.length > 0,
+  });
+
+  if (resolved.project?.id === sourceProjectId) {
+    throw new VercelEnvMigrationError(
+      'Destination resolved to the legacy source project; no ENV values were changed',
+    );
+  }
+  if (resolved.project?.accountId && resolved.project.accountId === sourceClient.teamId) {
+    throw new VercelEnvMigrationError(
+      'Destination resolved to the legacy source account; no ENV values were changed',
+    );
+  }
+
+  let destinationBefore = [];
+  if (resolved.project?.id && (plan.protectedEntries.length > 0 || !dryRun)) {
+    const before = await destinationClient.listEnvironmentVariables(resolved.project.id);
+    destinationBefore = Array.isArray(before?.envs) ? before.envs : [];
+  }
+
+  if (plan.protectedEntries.length > 0) {
+    const protectedVerification = verifyRotatedProtectedMetadata(
+      plan.protectedEntries,
+      destinationBefore,
+    );
+    if (!protectedVerification.ok) {
+      throw new VercelEnvMigrationError(
+        `Rotated sensitive ENV metadata verification failed; no destination values were changed. Missing: ${formatKeys(protectedVerification.missing)}; not sensitive: ${formatKeys(protectedVerification.incompatible)}`,
+        protectedVerification,
+      );
+    }
+  }
+
+  if (dryRun) {
+    return {
+      status: 'dry_run',
+      sourceCount: sourceRecords.length,
+      copyCount: plan.entries.length,
+      excluded: plan.excluded,
+      destinationProject: resolved.project,
+      destinationCreated: false,
+    };
+  }
+
+  const project = resolved.project;
+  if (!project?.id || !project?.accountId) {
+    throw new VercelEnvMigrationError('Destination project response lacked id or accountId');
+  }
+
+  const conflicts = destinationMetadataConflicts(
+    plan.entries,
+    destinationBefore,
+  );
+  if (conflicts.length > 0) {
+    throw new VercelEnvMigrationError(
+      `Destination contains incompatible ENV types; no values were changed: ${formatKeys(conflicts)}`,
+      { conflicts },
+    );
+  }
+
+  for (let index = 0; index < plan.entries.length; index += 50) {
+    await destinationClient.upsertEnvironmentVariables(
+      project.id,
+      plan.entries.slice(index, index + 50),
+    );
+  }
+
+  const destination = await loadDestinationEntries({
+    destinationClient,
+    destinationProjectId: project.id,
+    sourceEntries: plan.entries,
+  });
+  const verification = verifyEnvironmentParity(plan.entries, destination.hydrated);
+  if (!verification.ok) {
+    throw new VercelEnvMigrationError(
+      `Post-write verification failed. Missing: ${formatKeys(verification.missing)}; unreadable: ${formatKeys(verification.unreadable)}; mismatched: ${formatKeys(verification.mismatched)}`,
+      verification,
+    );
+  }
+
+  return {
+    status: 'verified',
+    sourceCount: sourceRecords.length,
+    copyCount: plan.entries.length,
+    excluded: plan.excluded,
+    destinationProject: project,
+    destinationCreated: resolved.created,
+  };
+}

--- a/scripts/sync-vercel-envs.mjs
+++ b/scripts/sync-vercel-envs.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from 'node:fs';
+import {
+  createVercelApiClient,
+  runVercelEnvMigration,
+  VercelEnvMigrationError,
+} from './lib/vercel-env-sync.mjs';
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new VercelEnvMigrationError(`Missing required configuration: ${name}`);
+  }
+  return value;
+}
+
+function booleanEnvironment(name, fallback = false) {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  throw new VercelEnvMigrationError(`${name} must be true or false`);
+}
+
+function countExcluded(excluded) {
+  return Object.values(excluded).reduce((total, keys) => total + keys.length, 0);
+}
+
+function writeOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`, 'utf8');
+}
+
+function writeSummary(result) {
+  if (!process.env.GITHUB_STEP_SUMMARY) {
+    return;
+  }
+  const project = result.destinationProject;
+  const lines = [
+    '## Vercel ENV migration evidence',
+    '',
+    `- Status: **${result.status}**`,
+    `- Source entries discovered: **${result.sourceCount}**`,
+    `- Application entries eligible: **${result.copyCount}**`,
+    `- System entries excluded: **${result.excluded.system.length}**`,
+    `- Integration-managed entries excluded: **${result.excluded.integrationManaged.length}**`,
+    `- Custom-environment entries excluded: **${result.excluded.customEnvironment.length}**`,
+    `- Sensitive entries verified as manually rotated: **${result.excluded.protectedRotated.length}**`,
+    `- Destination project: **${project?.name ?? 'not created during dry-run'}**`,
+    `- Destination created by this run: **${result.destinationCreated ? 'yes' : 'no'}**`,
+    '',
+    'No environment values were written to the workflow summary or outputs.',
+    '',
+  ];
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'), 'utf8');
+}
+
+async function main() {
+  const sourceClient = createVercelApiClient({
+    token: requiredEnvironment('OLD_VERCEL_TOKEN'),
+    teamId: requiredEnvironment('OLD_VERCEL_TEAM_ID'),
+  });
+  const destinationClient = createVercelApiClient({
+    token: requiredEnvironment('NEW_VERCEL_TOKEN'),
+    teamId: process.env.NEW_VERCEL_TEAM_ID ?? '',
+  });
+
+  const result = await runVercelEnvMigration({
+    sourceClient,
+    sourceProjectId: requiredEnvironment('OLD_VERCEL_PROJECT_ID'),
+    destinationClient,
+    destinationProjectId: process.env.NEW_VERCEL_PROJECT_ID ?? '',
+    destinationProjectName: requiredEnvironment('NEW_VERCEL_PROJECT_NAME'),
+    gitRepository: process.env.NEW_VERCEL_GIT_REPOSITORY ?? '',
+    includeIntegrationManaged: booleanEnvironment('INCLUDE_INTEGRATION_MANAGED'),
+    acknowledgeRotatedProtected: booleanEnvironment('ACKNOWLEDGE_ROTATED_PROTECTED'),
+    dryRun: booleanEnvironment('DRY_RUN', true),
+  });
+
+  writeOutput('verification_status', result.status);
+  writeOutput('source_count', result.sourceCount);
+  writeOutput('copy_count', result.copyCount);
+  writeOutput('excluded_count', countExcluded(result.excluded));
+  writeOutput('new_project_id', result.destinationProject?.id ?? '');
+  writeOutput('new_team_id', result.destinationProject?.accountId ?? '');
+  writeOutput('new_project_name', result.destinationProject?.name ?? '');
+  writeSummary(result);
+
+  process.stdout.write(
+    `Vercel ENV migration ${result.status}: ${result.copyCount} eligible, ${countExcluded(result.excluded)} safely excluded.\n`,
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : 'Unknown migration failure';
+  process.stderr.write(`Vercel ENV migration blocked: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/unit/scripts/vercel-env-sync.test.ts
+++ b/tests/unit/scripts/vercel-env-sync.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// @ts-expect-error The production helper is intentionally a native ESM module.
+import {
+  classifyEnvironmentVariables,
+  environmentIdentity,
+  prepareMigrationPlan,
+  runVercelEnvMigration,
+  verifyEnvironmentParity,
+} from '../../../scripts/lib/vercel-env-sync.mjs';
+
+describe('Vercel ENV migration', () => {
+  it('excludes system, integration-managed, and custom-environment values by default', () => {
+    const result = classifyEnvironmentVariables([
+      { key: 'VERCEL_URL', type: 'system' },
+      { key: 'GITHUB_TOKEN', type: 'encrypted' },
+      {
+        key: 'POSTGRES_URL',
+        type: 'encrypted',
+        contentHint: { type: 'postgres-url', storeId: 'store_1' },
+      },
+      {
+        key: 'CUSTOM_ONLY',
+        type: 'plain',
+        customEnvironmentIds: ['env_custom_1'],
+      },
+      { key: 'APP_URL', type: 'plain', target: ['production'], value: 'example' },
+    ]);
+
+    expect(result.candidates.map((entry: { key: string }) => entry.key)).toEqual(['APP_URL']);
+    expect(result.excluded).toEqual({
+      system: ['GITHUB_TOKEN', 'VERCEL_URL'],
+      integrationManaged: ['POSTGRES_URL'],
+      customEnvironment: ['CUSTOM_ONLY'],
+    });
+  });
+
+  it('preserves target, branch, and type with deterministic ordering', async () => {
+    const sourceClient = {
+      getEnvironmentVariable: vi.fn().mockResolvedValue({
+        type: 'encrypted',
+        value: 'resolved-value',
+        decrypted: true,
+      }),
+    };
+
+    const result = await prepareMigrationPlan({
+      records: [
+        {
+          id: 'env_b',
+          key: 'B_KEY',
+          type: 'encrypted',
+          target: ['production'],
+          decrypted: false,
+        },
+        {
+          id: 'env_a_preview',
+          key: 'A_KEY',
+          type: 'plain',
+          target: ['production', 'development', 'preview'],
+          gitBranch: 'release/test',
+          value: 'plain-value',
+        },
+        {
+          id: 'env_a_prod',
+          key: 'A_KEY',
+          type: 'plain',
+          target: ['production'],
+          value: 'production-value',
+        },
+      ],
+      sourceClient,
+      sourceProjectId: 'prj_source',
+    });
+
+    expect(result.entries).toEqual([
+      {
+        key: 'A_KEY',
+        value: 'plain-value',
+        type: 'plain',
+        target: ['development', 'preview', 'production'],
+        gitBranch: 'release/test',
+      },
+      {
+        key: 'A_KEY',
+        value: 'production-value',
+        type: 'plain',
+        target: ['production'],
+      },
+      {
+        key: 'B_KEY',
+        value: 'resolved-value',
+        type: 'encrypted',
+        target: ['production'],
+      },
+    ]);
+    expect(sourceClient.getEnvironmentVariable).toHaveBeenCalledOnce();
+  });
+
+  it('blocks protected values before any destination mutation', async () => {
+    const sourceClient = {
+      listEnvironmentVariables: vi.fn().mockResolvedValue({
+        envs: [
+          {
+            id: 'env_sensitive',
+            key: 'PAYMENT_SECRET',
+            type: 'sensitive',
+            target: ['production'],
+            decrypted: false,
+          },
+        ],
+        hiddenProductionEnvCount: 0,
+      }),
+      getEnvironmentVariable: vi.fn(),
+    };
+    const destinationClient = {
+      getProject: vi.fn(),
+      createProject: vi.fn(),
+      listEnvironmentVariables: vi.fn(),
+      upsertEnvironmentVariables: vi.fn(),
+    };
+
+    await expect(
+      runVercelEnvMigration({
+        sourceClient,
+        sourceProjectId: 'prj_source',
+        destinationClient,
+        destinationProjectName: 'dsg-control-plane',
+        dryRun: false,
+      }),
+    ).rejects.toThrow('PAYMENT_SECRET');
+
+    expect(destinationClient.getProject).not.toHaveBeenCalled();
+    expect(destinationClient.upsertEnvironmentVariables).not.toHaveBeenCalled();
+  });
+
+  it('blocks when Vercel reports hidden production values', async () => {
+    const destinationClient = { getProject: vi.fn(), upsertEnvironmentVariables: vi.fn() };
+    await expect(
+      runVercelEnvMigration({
+        sourceClient: {
+          listEnvironmentVariables: vi.fn().mockResolvedValue({
+            envs: [],
+            hiddenProductionEnvCount: 2,
+          }),
+        },
+        sourceProjectId: 'prj_source',
+        destinationClient,
+        destinationProjectName: 'dsg-control-plane',
+        dryRun: false,
+      }),
+    ).rejects.toThrow('withheld 2 protected production value(s)');
+    expect(destinationClient.getProject).not.toHaveBeenCalled();
+    expect(destinationClient.upsertEnvironmentVariables).not.toHaveBeenCalled();
+  });
+
+  it('accepts protected values only after sensitive destination metadata is verified', async () => {
+    const sourceClient = {
+      listEnvironmentVariables: vi.fn().mockResolvedValue({
+        envs: [
+          {
+            id: 'env_sensitive',
+            key: 'PAYMENT_SECRET',
+            type: 'sensitive',
+            target: ['production'],
+            decrypted: false,
+          },
+        ],
+        hiddenProductionEnvCount: 0,
+      }),
+      getEnvironmentVariable: vi.fn(),
+    };
+    const destinationClient = {
+      getProject: vi.fn().mockResolvedValue({
+        id: 'prj_destination',
+        accountId: 'team_destination',
+        name: 'dsg-control-plane',
+      }),
+      listEnvironmentVariables: vi.fn().mockResolvedValue({
+        envs: [
+          {
+            id: 'env_rotated',
+            key: 'PAYMENT_SECRET',
+            type: 'sensitive',
+            target: ['production'],
+          },
+        ],
+      }),
+    };
+
+    const result = await runVercelEnvMigration({
+      sourceClient,
+      sourceProjectId: 'prj_source',
+      destinationClient,
+      destinationProjectName: 'dsg-control-plane',
+      acknowledgeRotatedProtected: true,
+      dryRun: true,
+    });
+
+    expect(result.status).toBe('dry_run');
+    expect(result.copyCount).toBe(0);
+    expect(result.excluded.protectedRotated).toEqual(['PAYMENT_SECRET']);
+    expect(sourceClient.getEnvironmentVariable).not.toHaveBeenCalled();
+  });
+
+  it('upserts and reads back decryptable values before reporting verified', async () => {
+    const sourceClient = {
+      listEnvironmentVariables: vi.fn().mockResolvedValue({
+        envs: [
+          {
+            id: 'env_app_url',
+            key: 'APP_URL',
+            type: 'plain',
+            target: ['production'],
+            value: 'https://example.test',
+          },
+          {
+            id: 'env_api_token',
+            key: 'API_TOKEN',
+            type: 'encrypted',
+            target: ['preview', 'production'],
+            value: 'encrypted-value',
+            decrypted: true,
+          },
+        ],
+        hiddenProductionEnvCount: 0,
+      }),
+      getEnvironmentVariable: vi.fn(),
+    };
+    const destinationClient = {
+      getProject: vi.fn().mockResolvedValue({
+        id: 'prj_destination',
+        accountId: 'team_destination',
+        name: 'dsg-control-plane',
+      }),
+      createProject: vi.fn(),
+      listEnvironmentVariables: vi
+        .fn()
+        .mockResolvedValueOnce({ envs: [] })
+        .mockResolvedValueOnce({
+          envs: [
+            {
+              id: 'env_destination_app_url',
+              key: 'APP_URL',
+              type: 'plain',
+              target: ['production'],
+              value: 'https://example.test',
+            },
+            {
+              id: 'env_destination_api_token',
+              key: 'API_TOKEN',
+              type: 'encrypted',
+              target: ['production', 'preview'],
+              value: 'encrypted-value',
+              decrypted: true,
+            },
+          ],
+        }),
+      getEnvironmentVariable: vi.fn(),
+      upsertEnvironmentVariables: vi.fn().mockResolvedValue({ created: [] }),
+    };
+
+    const result = await runVercelEnvMigration({
+      sourceClient,
+      sourceProjectId: 'prj_source',
+      destinationClient,
+      destinationProjectName: 'dsg-control-plane',
+      dryRun: false,
+    });
+
+    expect(result.status).toBe('verified');
+    expect(result.copyCount).toBe(2);
+    expect(destinationClient.upsertEnvironmentVariables).toHaveBeenCalledOnce();
+    expect(destinationClient.createProject).not.toHaveBeenCalled();
+  });
+
+  it('reports parity failures by key without exposing either value', () => {
+    const source = [
+      {
+        key: 'API_TOKEN',
+        type: 'encrypted',
+        target: ['preview', 'production'],
+        value: 'source-value',
+      },
+      {
+        key: 'APP_URL',
+        type: 'plain',
+        target: ['production'],
+        value: 'https://example.test',
+      },
+    ];
+    const destination = [
+      {
+        key: 'API_TOKEN',
+        type: 'encrypted',
+        target: ['production', 'preview'],
+        value: 'different-value',
+      },
+    ];
+
+    expect(environmentIdentity(source[0])).toBe(environmentIdentity(destination[0]));
+    expect(verifyEnvironmentParity(source, destination)).toEqual({
+      ok: false,
+      missing: ['APP_URL'],
+      unreadable: [],
+      mismatched: ['API_TOKEN'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a fail-closed Vercel ENV migration script and manual workflow for the new account
- preserve environment target/type/preview branch, verify decryptable values after write, and require rotation metadata for non-readable sensitive values
- deploy and health-check a destination preview before atomically activating GitHub repository routing
- keep promoted production deployment, approval, evidence, health, and rollback gates unchanged

## Safety
- no ENV values are written to logs, artifacts, summaries, outputs, or repository files
- Vercel/system/CI values are never copied; integration-managed and custom-environment values are excluded by default
- merely adding `VERCEL_TOKEN_NEW` does not switch deployments; `VERCEL_USE_NEW_ACCOUNT=true` is set only after preview health passes

## Verification
- `node --check scripts/lib/vercel-env-sync.mjs`
- `node --check scripts/sync-vercel-envs.mjs`
- `npx vitest run tests/unit/scripts/vercel-env-sync.test.ts` (7/7 passed)
- `npm run typecheck`
- workflow YAML parse and `git diff --check`

## Operational note
`VERCEL_TOKEN_NEW` must be added as a GitHub Actions secret before dispatch. The currently connected Vercel integration still exposes only the legacy team, so no live ENV mutation or production deployment is claimed by this PR.