### PR TITLE
fix: discover authorized Vercel destination scope

### DIFF
--- a/.github/vercel-env-migration-request.json
+++ b/.github/vercel-env-migration-request.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "requestId": "dry-run-20260813-p1-repair",
+  "requestId": "dry-run-20260813-token-scope-probe",
   "newTeamId": "",
   "newProjectId": "",
   "newProjectName": "tdealer01-crypto-dsg-control-plane",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
         run: node scripts/resolve-vercel-routing.mjs
       - name: Verify Vercel credentials
         shell: bash

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Check available secrets
@@ -77,7 +77,7 @@ jobs:
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Install Vercel CLI

--- a/.github/workflows/promoted-production-deploy.yml
+++ b/.github/workflows/promoted-production-deploy.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Verify required release configuration
@@ -252,7 +252,7 @@ jobs:
     outputs:
       bootstrap_url: ${{ steps.bootstrap.outputs.bootstrap_url }}
     env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ inputs.destination_team_id }}
       VERCEL_PROJECT_ID: ${{ inputs.destination_project_id }}
       MIGRATION_REQUEST_ID: ${{ inputs.migration_request_id }}
@@ -296,6 +296,7 @@ jobs:
           node --check scripts/sync-vercel-envs.mjs
           node --check scripts/resolve-vercel-routing.mjs
           npx vitest run \
+            tests/unit/scripts/vercel-destination-auth.test.ts \
             tests/unit/scripts/vercel-env-sync.test.ts \
             tests/unit/scripts/vercel-routing.test.ts \
             tests/unit/scripts/vercel-env-migration-request.test.ts

--- a/.github/workflows/set-stripe-price-env.yml
+++ b/.github/workflows/set-stripe-price-env.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Validate required secrets

--- a/.github/workflows/sync-vercel-envs.yml
+++ b/.github/workflows/sync-vercel-envs.yml
@@ -105,11 +105,18 @@ jobs:
           test "${CHECKED_OUT,,}" = "${EXPECTED_MAIN_SHA,,}" || { echo "Checked-out commit mismatch"; exit 1; }
           test "$CHECKED_OUT" = "$MAIN_HEAD" || { echo "Commit is not current main head"; exit 1; }
 
+      - name: Resolve destination Vercel authorization
+        id: destination_auth
+        env:
+          LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          CONFIGURED_NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          REQUESTED_NEW_VERCEL_TEAM_ID: ${{ steps.request.outputs.new_team_id }}
+          LEGACY_VERCEL_TEAM_ID: team_n189mlAdVHR6cGGiaAwsKzQ0
+        run: node scripts/resolve-vercel-destination-auth.mjs
+
       - name: Validate migration configuration
         env:
           OLD_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
-          NEW_VERCEL_TEAM_ID: ${{ steps.request.outputs.new_team_id }}
           NEW_VERCEL_PROJECT_ID: ${{ steps.request.outputs.new_project_id }}
           NEW_VERCEL_PROJECT_NAME: ${{ steps.request.outputs.new_project_name }}
         shell: bash
@@ -128,7 +135,9 @@ jobs:
       - name: Check migration scripts
         run: |
           node --check scripts/lib/vercel-env-sync.mjs
+          node --check scripts/lib/vercel-destination-auth.mjs
           node --check scripts/sync-vercel-envs.mjs
+          node --check scripts/resolve-vercel-destination-auth.mjs
           node --check scripts/resolve-vercel-env-migration-request.mjs
           node --check scripts/resolve-vercel-routing.mjs
 
@@ -154,8 +163,6 @@ jobs:
           OLD_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           OLD_VERCEL_TEAM_ID: team_n189mlAdVHR6cGGiaAwsKzQ0
           OLD_VERCEL_PROJECT_ID: prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
-          NEW_VERCEL_TEAM_ID: ${{ steps.request.outputs.new_team_id }}
           NEW_VERCEL_PROJECT_ID: ${{ steps.request.outputs.new_project_id }}
           NEW_VERCEL_PROJECT_NAME: ${{ steps.request.outputs.new_project_name }}
           NEW_VERCEL_GIT_REPOSITORY: ${{ github.repository }}
