### PR TITLE
fix: add real Trinity MCP server files with verified stdio smoke test

### DIFF
--- a/trinity-mcp-server/.env.example
+++ b/trinity-mcp-server/.env.example
@@ -1,0 +1,10 @@
+# Trinity MCP Server Configuration
+
+# Trinity Backend API URL
+TRINITY_API_URL=http://localhost:3001
+
+# Optional: JWT token for authenticated requests
+TRINITY_JWT_TOKEN=
+
+# Server Configuration
+NODE_ENV=development

--- a/trinity-mcp-server/.gitignore
+++ b/trinity-mcp-server/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.local
+.DS_Store
+*.log

--- a/trinity-mcp-server/MCP_SERVER_SETUP.md
+++ b/trinity-mcp-server/MCP_SERVER_SETUP.md
@@ -1,0 +1,63 @@
+# Trinity DSG MCP Server Setup
+
+## What is verified
+
+The package builds and its stdio MCP transport can complete a protocol handshake and list 8 tools. Run:
+
+```bash
+npm install
+npm test
+```
+
+Expected result: one passing smoke test named `MCP server starts and lists exactly the 8 Trinity tools`.
+
+## Backend configuration
+
+The MCP bridge calls a separate Trinity Backend. Set:
+
+```bash
+export TRINITY_API_URL=https://your-trinity-backend.example.com
+# Optional:
+export TRINITY_JWT_TOKEN=your-token
+```
+
+Then run:
+
+```bash
+npm start
+```
+
+## Configure an MCP client
+
+Use an absolute path to the compiled server:
+
+```json
+{
+  "mcpServers": {
+    "trinity": {
+      "command": "node",
+      "args": ["/absolute/path/to/trinity-mcp-server/dist/index.js"],
+      "env": {
+        "TRINITY_API_URL": "https://your-trinity-backend.example.com"
+      }
+    }
+  }
+}
+```
+
+## Available tools
+
+- `trinity_health_check`
+- `trinity_get_agents`
+- `trinity_set_agent_mode`
+- `trinity_execute_task`
+- `trinity_chat_agent`
+- `trinity_get_costs`
+- `trinity_get_audit_logs`
+- `trinity_get_state`
+
+## Important deployment boundary
+
+The current implementation uses MCP **stdio transport**. It is designed to be spawned by a local MCP client. A remote Trinity Backend can be used through `TRINITY_API_URL`, but this package is not itself an HTTP MCP endpoint.
+
+Before claiming end-to-end production readiness, verify the real backend, database, auth, and all eight route contracts.

--- a/trinity-mcp-server/README.md
+++ b/trinity-mcp-server/README.md
@@ -1,0 +1,81 @@
+# Trinity DSG MCP Server
+
+A stdio MCP bridge between an MCP client and a Trinity Backend API.
+
+## Verified in this package
+
+- TypeScript build succeeds with `@modelcontextprotocol/sdk` 1.30.0.
+- The MCP process starts over stdio.
+- `tools/list` returns exactly 8 tools.
+- A protocol smoke test is included in `test/list-tools.test.mjs`.
+
+These checks do **not** prove that a remote Trinity Backend, Supabase database, authentication, or agent execution is live. Those require a reachable backend and separate integration tests.
+
+## Tools
+
+1. `trinity_health_check` → `GET /api/health`
+2. `trinity_get_agents` → `GET /api/agents/status`
+3. `trinity_set_agent_mode` → `POST /api/agents/mode`
+4. `trinity_execute_task` → `POST /api/agents/execute`
+5. `trinity_chat_agent` → `POST /api/agents/chat`
+6. `trinity_get_costs` → `GET /api/cost/tracker`
+7. `trinity_get_audit_logs` → `GET /api/security/audit`
+8. `trinity_get_state` → `GET /api/state/continuity`
+
+## Setup
+
+```bash
+npm install
+npm test
+```
+
+`npm test` builds the server and performs a real MCP stdio handshake plus `tools/list`.
+
+Configure the backend URL when running the server:
+
+```bash
+TRINITY_API_URL=https://your-trinity-backend.example.com npm start
+```
+
+Optional authenticated backend:
+
+```bash
+TRINITY_API_URL=https://your-trinity-backend.example.com \
+TRINITY_JWT_TOKEN=your-token \
+npm start
+```
+
+## MCP client configuration
+
+```json
+{
+  "mcpServers": {
+    "trinity": {
+      "command": "node",
+      "args": ["/absolute/path/to/trinity-mcp-server/dist/index.js"],
+      "env": {
+        "TRINITY_API_URL": "https://your-trinity-backend.example.com"
+      }
+    }
+  }
+}
+```
+
+## Transport boundary
+
+This implementation is **stdio-only**. Run it on the same machine/process environment as the MCP client. The Trinity Backend may be remote.
+
+Do not claim this package itself is a remotely hosted Vercel MCP endpoint. If remote MCP hosting is required, implement and test an HTTP MCP transport first.
+
+## Production claim boundary
+
+Production readiness requires evidence for all of the following:
+
+- Trinity Backend deployed and healthy.
+- Database migration applied to the intended database.
+- Authentication tested with valid/invalid credentials.
+- All 8 backend routes tested against real backend responses.
+- Mutation tools (`set_agent_mode`, `execute_task`) tested with authorization and governance controls.
+- Audit/evidence behavior verified.
+
+Until those checks exist, the accurate status is: **MCP bridge verified locally; backend-dependent integration pending verification.**

