### PR TITLE
fix: fail closed billing checkout and workspace bootstrap

### DIFF
--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -65,21 +65,31 @@ async function resolveCheckoutProfile(
   user: { id: string; email?: string | null },
   email?: string | null
 ): Promise<CheckoutProfileResult> {
-  const { data: existingProfile } = await supabase
+  const { data: existingProfile, error: existingProfileError } = await supabase
     .from('users')
     .select('org_id, is_active, email')
     .eq('auth_user_id', user.id)
     .maybeSingle();
 
+  if (existingProfileError) {
+    return { ok: false, status: 500, error: 'workspace_profile_lookup_failed' };
+  }
+
+  // Billing must never act as an implicit identity-reactivation workflow.
+  // Existing disabled/suspended identities fail closed before Stripe is called.
+  if (existingProfile && existingProfile.is_active !== true) {
+    return { ok: false, status: 403, error: 'ACCOUNT_INACTIVE' };
+  }
+
   if (existingProfile?.org_id) {
     return {
       ok: true,
-      bootstrapped: existingProfile.is_active !== true,
+      bootstrapped: false,
       profile: {
         auth_user_id: user.id,
         email: existingProfile.email || email || user.email || null,
         org_id: String(existingProfile.org_id),
-        is_active: existingProfile.is_active === true,
+        is_active: true,
       },
     };
   }
@@ -112,7 +122,8 @@ export async function GET(request: Request) {
     const workspace = await resolveCheckoutProfile(supabase, user, user.email || null);
 
     if (isWorkspaceFailure(workspace)) {
-      return NextResponse.redirect(`${appUrl}/marketplace/skills?checkout=setup_failed`);
+      const checkoutState = workspace.error === 'ACCOUNT_INACTIVE' ? 'account_inactive' : 'setup_failed';
+      return NextResponse.redirect(`${appUrl}/marketplace/skills?checkout=${checkoutState}`);
     }
 
     const profile = workspace.profile;

--- a/lib/auth/ensure-user-workspace.ts
+++ b/lib/auth/ensure-user-workspace.ts
@@ -33,6 +33,10 @@ function errorMessage(error: unknown) {
   return String((error as { message?: string } | null)?.message || 'unknown error');
 }
 
+function inactiveWorkspaceFailure(): EnsureUserWorkspaceFailure {
+  return { ok: false, status: 403, error: 'ACCOUNT_INACTIVE' };
+}
+
 export async function ensureUserWorkspace(
   admin: unknown,
   input: { authUserId: string; email?: string | null }
@@ -43,6 +47,41 @@ export async function ensureUserWorkspace(
 
   const client = admin as SupabaseAdminLoose;
 
+  // Never use workspace/bootstrap as an implicit account-reactivation path.
+  // Existing identity state is authoritative; only a dedicated reactivation
+  // workflow may change is_active from false to true.
+  const { data: existingProfile, error: existingProfileError } = await client
+    .from('users')
+    .select('id, auth_user_id, email, org_id, is_active')
+    .eq('auth_user_id', input.authUserId)
+    .maybeSingle();
+
+  if (existingProfileError) {
+    return {
+      ok: false,
+      status: 500,
+      error: `workspace_profile_lookup_failed: ${errorMessage(existingProfileError)}`,
+    };
+  }
+
+  if (existingProfile && existingProfile.is_active !== true) {
+    return inactiveWorkspaceFailure();
+  }
+
+  if (existingProfile?.org_id) {
+    return {
+      ok: true,
+      bootstrapped: false,
+      profile: {
+        id: existingProfile.id || null,
+        auth_user_id: String(existingProfile.auth_user_id || input.authUserId),
+        email: (existingProfile.email || input.email || null) as string | null,
+        org_id: String(existingProfile.org_id),
+        is_active: true,
+      },
+    };
+  }
+
   const { data: ensuredOrgId, error: rpcError } = await client.rpc(
     'dsg_ensure_workspace_for_auth_user',
     {
@@ -52,6 +91,9 @@ export async function ensureUserWorkspace(
   );
 
   if (rpcError || !ensuredOrgId) {
+    if (errorMessage(rpcError).includes('ACCOUNT_INACTIVE')) {
+      return inactiveWorkspaceFailure();
+    }
     return {
       ok: false,
       status: 500,
@@ -73,14 +115,35 @@ export async function ensureUserWorkspace(
     };
   }
 
+  if (profile && profile.is_active !== true) {
+    return inactiveWorkspaceFailure();
+  }
+
   const orgId = String(profile?.org_id || ensuredOrgId || '');
   if (!orgId) {
     return { ok: false, status: 500, error: 'workspace_bootstrap_missing_org_id' };
   }
 
+  // Parent organization must exist before the profile can be treated as a
+  // usable tenant. This turns best-effort org creation into a fail-closed
+  // boundary at the application layer as well as the database layer.
+  const { data: organization, error: organizationError } = await client
+    .from('organizations')
+    .select('id')
+    .eq('id', orgId)
+    .maybeSingle();
+
+  if (organizationError || !organization?.id) {
+    return {
+      ok: false,
+      status: 500,
+      error: `workspace_bootstrap_missing_organization: ${errorMessage(organizationError)}`,
+    };
+  }
+
   return {
     ok: true,
-    bootstrapped: !profile?.org_id || profile?.is_active !== true,
+    bootstrapped: true,
     profile: {
       id: profile?.id || null,
       auth_user_id: String(profile?.auth_user_id || input.authUserId),

--- a/supabase/migrations/20260815111500_workspace_bootstrap_fail_closed.sql
+++ b/supabase/migrations/20260815111500_workspace_bootstrap_fail_closed.sql
@@ -1,14 +1,40 @@
--- Harden paid-flow workspace bootstrap against implicit account reactivation
--- and orphan tenant state.
+-- DSG ONE workspace bootstrap truth boundary.
+--
+-- This migration is intentionally self-contained. Production/dev database
+-- inspection showed that some environments have public.users and
+-- public.organizations but do not have the historical
+-- dsg_user_workspace_bootstrap table/helper RPC. Bootstrap therefore uses the
+-- canonical parent/child tables directly and fails closed on inconsistent
+-- identity state.
 --
 -- Invariants:
---   1. Existing inactive identities are never reactivated by bootstrap.
---   2. Existing identity is_active is never mutated by bootstrap.
---   3. A canonical organizations row must exist before users.org_id is written.
---   4. Any parent-org creation failure aborts the transaction instead of
---      allowing a partial workspace mapping to survive.
+--   1. One non-null auth_user_id maps to at most one public.users row.
+--   2. Existing inactive identities are never reactivated by bootstrap.
+--   3. Existing identity is_active is never mutated by bootstrap.
+--   4. users.org_id is written only after its organizations parent exists.
+--   5. New workspace + owner profile creation is one database transaction.
 
 BEGIN;
+
+-- Fail with an explicit migration error rather than silently choosing one row
+-- if legacy data already violates the identity uniqueness invariant.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.users
+    WHERE auth_user_id IS NOT NULL
+    GROUP BY auth_user_id
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'DUPLICATE_AUTH_USER_ID: reconcile public.users before enabling workspace bootstrap';
+  END IF;
+END;
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_auth_user_id_unique_not_null
+  ON public.users(auth_user_id)
+  WHERE auth_user_id IS NOT NULL;
 
 CREATE OR REPLACE FUNCTION public.dsg_ensure_workspace_for_auth_user(
   p_auth_user_id uuid,
@@ -23,13 +49,13 @@ DECLARE
   v_user record;
   v_user_exists boolean := false;
   v_org_id uuid;
-  v_email text := nullif(trim(coalesce(p_email, '')), '');
+  v_email text := nullif(lower(trim(coalesce(p_email, ''))), '');
 BEGIN
   IF p_auth_user_id IS NULL THEN
     RAISE EXCEPTION 'auth_user_id is required' USING ERRCODE = '22023';
   END IF;
 
-  -- Serialize bootstrap attempts for the same authenticated identity.
+  -- Serialize all bootstrap attempts for one Supabase Auth identity.
   PERFORM pg_advisory_xact_lock(hashtext(p_auth_user_id::text));
 
   SELECT id, auth_user_id, email, org_id, is_active
@@ -46,65 +72,67 @@ BEGIN
   END IF;
 
   IF v_user_exists THEN
-    v_email := coalesce(nullif(trim(coalesce(v_user.email, '')), ''), v_email);
-  END IF;
+    v_email := coalesce(nullif(lower(trim(coalesce(v_user.email, ''))), ''), v_email);
 
-  IF v_user_exists AND v_user.org_id IS NOT NULL THEN
-    v_org_id := v_user.org_id::text::uuid;
-  ELSE
-    SELECT org_id
-      INTO v_org_id
-    FROM public.dsg_user_workspace_bootstrap
-    WHERE auth_user_id = p_auth_user_id;
+    IF v_user.org_id IS NOT NULL THEN
+      v_org_id := v_user.org_id;
 
-    IF v_org_id IS NULL THEN
-      v_org_id := gen_random_uuid();
-      INSERT INTO public.dsg_user_workspace_bootstrap (auth_user_id, org_id, email)
-      VALUES (p_auth_user_id, v_org_id, v_email)
-      ON CONFLICT (auth_user_id) DO UPDATE
-        SET email = coalesce(public.dsg_user_workspace_bootstrap.email, EXCLUDED.email),
-            updated_at = now()
-      RETURNING org_id INTO v_org_id;
+      -- Never repair an orphan identity by inventing a parent tenant. An
+      -- inconsistent existing mapping is a data-integrity incident.
+      IF NOT EXISTS (
+        SELECT 1
+        FROM public.organizations
+        WHERE id = v_org_id
+      ) THEN
+        RAISE EXCEPTION 'WORKSPACE_PARENT_ORG_MISSING' USING ERRCODE = '23503';
+      END IF;
+
+      UPDATE public.users
+         SET email = coalesce(email, v_email),
+             updated_at = now()
+       WHERE id = v_user.id;
+
+      RETURN v_org_id;
     END IF;
   END IF;
 
-  -- organizations is the canonical tenant parent used by the application.
-  -- The legacy helper remains schema-tolerant, but its best-effort behavior is
-  -- no longer accepted as success: the row is verified immediately afterward.
-  PERFORM public.dsg_try_insert_workspace_org(
-    to_regclass('public.organizations'),
-    v_org_id,
-    coalesce(v_email, 'DSG Workspace')
-  );
-
-  IF to_regclass('public.organizations') IS NULL THEN
-    RAISE EXCEPTION 'WORKSPACE_PARENT_TABLE_MISSING' USING ERRCODE = '55000';
-  END IF;
-
-  IF NOT EXISTS (
-    SELECT 1
-    FROM public.organizations
-    WHERE id::text = v_org_id::text
-  ) THEN
-    RAISE EXCEPTION 'WORKSPACE_PARENT_ORG_MISSING' USING ERRCODE = '23503';
-  END IF;
-
-  UPDATE public.dsg_user_workspace_bootstrap
-     SET org_id = v_org_id,
-         email = coalesce(email, v_email),
-         updated_at = now()
-   WHERE auth_user_id = p_auth_user_id;
+  -- For a genuinely new/missing workspace, create the canonical parent first.
+  INSERT INTO public.organizations (name)
+  VALUES (coalesce(v_email, 'DSG Workspace'))
+  RETURNING id INTO v_org_id;
 
   IF v_user_exists THEN
     -- Deliberately do not modify is_active. Reactivation belongs to an explicit
-    -- account lifecycle operation, never billing/auth bootstrap.
+    -- account lifecycle operation, never auth/billing bootstrap.
     UPDATE public.users
        SET org_id = v_org_id,
-           email = coalesce(email, v_email)
+           email = coalesce(email, v_email),
+           role = CASE WHEN role = 'member' THEN 'owner' ELSE role END,
+           updated_at = now()
      WHERE id = v_user.id;
   ELSE
-    INSERT INTO public.users (auth_user_id, email, org_id, is_active)
-    VALUES (p_auth_user_id, v_email, v_org_id, true);
+    INSERT INTO public.users (
+      auth_user_id,
+      email,
+      org_id,
+      role,
+      is_active
+    ) VALUES (
+      p_auth_user_id,
+      v_email,
+      v_org_id,
+      'owner',
+      true
+    );
+  END IF;
+
+  -- Defense in depth: verify the parent still exists before returning success.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.organizations
+    WHERE id = v_org_id
+  ) THEN
+    RAISE EXCEPTION 'WORKSPACE_PARENT_ORG_MISSING' USING ERRCODE = '23503';
   END IF;
 
   RETURN v_org_id;

--- a/supabase/migrations/20260815111500_workspace_bootstrap_fail_closed.sql
+++ b/supabase/migrations/20260815111500_workspace_bootstrap_fail_closed.sql
@@ -1,0 +1,118 @@
+-- Harden paid-flow workspace bootstrap against implicit account reactivation
+-- and orphan tenant state.
+--
+-- Invariants:
+--   1. Existing inactive identities are never reactivated by bootstrap.
+--   2. Existing identity is_active is never mutated by bootstrap.
+--   3. A canonical organizations row must exist before users.org_id is written.
+--   4. Any parent-org creation failure aborts the transaction instead of
+--      allowing a partial workspace mapping to survive.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.dsg_ensure_workspace_for_auth_user(
+  p_auth_user_id uuid,
+  p_email text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user record;
+  v_user_exists boolean := false;
+  v_org_id uuid;
+  v_email text := nullif(trim(coalesce(p_email, '')), '');
+BEGIN
+  IF p_auth_user_id IS NULL THEN
+    RAISE EXCEPTION 'auth_user_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  -- Serialize bootstrap attempts for the same authenticated identity.
+  PERFORM pg_advisory_xact_lock(hashtext(p_auth_user_id::text));
+
+  SELECT id, auth_user_id, email, org_id, is_active
+    INTO v_user
+  FROM public.users
+  WHERE auth_user_id = p_auth_user_id
+  LIMIT 1
+  FOR UPDATE;
+
+  v_user_exists := FOUND;
+
+  IF v_user_exists AND v_user.is_active IS NOT TRUE THEN
+    RAISE EXCEPTION 'ACCOUNT_INACTIVE' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_exists THEN
+    v_email := coalesce(nullif(trim(coalesce(v_user.email, '')), ''), v_email);
+  END IF;
+
+  IF v_user_exists AND v_user.org_id IS NOT NULL THEN
+    v_org_id := v_user.org_id::text::uuid;
+  ELSE
+    SELECT org_id
+      INTO v_org_id
+    FROM public.dsg_user_workspace_bootstrap
+    WHERE auth_user_id = p_auth_user_id;
+
+    IF v_org_id IS NULL THEN
+      v_org_id := gen_random_uuid();
+      INSERT INTO public.dsg_user_workspace_bootstrap (auth_user_id, org_id, email)
+      VALUES (p_auth_user_id, v_org_id, v_email)
+      ON CONFLICT (auth_user_id) DO UPDATE
+        SET email = coalesce(public.dsg_user_workspace_bootstrap.email, EXCLUDED.email),
+            updated_at = now()
+      RETURNING org_id INTO v_org_id;
+    END IF;
+  END IF;
+
+  -- organizations is the canonical tenant parent used by the application.
+  -- The legacy helper remains schema-tolerant, but its best-effort behavior is
+  -- no longer accepted as success: the row is verified immediately afterward.
+  PERFORM public.dsg_try_insert_workspace_org(
+    to_regclass('public.organizations'),
+    v_org_id,
+    coalesce(v_email, 'DSG Workspace')
+  );
+
+  IF to_regclass('public.organizations') IS NULL THEN
+    RAISE EXCEPTION 'WORKSPACE_PARENT_TABLE_MISSING' USING ERRCODE = '55000';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.organizations
+    WHERE id::text = v_org_id::text
+  ) THEN
+    RAISE EXCEPTION 'WORKSPACE_PARENT_ORG_MISSING' USING ERRCODE = '23503';
+  END IF;
+
+  UPDATE public.dsg_user_workspace_bootstrap
+     SET org_id = v_org_id,
+         email = coalesce(email, v_email),
+         updated_at = now()
+   WHERE auth_user_id = p_auth_user_id;
+
+  IF v_user_exists THEN
+    -- Deliberately do not modify is_active. Reactivation belongs to an explicit
+    -- account lifecycle operation, never billing/auth bootstrap.
+    UPDATE public.users
+       SET org_id = v_org_id,
+           email = coalesce(email, v_email)
+     WHERE id = v_user.id;
+  ELSE
+    INSERT INTO public.users (auth_user_id, email, org_id, is_active)
+    VALUES (p_auth_user_id, v_email, v_org_id, true);
+  END IF;
+
+  RETURN v_org_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.dsg_ensure_workspace_for_auth_user(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dsg_ensure_workspace_for_auth_user(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.dsg_ensure_workspace_for_auth_user(uuid, text) TO service_role;
+
+COMMIT;

--- a/tests/unit/auth/ensure-user-workspace.test.ts
+++ b/tests/unit/auth/ensure-user-workspace.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureUserWorkspace } from '../../../lib/auth/ensure-user-workspace';
+
+function singleResult(data: unknown, error: unknown = null) {
+  const builder: any = {};
+  builder.select = vi.fn(() => builder);
+  builder.eq = vi.fn(() => builder);
+  builder.maybeSingle = vi.fn().mockResolvedValue({ data, error });
+  return builder;
+}
+
+describe('ensureUserWorkspace', () => {
+  it('fails closed for an existing inactive identity without calling bootstrap RPC', async () => {
+    const rpc = vi.fn();
+    const users = singleResult({
+      id: 'user-row-1',
+      auth_user_id: 'auth-user-1',
+      email: 'inactive@example.com',
+      org_id: null,
+      is_active: false,
+    });
+    const admin = {
+      rpc,
+      from: vi.fn((table: string) => {
+        expect(table).toBe('users');
+        return users;
+      }),
+    };
+
+    const result = await ensureUserWorkspace(admin, {
+      authUserId: 'auth-user-1',
+      email: 'inactive@example.com',
+    });
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'ACCOUNT_INACTIVE' });
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns an existing active workspace without invoking bootstrap RPC', async () => {
+    const rpc = vi.fn();
+    const users = singleResult({
+      id: 'user-row-1',
+      auth_user_id: 'auth-user-1',
+      email: 'active@example.com',
+      org_id: 'org-1',
+      is_active: true,
+    });
+    const admin = {
+      rpc,
+      from: vi.fn(() => users),
+    };
+
+    const result = await ensureUserWorkspace(admin, {
+      authUserId: 'auth-user-1',
+      email: 'active@example.com',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      bootstrapped: false,
+      profile: { org_id: 'org-1', is_active: true },
+    });
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('accepts a new bootstrap only when the canonical parent organization exists', async () => {
+    let userReads = 0;
+    const rpc = vi.fn().mockResolvedValue({ data: '11111111-1111-4111-8111-111111111111', error: null });
+    const firstUsers = singleResult(null);
+    const secondUsers = singleResult({
+      id: 'user-row-1',
+      auth_user_id: 'auth-user-1',
+      email: 'new@example.com',
+      org_id: '11111111-1111-4111-8111-111111111111',
+      is_active: true,
+    });
+    const organization = singleResult({ id: '11111111-1111-4111-8111-111111111111' });
+    const admin = {
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') return userReads++ === 0 ? firstUsers : secondUsers;
+        if (table === 'organizations') return organization;
+        throw new Error(`unexpected table: ${table}`);
+      }),
+    };
+
+    const result = await ensureUserWorkspace(admin, {
+      authUserId: 'auth-user-1',
+      email: 'new@example.com',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      bootstrapped: true,
+      profile: {
+        org_id: '11111111-1111-4111-8111-111111111111',
+        is_active: true,
+      },
+    });
+    expect(rpc).toHaveBeenCalledOnce();
+  });
+
+  it('rejects bootstrap success claims when the parent organization is missing', async () => {
+    let userReads = 0;
+    const rpc = vi.fn().mockResolvedValue({ data: '11111111-1111-4111-8111-111111111111', error: null });
+    const firstUsers = singleResult(null);
+    const secondUsers = singleResult({
+      id: 'user-row-1',
+      auth_user_id: 'auth-user-1',
+      email: 'new@example.com',
+      org_id: '11111111-1111-4111-8111-111111111111',
+      is_active: true,
+    });
+    const organization = singleResult(null);
+    const admin = {
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') return userReads++ === 0 ? firstUsers : secondUsers;
+        if (table === 'organizations') return organization;
+        throw new Error(`unexpected table: ${table}`);
+      }),
+    };
+
+    const result = await ensureUserWorkspace(admin, {
+      authUserId: 'auth-user-1',
+      email: 'new@example.com',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 500,
+    });
+    if (result.ok === false) {
+      expect(result.error).toContain('workspace_bootstrap_missing_organization');
+    }
+  });
+
+  it('maps database ACCOUNT_INACTIVE protection to a 403 response', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'ACCOUNT_INACTIVE' },
+    });
+    const users = singleResult(null);
+    const admin = {
+      rpc,
+      from: vi.fn(() => users),
+    };
+
+    const result = await ensureUserWorkspace(admin, {
+      authUserId: 'auth-user-1',
+      email: 'race@example.com',
+    });
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'ACCOUNT_INACTIVE' });
+  });
+});