@@ -167,21 +174,19 @@ jobs:
       - name: Pull verified destination preview configuration
         if: steps.request.outputs.dry_run == 'false' && steps.request.outputs.deploy_preview == 'true' && steps.sync.outputs.verification_status == 'verified'
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
           VERCEL_ORG_ID: ${{ steps.sync.outputs.new_team_id }}
           VERCEL_PROJECT_ID: ${{ steps.sync.outputs.new_project_id }}
-        run: npx --yes "vercel@$VERCEL_CLI_VERSION" pull --yes --environment=preview --token="$VERCEL_TOKEN"
+        run: npx --yes "vercel@$VERCEL_CLI_VERSION" pull --yes --environment=preview --token="$NEW_VERCEL_TOKEN"
 
       - name: Deploy destination preview
         id: preview
         if: steps.request.outputs.dry_run == 'false' && steps.request.outputs.deploy_preview == 'true' && steps.sync.outputs.verification_status == 'verified'
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
           VERCEL_ORG_ID: ${{ steps.sync.outputs.new_team_id }}
           VERCEL_PROJECT_ID: ${{ steps.sync.outputs.new_project_id }}
         shell: bash
         run: |
-          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" deploy --yes --token="$VERCEL_TOKEN" \
+          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" deploy --yes --token="$NEW_VERCEL_TOKEN" \
             --meta=migration_request="${{ steps.request.outputs.request_id }}" \
             --meta=migration_run="${{ github.run_id }}" \
             --meta=commit="${{ github.sha }}")

--- a/docs/deploy/vercel-account-env-migration.md
+++ b/docs/deploy/vercel-account-env-migration.md
@@ -19,9 +19,9 @@ The migration does not switch existing user traffic. Account routing changes onl
 ## One-time configuration
 
 1. Ensure the Vercel GitHub App for the new account can access `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`.
-2. Create a Vercel access token in the new account with access to the destination scope.
-3. Add that token as the GitHub Actions secret `VERCEL_TOKEN_NEW`. Prefer a repository secret so both the `preview` and `Production – dsg-qubo-api` environments can use it. If environment-scoped secrets are required, add the same secret name to both environments.
-4. Keep the existing `VERCEL_TOKEN` secret during migration; it is used only to read the legacy project.
+2. If the existing `VERCEL_TOKEN` already has access to exactly one non-legacy Vercel team, the workflow proves that scope through the Vercel Teams API and safely reuses the token with the distinct destination team ID.
+3. Otherwise, create a Vercel access token in the new account and add it as the GitHub Actions secret `VERCEL_TOKEN_NEW`. Prefer a repository secret so both the `preview` and `Production – dsg-qubo-api` environments can use it. If environment-scoped secrets are required, add the same secret name to both environments.
+4. Keep the existing `VERCEL_TOKEN` secret during migration; it remains the source credential and is reused for the destination only after the distinct-team authorization probe passes.
 5. Never paste either token into a PR, issue, workflow input, log, or chat.
 
 ## Run the migration without clicking Actions

