### PR TITLE
feat: prep Render migration path off blocked Vercel deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -865,6 +865,23 @@ After changing code:
 
 ## 23. Deployment and production control loop
 
+### Migration in progress: Vercel → Render (pending)
+
+As of 2026-08-13, the Vercel project below has an unresolved provisioning
+failure (see PR #1096) and a blocked follow-on account-migration attempt (PRs
+#1097–#1099, blocked on a missing authorized token — not a code issue). The
+decision is to move production to Render instead, mirroring the pattern
+already live in `dsg-one-v1` (`docs/FRAMER_RENDER_MIGRATION.md`). See
+`docs/RENDER_MIGRATION.md` for the full contract, `render.yaml` for the draft
+Blueprint, and the checklist there for what is done vs. still pending.
+
+Until that checklist's live-evidence items are checked off, the sections
+below remain the accurate description of what is actually live: Vercel git
+auto-deploy is already disabled (`vercel.json` → `git.deploymentEnabled`), and
+the production URL below is serving a stale commit, not current `main`. Do
+not treat this subsection as proof that Render is live — verify with the
+commands in `docs/RENDER_MIGRATION.md` before making that claim.
+
 ### Vercel project configuration (consolidated)
 
 DSG ONE uses a **single consolidated Vercel project**: `tdealer01-crypto-dsg-control-plane`.

--- a/docs/RENDER_MIGRATION.md
+++ b/docs/RENDER_MIGRATION.md
@@ -1,0 +1,94 @@
+# Vercel → Render Migration Contract
+
+Date: 2026-08-13
+
+## Why
+
+The consolidated Vercel project (`tdealer01-crypto-dsg-control-plane`) has an
+unresolved provisioning failure: git-triggered and CLI deployments both return
+`BUILD_FAILED: Resource provisioning failed` before a Vercel build log is even
+produced (see PR #1096). A follow-on attempt (PRs #1097–#1099) tried a
+fail-closed migration to a second Vercel account, but the automated dry-run is
+blocked on a real credential gap — no `VERCEL_TOKEN_NEW` secret is configured,
+and the existing `VERCEL_TOKEN` is not authorized for any non-legacy Vercel
+team. That path cannot proceed without a human adding a working token in the
+Vercel dashboard.
+
+Decision: stop pursuing the Vercel account migration and move the production
+runtime to Render instead, following the same pattern already completed for
+`dsg-one-v1` (see that repo's `docs/FRAMER_RENDER_MIGRATION.md`).
+
+As of this doc, `vercel.json` already has git auto-deploy disabled
+(`git.deploymentEnabled: { "*": false }`), so Vercel is not currently deploying
+`main` regardless of this migration. Live production
+(`https://tdealer01-crypto-dsg-control-plane.vercel.app`) is still serving commit
+`bb044e33` (PR #965, merged 2026-07-28) until a new origin is live.
+
+## What this change adds
+
+- `render.yaml` — a Render Blueprint defining:
+  - a `web` service (`dsg-control-plane`) running `npm ci && npm run build` /
+    `npm run start`, with `healthCheckPath: /api/health`.
+  - five `cron` services mirroring the five schedules currently in
+    `vercel.json`'s `crons` array (`flush-meter-outbox`, `reconcile-meter`,
+    `usage-alerts`, `trial-invite`, `weekly-report`), each a `curl` call to the
+    same protected route with the same `Authorization: Bearer $CRON_SECRET`
+    contract the routes already enforce (verified against each route's
+    exported `GET` handler and `CRON_SECRET` check).
+- `package.json` `start` script now honors `$PORT` (`next start -p
+  ${PORT:-3000}`) — required because Render assigns the service a port at
+  runtime; the previous hardcoded `-p 3000` would not bind to it.
+
+## What this change does NOT do
+
+- It does not create or connect a Render service. That is a one-time
+  dashboard action (or `render.yaml` Blueprint sync) that requires a Render
+  account and cannot be done from this repository alone.
+- It does not touch `vercel.json`, `.github/workflows/sync-vercel-envs.yml`,
+  or the other Vercel-specific workflows/scripts. They are left in place,
+  inert (auto-deploy already off), until Render is verified live.
+- It does not update the production URL referenced in `CLAUDE.md` §2 and §23,
+  or the smoke-check URLs baked into `docs/RUNBOOK_DEPLOY.md` / other
+  workflows. Those should change only after a Render origin is confirmed
+  `Ready` with live evidence — updating them now would be an unverified claim.
+- The `render.yaml` cron/env schema was checked against Render's published
+  Blueprint spec but has not been applied against a live Render account in
+  this session (no Render API/CLI access here). Treat it as a reviewed draft,
+  not a verified-working blueprint, until a Blueprint sync actually succeeds.
+
+## Manual cutover steps (human, in the Render dashboard)
+
+1. Create a new Blueprint from this repo (or a Web Service directly) pointed
+   at the `main` branch; Render should detect `render.yaml`.
+2. Set the `sync: false` env vars for the web service and each cron service
+   by name — see `.env.example` for the full variable list. At minimum the
+   web service needs `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`,
+   `SUPABASE_SERVICE_ROLE_KEY`, `ANTHROPIC_API_KEY`, `CRON_SECRET`, and
+   `APP_URL`/`NEXT_PUBLIC_APP_URL` pointed at the Render origin once assigned
+   (e.g. `https://dsg-control-plane.onrender.com`) — mirror the pattern in
+   `dsg-one-v1`'s `docs/FRAMER_RENDER_MIGRATION.md`.
+3. Deploy and wait for the web service to report `Ready`.
+4. Verify with live evidence, not assumption:
+   ```bash
+   curl -fsSL "https://<render-origin>/api/health"
+   curl -fsSL "https://<render-origin>/api/agent/status"
+   curl -fsSL "https://<render-origin>/api/readiness"
+   ```
+5. Confirm each cron service ran at least once (Render dashboard → service →
+   Logs) and returned a non-error status from the target route.
+6. Only after step 4 and 5 pass: update `CLAUDE.md` §2/§23, `docs/RUNBOOK_DEPLOY.md`,
+   and any workflow that hardcodes the Vercel production URL to point at the
+   Render origin instead, and disable/remove the now-unused Vercel project
+   and its GitHub Actions workflows.
+
+## Cutover checklist
+
+- [x] `render.yaml` blueprint added (web + 5 cron services).
+- [x] `start` script honors `$PORT`.
+- [ ] Render service created and connected to `main`.
+- [ ] Required env vars set in Render (by name, no values committed).
+- [ ] Render deployment reports `Ready`.
+- [ ] `/api/health`, `/api/agent/status`, `/api/readiness` verified live on the Render origin.
+- [ ] Cron services verified to have run successfully at least once each.
+- [ ] `CLAUDE.md`, `docs/RUNBOOK_DEPLOY.md`, and Vercel-referencing workflows updated to the Render origin.
+- [ ] Vercel project and its GitHub Actions workflows retired.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "node scripts/next-dev-compatible.mjs",
     "build": "next build",
-    "start": "next start -p 3000",
+    "start": "next start -p ${PORT:-3000}",
     "lint": "eslint app/ lib/ components/ --ext .ts,.tsx,.js,.jsx",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "db:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > lib/database.types.ts",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,95 @@
+services:
+  - type: web
+    name: dsg-control-plane
+    runtime: node
+    plan: starter
+    branch: main
+    buildCommand: npm ci && npm run build
+    startCommand: npm run start
+    healthCheckPath: /api/health
+    autoDeploy: true
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: APP_URL
+        sync: false
+      - key: NEXT_PUBLIC_APP_URL
+        sync: false
+      - key: NEXT_PUBLIC_SUPABASE_URL
+        sync: false
+      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: CRON_SECRET
+        sync: false
+
+  # Mirrors the schedules currently defined in vercel.json. Each job hits the
+  # same protected /api/cron/* route the Vercel cron previously called, using
+  # the same CRON_SECRET bearer-token contract the routes already enforce.
+  - type: cron
+    name: dsg-cron-flush-meter-outbox
+    runtime: node
+    plan: starter
+    schedule: "*/10 * * * *"
+    buildCommand: "true"
+    startCommand: 'curl -fsS -H "Authorization: Bearer $CRON_SECRET" "$APP_URL/api/cron/flush-meter-outbox"'
+    envVars:
+      - key: APP_URL
+        sync: false
+      - key: CRON_SECRET
+        sync: false
+
+  - type: cron
+    name: dsg-cron-reconcile-meter
+    runtime: node
+    plan: starter
+    schedule: "0 * * * *"
+    buildCommand: "true"
+    startCommand: 'curl -fsS -H "Authorization: Bearer $CRON_SECRET" "$APP_URL/api/cron/reconcile-meter"'
+    envVars:
+      - key: APP_URL
+        sync: false
+      - key: CRON_SECRET
+        sync: false
+
+  - type: cron
+    name: dsg-cron-usage-alerts
+    runtime: node
+    plan: starter
+    schedule: "0 8 * * *"
+    buildCommand: "true"
+    startCommand: 'curl -fsS -H "Authorization: Bearer $CRON_SECRET" "$APP_URL/api/cron/usage-alerts"'
+    envVars:
+      - key: APP_URL
+        sync: false
+      - key: CRON_SECRET
+        sync: false
+
+  - type: cron
+    name: dsg-cron-trial-invite
+    runtime: node
+    plan: starter
+    schedule: "0 9 * * *"
+    buildCommand: "true"
+    startCommand: 'curl -fsS -H "Authorization: Bearer $CRON_SECRET" "$APP_URL/api/cron/trial-invite"'
+    envVars:
+      - key: APP_URL
+        sync: false
+      - key: CRON_SECRET
+        sync: false
+
+  - type: cron
+    name: dsg-cron-weekly-report
+    runtime: node
+    plan: starter
+    schedule: "0 10 * * 1"
+    buildCommand: "true"
+    startCommand: 'curl -fsS -H "Authorization: Bearer $CRON_SECRET" "$APP_URL/api/cron/weekly-report"'
+    envVars:
+      - key: APP_URL
+        sync: false
+      - key: CRON_SECRET
+        sync: false


### PR DESCRIPTION
Goal:

Continue from PR #1096: the consolidated Vercel project has an unresolved `BUILD_FAILED: Resource provisioning failed` and the follow-on account-migration attempt (#1097–#1099) is blocked on a real credential gap (no `VERCEL_TOKEN_NEW`, and `VERCEL_TOKEN` isn't authorized for any non-legacy Vercel team — confirmed from the probe-run-#2 job logs after #1099 merged). Per direction, stop chasing the Vercel migration and prepare a Render deployment path instead, mirroring the pattern already live in `dsg-one-v1` (`docs/FRAMER_RENDER_MIGRATION.md`).

Files changed:
- `render.yaml` — new Render Blueprint: one `web` service (`npm ci && npm run build` / `npm run start`, `healthCheckPath: /api/health`) plus 5 `cron` services mirroring the exact schedules in `vercel.json`'s `crons` array, each a `curl` call to the same protected `/api/cron/*` route using the `Authorization: Bearer $CRON_SECRET` contract those routes already enforce.
- `package.json` — `start` script changed from `next start -p 3000` to `next start -p ${PORT:-3000}`; Render assigns the service a port at runtime, and the hardcoded port would prevent the service from ever becoming reachable.
- `docs/RENDER_MIGRATION.md` — new migration contract: why, what this PR does and explicitly does NOT do, manual cutover steps for the Render dashboard (env vars, verification commands), and a checklist so the remaining live-evidence steps aren't lost.
- `CLAUDE.md` — added a short pointer subsection at the top of §23 linking to the above, without rewriting the existing Vercel section (which is still an accurate description of what's currently live/stale).

Verification:
- [x] Inspected `vercel.json`, all 5 target cron routes' exported HTTP method (`GET`) and `CRON_SECRET` check, `.nvmrc` (node 24), and `package.json` scripts/engines before writing `render.yaml`.
- [x] `node -e "require('./package.json')"` — valid JSON.
- [x] `python3 -c "yaml.safe_load(open('render.yaml'))"` — valid YAML, 6 services parsed.
- [x] `git diff --check` — passed, no whitespace errors.
- [x] Verified `${PORT:-3000}` shell expansion behavior locally (falls back to 3000 when unset, uses `$PORT` when set).
- [ ] No live Render account/API access in this session — `render.yaml`'s cron/env schema was checked against Render's published Blueprint spec but has not been applied against a real Render account. Treated as a reviewed draft, not a verified-working blueprint, in both this PR and `docs/RENDER_MIGRATION.md`.
- [ ] `npm run typecheck` / `npm run build` not run — no TypeScript/app code changed, only a shell-invoked npm script string and docs/config.

Known limits:
- This PR does not create or connect an actual Render service — that requires a human with Render dashboard access (see the manual cutover steps in `docs/RENDER_MIGRATION.md`).
- `vercel.json` and Vercel-specific GitHub Actions workflows are untouched and left inert (git auto-deploy was already disabled before this PR).
- Production URLs referenced in `CLAUDE.md`, `docs/RUNBOOK_DEPLOY.md`, and other workflows are NOT updated yet — that should only happen once a Render origin reports `Ready` with live `/api/health`, `/api/agent/status`, `/api/readiness` evidence, per the checklist in `docs/RENDER_MIGRATION.md`.
- Live production is currently still serving commit `bb044e33` (PR #965, merged 2026-07-28) — confirmed via `curl https://tdealer01-crypto-dsg-control-plane.vercel.app/api/agent/status` — regardless of this change.

User-visible benefit:
- A reviewed, ready-to-sync deployment path exists so a human can connect Render in a few dashboard steps instead of continuing to fight the blocked Vercel account migration.

Next step:
- A human creates the Render Blueprint/service from this branch (or `main` after merge), sets the `sync: false` env vars by name, and works through the verification checklist in `docs/RENDER_MIGRATION.md`. Only after that checklist's live-evidence items pass should `CLAUDE.md`/`docs/RUNBOOK_DEPLOY.md` be updated to point at the new origin and the Vercel project retired.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVWnqNDW3oxUk7yTsHBw2H)_