### PR TITLE
docs: fix Claude plugin install command

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -4,10 +4,18 @@ Production AI governance control plane for Claude Code. Makes every Agent decisi
 
 ## 🚀 Installation
 
-### Claude Code CLI
+### One-line install (ClaudePluginHub)
 ```bash
-claude plugin add https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane
+claude plugin marketplace add tdealer01-crypto/tdealer01-crypto-dsg-control-plane && claude plugin install dsg-governance@dsg-plugins
 ```
+
+### Claude Code CLI — step by step
+```bash
+claude plugin marketplace add tdealer01-crypto/tdealer01-crypto-dsg-control-plane
+claude plugin install dsg-governance@dsg-plugins
+```
+
+The repository is the `dsg-plugins` marketplace. The `dsg-governance` plugin is distributed from `plugins/dsg-governance` through `.claude-plugin/marketplace.json`.
 
 ### Claude.ai
 Visit the Claude Code plugin marketplace and search for "DSG Governance Control Plane"
@@ -217,5 +225,5 @@ MIT — See LICENSE file in repository
 ---
 
 **Version:** 1.0.0  
-**Last Updated:** 2026-07-01  
+**Last Updated:** 2026-08-14  
 **Status:** Production-Connected


### PR DESCRIPTION
## Goal
Replace the obsolete direct plugin-add command with the current Claude Code marketplace install flow so ClaudePluginHub users get a working copy/paste command.

## Files changed
- `.claude-plugin/README.md`

## Verification
- Verified current repo marketplace name is `dsg-plugins` and includes `dsg-governance` under `metadata.pluginRoot: ./plugins`.
- Verified the plugin directory exists at `plugins/dsg-governance`.
- Checked current Anthropic Claude Code documentation: the supported non-interactive flow is `claude plugin marketplace add <source>` followed by `claude plugin install <plugin>@<marketplace>`.
- Re-fetched the branch file after commit and confirmed the new one-line and step-by-step commands are present.

## Known limits
- I did not claim `claude plugin validate .` was executed in a live Claude Code runtime; this environment cannot run the Claude Code CLI against the repository.
- ClaudePluginHub's owner-only `Set install command` field is external platform state and is not changed by this GitHub PR.

## User-visible benefit
Users now see a current install path instead of the obsolete `claude plugin add <repo>` command.

## Next step
After merge, set ClaudePluginHub's install command to:
`claude plugin marketplace add tdealer01-crypto/tdealer01-crypto-dsg-control-plane && claude plugin install dsg-governance@dsg-plugins`