--- a/scripts/lib/vercel-destination-auth.mjs
+++ b/scripts/lib/vercel-destination-auth.mjs
@@ -1,0 +1,104 @@
+const VERCEL_API_ORIGIN = 'https://api.vercel.com';
+
+export class VercelDestinationAuthError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'VercelDestinationAuthError';
+  }
+}
+
+function oneLineSecret(value, name) {
+  const normalized = typeof value === 'string' ? value : '';
+  if (/\r|\n/.test(normalized)) {
+    throw new VercelDestinationAuthError(`${name} must be a single-line token`);
+  }
+  return normalized;
+}
+
+function validTeamId(value) {
+  return typeof value === 'string' && /^[A-Za-z0-9_-]{3,128}$/.test(value);
+}
+
+export async function listAuthorizedTeams(token, { fetchImpl = fetch } = {}) {
+  const response = await fetchImpl(`${VERCEL_API_ORIGIN}/v2/teams?limit=100`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new VercelDestinationAuthError(
+      `Vercel rejected the existing-token scope probe (${response.status})`,
+    );
+  }
+  const payload = await response.json();
+  return (Array.isArray(payload?.teams) ? payload.teams : [])
+    .filter((team) => validTeamId(team?.id))
+    .map((team) => ({ id: team.id, name: typeof team.name === 'string' ? team.name : '' }));
+}
+
+export async function resolveDestinationAuthorization({
+  legacyToken,
+  configuredNewToken = '',
+  requestedTeamId = '',
+  legacyTeamId,
+  teamLoader = listAuthorizedTeams,
+}) {
+  const sourceToken = oneLineSecret(legacyToken, 'VERCEL_TOKEN');
+  const newToken = oneLineSecret(configuredNewToken, 'VERCEL_TOKEN_NEW');
+  if (!sourceToken) {
+    throw new VercelDestinationAuthError('Missing VERCEL_TOKEN');
+  }
+  if (!validTeamId(legacyTeamId)) {
+    throw new VercelDestinationAuthError('Invalid legacy Vercel team ID');
+  }
+  if (requestedTeamId && !validTeamId(requestedTeamId)) {
+    throw new VercelDestinationAuthError('Invalid requested destination Vercel team ID');
+  }
+  if (requestedTeamId === legacyTeamId) {
+    throw new VercelDestinationAuthError('Destination Vercel team is the legacy team');
+  }
+
+  if (newToken) {
+    return {
+      token: newToken,
+      teamId: requestedTeamId,
+      mode: 'dedicated-new-token',
+    };
+  }
+
+  const authorizedTeams = (await teamLoader(sourceToken))
+    .filter((team) => team.id !== legacyTeamId)
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  if (requestedTeamId) {
+    const requested = authorizedTeams.find((team) => team.id === requestedTeamId);
+    if (!requested) {
+      throw new VercelDestinationAuthError(
+        `VERCEL_TOKEN is not authorized for requested non-legacy team ${requestedTeamId}`,
+      );
+    }
+    return {
+      token: sourceToken,
+      teamId: requested.id,
+      mode: 'shared-authorized-token',
+    };
+  }
+
+  if (authorizedTeams.length === 1) {
+    return {
+      token: sourceToken,
+      teamId: authorizedTeams[0].id,
+      mode: 'shared-authorized-token',
+    };
+  }
+  if (authorizedTeams.length === 0) {
+    throw new VercelDestinationAuthError(
+      'VERCEL_TOKEN_NEW is missing and VERCEL_TOKEN authorizes no non-legacy Vercel team',
+    );
+  }
+  throw new VercelDestinationAuthError(
+    `VERCEL_TOKEN_NEW is missing and multiple non-legacy teams are authorized; set newTeamId to one of: ${authorizedTeams.map((team) => team.id).join(', ')}`,
+  );
+}

