### PR TITLE
fix: is_first_execution always true due to non-existent global hook

### DIFF
--- a/app/api/spine/execute/route.ts
+++ b/app/api/spine/execute/route.ts
@@ -10,6 +10,7 @@ import { logQuotaConsumption } from '../../../../lib/database/quotas';
 import { checkQuota } from '../../../../lib/usage/quota';
 import { fireWebhook } from '../../../../lib/webhooks/deliver';
 import { meterExecution } from '../../../../lib/billing/metered';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { verifySafeDomIntentOrPass } from '../../../../lib/spine/verify-safe-dom-intent';
 import { StopReason } from '../../../../lib/types/task';
 import { captureEvent } from '../../../../lib/telemetry/capture-event';
@@ -160,9 +161,13 @@ export async function POST(request: Request) {
     // Check if this is first execution for agent (before quota check)
     const { count: agentExecutions } = await (async () => {
       try {
-        // Try to get execution count, but don't fail if unavailable
-        const result = await (global as any).__supabaseExecutionCount?.(agentId);
-        return { count: result?.count || 0 };
+        const supabase = getSupabaseAdmin();
+        const { count, error } = await supabase
+          .from('executions')
+          .select('id', { count: 'exact', head: true })
+          .eq('agent_id', agentId);
+        if (error) throw error;
+        return { count: count ?? 0 };
       } catch {
         return { count: 0 };
       }

--- a/tests/integration/api/spine-execute.test.ts
+++ b/tests/integration/api/spine-execute.test.ts
@@ -318,6 +318,69 @@ describe('/api/spine/execute', () => {
     expect(incrementQuota).not.toHaveBeenCalled();
   });
 
+  it('reports is_first_execution based on the real executions count, not a stub', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+    mockQuota();
+
+    const resolveAgentFromApiKey = vi.fn(async () => ({
+      id: 'agt_1',
+      org_id: 'org_1',
+      status: 'active',
+    }));
+    const executeSpineIntent = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: { request_id: 'req_1', decision: 'ALLOW', stop_reason: 'NONE' },
+    }));
+    const captureEvent = vi.fn(async () => undefined);
+
+    // Simulate an agent that already has 3 prior rows in `executions`.
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => Promise.resolve({ count: 3, error: null })),
+    }));
+    const from = vi.fn(() => ({ select }));
+
+    vi.doMock('../../../lib/agent-auth', () => ({ resolveAgentFromApiKey }));
+    vi.doMock('../../../lib/spine/engine', () => ({ executeSpineIntent, issueSpineIntent: vi.fn() }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: {},
+        context: {},
+        canonicalRequest: { action: 'scan', input: {}, context: {} },
+      })),
+    }));
+    vi.doMock('../../../lib/telemetry/capture-event', () => ({ captureEvent }));
+    vi.doMock('../../../lib/supabase-server', () => ({
+      getSupabaseAdmin: vi.fn(() => ({ from })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer dsg_live_good',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ agent_id: 'agt_1' }),
+    });
+
+    const res = await POST(req as never);
+    expect(res.status).toBe(200);
+
+    expect(from).toHaveBeenCalledWith('executions');
+    expect(captureEvent).toHaveBeenCalledWith(
+      'execution_submitted',
+      expect.objectContaining({ agentId: 'agt_1' }),
+      expect.objectContaining({ is_first_execution: false })
+    );
+  });
+
   it('issues intent and retries execute when no pending runtime intent exists', async () => {
     mockCors();
     mockRateLimit();


### PR DESCRIPTION
Goal:
Fix a bug flagged in a PostHog usage analysis of the `finance_skills` plan: org `472a1980-...`'s agent `4442bdf2-...` produced three `execution_submitted` events in ~1 minute, all with `is_first_execution: true`, which should not repeat for the same agent.

Files changed:
- `app/api/spine/execute/route.ts` — `isFirstExecution` was computed by calling `(global as any).__supabaseExecutionCount?.(agentId)`, a global hook that is never assigned anywhere in the codebase. The optional call always resolves to `undefined`, so `count` always defaulted to `0` and `is_first_execution` was `true` on every request. Replaced it with a real Supabase count query against the `executions` table (`select('id', { count: 'exact', head: true }).eq('agent_id', agentId)`), using the existing `getSupabaseAdmin` helper — the same table this route's runtime-commit RPC already inserts into.
- `tests/integration/api/spine-execute.test.ts` — added a regression test that mocks `getSupabaseAdmin` to report 3 prior `executions` rows for an agent and asserts `captureEvent('execution_submitted', ...)` receives `is_first_execution: false` (previously this would incorrectly assert `true`).

Verification:
- [x] `npm run typecheck` — no new errors from this change (pre-existing `TS5101` deprecation warnings on `baseUrl`/`downlevelIteration` are present on `main` too, unrelated to this diff — confirmed via `git stash`).
- [x] `npm run test -- tests/integration/api/spine-execute.test.ts tests/unit/api/spine-execute-phase2.test.ts tests/integration/api/execute-compat.test.ts` — 24 tests passed, including the new regression test.
- [x] `npm run build` — completed successfully.

Known limits:
- No live Supabase credentials in this environment, so the query path itself was verified via a mocked `getSupabaseAdmin` in the test, not against a live database.
- This only fixes the `is_first_execution` telemetry flag. It does not address the other items noted in the same analysis (verifying the Stripe `cs_live_...` checkout session completed, or adding an in-app nudge toward evidence export) — those are separate follow-ups.
- Under true concurrent requests for the same agent within the same uncommitted transaction window, two requests could theoretically still both see `count = 0`. This is an inherent race in count-based "first execution" detection and matches the original design intent (the broken code was already attempting a count-based approach); it is a smaller and much rarer race than the previous bug, which was wrong on every single call.

User-visible benefit:
`is_first_execution` in PostHog will now correctly reflect whether this is genuinely the agent's first execution, unblocking accurate first-run/activation analysis for the `finance_skills` plan cohort.

Next step:
Separately verify the Stripe `cs_live_b1dghaKYLHlSht3lK7ywykkCbAmUt767rEkdf62FAzYjj8m7fWjkiRxmaN` checkout session status directly in Stripe (not covered by this PR), and consider an in-app nudge after execution completion to drive evidence export.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJivvyuWNktWJuA1hXRzhT)_