### PR TITLE
fix: is_first_execution always true due to phantom global hook

### DIFF
--- a/app/api/spine/execute/route.ts
+++ b/app/api/spine/execute/route.ts
@@ -13,6 +13,7 @@ import { meterExecution } from '../../../../lib/billing/metered';
 import { verifySafeDomIntentOrPass } from '../../../../lib/spine/verify-safe-dom-intent';
 import { StopReason } from '../../../../lib/types/task';
 import { captureEvent } from '../../../../lib/telemetry/capture-event';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
 
@@ -158,17 +159,20 @@ export async function POST(request: Request) {
     const agentId = String(agent.id);
 
     // Check if this is first execution for agent (before quota check)
-    const { count: agentExecutions } = await (async () => {
+    const agentExecutions = await (async () => {
       try {
-        // Try to get execution count, but don't fail if unavailable
-        const result = await (global as any).__supabaseExecutionCount?.(agentId);
-        return { count: result?.count || 0 };
+        const supabase = getSupabaseAdmin();
+        const { count } = await supabase
+          .from('executions')
+          .select('id', { count: 'exact', head: true })
+          .eq('agent_id', agentId);
+        return count || 0;
       } catch {
-        return { count: 0 };
+        return 0;
       }
     })();
 
-    const isFirstExecution = (agentExecutions || 0) === 0;
+    const isFirstExecution = agentExecutions === 0;
 
     // Extract policyId and requestType from payload context/input
     const policyId = (payload.context.policy_id || payload.input.policy_id) as string | undefined;


### PR DESCRIPTION
Goal:
Fix the `is_first_execution` PostHog property in `/api/spine/execute` always reporting `true`, even for an agent's 2nd/3rd/Nth execution. Flagged by a PostHog timeline review of org `472a1980-...`, which showed three `execution_submitted` events for the same agent within one minute, all marked `is_first_execution: true`.

Root cause: the route computed the count via `(global as any).__supabaseExecutionCount?.(agentId)` — a global hook never defined anywhere in the codebase. The optional call always resolved to `undefined`, so the count defaulted to `0` and `is_first_execution` was unconditionally `true`.

Files changed:
- `app/api/spine/execute/route.ts` — replaced the phantom `__supabaseExecutionCount` global-hook call with a real `count`-only Supabase query against `public.executions` scoped to `agent_id`, matching the reference implementation already documented in `.telemetry/tracking-guide.md`. Added the `getSupabaseAdmin` import.

Verification:
- [x] Inspected `public.executions` schema (`supabase/schema.sql`) — confirms `agent_id` column and a supporting `(org_id, agent_id, created_at)` index.
- [x] `npm run typecheck` — pass
- [x] `npm run test -- tests/integration/api/spine-execute.test.ts` — 8/8 pass
- [x] `npm run test -- tests/integration/api/spine-evidence-chain.test.ts tests/integration/api/spine-execute-safe-dom.test.ts` — 22/22 pass

Known limits:
- No dedicated regression test was added asserting `is_first_execution` is `false` on a 2nd execution for the same agent (existing test suite mocks Supabase at a level that doesn't exercise this query's count value).
- Fix is code-only; it does not touch or backfill already-recorded PostHog events, so historical `is_first_execution: true` duplicates in existing data remain as-is.
- Live/production behavior not verified against a real Supabase instance in this session — verification was via the local test suite with Supabase calls mocked/absent.

User-visible benefit:
Product/growth analytics (e.g. onboarding funnel, first-execution activation tracking) will now see an accurate signal instead of every execution looking like a first-time activation.

Next step:
Consider adding a targeted integration test that seeds two rows in a mocked/live `executions` table for one agent and asserts the second `execution_submitted` event carries `is_first_execution: false`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QiHfcunNbvMBRswQUiRShb)_