--- a/trinity-mcp-server/package.json
+++ b/trinity-mcp-server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "trinity-dsg-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP Server for Trinity DSG API — Control Plane for DSG Agent OS",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "node --loader ts-node/esm src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "inspector": "npx @modelcontextprotocol/inspector node dist/index.js",
+    "test": "npm run build && node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/trinity-mcp-server/src/client.ts
+++ b/trinity-mcp-server/src/client.ts
@@ -1,0 +1,158 @@
+/**
+ * Trinity API Client
+ * Handles all communication with Trinity Backend API
+ */
+
+export interface TrinityClientConfig {
+  apiUrl: string;
+  jwtToken?: string;
+}
+
+export class TrinityClient {
+  private apiUrl: string;
+  private jwtToken?: string;
+
+  constructor(config: TrinityClientConfig) {
+    this.apiUrl = config.apiUrl;
+    this.jwtToken = config.jwtToken;
+  }
+
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(options.headers as Record<string, string> || {}),
+    };
+
+    if (this.jwtToken) {
+      headers['Authorization'] = `Bearer ${this.jwtToken}`;
+    }
+
+    const url = `${this.apiUrl}${path}`;
+    const response = await fetch(url, {
+      ...options,
+      headers,
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(
+        `Trinity API Error (${response.status}): ${response.statusText} - ${error}`
+      );
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  async health() {
+    return this.request<{
+      status: string;
+      uptime: number;
+      version: string;
+      timestamp: string;
+      database?: string;
+    }>('/api/health');
+  }
+
+  async getAgentStatus() {
+    return this.request<{
+      agents: Array<{
+        id: string;
+        name: string;
+        role: string;
+        status: 'running' | 'idle' | 'error' | 'stopped';
+        uptime: string;
+        reliability: number;
+        jobsProcessed: number;
+        cpuUsage: number;
+        mode: 'sandbox' | 'live';
+      }>;
+      total: number;
+      healthy: number;
+    }>('/api/agents/status');
+  }
+
+  async setAgentMode(agentId: string, mode: 'sandbox' | 'live') {
+    return this.request<{
+      success: boolean;
+      previousMode: string;
+      newMode: string;
+    }>('/api/agents/mode', {
+      method: 'POST',
+      body: JSON.stringify({ agentId, mode }),
+    });
+  }
+
+  async executeTask(agentId: string, task: string) {
+    return this.request<{
+      success: boolean;
+      result: string;
+      duration: number;
+    }>('/api/agents/execute', {
+      method: 'POST',
+      body: JSON.stringify({ agentId, task }),
+    });
+  }
+
+  async chatWithAgent(agentId: string, message: string) {
+    return this.request<{
+      response: string;
+      agentId: string;
+      timestamp: string;
+    }>('/api/agents/chat', {
+      method: 'POST',
+      body: JSON.stringify({ agentId, message }),
+    });
+  }
+
+  async getCostTracker(period: '1h' | '24h' | '7d' = '24h') {
+    return this.request<{
+      total_usd: number;
+      budget: {
+        remaining_usd: number;
+        used_percent: number;
+      };
+      by_agent: Array<{
+        agent: string;
+        cost: number;
+      }>;
+      period: string;
+    }>(`/api/cost/tracker?period=${period}`);
+  }
+
+  async getSecurityAudit(limit: number = 10) {
+    return this.request<{
+      entries: Array<{
+        id: string;
+        timestamp: string;
+        event: string;
+        status: 'PASS' | 'WARN' | 'FAIL';
+        risk_score: number;
+        agent: string;
+      }>;
+      chain_valid: boolean;
+    }>(`/api/security/audit?limit=${limit}`);
+  }
+
+  async getStateContinuity() {
+    return this.request<{
+      all_agents_running: boolean;
+      context_sharing: number;
+      fragmentation_risk: number;
+      cost_per_hour: number;
+    }>('/api/state/continuity');
+  }
+
+  async login(username: string, password: string) {
+    return this.request<{
+      token: string;
+      expiresIn: string;
+    }>('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
+    });
+  }
+
+  setToken(token: string) {
+    this.jwtToken = token;
+  }
+}

