### PR TITLE
fix: real z3-solver calls in /api/dsg/z3/prove and /verify-plan

### DIFF
--- a/app/api/dsg/z3/prove/route.ts
+++ b/app/api/dsg/z3/prove/route.ts
@@ -4,6 +4,7 @@ import { buildCorsHeaders, buildPreflightResponse } from '@/lib/security/cors';
 import { readJsonBody } from '@/lib/security/request-json';
 import { logServerError, serverErrorResponse } from '@/lib/security/error-response';
 import type { Z3ConstraintSet } from '@/lib/spine/types';
+import { init } from 'z3-solver';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,21 +37,84 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const proof = {
-      theorem,
-      status: 'PROVEN' as const,
-      proof_hash: Buffer.from(theorem + JSON.stringify(constraints))
-        .toString('hex')
-        .slice(0, 32),
-      constraints_id: constraints.id || 'default',
-      constraint_count: constraints.constraints?.length || 0,
-      sla_contracts: constraints.slaContracts.length,
-      security_invariants: constraints.securityInvariants.length,
-      proof_time_ms: Math.random() * 500,
-      verified_at: new Date().toISOString(),
-    };
+    const startTime = Date.now();
 
-    return NextResponse.json(proof, { headers: corsHeaders });
+    try {
+      const { Context } = await init();
+      const ctx = Context('main');
+      const solver = new ctx.Solver();
+
+      try {
+        solver.set('timeout', timeout);
+      } catch {
+        // Older Z3 binaries may not support timeout; continue anyway
+      }
+
+      // Load caller-supplied declarations/assumptions (raw SMT-LIB v2 strings).
+      if (Array.isArray(constraints.constraints)) {
+        for (const constraint of constraints.constraints) {
+          if (typeof constraint === 'string') {
+            solver.fromString(constraint);
+          }
+        }
+      }
+
+      // A theorem holds under the given constraints iff
+      // (constraints AND NOT theorem) is unsatisfiable.
+      solver.fromString(`(assert (not ${theorem}))`);
+
+      const statusStr = await solver.check();
+      const status: 'PROVEN' | 'DISPROVEN' | 'UNKNOWN' =
+        statusStr === 'unsat' ? 'PROVEN' : statusStr === 'sat' ? 'DISPROVEN' : 'UNKNOWN';
+
+      let counterexample: Record<string, string> | null = null;
+      if (statusStr === 'sat') {
+        try {
+          const m = solver.model();
+          counterexample = {};
+          for (const decl of m.decls()) {
+            counterexample[decl.name().toString()] = m.get(decl).toString();
+          }
+        } catch {
+          // Model extraction is best-effort
+        }
+      }
+
+      const proof = {
+        theorem,
+        status,
+        counterexample,
+        proof_hash: Buffer.from(
+          JSON.stringify({ theorem, constraints, status, counterexample })
+        ).toString('hex').slice(0, 32),
+        constraints_id: constraints.id || 'default',
+        constraint_count: constraints.constraints?.length || 0,
+        sla_contracts: constraints.slaContracts.length,
+        security_invariants: constraints.securityInvariants.length,
+        proof_time_ms: Date.now() - startTime,
+        verified_at: new Date().toISOString(),
+      };
+
+      return NextResponse.json(proof, { headers: corsHeaders });
+    } catch (solverError) {
+      logServerError(solverError, 'z3-solver-prove');
+      return NextResponse.json(
+        {
+          theorem,
+          status: 'ERROR' as const,
+          error: 'Z3 solver error',
+          counterexample: null,
+          proof_hash: '',
+          constraints_id: constraints.id || 'default',
+          constraint_count: constraints.constraints?.length || 0,
+          sla_contracts: constraints.slaContracts.length,
+          security_invariants: constraints.securityInvariants.length,
+          proof_time_ms: Date.now() - startTime,
+          verified_at: new Date().toISOString(),
+        },
+        { status: 500, headers: corsHeaders }
+      );
+    }
   } catch (error) {
     logServerError(error, 'z3-prove');
     return serverErrorResponse({ status: 500 });

--- a/app/api/dsg/z3/verify-plan/route.ts
+++ b/app/api/dsg/z3/verify-plan/route.ts
@@ -3,12 +3,35 @@ import type { NextRequest } from 'next/server';
 import { buildCorsHeaders, buildPreflightResponse } from '@/lib/security/cors';
 import { readJsonBody } from '@/lib/security/request-json';
 import { logServerError, serverErrorResponse } from '@/lib/security/error-response';
-import type { Z3ConstraintSet } from '@/lib/spine/types';
+import type { Z3ConstraintSet, SLAContract } from '@/lib/spine/types';
+import { init } from 'z3-solver';
 
 export const dynamic = 'force-dynamic';
 
 export async function OPTIONS(request: NextRequest) {
   return buildPreflightResponse(request);
+}
+
+const SMT_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const OP_SYMBOL: Record<SLAContract['operator'], string> = {
+  lt: '<',
+  lte: '<=',
+  gt: '>',
+  gte: '>=',
+};
+
+function smtNum(n: number): string {
+  return n < 0 ? `(- ${Math.abs(n)})` : String(n);
+}
+
+interface CheckResult {
+  constraint_id: string;
+  kind: 'sla' | 'security_invariant' | 'resource_limit';
+  description: string;
+  evaluated: boolean;
+  satisfied: boolean | null;
+  severity?: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -36,28 +59,147 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const planHash = Buffer.from(JSON.stringify(plan))
-      .toString('hex')
-      .slice(0, 32);
-    const constraintHash = Buffer.from(JSON.stringify(constraints))
-      .toString('hex')
-      .slice(0, 32);
+    const startTime = Date.now();
+    const planHash = Buffer.from(JSON.stringify(plan)).toString('hex').slice(0, 32);
+    const constraintHash = Buffer.from(JSON.stringify(constraints)).toString('hex').slice(0, 32);
+
+    const checks: CheckResult[] = [];
+
+    try {
+      const { Context } = await init();
+      const ctx = Context('main');
+
+      // A requirement is violated iff NOT(requirement) is satisfiable under
+      // the plan's fixed variable bindings — each check gets its own solver.
+      const runCheck = async (
+        id: string,
+        kind: CheckResult['kind'],
+        description: string,
+        boundVars: Array<{ name: string; value: number }>,
+        requirement: string,
+        severity?: string
+      ): Promise<CheckResult> => {
+        try {
+          const solver = new ctx.Solver();
+          const decls = boundVars
+            .map((v) => `(declare-const ${v.name} Real) (assert (= ${v.name} ${smtNum(v.value)}))`)
+            .join(' ');
+          if (decls) solver.fromString(decls);
+          solver.fromString(`(assert (not ${requirement}))`);
+          const status = await solver.check();
+          return { constraint_id: id, kind, description, evaluated: true, satisfied: status === 'unsat', severity };
+        } catch {
+          return { constraint_id: id, kind, description, evaluated: false, satisfied: null, severity };
+        }
+      };
+
+      for (const contract of constraints.slaContracts || []) {
+        const id = `sla-${contract.metric}`;
+        const actual = plan[contract.metric];
+        if (!SMT_IDENTIFIER.test(contract.metric) || typeof actual !== 'number') {
+          checks.push({ constraint_id: id, kind: 'sla', description: contract.description, evaluated: false, satisfied: null });
+          continue;
+        }
+        const requirement = `(${OP_SYMBOL[contract.operator]} ${contract.metric} ${smtNum(contract.threshold)})`;
+        checks.push(
+          await runCheck(id, 'sla', contract.description, [{ name: contract.metric, value: actual }], requirement)
+        );
+      }
+
+      // Security invariant expressions are expected as SMT-LIB v2 boolean
+      // terms over numeric plan fields; every numeric plan field is bound
+      // so invariants may reference any of them.
+      const planNumericVars = Object.entries(plan)
+        .filter((entry): entry is [string, number] => SMT_IDENTIFIER.test(entry[0]) && typeof entry[1] === 'number')
+        .map(([name, value]) => ({ name, value }));
+
+      for (const invariant of constraints.securityInvariants || []) {
+        checks.push(
+          await runCheck(
+            `security-${invariant.name}`,
+            'security_invariant',
+            invariant.name,
+            planNumericVars,
+            invariant.expression,
+            invariant.severity
+          )
+        );
+      }
+
+      const resourceLimits = constraints.resourceLimits;
+      if (resourceLimits) {
+        const resourceChecks: Array<{ key: string; planField: string; limit: number }> = [
+          { key: 'maxConcurrentExecutions', planField: 'concurrentExecutions', limit: resourceLimits.maxConcurrentExecutions },
+          { key: 'maxMemoryMB', planField: 'memoryMB', limit: resourceLimits.maxMemoryMB },
+          { key: 'maxRpsPerAgent', planField: 'requestsPerSecond', limit: resourceLimits.maxRpsPerAgent },
+        ];
+        for (const rc of resourceChecks) {
+          const id = `resource-${rc.key}`;
+          const description = `${rc.planField} <= ${rc.key}`;
+          const actual = plan[rc.planField];
+          if (typeof actual !== 'number' || typeof rc.limit !== 'number') {
+            checks.push({ constraint_id: id, kind: 'resource_limit', description, evaluated: false, satisfied: null });
+            continue;
+          }
+          const requirement = `(<= ${rc.planField} ${smtNum(rc.limit)})`;
+          checks.push(await runCheck(id, 'resource_limit', description, [{ name: rc.planField, value: actual }], requirement));
+        }
+      }
+    } catch (solverError) {
+      logServerError(solverError, 'z3-solver-verify-plan');
+      return NextResponse.json(
+        {
+          plan_hash: planHash,
+          constraint_hash: constraintHash,
+          status: 'ERROR' as const,
+          error: 'Z3 solver error',
+          checks: [],
+          violations: [],
+          verification_time_ms: Date.now() - startTime,
+          verified_at: new Date().toISOString(),
+        },
+        { status: 500, headers: corsHeaders }
+      );
+    }
+
+    const evaluatedChecks = checks.filter((c) => c.evaluated);
+    const violations = evaluatedChecks
+      .filter((c) => c.satisfied === false)
+      .slice(0, max_violations)
+      .map((c) => ({
+        constraint_id: c.constraint_id,
+        severity: c.severity || 'medium',
+        description: c.description,
+      }));
+
+    const slaChecks = evaluatedChecks.filter((c) => c.kind === 'sla');
+    const securityChecks = evaluatedChecks.filter((c) => c.kind === 'security_invariant');
+    const resourceLimitChecks = evaluatedChecks.filter((c) => c.kind === 'resource_limit');
+
+    const complianceScore =
+      evaluatedChecks.length > 0
+        ? Math.round((evaluatedChecks.filter((c) => c.satisfied).length / evaluatedChecks.length) * 10000) / 100
+        : 0;
+
+    // Only claim VERIFIED when something was actually checked — an empty or
+    // fully-skipped check set must never read as a pass.
+    const status: 'VERIFIED' | 'VIOLATIONS_FOUND' | 'INCONCLUSIVE' =
+      violations.length > 0 ? 'VIOLATIONS_FOUND' : evaluatedChecks.length > 0 ? 'VERIFIED' : 'INCONCLUSIVE';
 
     const verification = {
       plan_hash: planHash,
       constraint_hash: constraintHash,
-      status: 'VERIFIED' as const,
-      violations: [] as Array<{
-        constraint_id: string;
-        severity: string;
-        description: string;
-      }>,
-      compliance_score: 100,
-      sla_compliant: true,
-      security_invariants_satisfied: true,
-      resource_limits_respected: true,
+      status,
+      checks_total: checks.length,
+      checks_evaluated: evaluatedChecks.length,
+      checks_skipped: checks.length - evaluatedChecks.length,
+      violations,
+      compliance_score: complianceScore,
+      sla_compliant: slaChecks.every((c) => c.satisfied),
+      security_invariants_satisfied: securityChecks.every((c) => c.satisfied),
+      resource_limits_respected: resourceLimitChecks.every((c) => c.satisfied),
       verified_at: new Date().toISOString(),
-      verification_time_ms: Math.random() * 200,
+      verification_time_ms: Date.now() - startTime,
     };
 
     return NextResponse.json(verification, { headers: corsHeaders });

--- a/app/api/spine/execute/route.ts
+++ b/app/api/spine/execute/route.ts
@@ -10,6 +10,7 @@ import { logQuotaConsumption } from '../../../../lib/database/quotas';
 import { checkQuota } from '../../../../lib/usage/quota';
 import { fireWebhook } from '../../../../lib/webhooks/deliver';
 import { meterExecution } from '../../../../lib/billing/metered';
+import { getSupabaseAdmin } from '../../../../lib/supabase-server';
 import { verifySafeDomIntentOrPass } from '../../../../lib/spine/verify-safe-dom-intent';
 import { StopReason } from '../../../../lib/types/task';
 import { captureEvent } from '../../../../lib/telemetry/capture-event';
@@ -160,9 +161,13 @@ export async function POST(request: Request) {
     // Check if this is first execution for agent (before quota check)
     const { count: agentExecutions } = await (async () => {
       try {
-        // Try to get execution count, but don't fail if unavailable
-        const result = await (global as any).__supabaseExecutionCount?.(agentId);
-        return { count: result?.count || 0 };
+        const supabase = getSupabaseAdmin();
+        const { count, error } = await supabase
+          .from('executions')
+          .select('id', { count: 'exact', head: true })
+          .eq('agent_id', agentId);
+        if (error) throw error;
+        return { count: count ?? 0 };
       } catch {
         return { count: 0 };
       }

--- a/tests/integration/api/spine-execute.test.ts
+++ b/tests/integration/api/spine-execute.test.ts
@@ -318,6 +318,69 @@ describe('/api/spine/execute', () => {
     expect(incrementQuota).not.toHaveBeenCalled();
   });
 
+  it('reports is_first_execution based on the real executions count, not a stub', async () => {
+    mockCors();
+    mockRateLimit();
+    mockApiError();
+    mockQuota();
+
+    const resolveAgentFromApiKey = vi.fn(async () => ({
+      id: 'agt_1',
+      org_id: 'org_1',
+      status: 'active',
+    }));
+    const executeSpineIntent = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: { request_id: 'req_1', decision: 'ALLOW', stop_reason: 'NONE' },
+    }));
+    const captureEvent = vi.fn(async () => undefined);
+
+    // Simulate an agent that already has 3 prior rows in `executions`.
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => Promise.resolve({ count: 3, error: null })),
+    }));
+    const from = vi.fn(() => ({ select }));
+
+    vi.doMock('../../../lib/agent-auth', () => ({ resolveAgentFromApiKey }));
+    vi.doMock('../../../lib/spine/engine', () => ({ executeSpineIntent, issueSpineIntent: vi.fn() }));
+    vi.doMock('../../../lib/spine/request', () => ({
+      normalizeSpinePayload: vi.fn(() => ({
+        agentId: 'agt_1',
+        action: 'scan',
+        input: {},
+        context: {},
+        canonicalRequest: { action: 'scan', input: {}, context: {} },
+      })),
+    }));
+    vi.doMock('../../../lib/telemetry/capture-event', () => ({ captureEvent }));
+    vi.doMock('../../../lib/supabase-server', () => ({
+      getSupabaseAdmin: vi.fn(() => ({ from })),
+    }));
+
+    const { POST } = await import('../../../app/api/spine/execute/route');
+
+    const req = new Request('http://localhost/api/spine/execute', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example.com',
+        authorization: 'Bearer dsg_live_good',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ agent_id: 'agt_1' }),
+    });
+
+    const res = await POST(req as never);
+    expect(res.status).toBe(200);
+
+    expect(from).toHaveBeenCalledWith('executions');
+    expect(captureEvent).toHaveBeenCalledWith(
+      'execution_submitted',
+      expect.objectContaining({ agentId: 'agt_1' }),
+      expect.objectContaining({ is_first_execution: false })
+    );
+  });
+
   it('issues intent and retries execute when no pending runtime intent exists', async () => {
     mockCors();
     mockRateLimit();

--- a/tests/integration/api/z3-prove-verify-plan.test.ts
+++ b/tests/integration/api/z3-prove-verify-plan.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { POST as proveRoute } from '../../../app/api/dsg/z3/prove/route';
+import { POST as verifyPlanRoute } from '../../../app/api/dsg/z3/verify-plan/route';
+import type { Z3ConstraintSet } from '../../../lib/spine/types';
+
+function baseConstraints(overrides: Partial<Z3ConstraintSet> = {}): Z3ConstraintSet {
+  return {
+    slaContracts: [],
+    securityInvariants: [],
+    resourceLimits: { maxConcurrentExecutions: 10, maxMemoryMB: 512, maxRpsPerAgent: 100 },
+    auditRequirements: [],
+    ...overrides,
+  };
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: 'POST',
+    headers: { origin: 'https://app.example.com', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/dsg/z3/prove — real z3-solver theorem proving', () => {
+  it('returns PROVEN when the theorem is a real logical consequence of the constraints', async () => {
+    const constraints = baseConstraints({
+      constraints: ['(declare-const x Int) (assert (> x 0)) (assert (< x 10))'],
+    });
+
+    const res = await proveRoute(
+      jsonRequest('http://localhost/api/dsg/z3/prove', {
+        constraints,
+        theorem: '(> x -1)',
+      }) as never
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('PROVEN');
+    expect(body.counterexample).toBeNull();
+  });
+
+  it('returns DISPROVEN with a counterexample when the theorem does not always hold', async () => {
+    const constraints = baseConstraints({
+      constraints: ['(declare-const y Int) (assert (> y 0)) (assert (< y 10))'],
+    });
+
+    const res = await proveRoute(
+      jsonRequest('http://localhost/api/dsg/z3/prove', {
+        constraints,
+        theorem: '(> y 5)',
+      }) as never
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('DISPROVEN');
+    expect(body.counterexample).not.toBeNull();
+  });
+
+  it('returns 400 when theorem is missing', async () => {
+    const res = await proveRoute(
+      jsonRequest('http://localhost/api/dsg/z3/prove', {
+        constraints: baseConstraints(),
+      }) as never
+    );
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('/api/dsg/z3/verify-plan — real z3-solver plan verification', () => {
+  it('reports VERIFIED when the plan satisfies all SLA contracts', async () => {
+    const constraints = baseConstraints({
+      slaContracts: [
+        { metric: 'latency_p99_ms', operator: 'lt', threshold: 500, description: 'p99 under 500ms' },
+      ],
+    });
+
+    const res = await verifyPlanRoute(
+      jsonRequest('http://localhost/api/dsg/z3/verify-plan', {
+        plan: { latency_p99_ms: 300 },
+        constraints,
+      }) as never
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('VERIFIED');
+    expect(body.violations).toHaveLength(0);
+    expect(body.sla_compliant).toBe(true);
+  });
+
+  it('reports VIOLATIONS_FOUND when the plan breaches an SLA contract', async () => {
+    const constraints = baseConstraints({
+      slaContracts: [
+        { metric: 'latency_p99_ms', operator: 'lt', threshold: 500, description: 'p99 under 500ms' },
+      ],
+    });
+
+    const res = await verifyPlanRoute(
+      jsonRequest('http://localhost/api/dsg/z3/verify-plan', {
+        plan: { latency_p99_ms: 800 },
+        constraints,
+      }) as never
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('VIOLATIONS_FOUND');
+    expect(body.violations).toEqual([
+      expect.objectContaining({ constraint_id: 'sla-latency_p99_ms' }),
+    ]);
+    expect(body.compliance_score).toBe(0);
+  });
+
+  it('never reports VERIFIED when nothing could be evaluated (regression guard for the old always-pass mock)', async () => {
+    const constraints = baseConstraints({
+      slaContracts: [
+        { metric: 'latency_p99_ms', operator: 'lt', threshold: 500, description: 'p99 under 500ms' },
+      ],
+    });
+
+    // Plan carries no field matching the contract's metric, so it can't be evaluated.
+    const res = await verifyPlanRoute(
+      jsonRequest('http://localhost/api/dsg/z3/verify-plan', {
+        plan: { unrelated_field: 1 },
+        constraints,
+      }) as never
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('INCONCLUSIVE');
+    expect(body.checks_evaluated).toBe(0);
+    expect(body.compliance_score).toBe(0);
+  });
+
+  it('evaluates a security invariant expressed as an SMT-LIB v2 term over plan variables', async () => {
+    const constraints = baseConstraints({
+      securityInvariants: [
+        { name: 'token-budget', expression: '(<= tokensUsed maxTokenBudget)', severity: 'high' },
+      ],
+    });
+
+    const res = await verifyPlanRoute(
+      jsonRequest('http://localhost/api/dsg/z3/verify-plan', {
+        plan: { tokensUsed: 500, maxTokenBudget: 1000000 },
+        constraints,
+      }) as never
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('VERIFIED');
+    expect(body.security_invariants_satisfied).toBe(true);
+  });
+
+  it('returns 400 when plan or constraints are missing', async () => {
+    const res = await verifyPlanRoute(
+      jsonRequest('http://localhost/api/dsg/z3/verify-plan', {
+        constraints: baseConstraints(),
+      }) as never
+    );
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Goal:
Follow-up to issue #1104 (P0 item 1: audit mock-Z3 simulation consumers). While auditing `app/api/dsg/z3/*`, found `POST /api/dsg/z3/prove` and `POST /api/dsg/z3/verify-plan` were fully hardcoded — `prove` always returned `status: 'PROVEN'` with `Math.random()` timing, and `verify-plan` always returned `status: 'VERIFIED'`, `compliance_score: 100`, and every `*_satisfied` flag `true`, regardless of input. Neither called Z3 at all. (Their sibling route, `/api/dsg/z3/evaluate`, already did real Z3 solving via the `z3-solver` package — used as the reference implementation here.)

Files changed:
- `app/api/dsg/z3/prove/route.ts` — now builds a real `z3-solver` `Solver`, loads the caller's constraints, asserts the negation of the theorem, and checks satisfiability: `unsat` → `PROVEN`, `sat` → `DISPROVEN` (with an extracted counterexample model), `unknown`/solver error → `UNKNOWN`/`ERROR`. `proof_time_ms` is now a real measured duration.
- `app/api/dsg/z3/verify-plan/route.ts` — now binds each numeric field of the submitted `plan` to Z3 constants and checks SLA contracts, security invariants (as SMT-LIB v2 boolean terms over plan variables), and resource limits by asserting the negation of each requirement via a real solver call. Anything that can't be evaluated (missing plan field, unparseable expression) is marked not-evaluated rather than silently counted as passing — the route can no longer report `VERIFIED` when nothing was actually checked (new `INCONCLUSIVE` status covers that case).
- `tests/integration/api/z3-prove-verify-plan.test.ts` (new) — 8 tests exercising both routes against the real solver: proven/disproven theorems with counterexample extraction, satisfied/violated SLA contracts, a security-invariant check over two bound plan variables, the `INCONCLUSIVE` regression guard (nothing evaluated ⇒ never `VERIFIED`), and 400s for missing input.

Verification:
- [x] Standalone smoke script directly against `z3-solver` (declare-const/assert/check, negative-literal wrapping, multi-variable invariant, theorem refutation with counterexample) — all 6 cases matched expected SAT/UNSAT results. Not committed (scratch-only), but full output:
  ```
  SLA satisfied case (expect true): true
  SLA violated case (expect false): false
  Negative literal case (expect true, -5 > -10): true
  Multi-var invariant case (expect true): true
  Prove PROVEN case (expect unsat): unsat
  Prove DISPROVEN case (expect sat): sat
    counterexample: { y: '1' }
  ```
- [x] `npm run typecheck` — pass, 0 errors
- [x] `npm run test -- tests/integration/api/z3-prove-verify-plan.test.ts` — 8/8 pass
- [x] `npm run test:unit` — 218 files / 3021 tests pass (no regressions)
- [x] `npm run build` — pass

Known limits:
- `prove`'s `theorem` and `verify-plan`'s `securityInvariants[].expression` are expected to be valid SMT-LIB v2 boolean terms. This is a new explicit contract for these two routes (previously undefined, since both were stubs); callers passing free-text/JS-style expressions will get `evaluated: false` (verify-plan) or a caught solver error (prove) rather than a crash or a false pass.
- `verify-plan`'s resource-limit checks look for specific plan field names (`concurrentExecutions`, `memoryMB`, `requestsPerSecond`); a plan that doesn't use those names is marked not-evaluated for that check rather than assumed compliant.
- This PR does not address the `lib/deeptutor/*` continuous-simulator mock (tracked separately in #1104's item 1) or the `lib/spine/types.ts` policy-hash gap (#1104's item 2).
- This branch also carries an earlier commit (`0b8605c`, fixing `is_first_execution` always being `true`) from a duplicate of #1101, which is the surviving PR for that fix — that commit is not new work in this PR, only the two commits touching `app/api/dsg/z3/*` and the new test file are.

User-visible benefit:
`POST /api/dsg/z3/prove` and `POST /api/dsg/z3/verify-plan` now perform genuine constraint solving instead of returning a fixed "everything passes" response — callers get real proof/violation results instead of a false sense of formal verification.

Next step:
Continue #1104: audit `lib/deeptutor/*` simulation output for the same "presented as real Z3" risk, and confirm `computePolicyHash()` includes the newer `Z3ConstraintSet` fields.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJivvyuWNktWJuA1hXRzhT)_