--- a/scripts/resolve-vercel-destination-auth.mjs
+++ b/scripts/resolve-vercel-destination-auth.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+import {
+  resolveDestinationAuthorization,
+  VercelDestinationAuthError,
+} from './lib/vercel-destination-auth.mjs';
+
+function writeLine(path, name, value) {
+  if (path) {
+    appendFileSync(path, `${name}=${value}\n`, 'utf8');
+  }
+}
+
+async function main() {
+  const result = await resolveDestinationAuthorization({
+    legacyToken: process.env.LEGACY_VERCEL_TOKEN ?? '',
+    configuredNewToken: process.env.CONFIGURED_NEW_VERCEL_TOKEN ?? '',
+    requestedTeamId: process.env.REQUESTED_NEW_VERCEL_TEAM_ID ?? '',
+    legacyTeamId: process.env.LEGACY_VERCEL_TEAM_ID ?? '',
+  });
+
+  writeLine(process.env.GITHUB_ENV, 'NEW_VERCEL_TOKEN', result.token);
+  writeLine(process.env.GITHUB_ENV, 'NEW_VERCEL_TEAM_ID', result.teamId);
+  writeLine(process.env.GITHUB_OUTPUT, 'destination_team_id', result.teamId);
+  writeLine(process.env.GITHUB_OUTPUT, 'credential_mode', result.mode);
+  process.stdout.write(
+    `Destination Vercel authorization resolved: ${result.mode}; team ${result.teamId || '(token default scope)'}.\n`,
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof VercelDestinationAuthError || error instanceof Error
+    ? error.message
+    : 'Unknown destination authorization failure';
+  process.stderr.write(`Destination Vercel authorization blocked: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/unit/scripts/vercel-destination-auth.test.ts
+++ b/tests/unit/scripts/vercel-destination-auth.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// @ts-expect-error The production helper is intentionally a native ESM module.
+import { resolveDestinationAuthorization } from '../../../scripts/lib/vercel-destination-auth.mjs';
+
+const legacyTeamId = 'team_legacy123';
+
+describe('resolveDestinationAuthorization', () => {
+  it('prefers a dedicated new-account token without probing the legacy token', async () => {
+    const teamLoader = vi.fn();
+    await expect(resolveDestinationAuthorization({
+      legacyToken: 'legacy-token',
+      configuredNewToken: 'new-token',
+      requestedTeamId: 'team_new123',
+      legacyTeamId,
+      teamLoader,
+    })).resolves.toEqual({
+      token: 'new-token',
+      teamId: 'team_new123',
+      mode: 'dedicated-new-token',
+    });
+    expect(teamLoader).not.toHaveBeenCalled();
+  });
+
+  it('reuses the existing token only when exactly one distinct team is authorized', async () => {
+    const teamLoader = vi.fn().mockResolvedValue([
+      { id: legacyTeamId, name: 'Legacy' },
+      { id: 'team_new123', name: 'New' },
+    ]);
+    await expect(resolveDestinationAuthorization({
+      legacyToken: 'legacy-token',
+      legacyTeamId,
+      teamLoader,
+    })).resolves.toEqual({
+      token: 'legacy-token',
+      teamId: 'team_new123',
+      mode: 'shared-authorized-token',
+    });
+  });
+
+  it('blocks fallback when no distinct destination team is authorized', async () => {
+    await expect(resolveDestinationAuthorization({
+      legacyToken: 'legacy-token',
+      legacyTeamId,
+      teamLoader: vi.fn().mockResolvedValue([{ id: legacyTeamId, name: 'Legacy' }]),
+    })).rejects.toThrow('authorizes no non-legacy Vercel team');
+  });
+
+  it('requires an explicit team when the existing token reaches multiple destinations', async () => {
+    await expect(resolveDestinationAuthorization({
+      legacyToken: 'legacy-token',
+      legacyTeamId,
+      teamLoader: vi.fn().mockResolvedValue([
+        { id: legacyTeamId, name: 'Legacy' },
+        { id: 'team_new123', name: 'New A' },
+        { id: 'team_new456', name: 'New B' },
+      ]),
+    })).rejects.toThrow('set newTeamId to one of: team_new123, team_new456');
+  });
+});


### PR DESCRIPTION
## Outcome

Automatically tests the only credential-free path left after migration run #1 proved `VERCEL_TOKEN_NEW` is absent.

## Changes

- prefer `VERCEL_TOKEN_NEW` when configured
- otherwise query Vercel's Teams API with the existing `VERCEL_TOKEN`
- reuse the existing token only when it is explicitly authorized for exactly one distinct, non-legacy team
- fail closed when no non-legacy team is visible or when multiple teams require disambiguation
- propagate the same authorized-token fallback through preview, protected bootstrap, readiness, deploy, and Stripe workflows
- rotate the versioned dry-run request ID so merge automatically triggers probe run #2
- add focused authorization-selection tests and update the runbook

## Safety

- dry-run remains `true`
- no ENV values are written
- no routing or user traffic is switched
- tokens are never written to logs, outputs, summaries, or repository files
- legacy team/project IDs remain forbidden as destinations
- production commands remain isolated in the protected production workflow

## Verification

- agent workspace production boundary — PASS
- typecheck — PASS
- production dependency audit — PASS, 0 vulnerabilities
- JSON and 5 workflow YAML files parse — PASS
- script syntax checks — PASS
- focused Vitest — 4 files, 19 tests, 19 passed
- git diff check — PASS