--- a/tests/unit/billing/checkout-route.test.ts
+++ b/tests/unit/billing/checkout-route.test.ts
@@ -90,7 +90,7 @@ describe('POST /api/billing/checkout', () => {
     expect(res.status).toBe(401);
   });
 
-  it('allows inactive trial profile with org_id', async () => {
+  it('blocks inactive profile before creating a Stripe session', async () => {
     mockCreateClient.mockResolvedValue(
       makeSupabaseClient(
         { id: 'user-1' },
@@ -98,7 +98,9 @@ describe('POST /api/billing/checkout', () => {
       ) as any
     );
     const res = await POST(makeRequest({ plan: 'pro' }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: 'ACCOUNT_INACTIVE' });
+    expect(mockStripeInstance.checkout.sessions.create).not.toHaveBeenCalled();
   });
 
   it('returns 403 when org_id in body does not match user org', async () => {


### PR DESCRIPTION
## Scope

P0 billing/auth truth-boundary hardening from the Billing Deep Code Audit. This PR intentionally does **not** claim seat-limit or exactly-once billing readiness.

## Changes

- Block inactive/suspended profiles before Stripe checkout; return `403 ACCOUNT_INACTIVE` and do not create a Stripe session.
- Harden shared `ensureUserWorkspace()` so existing inactive identities never invoke bootstrap RPC and existing active workspaces do not get re-bootstrapped.
- Add a self-contained DB migration for `dsg_ensure_workspace_for_auth_user()` that does not depend on historical helper/bootstrap objects missing from the connected live dev schema.
- Add a conditional unique index enforcing one non-null `auth_user_id` per `users` row; migration fails explicitly if legacy duplicates exist.
- Create the canonical `organizations` row before assigning `users.org_id`; orphan existing mappings fail closed instead of inventing a replacement tenant.
- Never set an existing inactive user's `is_active=true`; genuinely new bootstrap profiles are created as `owner`, matching the existing auth-confirm provisioning contract.
- Add unit tests covering inactive-account denial, no-RPC behavior, canonical parent verification, and checkout no-Stripe side effect.

## Evidence / truth boundary

Verified from current repository main before this change:
- Checkout unit test explicitly expected inactive profile checkout to return 200.
- Historical workspace bootstrap migration explicitly updated existing users with `is_active = true` and swallowed parent-org insertion errors as NOTICE/best-effort behavior.
- `app/auth/confirm/route.ts` provisions newly created workspace users with role `owner`.

Verified read-only against connected Supabase project `dsg-control-plane-dev` on 2026-08-15:
- `public.users`, `public.organizations`, `billing_events`, `billing_customers`, `billing_subscriptions`, `org_billing_policies`, and `seat_activations` exist.
- Historical `public.dsg_user_workspace_bootstrap`, `public.dsg_try_insert_workspace_org(...)`, and `public.dsg_ensure_workspace_for_auth_user(...)` are absent; migration history also has no matching paid-flow/bootstrap entry.
- `organizations.id` and `users.org_id` are UUID in the live schema.
- `users.auth_user_id` had no uniqueness constraint, but a read-only duplicate check returned zero duplicate non-null auth IDs at inspection time.

## CI evidence

Previous head before the self-contained migration change passed lint, TypeScript typecheck, runtime-contract subset, full test suite, and stripe-app typecheck. Those results are superseded by the latest migration commit; the latest head must pass CI again before merge.

Vercel preview failures observed on the previous head were `BUILD_FAILED: Resource provisioning failed` with no build stderr/code error. They are not accepted as a green deployment.

Supabase Preview integration was skipped because no isolated preview database was available; a skipped preview is **not** migration-runtime proof.

## Not solved in this PR

- Atomic seat-limit enforcement: BLOCKED until a canonical purchased-seat entitlement source is defined and synchronized from the actual commercial contract/Stripe model.
- PR #1103 is not safe to merge as-is: its migration contains invalid PostgreSQL forms and introduces `purchased_seats default 0` without an identified producer/source-of-truth; its integration test targets configured Supabase service-role credentials.
- Webhook ambiguous-tenant quarantine and reordered/refund/concurrency test matrix remain separate P0 work. Main now has dedicated webhook unit tests for invalid signature, duplicate replay, fulfill/revoke, and payment-failed paths, so the old blanket claim “no webhook tests” is no longer accurate.
- Float-to-integer monetary representation, bounded overage config, seat reversal lifecycle, and dashboard reconciliation remain P1.

## Merge gate

Do not merge until required CI checks are green. Passing this PR proves only the scoped inactive-account/bootstrap invariants above; it does not prove financial production readiness.