--- a/trinity-mcp-server/src/index.ts
+++ b/trinity-mcp-server/src/index.ts
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+/**
+ * Trinity DSG API MCP Server
+ * Provides Claude and other LLMs with access to Trinity Backend API
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { TrinityClient } from './client.js';
+
+const TRINITY_API_URL = process.env.TRINITY_API_URL || 'http://localhost:3001';
+const TRINITY_JWT_TOKEN = process.env.TRINITY_JWT_TOKEN;
+
+const client = new TrinityClient({
+  apiUrl: TRINITY_API_URL,
+  jwtToken: TRINITY_JWT_TOKEN,
+});
+
+const server = new Server(
+  {
+    name: 'trinity-dsg-mcp',
+    version: '1.0.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+const tools = [
+  {
+    name: 'trinity_health_check',
+    description:
+      'Check Trinity API server and database connection status. Use this to verify the system is running and responsive.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'trinity_get_agents',
+    description:
+      'Get status of all DSG agents from the Trinity Backend API, including role, status, reliability, jobs processed, CPU usage, and mode when provided by the backend.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'trinity_set_agent_mode',
+    description:
+      'Request an agent mode change through the Trinity Backend API.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentId: {
+          type: 'string',
+          description: 'Agent ID or agent name',
+        },
+        mode: {
+          type: 'string',
+          enum: ['sandbox', 'live'],
+          description: 'Target mode: sandbox or live',
+        },
+      },
+      required: ['agentId', 'mode'],
+    },
+  },
+  {
+    name: 'trinity_execute_task',
+    description:
+      'Execute a task on a specific agent through the Trinity Backend API and return the backend result and duration.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentId: {
+          type: 'string',
+          description: 'Agent ID or agent name',
+        },
+        task: {
+          type: 'string',
+          description: 'Task description or command to execute',
+        },
+      },
+      required: ['agentId', 'task'],
+    },
+  },
+  {
+    name: 'trinity_chat_agent',
+    description:
+      'Send a message to an agent through the Trinity Backend API and return the backend response.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentId: {
+          type: 'string',
+          description: 'Agent ID or agent name',
+        },
+        message: {
+          type: 'string',
+          description: 'Message to send to the agent',
+        },
+      },
+      required: ['agentId', 'message'],
+    },
+  },
+  {
+    name: 'trinity_get_costs',
+    description:
+      'Get cost tracking information from the Trinity Backend API for a selected period.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        period: {
+          type: 'string',
+          enum: ['1h', '24h', '7d'],
+          description: 'Time period for cost tracking (default: 24h)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'trinity_get_audit_logs',
+    description:
+      'Get security audit logs from the Trinity Backend API.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Number of audit log entries to return (default: 10)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'trinity_get_state',
+    description:
+      'Get current system state and continuity metrics from the Trinity Backend API.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case 'trinity_health_check': {
+        const result = await client.health();
+        const dbStatus = result.database ? `Database: ${result.database}` : 'Database: Unknown';
+        const status = result.status === 'healthy' ? '✅ Healthy' : '⚠️ Unhealthy';
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `🏥 Trinity API Health\n\nStatus: ${status}\nVersion: ${result.version}\n${dbStatus}\nUptime: ${result.uptime.toFixed(1)}s\nChecked: ${result.timestamp}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_get_agents': {
+        const result = await client.getAgentStatus();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `## Trinity Agents Status\n\nTotal Agents: ${result.total}\nHealthy (Running): ${result.healthy}\n\n### Agents:\n${result.agents
+                .map(
+                  (agent) =>
+                    `- **${agent.name}** (${agent.role})\n  - Status: ${agent.status}\n  - Reliability: ${(agent.reliability * 100).toFixed(1)}%\n  - Jobs: ${agent.jobsProcessed}\n  - CPU: ${agent.cpuUsage.toFixed(1)}%\n  - Mode: ${agent.mode}\n  - Uptime: ${agent.uptime}`
+                )
+                .join('\n\n')}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_set_agent_mode': {
+        const { agentId, mode } = args as { agentId: string; mode: string };
+        const result = await client.setAgentMode(agentId, mode as 'sandbox' | 'live');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `✅ Agent Mode Switch Successful\n\nAgent: ${agentId}\nPrevious Mode: ${result.previousMode}\nNew Mode: ${result.newMode}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_execute_task': {
+        const { agentId, task } = args as { agentId: string; task: string };
+        const result = await client.executeTask(agentId, task);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `✅ Task Execution Complete\n\nAgent: ${agentId}\nResult: ${result.result}\nDuration: ${result.duration}ms`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_chat_agent': {
+        const { agentId, message } = args as { agentId: string; message: string };
+        const result = await client.chatWithAgent(agentId, message);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `💬 Agent Response\n\nAgent: ${result.agentId}\nResponse: ${result.response}\nTime: ${result.timestamp}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_get_costs': {
+        const period = (args as { period?: string }).period || '24h';
+        const result = await client.getCostTracker(period as '1h' | '24h' | '7d');
+
+        const costTable = result.by_agent
+          .map((entry) => `- ${entry.agent}: $${entry.cost.toFixed(4)}`)
+          .join('\n');
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `💰 Cost Tracking (${period})\n\nTotal Cost: $${result.total_usd.toFixed(2)}\nBudget Remaining: $${result.budget.remaining_usd.toFixed(2)}\nBudget Used: ${result.budget.used_percent.toFixed(1)}%\n\n### Cost by Agent:\n${costTable}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_get_audit_logs': {
+        const limit = (args as { limit?: number }).limit || 10;
+        const result = await client.getSecurityAudit(limit);
+
+        const logTable = result.entries
+          .map(
+            (entry) =>
+              `- [${entry.status}] ${entry.event} (Agent: ${entry.agent}, Risk: ${entry.risk_score.toFixed(1)}, Time: ${entry.timestamp})`
+          )
+          .join('\n');
+
+        const chainStatus = result.chain_valid ? '✅ Valid' : '⚠️ Invalid';
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `🔐 Security Audit Logs\n\nChain Valid: ${chainStatus}\n\n### Recent Events:\n${logTable}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      case 'trinity_get_state': {
+        const result = await client.getStateContinuity();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `📊 System State & Continuity\n\nAll Agents Running: ${result.all_agents_running ? '✅ Yes' : '❌ No'}\nContext Sharing: ${result.context_sharing.toFixed(1)}%\nFragmentation Risk: ${result.fragmentation_risk.toFixed(1)}%\nCost per Hour: $${parseFloat(String(result.cost_per_hour)).toFixed(2)}`,
+            },
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+              mimeType: 'application/json',
+            },
+          ],
+        };
+      }
+
+      default:
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Unknown tool: ${name}`,
+            },
+          ],
+          isError: true,
+        };
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(
+    `[Trinity MCP Server] Connected to ${TRINITY_API_URL} (JWT: ${TRINITY_JWT_TOKEN ? 'Yes' : 'No'})`
+  );
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/trinity-mcp-server/test/list-tools.test.mjs
+++ b/trinity-mcp-server/test/list-tools.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '..');
+
+test('MCP server starts and lists exactly the 8 Trinity tools', async () => {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ['dist/index.js'],
+    cwd: projectRoot,
+    stderr: 'pipe',
+  });
+
+  const client = new Client(
+    { name: 'trinity-mcp-smoke-test', version: '1.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    const result = await client.listTools();
+    const names = result.tools.map((tool) => tool.name).sort();
+
+    assert.deepEqual(names, [
+      'trinity_chat_agent',
+      'trinity_execute_task',
+      'trinity_get_agents',
+      'trinity_get_audit_logs',
+      'trinity_get_costs',
+      'trinity_get_state',
+      'trinity_health_check',
+      'trinity_set_agent_mode',
+    ]);
+  } finally {
+    await client.close();
+  }
+});

--- a/trinity-mcp-server/tsconfig.json
+++ b/trinity-mcp-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What this fixes

The previous Trinity integration commit added a nested-repository gitlink instead of the actual MCP server files. This PR adds the real MCP source from the supplied archive under `trinity-mcp-server/`.

## Verified locally from the supplied archive

- TypeScript build passes.
- MCP stdio process starts.
- MCP handshake succeeds.
- `tools/list` returns exactly 8 Trinity tools.
- Added a smoke test that performs the real stdio MCP handshake and verifies the exact tool names.

## Runtime fix

The supplied server crashed with the installed `@modelcontextprotocol/sdk` 1.30.0 because the low-level `Server` did not declare the `tools` capability. This PR registers `capabilities.tools` before attaching tool handlers.

## Truth-boundary corrections

- Removed the invented task-cost calculation that was derived from duration rather than backend data.
- Corrected documentation from 9 tools to 8 tools.
- Removed the claim that the stdio-only MCP process can be deployed to Vercel as a remote MCP endpoint.
- Explicitly marks backend/Supabase/auth/end-to-end production readiness as pending real backend verification.

## Not included

The Trinity Backend source was not present in this archive, so this PR does not claim that the 8 REST route contracts or Supabase integration are deployed or production-ready.