### PR TITLE
E2E install + sales funnel with truthful integration states

### DIFF
--- a/.github/vercel-routing.json
+++ b/.github/vercel-routing.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "activeAccount": "legacy",
+  "activeAccount": "new",
   "accounts": {
     "legacy": {
       "teamId": "team_n189mlAdVHR6cGGiaAwsKzQ0",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,9 @@ jobs:
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
       - name: Verify Vercel credentials
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,7 +146,25 @@ jobs:
         id: preview
         shell: bash
         run: |
-          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" --local-config vercel.preview.json deploy --yes --token="$VERCEL_TOKEN" \
+          set -euo pipefail
+
+          # Vercel's remote build reads the root vercel.json from uploaded source.
+          # For Hobby previews, replace it only inside this ephemeral CI checkout
+          # so production cron schedules never enter the preview build input.
+          cp vercel.json "$RUNNER_TEMP/vercel.production.json"
+          trap 'cp "$RUNNER_TEMP/vercel.production.json" vercel.json' EXIT
+          cp vercel.preview.json vercel.json
+
+          node <<'NODE'
+          const fs = require('fs');
+          const cfg = JSON.parse(fs.readFileSync('vercel.json', 'utf8'));
+          if (Array.isArray(cfg.crons) && cfg.crons.length !== 0) {
+            throw new Error('Preview vercel.json still contains cron schedules');
+          }
+          console.log('Preview deployment input verified: no cron schedules in root vercel.json');
+          NODE
+
+          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" deploy --yes --token="$VERCEL_TOKEN" \
             --meta=branch="${{ github.head_ref }}" \
             --meta=commit="${{ github.event.pull_request.head.sha }}")
           test -n "$PREVIEW_URL"
@@ -162,7 +180,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Preview verified: ${{ steps.preview.outputs.preview_url }}\n\nPreview deployment intentionally uses vercel.preview.json without production cron schedules so Hobby preview validation does not alter production cron semantics. Production was not deployed. Production requires the separate Promoted Production Deployment workflow.`
+              body: `Preview verified: ${{ steps.preview.outputs.preview_url }}\n\nPreview deployment swaps the root vercel.json only inside the ephemeral CI checkout so production cron schedules are excluded from the Hobby preview build input. The repository production vercel.json is not changed by this deploy step. Production requires the separate Promoted Production Deployment workflow.`
             })
 
   notify-failure:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,7 +146,7 @@ jobs:
         id: preview
         shell: bash
         run: |
-          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" deploy --yes --token="$VERCEL_TOKEN" \
+          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" --local-config vercel.preview.json deploy --yes --token="$VERCEL_TOKEN" \
             --meta=branch="${{ github.head_ref }}" \
             --meta=commit="${{ github.event.pull_request.head.sha }}")
           test -n "$PREVIEW_URL"
@@ -162,7 +162,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Preview verified: ${{ steps.preview.outputs.preview_url }}\n\nProduction was not deployed. Production requires the separate Promoted Production Deployment workflow.`
+              body: `Preview verified: ${{ steps.preview.outputs.preview_url }}\n\nPreview deployment intentionally uses vercel.preview.json without production cron schedules so Hobby preview validation does not alter production cron semantics. Production was not deployed. Production requires the separate Promoted Production Deployment workflow.`
             })
 
   notify-failure:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,45 @@ jobs:
         with:
           node-version: '24'
           cache: npm
+
+      - name: Bootstrap new Vercel project when project ID is unavailable
+        shell: bash
+        env:
+          NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
+          NEW_VERCEL_SCOPE: thanawats-projects-336871dc
+          NEW_VERCEL_PROJECT_NAME: tdealer01-crypto-dsg-control-plane
+        run: |
+          set -euo pipefail
+          test -n "$NEW_VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN_NEW"; exit 1; }
+
+          if [[ "$NEW_VERCEL_PROJECT_ID" =~ ^prj_[A-Za-z0-9]+$ ]]; then
+            echo "Existing VERCEL_PROJECT_ID_NEW is syntactically valid; bootstrap not required."
+            exit 0
+          fi
+
+          echo "VERCEL_PROJECT_ID_NEW is unavailable/invalid; linking project through the new Vercel scope."
+          rm -rf .vercel
+          npx --yes "vercel@$VERCEL_CLI_VERSION" link --yes \
+            --project "$NEW_VERCEL_PROJECT_NAME" \
+            --scope "$NEW_VERCEL_SCOPE" \
+            --token "$NEW_VERCEL_TOKEN"
+
+          test -f .vercel/project.json || { echo "Vercel link did not create .vercel/project.json"; exit 1; }
+          node <<'NODE'
+          const fs = require('fs');
+          const p = JSON.parse(fs.readFileSync('.vercel/project.json', 'utf8'));
+          if (!/^prj_[A-Za-z0-9]+$/.test(String(p.projectId || ''))) {
+            throw new Error('Bootstrapped Vercel projectId is missing or invalid');
+          }
+          if (!/^[A-Za-z0-9_-]{3,128}$/.test(String(p.orgId || ''))) {
+            throw new Error('Bootstrapped Vercel orgId is missing or invalid');
+          }
+          fs.appendFileSync(process.env.GITHUB_ENV, `BOOTSTRAP_VERCEL_ORG_ID=${p.orgId}\n`);
+          fs.appendFileSync(process.env.GITHUB_ENV, `BOOTSTRAP_VERCEL_PROJECT_ID=${p.projectId}\n`);
+          console.log('Bootstrapped Vercel project identity from .vercel/project.json');
+          NODE
+
       - name: Resolve audited Vercel routing
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -87,6 +126,7 @@ jobs:
           NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
           NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
+
       - name: Verify Vercel credentials
         shell: bash
         run: |
@@ -97,6 +137,7 @@ jobs:
             test "$VERCEL_ORG_ID" != "team_n189mlAdVHR6cGGiaAwsKzQ0" || { echo "New-account routing has the legacy account ID"; exit 1; }
             test "$VERCEL_PROJECT_ID" != "prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW" || { echo "New-account routing has the legacy project ID"; exit 1; }
           fi
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Pull preview configuration

--- a/.github/workflows/dsg-secure-deploy-gate.yml
+++ b/.github/workflows/dsg-secure-deploy-gate.yml
@@ -10,10 +10,15 @@ jobs:
   dsg-gate:
     runs-on: ubuntu-latest
     steps:
+      # The origin is a repository variable so it can follow the production
+      # deployment without a code change — set DSG_PRODUCTION_ORIGIN once a
+      # custom domain exists. The default is the rebuilt Vercel project; the
+      # previous hardcoded host belonged to the retired project and answers 402
+      # DEPLOYMENT_DISABLED, so the gate was reporting on a dead origin.
       - uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1
         with:
-          readiness_url: "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/finance-governance/readiness"
+          readiness_url: "${{ vars.DSG_PRODUCTION_ORIGIN || 'https://tdealer01-crypto-dsg-control-plane-thanawats-projects-336871dc.vercel.app' }}/api/finance-governance/readiness"
           expected_status: "200"
           require_json_ok: "true"
-          protected_url: "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/api-keys"
+          protected_url: "${{ vars.DSG_PRODUCTION_ORIGIN || 'https://tdealer01-crypto-dsg-control-plane-thanawats-projects-336871dc.vercel.app' }}/api/api-keys"
           protected_expected: "401,403"

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Check available secrets
@@ -83,6 +85,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Install Vercel CLI

--- a/.github/workflows/promoted-production-deploy.yml
+++ b/.github/workflows/promoted-production-deploy.yml
@@ -105,6 +105,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Verify required release configuration

--- a/.github/workflows/set-stripe-price-env.yml
+++ b/.github/workflows/set-stripe-price-env.yml
@@ -72,6 +72,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Validate required secrets

--- a/.github/workflows/unify-dsg-governed-chain.yml
+++ b/.github/workflows/unify-dsg-governed-chain.yml
@@ -7,8 +7,11 @@ on:
       - 'lib/runtime/makk8-z3-verifier.ts'
       - 'app/api/dsg/makk8-z3/verify/**'
       - 'lib/unify/**'
+      - 'lib/dsg-one/**'
+      - 'lib/mcp/canonical-action-adapter.ts'
       - 'tests/unit/runtime/makk8-z3-verifier.test.ts'
       - 'tests/unit/unify/**'
+      - 'tests/unit/dsg-one/**'
       - 'trinity-mcp-server/**'
       - '.github/workflows/unify-dsg-governed-chain.yml'
   workflow_dispatch:
@@ -39,14 +42,24 @@ jobs:
       - name: Typecheck control-plane integration
         run: npm run typecheck
 
-      - name: Run real Z3 and Unify bridge tests
+      - name: Run canonical DSG ONE + real Z3 + Unify bridge tests
         run: >-
           npx vitest run
           tests/unit/runtime/makk8-z3-verifier.test.ts
           tests/unit/unify/desktop-dsg-bridge.test.ts
+          tests/unit/dsg-one/canonical-e2e-pipeline.test.ts
+          tests/unit/dsg-one/canonical-action-e2e.test.ts
 
       - name: Install Trinity MCP dependencies
-        run: npm --prefix trinity-mcp-server ci --ignore-scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f trinity-mcp-server/package-lock.json ] || [ -f trinity-mcp-server/npm-shrinkwrap.json ]; then
+            npm --prefix trinity-mcp-server ci --ignore-scripts
+          else
+            echo 'Trinity MCP has no lockfile; using npm install for this package only.'
+            npm --prefix trinity-mcp-server install --ignore-scripts --no-audit --no-fund
+          fi
 
       - name: Build Trinity MCP including Unify entrypoint
         run: npm --prefix trinity-mcp-server run build
@@ -62,11 +75,11 @@ jobs:
           {
             echo '## Unify Desktop DSG Governed Chain'
             echo ''
-            echo '- Makk-8 invariant snapshot: verified by actual z3-solver runtime'
-            echo '- Z3 result: SAT is required before command authorization'
+            echo '- Canonical optimization: deterministic Simulation → QUBO → Ising → Z3 → exact proof'
+            echo '- Global optimum: only emitted when explicit business objective is bound and exact proof completes'
             echo '- DSG ONE agent command gate: PASS/actionEnvelope required before local execution'
             echo '- Desktop/Browser/Shell execution: local Unify executor only; CI does not fake OS execution'
             echo '- Evidence: canonical SHA-256 local bundle + DSG result receipt callback'
-            echo '- Replay: local evidence integrity + repeat Makk-8/Z3 proof hash'
-            echo '- Trinity MCP: compiled unify-dsg entrypoint with verify/result/replay tools'
+            echo '- Replay: canonical chain/action/receipt hashes are preserved for verification'
+            echo '- Trinity MCP/Unify: transport adapters only; no second ALLOW/BLOCK engine'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/unify-dsg-governed-chain.yml
+++ b/.github/workflows/unify-dsg-governed-chain.yml
@@ -1,0 +1,72 @@
+name: Unify Desktop DSG Governed Chain
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'lib/runtime/makk8-z3-verifier.ts'
+      - 'app/api/dsg/makk8-z3/verify/**'
+      - 'lib/unify/**'
+      - 'tests/unit/runtime/makk8-z3-verifier.test.ts'
+      - 'tests/unit/unify/**'
+      - 'trinity-mcp-server/**'
+      - '.github/workflows/unify-dsg-governed-chain.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unify-dsg-chain-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-control-chain:
+    name: Verify Makk-8/Z3 → DSG Gate → Evidence → Replay
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install control-plane dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Typecheck control-plane integration
+        run: npm run typecheck
+
+      - name: Run real Z3 and Unify bridge tests
+        run: >-
+          npx vitest run
+          tests/unit/runtime/makk8-z3-verifier.test.ts
+          tests/unit/unify/desktop-dsg-bridge.test.ts
+
+      - name: Install Trinity MCP dependencies
+        run: npm --prefix trinity-mcp-server ci --ignore-scripts
+
+      - name: Build Trinity MCP including Unify entrypoint
+        run: npm --prefix trinity-mcp-server run build
+
+      - name: Run Trinity MCP contract tests
+        run: npm --prefix trinity-mcp-server test
+
+      - name: Assert compiled Unify MCP entrypoint exists
+        run: test -f trinity-mcp-server/dist/unify-dsg.js
+
+      - name: Governance chain summary
+        run: |
+          {
+            echo '## Unify Desktop DSG Governed Chain'
+            echo ''
+            echo '- Makk-8 invariant snapshot: verified by actual z3-solver runtime'
+            echo '- Z3 result: SAT is required before command authorization'
+            echo '- DSG ONE agent command gate: PASS/actionEnvelope required before local execution'
+            echo '- Desktop/Browser/Shell execution: local Unify executor only; CI does not fake OS execution'
+            echo '- Evidence: canonical SHA-256 local bundle + DSG result receipt callback'
+            echo '- Replay: local evidence integrity + repeat Makk-8/Z3 proof hash'
+            echo '- Trinity MCP: compiled unify-dsg entrypoint with verify/result/replay tools'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/app/api/access/request/route.ts
+++ b/app/api/access/request/route.ts
@@ -13,6 +13,10 @@ function extractDomain(email: string) {
   return email.split('@')[1] || '';
 }
 
+function normalizeIntegration(value: unknown) {
+  const integration = String(value || '').trim().toLowerCase();
+  return integration === 'github' || integration === 'vercel' ? integration : null;
+}
 
 async function resolveRequesterOrgId() {
   try {
@@ -66,6 +70,7 @@ async function parseBody(request: NextRequest) {
     workspace_name: form.get('workspace_name'),
     full_name: form.get('full_name'),
     reason: form.get('reason'),
+    integration: form.get('integration'),
   } as Record<string, unknown>;
 }
 
@@ -89,7 +94,11 @@ export async function POST(request: NextRequest) {
     const workspaceName = String(body.workspace_name || '').trim() || null;
     const fullName = String(body.full_name || '').trim() || null;
     const reason = String(body.reason || '').trim() || null;
+    const integration = normalizeIntegration(body.integration);
     const explicitOrgId = String(body.org_id || '').trim() || null;
+    const reviewNote = [integration ? `integration:${integration}` : null, reason]
+      .filter(Boolean)
+      .join(' | ') || null;
 
     if (!email || !domain) {
       return NextResponse.json(
@@ -122,7 +131,7 @@ export async function POST(request: NextRequest) {
         full_name: fullName,
         requested_org_hint: workspaceName,
         status: 'pending',
-        review_note: reason,
+        review_note: reviewNote,
         ref_code: refCode,
       });
 
@@ -134,9 +143,9 @@ export async function POST(request: NextRequest) {
     await logSignInEvent({
       email,
       eventType: 'request_access_submitted',
-      source: 'request-access',
+      source: integration ? `request-access:${integration}` : 'request-access',
       success: true,
-      metadata: { workspace_name: workspaceName },
+      metadata: { workspace_name: workspaceName, integration },
     });
 
     const acceptsHtml = (request.headers.get('accept') || '').includes('text/html');
@@ -144,6 +153,7 @@ export async function POST(request: NextRequest) {
       const redirectTo = new URL('/request-access', request.url);
       redirectTo.searchParams.set('email', email);
       if (workspaceName) redirectTo.searchParams.set('workspace_name', workspaceName);
+      if (integration) redirectTo.searchParams.set('integration', integration);
       redirectTo.searchParams.set('success', '1');
       return NextResponse.redirect(redirectTo, {
         status: 302,
@@ -151,7 +161,7 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    return NextResponse.json({ ok: true }, { headers: buildRateLimitHeaders(rateLimit, 10) });
+    return NextResponse.json({ ok: true, integration }, { headers: buildRateLimitHeaders(rateLimit, 10) });
   } catch (error) {
     return handleApiError('api/access/request', error);
   }

--- a/app/api/dsg-one/optimization/verify/route.ts
+++ b/app/api/dsg-one/optimization/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireOrgPermission } from '@/lib/auth/require-org-permission';
+import { handleApiError } from '@/lib/security/api-error';
 import { runVerifiedOptimizationPipeline } from '@/lib/dsg-one/verified-optimization-pipeline';
 import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
 
@@ -55,13 +56,13 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: 'DSG_VERIFIED_OPTIMIZATION_FAILED',
-        message: error instanceof Error ? error.message : 'Unknown optimization error',
-      },
-      { status: 400 },
-    );
+    // The raw message was echoed to the client here, which
+    // scripts/check-error-handlers.sh fails as error-message leakage: this
+    // catch also receives internal failures, not just the pipeline's input
+    // validation. 400 is kept because the throws that reach it are dominated
+    // by bad request payloads, so the status is unchanged and only the
+    // message stops crossing the boundary. handleApiError still logs the real
+    // error server-side with redaction.
+    return handleApiError('api/dsg-one/optimization/verify', error, { status: 400 });
   }
 }

--- a/app/api/dsg-one/optimization/verify/route.ts
+++ b/app/api/dsg-one/optimization/verify/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgPermission } from '@/lib/auth/require-org-permission';
+import { runVerifiedOptimizationPipeline } from '@/lib/dsg-one/verified-optimization-pipeline';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+
+export const dynamic = 'force-dynamic';
+
+type Body = {
+  problemId?: unknown;
+  tasks?: unknown;
+  agentCapacities?: unknown;
+  seed?: unknown;
+  useMock?: unknown;
+  timeout?: unknown;
+  exactProofMaxVariables?: unknown;
+};
+
+type DeniedAuth = { ok: false; error: string; status: 401 | 403 };
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOrgPermission('org.execute');
+  if (auth.ok === false) {
+    const denied = auth as DeniedAuth;
+    return NextResponse.json({ ok: false, error: denied.error }, { status: denied.status });
+  }
+
+  try {
+    const body = (await request.json()) as Body;
+    if (typeof body.problemId !== 'string' || !Array.isArray(body.tasks) || !Array.isArray(body.agentCapacities)) {
+      return NextResponse.json(
+        { ok: false, error: 'problemId, tasks, and agentCapacities are required' },
+        { status: 400 },
+      );
+    }
+
+    const result = await runVerifiedOptimizationPipeline({
+      problemId: body.problemId,
+      tasks: body.tasks as Task[],
+      agentCapacities: body.agentCapacities as AgentCapacity[],
+      seed: typeof body.seed === 'number' ? body.seed : 0,
+      useMock: typeof body.useMock === 'boolean' ? body.useMock : undefined,
+      timeout: typeof body.timeout === 'number' ? body.timeout : undefined,
+      exactProofMaxVariables:
+        typeof body.exactProofMaxVariables === 'number' ? body.exactProofMaxVariables : undefined,
+    });
+
+    return NextResponse.json({
+      ok: result.verdict === 'VERIFIED_GLOBAL_OPTIMUM',
+      result,
+      actor: { userId: auth.userId, orgId: auth.orgId, role: auth.role },
+      boundary: {
+        executionPerformed: false,
+        statement:
+          'VERIFIED_GLOBAL_OPTIMUM is emitted only when Z3 verifies feasibility and deterministic exhaustive enumeration proves no binary QUBO state has lower energy within the configured exact-proof bound. Any other verdict remains non-executable.',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'DSG_VERIFIED_OPTIMIZATION_FAILED',
+        message: error instanceof Error ? error.message : 'Unknown optimization error',
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/dsg/makk8-z3/verify/route.ts
+++ b/app/api/dsg/makk8-z3/verify/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from 'next/server';
+import { verifyMakk8WithZ3 } from '@/lib/runtime/makk8-z3-verifier';
+import type { Makk8ActionData } from '@/lib/runtime/makk8-arbiter';
+
+export const dynamic = 'force-dynamic';
+
+interface VerifyBody {
+  context?: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+export async function POST(request: Request) {
+  let body: VerifyBody;
+  try {
+    body = (await request.json()) as VerifyBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'INVALID_JSON' }, { status: 400 });
+  }
+
+  const context = body.context;
+  if (!context || typeof context !== 'object' || Array.isArray(context)) {
+    return NextResponse.json(
+      { ok: false, error: 'CONTEXT_REQUIRED', message: 'context must be a JSON object' },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseStrictActionData(context);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        decision: 'BLOCK',
+        error: 'MAKK8_CONTEXT_INCOMPLETE',
+        missing: parsed.missing,
+        message: 'Makk-8 formal verification is fail-closed: all required action facts must be supplied explicitly.',
+      },
+      { status: 400 },
+    );
+  }
+
+  const timeoutMs = clampTimeout(body.timeoutMs);
+  const result = await verifyMakk8WithZ3(parsed.actionData, timeoutMs);
+
+  return NextResponse.json(
+    {
+      ok: result.ok,
+      decision: result.decision,
+      makk8: result,
+      boundary: {
+        statement: result.ok
+          ? 'The supplied Makk-8 facts were satisfiable under the eight-invariant Z3 model. This is an execution precondition, not execution permission by itself.'
+          : 'The supplied facts did not produce an ALLOW result. The caller must not execute based on this verification.',
+        requiresAgentCommandGate: true,
+      },
+    },
+    { status: result.ok ? 200 : 409 },
+  );
+}
+
+function parseStrictActionData(context: Record<string, unknown>):
+  | { ok: true; actionData: Makk8ActionData }
+  | { ok: false; missing: string[] } {
+  const requiredBooleans = [
+    'is_grounded',
+    'is_api_clean',
+    'source_verified',
+    'has_audit_trail',
+    'nonce_lock',
+  ] as const;
+  const requiredNumbers = ['value', 'intent_score', 'compute_cost'] as const;
+  const missing: string[] = [];
+
+  for (const key of requiredBooleans) {
+    if (typeof context[key] !== 'boolean') missing.push(key);
+  }
+  for (const key of requiredNumbers) {
+    if (typeof context[key] !== 'number' || !Number.isFinite(context[key] as number)) missing.push(key);
+  }
+
+  if (missing.length > 0) return { ok: false, missing };
+
+  return {
+    ok: true,
+    actionData: {
+      is_grounded: context.is_grounded as boolean,
+      is_api_clean: context.is_api_clean as boolean,
+      source_verified: context.source_verified as boolean,
+      has_audit_trail: context.has_audit_trail as boolean,
+      nonce_lock: context.nonce_lock as boolean,
+      value: context.value as number,
+      intent_score: context.intent_score as number,
+      compute_cost: context.compute_cost as number,
+    },
+  };
+}
+
+function clampTimeout(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 5_000;
+  return Math.min(10_000, Math.max(100, Math.floor(value)));
+}

--- a/app/api/dsg/makk8-z3/verify/route.ts
+++ b/app/api/dsg/makk8-z3/verify/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
   }
 
   const parsed = parseStrictActionData(context);
-  if (!parsed.ok) {
+  if ('missing' in parsed) {
     return NextResponse.json(
       {
         ok: false,

--- a/app/api/dsg/v1/actions/replay/route.ts
+++ b/app/api/dsg/v1/actions/replay/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from 'next/server';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import { validateVerifiedActionRequest } from '@/lib/dsg-one/verified-action-request';
+import {
+  checkReceiptIntegrity,
+  replayVerifiedAction,
+  VERIFIED_ACTION_RECEIPT_SCHEMA,
+  type VerifiedActionReceipt,
+} from '@/lib/dsg-one/verified-action-receipt';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import {
+  requireDsgAuth,
+  dsgAuthError,
+  logDsgApiCall,
+} from '@/lib/dsg/auth/require-dsg-auth';
+
+export const dynamic = 'force-dynamic';
+
+function isReceipt(value: unknown): value is VerifiedActionReceipt {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.schema === VERIFIED_ACTION_RECEIPT_SCHEMA &&
+    typeof candidate.receiptId === 'string' &&
+    typeof candidate.chain === 'object' &&
+    candidate.chain !== null
+  );
+}
+
+/**
+ * POST /api/dsg/v1/actions/replay — independently re-verify a receipt.
+ *
+ * Two modes, both free of charge because replay is what makes a receipt worth
+ * paying for and charging to check your own evidence would defeat that:
+ *
+ *   1. receipt only            -> integrity check (was the document altered?)
+ *   2. receipt + original request -> full replay (does the chain still produce
+ *                                    the same hashes and the same verdict?)
+ *
+ * Mode 2 is the measurable claim: provider, model, or orchestration drift shows
+ * up as a per-field hash mismatch instead of silently passing.
+ */
+export async function POST(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const startMs = Date.now();
+
+  const rateLimitResult = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-action-replay:${caller.orgId}`),
+    limit: 60,
+    windowMs: 60_000,
+  });
+  const rateLimitHeaders = buildRateLimitHeaders(rateLimitResult, 60);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limit_exceeded' },
+      { status: 429, headers: rateLimitHeaders },
+    );
+  }
+
+  const body = await readJsonBody(request, { maxBytes: 96_000 });
+  if (!body.ok) {
+    return NextResponse.json(
+      { ok: false, error: body.error },
+      { status: body.status, headers: rateLimitHeaders },
+    );
+  }
+
+  const payload = body.value as Record<string, unknown>;
+  if (!isReceipt(payload?.receipt)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'validation_failed',
+        details: [
+          { field: 'receipt', message: `must be a ${VERIFIED_ACTION_RECEIPT_SCHEMA} document` },
+        ],
+      },
+      { status: 400, headers: rateLimitHeaders },
+    );
+  }
+
+  const receipt = payload.receipt;
+  const integrity = checkReceiptIntegrity(receipt);
+
+  // Mode 1: no original request supplied — report integrity only, and say so
+  // rather than letting the caller read it as a full replay.
+  if (payload.request === undefined) {
+    const durationMs = Date.now() - startMs;
+    void logDsgApiCall({
+      orgId: caller.orgId,
+      actorType: caller.actorType,
+      apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+      userId: caller.actorType === 'user' ? caller.userId : undefined,
+      route: 'actions/replay',
+      statusCode: 200,
+      gateStatus: integrity.intact ? 'INTACT' : 'ALTERED',
+      proofId: receipt.receiptId,
+      durationMs,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        type: 'dsg-verified-action-integrity',
+        mode: 'integrity-only',
+        receiptId: receipt.receiptId,
+        receiptIntact: integrity.intact,
+        reason: integrity.intact
+          ? 'Receipt contents hash to the presented receiptId.'
+          : integrity.reason,
+        replayPerformed: false,
+        note: 'Supply the original verify request as `request` to replay the chain and compare every hash.',
+      },
+      { headers: rateLimitHeaders },
+    );
+  }
+
+  const validated = validateVerifiedActionRequest(payload.request);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'validation_failed', details: validated.details },
+      { status: 400, headers: rateLimitHeaders },
+    );
+  }
+
+  const req = validated.value;
+  const auth: UnifiedAuthContext = {
+    source: caller.actorType === 'api_key' ? 'api-key' : 'session',
+    actorId: caller.actorType === 'api_key' ? caller.apiKeyId : caller.userId,
+    orgId: caller.orgId,
+    roles: ['operator'],
+  };
+
+  const fresh = await runCanonicalActionFromSurface(
+    {
+      surface: req.surface,
+      sessionId: req.sessionId,
+      agentId: req.agentId,
+      agentName: req.agentName,
+      planContractVerified: req.planContractVerified,
+      optimization: req.optimization as never,
+      actionSolution: req.actionSolution,
+      approval: req.approval,
+      audit: req.audit,
+      evidence: req.evidence,
+    },
+    auth,
+    {
+      simulate: async () => req.observed.simulation,
+      execute: async () => req.observed.execution,
+    },
+  );
+
+  const replay = replayVerifiedAction(receipt, fresh.result);
+  const durationMs = Date.now() - startMs;
+
+  void logDsgApiCall({
+    orgId: caller.orgId,
+    actorType: caller.actorType,
+    apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+    userId: caller.actorType === 'user' ? caller.userId : undefined,
+    route: 'actions/replay',
+    statusCode: 200,
+    gateStatus: replay.replayMatch ? 'REPLAY_MATCH' : 'REPLAY_MISMATCH',
+    proofId: receipt.receiptId,
+    durationMs,
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      type: 'dsg-verified-action-replay',
+      mode: 'full-replay',
+      receiptId: receipt.receiptId,
+      replayMatch: replay.replayMatch,
+      receiptIntact: replay.receiptIntact,
+      verdictMatch: replay.verdictMatch,
+      comparedFields: replay.comparedFields,
+      mismatchedFields: replay.mismatchedFields,
+      fields: replay.fields,
+      reason: replay.reason,
+      boundary:
+        'Replay re-runs the canonical chain over the same inputs and compares hashes. It does not re-execute the action against any live system.',
+    },
+    { headers: rateLimitHeaders },
+  );
+}

--- a/app/api/dsg/v1/actions/verify/route.ts
+++ b/app/api/dsg/v1/actions/verify/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import { validateVerifiedActionRequest } from '@/lib/dsg-one/verified-action-request';
+import { buildVerifiedActionReceipt } from '@/lib/dsg-one/verified-action-receipt';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import {
+  requireDsgAuth,
+  dsgAuthError,
+  logDsgApiCall,
+} from '@/lib/dsg/auth/require-dsg-auth';
+import {
+  checkGateEntitlement,
+  recordGateEvaluation,
+} from '@/lib/dsg/gate-entitlement';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/dsg/v1/actions/verify — Verified Agent Action.
+ *
+ * The first HTTP surface over the canonical DSG chain
+ * (QUBO -> Ising -> Z3 -> exact proof -> Action IR -> DSG gate ->
+ * pre-execution simulation -> evidence -> receipt/replay).
+ *
+ * Boundary: the caller's runtime executes the action and submits what it
+ * observed. This route verifies that observation against the chain and issues a
+ * receipt. It never executes anything, so the simulate/execute hooks below are
+ * bound to the submitted evidence rather than to any live executor.
+ */
+export async function POST(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const startMs = Date.now();
+
+  const rateLimitResult = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-verified-action:${caller.orgId}`),
+    limit: 60,
+    windowMs: 60_000,
+  });
+  const rateLimitHeaders = buildRateLimitHeaders(rateLimitResult, 60);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limit_exceeded' },
+      { status: 429, headers: rateLimitHeaders },
+    );
+  }
+
+  const entitlement = await checkGateEntitlement(caller.orgId);
+  if (!entitlement.allowed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: entitlement.message,
+        requiresUpgrade: entitlement.requiresPayment,
+        tier: entitlement.tier,
+        accessMode: entitlement.accessMode,
+        upgradeUrl: entitlement.upgradeUrl,
+      },
+      {
+        status: entitlement.requiresPayment ? 402 : 503,
+        headers: rateLimitHeaders,
+      },
+    );
+  }
+
+  const body = await readJsonBody(request, { maxBytes: 64_000 });
+  if (!body.ok) {
+    return NextResponse.json(
+      { ok: false, error: body.error },
+      { status: body.status, headers: rateLimitHeaders },
+    );
+  }
+
+  const validated = validateVerifiedActionRequest(body.value);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'validation_failed', details: validated.details },
+      { status: 400, headers: rateLimitHeaders },
+    );
+  }
+
+  const req = validated.value;
+
+  const auth: UnifiedAuthContext = {
+    source: caller.actorType === 'api_key' ? 'api-key' : 'session',
+    actorId: caller.actorType === 'api_key' ? caller.apiKeyId : caller.userId,
+    orgId: caller.orgId,
+    roles: ['operator'],
+  };
+
+  const canonicalResult = await runCanonicalActionFromSurface(
+    {
+      surface: req.surface,
+      sessionId: req.sessionId,
+      agentId: req.agentId,
+      agentName: req.agentName,
+      planContractVerified: req.planContractVerified,
+      optimization: req.optimization as never,
+      actionSolution: req.actionSolution,
+      approval: req.approval,
+      audit: req.audit,
+      evidence: req.evidence,
+    },
+    auth,
+    {
+      simulate: async () => req.observed.simulation,
+      execute: async () => req.observed.execution,
+    },
+  );
+
+  const problemId = String(
+    (req.optimization as Record<string, unknown>).problemId ?? '',
+  );
+  const receipt = buildVerifiedActionReceipt({
+    canonicalResult: canonicalResult.result,
+    surface: req.surface,
+    workspaceId: caller.orgId,
+    problemId,
+  });
+
+  const durationMs = Date.now() - startMs;
+
+  // Metered on every verified action, PASS or BLOCK: a BLOCK receipt is the
+  // product working, not a failed request, and the caller keeps the evidence.
+  const usage = await recordGateEvaluation(
+    req.idempotencyKey,
+    caller.orgId,
+    'actions/verify',
+    receipt.verdict,
+    durationMs,
+  );
+
+  if (!usage.recorded) {
+    const accessMode = usage.error?.startsWith('delivery_blocked:')
+      ? usage.error.slice('delivery_blocked:'.length)
+      : 'billing_unavailable';
+    const requiresUpgrade =
+      accessMode === 'quota_exceeded' || accessMode === 'subscription_inactive';
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'usage_evidence_unavailable',
+        accessMode,
+        requiresUpgrade,
+        message:
+          'Receipt withheld because usage evidence could not be recorded safely.',
+        upgradeUrl: '/pricing#dsg-gate',
+      },
+      { status: requiresUpgrade ? 402 : 503, headers: rateLimitHeaders },
+    );
+  }
+
+  const response = NextResponse.json(
+    {
+      ok: true,
+      type: 'dsg-verified-action',
+      receipt,
+      canonical: canonicalResult.canonical,
+      surface: canonicalResult.surface,
+      entitlement: {
+        tier: entitlement.tier,
+        evalsRemaining: entitlement.evalsRemaining,
+        accessMode: entitlement.accessMode,
+      },
+      caller: { orgId: caller.orgId, actorType: caller.actorType },
+      replayWith: '/api/dsg/v1/actions/replay',
+      boundary: canonicalResult.boundary,
+    },
+    { headers: rateLimitHeaders },
+  );
+
+  void logDsgApiCall({
+    orgId: caller.orgId,
+    actorType: caller.actorType,
+    apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+    userId: caller.actorType === 'user' ? caller.userId : undefined,
+    route: 'actions/verify',
+    statusCode: 200,
+    gateStatus: receipt.verdict,
+    proofId: receipt.receiptId,
+    durationMs,
+  });
+
+  return response;
+}

--- a/app/api/install/manifest/route.ts
+++ b/app/api/install/manifest/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-static';
+
+export type InstallChannel = {
+  id: 'web' | 'api' | 'mcp' | 'github' | 'vercel';
+  name: string;
+  status: 'ready' | 'guided' | 'planned';
+  installMode: 'one-click' | 'guided' | 'manual';
+  href: string;
+  firstValue: string;
+  notes?: string;
+};
+
+const channels: InstallChannel[] = [
+  {
+    id: 'web',
+    name: 'DSG ONE Web',
+    status: 'ready',
+    installMode: 'one-click',
+    href: '/demo',
+    firstValue: 'Run a public proof demo without connecting production systems.',
+  },
+  {
+    id: 'api',
+    name: 'DSG Gate API',
+    status: 'ready',
+    installMode: 'guided',
+    href: '/dashboard/api-keys',
+    firstValue: 'Create an API key, submit a governed action, and receive a decision with evidence.',
+  },
+  {
+    id: 'mcp',
+    name: 'DSG ONE MCP Server',
+    status: 'guided',
+    installMode: 'manual',
+    href: '/start#mcp',
+    firstValue: 'Connect an MCP client to DSG services after configuring the required service credentials.',
+    notes: 'The repository MCP server currently requires local installation and environment configuration.',
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    status: 'planned',
+    installMode: 'guided',
+    href: '/request-access?integration=github',
+    firstValue: 'Gate repository or agent actions before execution.',
+    notes: 'Do not advertise one-click GitHub App installation until the production GitHub App registration and callback flow are verified.',
+  },
+  {
+    id: 'vercel',
+    name: 'Vercel',
+    status: 'planned',
+    installMode: 'guided',
+    href: '/request-access?integration=vercel',
+    firstValue: 'Verify deployment actions and retain evidence for review.',
+    notes: 'Do not advertise one-click Vercel installation until a production integration installation flow is verified.',
+  },
+];
+
+export function GET() {
+  return NextResponse.json({
+    ok: true,
+    version: 1,
+    principle: 'Only advertise automation that is actually wired and verifiable.',
+    channels,
+  });
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -99,19 +99,22 @@ export default function PricingPage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-950 py-12 px-4">
       <div className="max-w-6xl mx-auto">
-        {/* Page Header */}
         <div className="text-center mb-16">
           <p className="text-xs uppercase tracking-[0.25em] text-emerald-300 mb-3">Pricing</p>
           <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
             AI Governance, Designed to Scale
           </h1>
           <p className="text-lg text-slate-300 max-w-2xl mx-auto">
-            Two powerful products — Delivery Proof Scanning and the DSG Gate API —
-            so every AI action is governed, proven, and auditable.
+            Two products — Delivery Proof Scanning and the DSG Gate API — so teams can inspect evidence before expanding production usage.
           </p>
+          <Link
+            href="/start"
+            className="mt-6 inline-flex rounded-xl border border-emerald-300/30 bg-emerald-300/10 px-5 py-3 text-sm font-bold text-emerald-100 hover:border-emerald-300/60"
+          >
+            See connection and install paths →
+          </Link>
         </div>
 
-        {/* ── Section 1: DSG Gate API ──────────────────────────────────────── */}
         <section id="dsg-gate" className="mb-20">
           <div className="mb-8">
             <span className="inline-block px-3 py-1 text-xs font-bold uppercase tracking-widest rounded-full bg-violet-500/20 text-violet-300 border border-violet-500/30 mb-3">
@@ -121,8 +124,7 @@ export default function PricingPage() {
               Deterministic AI Governance API
             </h2>
             <p className="text-slate-400 max-w-xl">
-              Same input → same decision, always. Cryptographic proof per evaluation.
-              Hash-chained audit trail. Replay-protected intent flow.
+              Same input and policy context produce a replayable decision path with evidence hashes for later verification.
             </p>
           </div>
           <div className="grid md:grid-cols-3 gap-6">
@@ -132,7 +134,6 @@ export default function PricingPage() {
           </div>
         </section>
 
-        {/* ── Section 2: Delivery Proof ────────────────────────────────────── */}
         <section id="delivery-proof" className="mb-20">
           <div className="mb-8">
             <span className="inline-block px-3 py-1 text-xs font-bold uppercase tracking-widest rounded-full bg-emerald-500/20 text-emerald-300 border border-emerald-500/30 mb-3">
@@ -142,8 +143,7 @@ export default function PricingPage() {
               AI Delivery Proof Scanning
             </h2>
             <p className="text-slate-400 max-w-xl">
-              Instantly prove your deployment is production-ready with a shareable
-              compliance report — homepage, auth, health, and CCVS evidence chain.
+              Generate a shareable readiness report for the checks the scanner actually runs, including homepage, auth, health, and available evidence-chain checks.
             </p>
           </div>
           <div className="grid md:grid-cols-3 gap-6">
@@ -153,21 +153,18 @@ export default function PricingPage() {
           </div>
         </section>
 
-        {/* FAQ */}
         <div className="max-w-2xl mx-auto border border-white/10 rounded-2xl bg-white/[0.02] p-8 mb-12">
           <h2 className="text-2xl font-bold text-white mb-6">Frequently Asked Questions</h2>
           <div className="space-y-4">
             <details className="group cursor-pointer">
               <summary className="flex items-center justify-between font-semibold text-white hover:text-emerald-300">
-                <span>What makes the DSG Gate API unique?</span>
+                <span>What evidence does the DSG Gate API return?</span>
                 <span className="transition group-open:rotate-180">▼</span>
               </summary>
               <p className="mt-3 text-sm text-slate-400 pl-4">
-                Every evaluation returns a <code className="text-emerald-300">proofHash</code>,{' '}
+                Gate responses can include a <code className="text-emerald-300">proofHash</code>,{' '}
                 <code className="text-emerald-300">constraintSetHash</code>, and{' '}
-                <code className="text-emerald-300">inputHash</code> — forming a cryptographic
-                chain that cannot be altered retroactively. No other AI governance product
-                provides deterministic replay with formal proof evidence.
+                <code className="text-emerald-300">inputHash</code> so the recorded decision can be checked against its input and constraint context.
               </p>
             </details>
 
@@ -177,9 +174,7 @@ export default function PricingPage() {
                 <span className="transition group-open:rotate-180">▼</span>
               </summary>
               <p className="mt-3 text-sm text-slate-400 pl-4">
-                Yes. The Free tier includes all core proof and gate features — PASS/REVIEW/BLOCK
-                decisions, replay protection, and JSON audit logs. The 50 eval/month limit
-                is a lead magnet; upgrade to Pro for high-volume production use.
+                Use the Free tier to validate fit and the evidence flow within its published quota. Production suitability still depends on your own availability, security, compliance, and support requirements.
               </p>
             </details>
 
@@ -189,34 +184,30 @@ export default function PricingPage() {
                 <span className="transition group-open:rotate-180">▼</span>
               </summary>
               <p className="mt-3 text-sm text-slate-400 pl-4">
-                Absolutely. Monthly plans can be changed or cancelled at any time.
-                Pro Scan ($49 one-time) purchases are non-refundable but add to your monthly quota.
+                Monthly plan changes and cancellation follow the checkout and billing terms presented for the active plan. One-time purchases follow the terms shown at checkout.
               </p>
             </details>
 
             <details className="group cursor-pointer">
               <summary className="flex items-center justify-between font-semibold text-white hover:text-emerald-300">
-                <span>Do you offer enterprise pricing?</span>
+                <span>Do you offer enterprise integration?</span>
                 <span className="transition group-open:rotate-180">▼</span>
               </summary>
               <p className="mt-3 text-sm text-slate-400 pl-4">
-                Yes. The Enterprise plan includes unlimited gate evaluations, Hermes Controlled
-                Executor access, credential brokering, 99.9% SLA, and dedicated Slack support.
-                Contact sales for custom connector integrations and white-label options.
+                Yes. Use the start page to see which connection paths are ready now and which managed GitHub or Vercel integration paths require access setup before they are advertised as one-click installs.
               </p>
             </details>
           </div>
         </div>
 
-        {/* Footer CTA */}
         <div className="text-center mt-4">
-          <p className="text-slate-400 mb-4">Ready to prove your AI governance?</p>
+          <p className="text-slate-400 mb-4">Ready to connect DSG ONE?</p>
           <div className="flex gap-4 justify-center flex-wrap">
             <Link
-              href="/dashboard/api-keys"
+              href="/start"
               className="px-6 py-3 rounded-xl bg-violet-500 text-white font-bold hover:bg-violet-400 transition"
             >
-              Get DSG Gate API Key →
+              Start and connect →
             </Link>
             <Link
               href="/delivery-proof"

--- a/app/request-access/page.tsx
+++ b/app/request-access/page.tsx
@@ -1,20 +1,34 @@
 export default async function RequestAccessPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ email?: string; workspace_name?: string; success?: string }>;
+  searchParams?: Promise<{
+    email?: string;
+    workspace_name?: string;
+    success?: string;
+    integration?: string;
+  }>;
 }) {
   const params = await searchParams;
   const email = String(params?.email || '').trim().toLowerCase();
   const workspaceName = String(params?.workspace_name || '').trim();
   const success = params?.success === '1';
+  const requestedIntegration = String(params?.integration || '').trim().toLowerCase();
+  const integration = requestedIntegration === 'github' || requestedIntegration === 'vercel'
+    ? requestedIntegration
+    : '';
+  const integrationLabel = integration === 'github' ? 'GitHub' : integration === 'vercel' ? 'Vercel' : '';
 
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-16 text-white">
       <div className="mx-auto max-w-3xl rounded-[2rem] border border-white/10 bg-white/5 p-8 backdrop-blur-sm">
         <p className="text-sm uppercase tracking-[0.3em] text-emerald-200">Request access</p>
-        <h1 className="mt-4 text-4xl font-bold">Your finance organization requires approval</h1>
+        <h1 className="mt-4 text-4xl font-bold">
+          {integrationLabel ? `Request DSG ONE + ${integrationLabel} integration` : 'Request governed workspace access'}
+        </h1>
         <p className="mt-4 text-base leading-7 text-slate-300">
-          Submit this request when your organization restricts governed workspace access. Public proof pages can remain open for evaluation, while protected finance workspace pages require approved access.
+          {integrationLabel
+            ? `Submit this request so the ${integrationLabel} connection can be provisioned and verified before it is treated as an automated production install.`
+            : 'Submit this request when your organization restricts governed workspace access. Public proof pages can remain open for evaluation, while protected workspace pages require approved access.'}
         </p>
 
         {success ? (
@@ -24,6 +38,8 @@ export default async function RequestAccessPage({
         ) : null}
 
         <form action="/api/access/request" method="post" className="mt-8 space-y-4">
+          {integration ? <input type="hidden" name="integration" value={integration} /> : null}
+
           <div>
             <label htmlFor="email" className="mb-2 block text-sm font-medium text-slate-200">
               Work email
@@ -65,12 +81,13 @@ export default async function RequestAccessPage({
 
           <div>
             <label htmlFor="reason" className="mb-2 block text-sm font-medium text-slate-200">
-              Reason (optional)
+              What do you want to connect? (optional)
             </label>
             <textarea
               id="reason"
               name="reason"
               rows={4}
+              defaultValue={integrationLabel ? `Provision and verify DSG ONE for ${integrationLabel}.` : undefined}
               className="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-4 text-slate-100 outline-none"
             />
           </div>

--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -1,0 +1,143 @@
+import Link from 'next/link';
+
+const channels = [
+  {
+    title: 'Web demo',
+    status: 'Ready now',
+    body: 'Try DSG without connecting production systems. See the decision and evidence flow first.',
+    href: '/demo',
+    cta: 'Run demo',
+  },
+  {
+    title: 'DSG Gate API',
+    status: 'Ready now',
+    body: 'Create an API key, submit governed actions, and receive deterministic decision evidence.',
+    href: '/dashboard/api-keys',
+    cta: 'Create API key',
+  },
+  {
+    title: 'MCP server',
+    status: 'Guided install',
+    body: 'Use the repository MCP server with your own configured Supabase, Vercel, Stripe, Spine, DSG Brain, or compliance services.',
+    href: '#mcp',
+    cta: 'See MCP setup',
+  },
+  {
+    title: 'GitHub integration',
+    status: 'Access request',
+    body: 'Use DSG as a verification layer around repository and agent actions. One-click GitHub App installation is not advertised until the production app flow is verified.',
+    href: '/request-access?integration=github',
+    cta: 'Request GitHub integration',
+  },
+  {
+    title: 'Vercel integration',
+    status: 'Access request',
+    body: 'Verify deployment actions and retain evidence. One-click installation will only be exposed after the production integration callback is verified.',
+    href: '/request-access?integration=vercel',
+    cta: 'Request Vercel integration',
+  },
+];
+
+const flow = [
+  ['1', 'Choose a connection', 'Start with Web/API now, or request a managed GitHub/Vercel integration.'],
+  ['2', 'Connect only what is needed', 'DSG should not ask for unrelated credentials or force a migration.'],
+  ['3', 'Run the first governed action', 'See the recommended/received action, policy result, reason, and evidence in one place.'],
+  ['4', 'Execute only when authorized', 'Plan-authorized execution continues unless a verified constraint requires REVIEW or BLOCK.'],
+  ['5', 'Keep evidence and replay', 'Store hashes, solver/version context, decision evidence, and enough input context to verify later.'],
+  ['6', 'Upgrade when usage proves value', 'Pricing and checkout come after first value, not before the user can understand the product.'],
+] as const;
+
+export default function StartPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-white">
+      <section className="border-b border-white/10 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.16),transparent_36%)]">
+        <div className="mx-auto max-w-6xl px-6 py-16">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-emerald-300">Start DSG ONE</p>
+          <h1 className="mt-4 max-w-4xl text-4xl font-black leading-tight md:text-6xl">
+            Connect → verify → execute → evidence.
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+            This is the shortest supported path to first value. DSG ONE does not label a connection “automatic” until that production install flow is actually wired and testable.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link href="/demo" className="rounded-xl bg-emerald-400 px-6 py-3 font-bold text-slate-950 hover:bg-emerald-300">
+              Try before login
+            </Link>
+            <Link href="/pricing" className="rounded-xl border border-white/15 px-6 py-3 font-bold text-white hover:border-emerald-300/50">
+              View pricing
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-14">
+        <div className="mb-8">
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">Sales + install channels</p>
+          <h2 className="mt-2 text-3xl font-black">Use the channel you already work in.</h2>
+        </div>
+        <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {channels.map((channel) => (
+            <div key={channel.title} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+              <div className="flex items-start justify-between gap-4">
+                <h3 className="text-xl font-bold">{channel.title}</h3>
+                <span className="rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-emerald-200">
+                  {channel.status}
+                </span>
+              </div>
+              <p className="mt-4 min-h-24 text-sm leading-7 text-slate-300">{channel.body}</p>
+              <Link href={channel.href} className="mt-5 inline-flex rounded-xl bg-white/10 px-4 py-3 text-sm font-bold hover:bg-white/15">
+                {channel.cta} →
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-slate-900/50">
+        <div className="mx-auto max-w-6xl px-6 py-14">
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">End-to-end flow</p>
+          <h2 className="mt-2 text-3xl font-black">One flow from first click to paid usage.</h2>
+          <div className="mt-8 grid gap-4 md:grid-cols-2">
+            {flow.map(([number, title, body]) => (
+              <div key={number} className="grid grid-cols-[44px_1fr] gap-4 rounded-2xl border border-white/10 bg-black/20 p-5">
+                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-emerald-400 font-black text-slate-950">{number}</div>
+                <div>
+                  <h3 className="font-bold">{title}</h3>
+                  <p className="mt-1 text-sm leading-6 text-slate-300">{body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="mcp" className="mx-auto max-w-6xl px-6 py-14">
+        <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">MCP setup — current verified boundary</p>
+        <h2 className="mt-2 text-3xl font-black">Repository install is available; managed one-click install is not claimed yet.</h2>
+        <p className="mt-4 max-w-3xl text-slate-300 leading-7">
+          The current DSG ONE MCP server is installed from the repository, configured with the service credentials you actually use, built, and then started. This page deliberately does not invent a public package name or a production OAuth flow that has not been verified.
+        </p>
+        <div className="mt-6 overflow-x-auto rounded-2xl border border-white/10 bg-black/40 p-5">
+          <pre className="text-sm leading-7 text-emerald-200"><code>{`cd dsg-one-mcp-server\nnpm install\nnpm run build\nnpm start`}</code></pre>
+        </div>
+        <p className="mt-4 text-sm text-slate-400">
+          Configure only the environment variables for the connected services you intend to use. Required credentials remain server-side and should never be pasted into a public page.
+        </p>
+      </section>
+
+      <section className="border-t border-white/10 bg-emerald-400/10">
+        <div className="mx-auto max-w-6xl px-6 py-12 text-center">
+          <h2 className="text-3xl font-black">See value first. Pay when you need production volume.</h2>
+          <p className="mx-auto mt-3 max-w-2xl text-slate-300">
+            Start with the demo or API path, verify the evidence flow, then choose a paid plan or enterprise integration.
+          </p>
+          <div className="mt-7 flex flex-wrap justify-center gap-3">
+            <Link href="/demo" className="rounded-xl bg-emerald-400 px-6 py-3 font-black text-slate-950 hover:bg-emerald-300">Run demo</Link>
+            <Link href="/pricing" className="rounded-xl border border-emerald-300/30 px-6 py-3 font-black text-emerald-100">Choose plan</Link>
+            <Link href="/request-access" className="rounded-xl border border-white/15 px-6 py-3 font-black">Enterprise access</Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/docs/DSG_ONE_CANONICAL_PRODUCT_E2E.md
+++ b/docs/DSG_ONE_CANONICAL_PRODUCT_E2E.md
@@ -1,0 +1,315 @@
+# DSG ONE Canonical Product E2E Plan
+
+Date baseline: 2026-08-15
+
+## Product position
+
+DSG ONE is a verification layer for agent actions after authorization and before/after execution.
+
+Primary customer question:
+
+> Can this agent action be independently verified, executed as authorized, and replayed from evidence?
+
+DSG ONE should not compete on generic approval prompts, policy toggles, dashboards, or basic monitoring. Those are increasingly platform features. DSG ONE differentiates on deterministic verification, exact/constraint proof, execution binding, evidence receipts, and replay.
+
+## Canonical chain
+
+Authenticated AGI/AIMO request
+→ deterministic Simulation / scenario witness
+→ canonical QUBO problem
+→ Ising candidate search
+→ Z3 feasibility verification
+→ exact optimality proof when tractable
+→ VERIFIED_GLOBAL_OPTIMUM only when the optimum claim is actually proven
+→ Verified Action Compiler / Action IR
+→ DSG plan + scope + authorization gate
+→ ALLOW or BLOCK
+→ pre-execution ROM/Desktop/Browser/Shell simulation
+→ controlled executor
+→ observed postconditions
+→ local/runtime evidence
+→ deterministic receipt
+→ replay / audit verification
+→ Trinity MCP / Unify surface
+
+No stage may silently create a second independent production decision engine.
+
+## Truth boundaries
+
+1. Simulation may generate candidates or predict outcomes. It does not authorize execution.
+2. Ising may produce a candidate. Candidate quality is not itself a proof.
+3. Z3 SAT proves feasibility of the pinned assignment under encoded constraints. SAT alone is not proof of global optimality.
+4. VERIFIED_GLOBAL_OPTIMUM may be emitted only when the objective and constraints are bound to the same canonical problem and exact optimality is actually proven.
+5. Compilation PASS is not execution permission.
+6. ALLOW is issued only after verified plan/scope/authorization checks.
+7. An execution is complete only after observed postconditions and evidence are recorded.
+8. Replay must bind to the same hashes/versions and clearly report mismatch or unverifiable states.
+
+## Immediate technical blocker before strong global-optimum marketing
+
+The current QUBO builder is primarily feasibility/penalty oriented. Before using VERIFIED_GLOBAL_OPTIMUM as a paid product claim for business optimization, DSG ONE needs an explicit domain objective with versioned semantics, for example cost, risk, latency, capital usage, expected loss, or deployment risk. The objective hash must be included in the canonical problem hash and used by Ising and exact/Z3 verification.
+
+For problem sizes above the exact proof bound, the product must downgrade the claim to VERIFIED_FEASIBLE or another accurately scoped verdict rather than claiming global optimum.
+
+## Paid offers
+
+### Offer A — Verified Agent Action
+
+Customer supplies or authorizes an agent plan. DSG verifies constraints and plan alignment before execution, then produces evidence and replay receipt after execution.
+
+Customer-visible result:
+- VERIFIED + ALLOW + EXECUTED + REPLAYABLE
+- or BLOCK with exact reason and remediation
+
+Best initial use cases: finance operations, payment workflows, approvals with external effects, deployment agents, regulated automation.
+
+### Offer B — Verified Deployment Proof
+
+GitHub/Vercel workflow:
+Authorize repository/project → bind commit and plan → verify constraints → deploy → observe health/postconditions → issue deployment proof receipt → replay.
+
+Positioning:
+GitHub authorization/policy → DSG verification → controlled execution → evidence/replay receipt.
+
+Do not position DSG as a replacement for GitHub enterprise policy controls.
+
+### Offer C — Audit Evidence Pack
+
+Convert logs, runtime telemetry, Supabase evidence, plan hashes, proof hashes, execution receipts, and replay results into a human-readable/exportable evidence pack.
+
+Do not compete with Grafana/Supabase as a monitoring dashboard. Monitoring data is input evidence; verified evidence is the paid output.
+
+## User experience
+
+The core product flow must be shorter than the current integration burden:
+
+Install → Connect → Choose verification profile → Run first verified action → See proof
+
+The main execution screen should show only the information needed to make a decision:
+
+Plan | Constraints | Decision | Execution | Evidence | Replay
+
+BLOCK states must show:
+- what failed
+- why it failed
+- what the user must change
+
+ALLOW states must show:
+- what was authorized
+- what actually ran
+- observed postconditions
+- receipt/proof hashes
+- replay status
+
+Advanced solver, Z3, Ising, and QUBO details belong in an expandable proof view, not the first screen.
+
+## Distribution order
+
+### 1. GitHub Action first
+
+Goal: zero-new-dashboard adoption for engineering teams.
+
+Installation target:
+Add DSG GitHub Action → authenticate → select verification profile → next PR/deployment receives proof status/check and receipt.
+
+GitHub Action should block only unsupported or unverified execution claims/actions outside the authorized plan. It must not block plan-authorized execution merely because DSG is present.
+
+### 2. Direct DSG ONE API + MCP
+
+Expose canonical verification through DSG ONE API and Trinity MCP so desktop/agent clients can request verify → execute → evidence → replay using the same proof model.
+
+### 3. Vercel integration / Marketplace preparation
+
+Target install path:
+Install → authorize project → choose policy/profile → run first verification → see proof.
+
+Provisioning, authentication, usage metering, billing handoff, project linking, and first-run verification must be automated before marketplace submission.
+
+### 4. Finance vertical package
+
+Ship one concrete finance demo rather than a generic agent demo.
+
+Recommended first scenario:
+Agent proposes a financial or deployment action with an external effect → simulation → constraint/objective model → Ising candidate → Z3/exact verification → approved action compilation → controlled execution → evidence → replay.
+
+The demo must measure:
+- replay match rate
+- evidence completeness
+- constraint/policy violation detection
+- deterministic receipt consistency
+- time-to-first-proof
+
+## Revenue funnel
+
+Landing page claim → interactive verified-action demo → GitHub/Vercel install → first proof → evidence history → paid quota / team / audit export.
+
+The paid conversion event should be tied to a useful verified outcome, not account creation or dashboard access.
+
+Suggested packaging logic:
+- one-time Verified Readiness / Deployment Proof
+- Solo: limited projects/executions
+- Team: shared evidence/replay and alerts
+- Production: higher execution limits, audit export, policy/constraint profiles, support
+
+Pricing must be validated from actual conversion data before being treated as final.
+
+## Implementation phases and Definition of Done
+
+### Phase 0 — Canonical truth contract
+
+Deliver:
+- one canonical problem schema
+- objective version + constraint version
+- problemHash/objectiveHash/constraintHash
+- one verdict vocabulary
+- no duplicate production gates
+
+Done when same normalized input produces the same canonical hashes and different objective/constraint versions produce different hashes.
+
+### Phase 1 — Simulation → QUBO → Ising → Z3 → exact proof
+
+Deliver:
+- bind deterministic simulation witness to canonical problem
+- build QUBO from the same canonical data
+- Ising candidate with solutionHash
+- Z3 pinned-assignment feasibility proof
+- exact optimality proof for tractable sizes
+- accurate downgrade for unproven optimum
+
+Done when:
+- same input + seed → same hashes/verdict
+- invalid candidate → BLOCKED_INFEASIBLE
+- better candidate exists → BLOCKED_NOT_GLOBAL_OPTIMUM
+- proven optimum → VERIFIED_GLOBAL_OPTIMUM
+- oversized exact case → no false global-optimum claim
+
+### Phase 2 — Verified Action Compiler
+
+Deliver:
+- map verified solution into deterministic Action IR
+- preserve every supported parameter
+- reject unsupported or dropped parameters
+- bind upstream proofHash to actionPlanHash
+
+Done when plan mutation, missing parameter, unsupported mapping, or proof mismatch fails closed.
+
+### Phase 3 — DSG ALLOW/BLOCK
+
+Deliver:
+- plan hash verification
+- scope/RBAC/authorization verification
+- action envelope verification
+- idempotency / replay protection
+
+Done when:
+- plan-authorized valid action → ALLOW
+- plan mismatch → BLOCK
+- scope mismatch → BLOCK
+- unsupported action → BLOCK
+- same idempotency key cannot cause duplicate execution
+
+### Phase 4 — Pre-execution simulation + executor
+
+Deliver:
+- ROM/Desktop/Browser/Shell simulation for the compiled Action IR
+- controlled executor invoked only after ALLOW
+- execution exactly once
+
+Done when BLOCK never invokes executor and ALLOW invokes only the approved action/arguments.
+
+### Phase 5 — Evidence + deterministic receipt + replay
+
+Deliver:
+- observed result/postconditions
+- evidence hashes
+- solver and policy versions
+- chainHash/receiptHash
+- durable evidence storage
+- replay endpoint and UI
+
+Done when tampering with plan, proof, evidence, outcome, or version is detected and replay gives a clear deterministic/mismatch/unverifiable result.
+
+### Phase 6 — Trinity MCP + Unify
+
+Deliver:
+- same canonical tools available through Trinity MCP
+- no alternate decision logic in MCP/Desktop surfaces
+- local executors return result receipt to DSG ONE
+
+Done when MCP/Desktop requests produce the same proof/decision hashes as the API path for the same canonical request.
+
+### Phase 7 — GitHub Action paid wedge
+
+Deliver:
+- installable workflow/action
+- verification check on PR/deploy
+- proof receipt artifact/status
+- one-click route to evidence view
+
+Done when a new customer can install and obtain a first real proof without manually wiring solver internals.
+
+### Phase 8 — Vercel distribution
+
+Deliver:
+- automated project authorization/linking
+- provisioning
+- environment setup
+- first verification
+- usage/billing integration
+- marketplace-ready metadata/docs
+
+Done when install-to-first-proof is a short guided flow with no secret hunting for normal customers.
+
+### Phase 9 — Finance launch
+
+Deliver:
+- one finance-specific verification profile
+- benchmark against non-verified baseline
+- finance evidence pack
+- case-study/demo flow
+
+Done when DSG can demonstrate measurable improvement in verification/replay/evidence quality without claiming capabilities not proven by the benchmark.
+
+## Priority order from now
+
+P0: finish canonical proof chain and eliminate false/ambiguous global-optimum claims.
+
+P1: connect VERIFIED_GLOBAL_OPTIMUM → Action IR → DSG ALLOW/BLOCK → executor → evidence → replay → Trinity/Unify in one automated E2E test.
+
+P2: ship GitHub Action + Verified Deployment Proof as the first low-friction paid wedge.
+
+P3: expose Evidence Pack and replay UI.
+
+P4: automate Vercel install/provisioning and prepare marketplace distribution.
+
+P5: package the first finance vertical and benchmark it.
+
+## Product success metrics
+
+Technical:
+- deterministic replay match rate
+- evidence completeness rate
+- false ALLOW rate
+- false BLOCK rate
+- proof verification latency
+- exact-proof coverage by problem size
+- executor duplicate rate
+
+Product/revenue:
+- install → first proof conversion
+- time to first proof
+- first proof → second verified action rate
+- free → paid conversion after verified outcome
+- verified actions per active project
+- evidence-pack export rate
+- paid retention by project/team
+
+## Stop-doing list
+
+Do not prioritize another generic dashboard, generic monitoring, another approval UI, or a second policy engine before the canonical verified-action flow is complete.
+
+Do not market Z3 SAT as global optimality.
+
+Do not market deterministic replay unless the same input, objective, constraints, solver/policy versions, and evidence bindings are actually preserved or the product explicitly reports the boundary.
+
+Do not add distribution channels before install-to-first-proof works reliably in the existing GitHub/Vercel path.

--- a/docs/E2E_INSTALL_SALES_FUNNEL.md
+++ b/docs/E2E_INSTALL_SALES_FUNNEL.md
@@ -1,0 +1,55 @@
+# DSG ONE E2E Install + Sales Funnel
+
+## Goal
+
+One supported path from discovery to first value to paid usage:
+
+`Discover -> Start -> Connect -> Verify -> Execute (when authorized) -> Evidence -> Upgrade`
+
+## Truth boundary
+
+A channel is only labeled **one-click** when its production installation flow is wired and testable end-to-end.
+
+Current states are published by `GET /api/install/manifest`:
+
+- Web demo: ready / one-click
+- DSG Gate API: ready / guided API-key setup
+- MCP server: guided / repository install + environment configuration
+- GitHub managed install: planned until the production GitHub App registration/callback flow is verified
+- Vercel managed install: planned until the production integration install/callback flow is verified
+
+This prevents the product UI from claiming automation that is not actually available.
+
+## Sales surfaces
+
+- `/start` — connection chooser and first-value path
+- `/pricing` — pricing plus a direct route into `/start`
+- `/demo` — public proof path before login
+- `/dashboard/api-keys` — API activation path
+- `/request-access?integration=github` — managed GitHub integration request
+- `/request-access?integration=vercel` — managed Vercel integration request
+
+## User benefit contract
+
+Every install path must answer:
+
+1. What can I connect?
+2. What do I have to do?
+3. What happens automatically?
+4. What result will I see first?
+5. Where is the evidence?
+6. What is required before execution?
+7. When and why would I pay?
+
+## Execution contract
+
+DSG must not block plan-authorized execution without a verified constraint or unsupported-action reason. `REVIEW` and `BLOCK` must provide a reason and next action. Evidence must be retained for later verification/replay where the underlying execution path supports it.
+
+## Completion checks
+
+- TypeScript typecheck passes.
+- Production build passes.
+- Install manifest integration test passes.
+- `/start` renders in production build.
+- `/pricing` links to `/start`.
+- No GitHub/Vercel one-click claim is shipped until those production install flows are verified.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -1,0 +1,23 @@
+# DSG ONE Provenance
+
+This file records provenance for the end-to-end install and sales funnel added in August 2026.
+
+## Implementation
+
+- Branch: `feat/e2e-install-sales-funnel`
+- Product: DSG ONE / ProofGate Control Plane
+- Scope: `/start`, install-channel manifest, pricing-to-start conversion path, integration and E2E tests
+- Related public formal-verification artifact: DOI `10.5281/zenodo.18225586`
+
+The DOI is cited as provenance for the DSG formal-verification body of work. It does not imply that every UI, installer, integration, or commercial feature in this repository is contained in or formally verified by that archived artifact.
+
+## Claim boundary
+
+New source should distinguish:
+
+- implementation behavior verified by current tests,
+- formal properties verified by a solver under encoded assumptions,
+- commercial or production claims that require live evidence,
+- historical provenance established by archived artifacts.
+
+Do not use a DOI as a substitute for runtime test evidence or as proof of product adoption.

--- a/lib/dsg-one/canonical-action-e2e.ts
+++ b/lib/dsg-one/canonical-action-e2e.ts
@@ -124,7 +124,7 @@ export async function runCanonicalActionE2E(req: CanonicalActionE2ERequest) {
       proofHash: optimization.proof.proofHash,
     },
   });
-  if (!compiled.ok) {
+  if (compiled.ok === false) {
     return {
       verdict: 'BLOCK' as const,
       stage: 'compile' as const,

--- a/lib/dsg-one/canonical-action-e2e.ts
+++ b/lib/dsg-one/canonical-action-e2e.ts
@@ -1,0 +1,269 @@
+import { createHash } from 'node:crypto';
+import type { VerifiedOptimizationRequest } from './verified-optimization-pipeline';
+import { runCanonicalE2EOptimization } from './canonical-e2e-pipeline';
+import {
+  callVerifiedActionTool,
+  type ActionPlan,
+} from '@/lib/mcp/verified-action-tools';
+import {
+  evaluateAgentCommandGate,
+  buildAgentActionResultReceipt,
+  type AgentCommandGateRequest,
+  type AgentCommandRuntime,
+  type AgentCommandRbacProof,
+  type AgentCommandAuditBinding,
+  type AgentCommandEvidenceBinding,
+  type AgentActionType,
+} from '@/lib/dsg/agent-command-gate';
+
+type JsonRecord = Record<string, unknown>;
+
+export type CanonicalActionSolution = {
+  database?: 'supabase';
+  runtime?: 'render' | 'netlify';
+  environment: string;
+  commitSha: string;
+};
+
+export type CanonicalGateContext = {
+  workspaceId: string;
+  runtime: AgentCommandRuntime;
+  rbac: AgentCommandRbacProof;
+  audit: AgentCommandAuditBinding;
+  evidence: AgentCommandEvidenceBinding;
+  /**
+   * True only when the caller has already validated actionPlanHash against the
+   * server-side approved plan/scope contract. This library never invents that proof.
+   */
+  planContractVerified?: boolean;
+};
+
+export type PreExecutionSimulationResult = {
+  ok: boolean;
+  witnessHash: string;
+  reason?: string;
+};
+
+export type ControlledExecutionResult = {
+  status: 'SUCCESS' | 'FAILED' | 'PARTIAL';
+  observations: Record<string, unknown>;
+  evidence: Array<{
+    fact: string;
+    observerRole: 'verifier';
+    hash: string;
+    [key: string]: unknown;
+  }>;
+  observedResultHash: string;
+  evidenceItemIds: string[];
+};
+
+export interface CanonicalActionE2ERequest {
+  optimization: VerifiedOptimizationRequest;
+  actionSolution: CanonicalActionSolution;
+  gate: CanonicalGateContext;
+  simulate: (plan: ActionPlan) => Promise<PreExecutionSimulationResult>;
+  execute: (plan: ActionPlan) => Promise<ControlledExecutionResult>;
+}
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    const record = value as JsonRecord;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, stable(record[key])]),
+    );
+  }
+  return value;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function actionTypeForStep(action: string): AgentActionType {
+  if (action.includes('deploy')) return 'deploy';
+  return 'write';
+}
+
+/**
+ * Canonical product chain:
+ * Simulation witness -> QUBO -> Ising -> Z3 -> exact proof ->
+ * VERIFIED_GLOBAL_OPTIMUM -> Action IR -> DSG ALLOW/BLOCK ->
+ * pre-execution simulation -> controlled executor -> evidence -> receipt/replay.
+ *
+ * Trinity/Unify are transport/surface adapters and must call this same chain,
+ * not reimplement a second decision engine.
+ */
+export async function runCanonicalActionE2E(req: CanonicalActionE2ERequest) {
+  const upstream = await runCanonicalE2EOptimization(req.optimization);
+  const optimization = upstream.stages.optimization;
+
+  if (optimization.verdict !== 'VERIFIED_GLOBAL_OPTIMUM') {
+    return {
+      verdict: 'BLOCK' as const,
+      stage: 'optimization' as const,
+      executionPerformed: false,
+      upstream,
+      reason: `Action compilation requires VERIFIED_GLOBAL_OPTIMUM; got ${optimization.verdict}.`,
+    };
+  }
+
+  const compiled = await callVerifiedActionTool('dsg.action.compile', {
+    profile: 'software.deploy.v1',
+    solution: req.actionSolution,
+    proof: {
+      verdict: optimization.verdict,
+      proofHash: optimization.proof.proofHash,
+    },
+  });
+  if (!compiled.ok) {
+    return {
+      verdict: 'BLOCK' as const,
+      stage: 'compile' as const,
+      executionPerformed: false,
+      upstream,
+      reason: compiled.message,
+    };
+  }
+
+  const compiledResult = asRecord(compiled.result);
+  const plan = asRecord(compiledResult?.plan) as ActionPlan | null;
+  if (compiledResult?.verdict !== 'PASS' || !plan || !Array.isArray(plan.steps) || plan.steps.length === 0) {
+    return {
+      verdict: 'BLOCK' as const,
+      stage: 'compile' as const,
+      executionPerformed: false,
+      upstream,
+      compilation: compiled.result,
+      reason: String(compiledResult?.reason ?? 'Verified Action Compiler did not emit an executable Action IR.'),
+    };
+  }
+
+  const firstStep = plan.steps[0];
+  const target = String(firstStep.args.target ?? firstStep.executorTool);
+  const planHashForGate = req.gate.planContractVerified ? plan.actionPlanHash : undefined;
+  const gateRequest: AgentCommandGateRequest = {
+    workspaceId: req.gate.workspaceId,
+    runtime: req.gate.runtime,
+    rbac: req.gate.rbac,
+    audit: req.gate.audit,
+    evidence: req.gate.evidence,
+    command: {
+      commandId: firstStep.id,
+      actionType: actionTypeForStep(firstStep.action),
+      targetSystemId: target,
+      operationName: firstStep.action,
+      riskLevel: firstStep.risk,
+      dataClasses: [],
+      payloadHash: sha256(firstStep.args),
+      idempotencyKey: String(firstStep.args.idempotencyKey ?? ''),
+      rollbackPlanId: firstStep.rollback ?? undefined,
+      planHash: planHashForGate,
+    },
+  };
+
+  const gate = evaluateAgentCommandGate(gateRequest);
+  if (!gate.canAgentExecute || !gate.actionEnvelope) {
+    return {
+      verdict: 'BLOCK' as const,
+      stage: 'dsg-gate' as const,
+      executionPerformed: false,
+      upstream,
+      compilation: compiled.result,
+      gate,
+      reason: gate.reasons.join(','),
+    };
+  }
+
+  const simulation = await req.simulate(plan);
+  if (!simulation.ok) {
+    return {
+      verdict: 'BLOCK' as const,
+      stage: 'pre-execution-simulation' as const,
+      executionPerformed: false,
+      upstream,
+      compilation: compiled.result,
+      gate,
+      simulation,
+      reason: simulation.reason ?? 'Pre-execution simulation failed.',
+    };
+  }
+
+  const startedAt = new Date().toISOString();
+  const execution = await req.execute(plan);
+  const completedAt = new Date().toISOString();
+
+  const resultReceipt = buildAgentActionResultReceipt({
+    workspaceId: req.gate.workspaceId,
+    agentId: req.gate.runtime.agentId,
+    sessionId: req.gate.runtime.sessionId,
+    commandId: firstStep.id,
+    envelopeId: gate.actionEnvelope.envelopeId,
+    decisionHash: gate.decisionHash,
+    status: execution.status,
+    startedAt,
+    completedAt,
+    observedResultHash: execution.observedResultHash,
+    evidenceItemIds: execution.evidenceItemIds,
+    planHash: planHashForGate,
+  });
+
+  const acceptance = await callVerifiedActionTool('dsg.action.verifyAcceptance', {
+    plan,
+    observations: execution.observations,
+    evidence: execution.evidence,
+    proofChain: {
+      problemHash: optimization.quboHash,
+      formalModelHash: optimization.z3.proofHash,
+      encodingHash: optimization.exact.proofHash,
+    },
+  });
+
+  const acceptanceResult = acceptance.ok ? asRecord(acceptance.result) : null;
+  const completed =
+    resultReceipt.accepted &&
+    acceptance.ok &&
+    acceptanceResult?.verdict === 'PASS' &&
+    acceptanceResult?.completed === true;
+
+  const deterministicReceiptHash = sha256({
+    canonicalChainHash: upstream.binding.chainHash,
+    optimizationProofHash: optimization.proof.proofHash,
+    actionPlanHash: plan.actionPlanHash,
+    gateDecisionHash: gate.decisionHash,
+    simulationWitnessHash: simulation.witnessHash,
+    resultReceiptHash: resultReceipt.receiptHash,
+    acceptanceHash: acceptanceResult?.acceptanceHash ?? null,
+    finalReceiptHash: acceptanceResult?.finalReceiptHash ?? null,
+  });
+
+  return {
+    verdict: completed ? ('PASS' as const) : ('BLOCK' as const),
+    stage: completed ? ('complete' as const) : ('acceptance' as const),
+    executionPerformed: true,
+    upstream,
+    compilation: compiled.result,
+    gate,
+    simulation,
+    execution,
+    resultReceipt,
+    acceptance: acceptance.ok ? acceptance.result : acceptance,
+    deterministicReceiptHash,
+    replay: {
+      replayable: completed,
+      chainHash: upstream.binding.chainHash,
+      actionPlanHash: plan.actionPlanHash,
+      deterministicReceiptHash,
+    },
+    trinityUnifyBoundary:
+      'Trinity MCP and Unify must invoke this canonical chain (or its API wrapper) and return its hashes/receipts; they must not create an alternate ALLOW/BLOCK path.',
+  };
+}

--- a/lib/dsg-one/canonical-e2e-pipeline.ts
+++ b/lib/dsg-one/canonical-e2e-pipeline.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+import { runVerifiedOptimizationPipeline } from './verified-optimization-pipeline';
+
+export type CanonicalSimulationWitness = {
+  schemaVersion: 'dsg-simulation-witness/1.0';
+  problemId: string;
+  inputHash: string;
+  scenarioHash: string;
+  deterministic: true;
+};
+
+export type CanonicalE2ERequest = {
+  problemId: string;
+  tasks: Task[];
+  agentCapacities: AgentCapacity[];
+  seed?: number;
+  useMock?: boolean;
+  timeout?: number;
+  exactProofMaxVariables?: number;
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, canonicalize(record[key])]),
+    );
+  }
+  return value;
+}
+
+function hash(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex');
+}
+
+/**
+ * Deterministic upstream simulation witness for the canonical optimization chain.
+ *
+ * This stage does NOT authorize execution and does NOT claim optimality. It binds
+ * the exact normalized problem that will be handed to QUBO -> Ising -> Z3/exact.
+ * Runtime/ROM action simulation remains a separate pre-execution check after an
+ * Action IR exists, so simulation cannot silently become an authorization gate.
+ */
+export function buildCanonicalSimulationWitness(
+  req: CanonicalE2ERequest,
+): CanonicalSimulationWitness {
+  const normalizedProblem = {
+    problemId: req.problemId,
+    tasks: req.tasks,
+    agentCapacities: req.agentCapacities,
+    seed: req.seed ?? 0,
+  };
+  const inputHash = hash(normalizedProblem);
+  return {
+    schemaVersion: 'dsg-simulation-witness/1.0',
+    problemId: req.problemId,
+    inputHash,
+    scenarioHash: hash({ inputHash, stage: 'simulation', deterministic: true }),
+    deterministic: true,
+  };
+}
+
+export async function runCanonicalE2EOptimization(req: CanonicalE2ERequest) {
+  const simulation = buildCanonicalSimulationWitness(req);
+  const optimization = await runVerifiedOptimizationPipeline(req);
+
+  const chainHash = hash({
+    schemaVersion: 'dsg-canonical-e2e/1.0',
+    simulationWitnessHash: simulation.scenarioHash,
+    quboHash: optimization.quboHash,
+    optimizationProofHash: optimization.proof.proofHash,
+    optimizationReceiptHash: optimization.proof.receiptHash,
+    verdict: optimization.verdict,
+  });
+
+  return {
+    schemaVersion: 'dsg-canonical-e2e/1.0' as const,
+    executionAllowed: false as const,
+    stages: {
+      simulation,
+      optimization,
+    },
+    binding: {
+      simulationWitnessHash: simulation.scenarioHash,
+      quboHash: optimization.quboHash,
+      optimizationProofHash: optimization.proof.proofHash,
+      chainHash,
+      deterministic: true as const,
+    },
+    nextGate:
+      optimization.verdict === 'VERIFIED_GLOBAL_OPTIMUM'
+        ? 'Compile the verified solution into Action IR, bind the optimization proofHash, then require DSG plan/scope ALLOW before any executor runs.'
+        : 'BLOCK: no execution. The canonical chain requires VERIFIED_GLOBAL_OPTIMUM before Action IR compilation.',
+  };
+}

--- a/lib/dsg-one/verified-action-receipt.ts
+++ b/lib/dsg-one/verified-action-receipt.ts
@@ -1,0 +1,333 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Verified Agent Action receipt.
+ *
+ * The sellable unit of the canonical DSG chain: one action, verified after it
+ * was authorized, bound to the hashes that produced the verdict, and checkable
+ * again later by someone who did not run it.
+ *
+ * Claim boundary — this file does NOT do any of the following, and no caller
+ * may describe it as doing them:
+ *   - it does not execute anything (the customer runtime executes; DSG verifies);
+ *   - it does not invoke an external Z3 solver;
+ *   - it is not a certification and not an independent third-party audit.
+ * A receipt proves that a specific chain of hashes produced a specific verdict,
+ * and that a later run either reproduced those hashes or did not.
+ */
+
+export const VERIFIED_ACTION_RECEIPT_SCHEMA = 'dsg-verified-action-receipt/1.0';
+
+export type VerifiedActionSurface = 'api' | 'unify' | 'trinity-mcp';
+
+/**
+ * Hashes lifted from one canonical chain run. Every field is either a hash the
+ * chain produced or null when that stage was never reached, so a BLOCK receipt
+ * still records exactly how far the action got.
+ *
+ * These hashes split into two groups, and conflating them would make the replay
+ * claim false:
+ *
+ *   - Reproducible: derived only from the request inputs. A later run over the
+ *     same inputs must produce identical values, so these are what replayMatch
+ *     is computed from.
+ *   - Run-scoped: derived partly from wall-clock time, because
+ *     evaluateAgentCommandGate and buildAgentActionResultReceipt both hash a
+ *     timestamp (an audit receipt is supposed to record when it happened).
+ *     These are recorded and reported, but never asserted to reproduce.
+ *
+ * deterministicReceiptHash is run-scoped despite its name: it folds in the two
+ * timestamped hashes above, so it changes between runs of the same action.
+ */
+export interface VerifiedActionChainBinding {
+  canonicalChainHash: string | null;
+  optimizationProofHash: string | null;
+  actionPlanHash: string | null;
+  gateDecisionHash: string | null;
+  simulationWitnessHash: string | null;
+  resultReceiptHash: string | null;
+  acceptanceHash: string | null;
+  finalReceiptHash: string | null;
+  deterministicReceiptHash: string | null;
+}
+
+export interface VerifiedActionReceipt {
+  schema: typeof VERIFIED_ACTION_RECEIPT_SCHEMA;
+  receiptId: string;
+  issuedAt: string;
+  surface: VerifiedActionSurface;
+  workspaceId: string;
+  problemId: string;
+  verdict: 'PASS' | 'BLOCK';
+  stage: string;
+  executionPerformed: boolean;
+  replayable: boolean;
+  reason: string | null;
+  chain: VerifiedActionChainBinding;
+  boundary: {
+    certificationClaim: false;
+    independentAuditClaim: false;
+    externalZ3SolverInvoked: false;
+    executedByDsg: false;
+    statement: string;
+  };
+}
+
+const BOUNDARY_STATEMENT =
+  'DSG verified an action that the caller authorized and executed. This receipt binds a verdict to a chain of hashes; it is not a certification, not an independent audit, and does not assert that an external Z3 solver was invoked.';
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, stable(record[key])]),
+    );
+  }
+  return value;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
+
+function hashOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * The receiptId covers everything a verifier must not be able to change without
+ * detection: the verdict, the stage it stopped at, and every chain hash. It
+ * deliberately excludes issuedAt so the same chain run is addressable by the
+ * same id.
+ */
+function computeReceiptId(
+  receipt: Omit<VerifiedActionReceipt, 'receiptId' | 'issuedAt'>,
+): string {
+  return sha256({
+    schema: receipt.schema,
+    surface: receipt.surface,
+    workspaceId: receipt.workspaceId,
+    problemId: receipt.problemId,
+    verdict: receipt.verdict,
+    stage: receipt.stage,
+    executionPerformed: receipt.executionPerformed,
+    replayable: receipt.replayable,
+    reason: receipt.reason,
+    chain: receipt.chain,
+  });
+}
+
+/**
+ * Lift the chain hashes out of a canonical-chain result. The result shape is a
+ * discriminated union whose BLOCK arms omit later stages, so every field is
+ * read defensively rather than assumed present.
+ */
+export function extractChainBinding(canonicalResult: unknown): VerifiedActionChainBinding {
+  const result = asRecord(canonicalResult);
+  const upstream = asRecord(result?.upstream);
+  const binding = asRecord(upstream?.binding);
+  const stages = asRecord(upstream?.stages);
+  const optimization = asRecord(stages?.optimization);
+  const optimizationProof = asRecord(optimization?.proof);
+  const gate = asRecord(result?.gate);
+  const simulation = asRecord(result?.simulation);
+  const resultReceipt = asRecord(result?.resultReceipt);
+  const acceptance = asRecord(result?.acceptance);
+  const compilation = asRecord(result?.compilation);
+  const plan = asRecord(compilation?.plan);
+
+  return {
+    canonicalChainHash: hashOrNull(binding?.chainHash),
+    optimizationProofHash: hashOrNull(optimizationProof?.proofHash),
+    actionPlanHash: hashOrNull(plan?.actionPlanHash),
+    gateDecisionHash: hashOrNull(gate?.decisionHash),
+    simulationWitnessHash: hashOrNull(simulation?.witnessHash),
+    resultReceiptHash: hashOrNull(resultReceipt?.receiptHash),
+    acceptanceHash: hashOrNull(acceptance?.acceptanceHash),
+    finalReceiptHash: hashOrNull(acceptance?.finalReceiptHash),
+    deterministicReceiptHash: hashOrNull(result?.deterministicReceiptHash),
+  };
+}
+
+export function buildVerifiedActionReceipt(input: {
+  canonicalResult: unknown;
+  surface: VerifiedActionSurface;
+  workspaceId: string;
+  problemId: string;
+  issuedAt?: string;
+}): VerifiedActionReceipt {
+  const result = asRecord(input.canonicalResult);
+  const replay = asRecord(result?.replay);
+  const verdict = result?.verdict === 'PASS' ? 'PASS' : 'BLOCK';
+
+  const body = {
+    schema: VERIFIED_ACTION_RECEIPT_SCHEMA,
+    surface: input.surface,
+    workspaceId: input.workspaceId,
+    problemId: input.problemId,
+    verdict,
+    stage: String(result?.stage ?? 'unknown'),
+    executionPerformed: result?.executionPerformed === true,
+    replayable: replay?.replayable === true,
+    reason: typeof result?.reason === 'string' ? result.reason : null,
+    chain: extractChainBinding(input.canonicalResult),
+    boundary: {
+      certificationClaim: false,
+      independentAuditClaim: false,
+      externalZ3SolverInvoked: false,
+      executedByDsg: false,
+      statement: BOUNDARY_STATEMENT,
+    },
+  } as const satisfies Omit<VerifiedActionReceipt, 'receiptId' | 'issuedAt'>;
+
+  return {
+    ...body,
+    receiptId: computeReceiptId(body),
+    issuedAt: input.issuedAt ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Flat rather than a discriminated union: this project compiles with
+ * `strict: false`, so narrowing on a boolean literal discriminant does not
+ * apply and every field has to be readable without it.
+ */
+export interface ReceiptIntegrityResult {
+  intact: boolean;
+  presentedReceiptId: string;
+  expectedReceiptId: string;
+  reason: string;
+}
+
+/**
+ * Recompute a receipt's id from its own contents. This detects a receipt whose
+ * verdict, stage, or any chain hash was edited after issue. It is an integrity
+ * check on the document, not a re-run of the action — use replayVerifiedAction
+ * for that.
+ */
+export function checkReceiptIntegrity(receipt: VerifiedActionReceipt): ReceiptIntegrityResult {
+  if (receipt.schema !== VERIFIED_ACTION_RECEIPT_SCHEMA) {
+    return {
+      intact: false,
+      presentedReceiptId: receipt.receiptId,
+      expectedReceiptId: '',
+      reason: `Unsupported receipt schema: ${String(receipt.schema)}`,
+    };
+  }
+
+  const { receiptId, issuedAt: _issuedAt, ...body } = receipt;
+  const expected = computeReceiptId(body);
+  const intact = expected === receiptId;
+  return {
+    intact,
+    presentedReceiptId: receiptId,
+    expectedReceiptId: expected,
+    reason: intact
+      ? 'Receipt contents hash to the presented receiptId.'
+      : 'Receipt contents do not hash to the presented receiptId.',
+  };
+}
+
+export interface ReplayFieldComparison {
+  field: keyof VerifiedActionChainBinding;
+  receipt: string | null;
+  replay: string | null;
+  match: boolean;
+}
+
+export interface ReplayVerificationResult {
+  replayMatch: boolean;
+  receiptIntact: boolean;
+  verdictMatch: boolean;
+  comparedFields: number;
+  mismatchedFields: ReplayFieldComparison[];
+  fields: ReplayFieldComparison[];
+  /** Timestamped hashes, reported for audit but excluded from replayMatch. */
+  runScopedFields: ReplayFieldComparison[];
+  reason: string;
+}
+
+/** Input-determined. A replay over the same inputs must reproduce all of these. */
+export const REPRODUCIBLE_CHAIN_FIELDS: Array<keyof VerifiedActionChainBinding> = [
+  'canonicalChainHash',
+  'optimizationProofHash',
+  'actionPlanHash',
+  'simulationWitnessHash',
+  'acceptanceHash',
+  'finalReceiptHash',
+];
+
+/** Time-dependent by design. Recorded, never asserted to reproduce. */
+export const RUN_SCOPED_CHAIN_FIELDS: Array<keyof VerifiedActionChainBinding> = [
+  'gateDecisionHash',
+  'resultReceiptHash',
+  'deterministicReceiptHash',
+];
+
+/**
+ * Independently re-verify a receipt against a fresh canonical-chain run.
+ *
+ * This is the measurable claim the product is sold on: given the same inputs,
+ * does the chain still produce the same input-determined hashes and the same
+ * verdict? A mismatch is reported per field so the caller can see which stage
+ * drifted — provider, model, and orchestration changes surface here rather than
+ * silently passing.
+ *
+ * Run-scoped hashes are compared and returned separately. They are expected to
+ * differ between runs and a difference there is not a replay failure.
+ */
+export function replayVerifiedAction(
+  receipt: VerifiedActionReceipt,
+  freshCanonicalResult: unknown,
+): ReplayVerificationResult {
+  const integrity = checkReceiptIntegrity(receipt);
+  const fresh = extractChainBinding(freshCanonicalResult);
+  const freshVerdict = asRecord(freshCanonicalResult)?.verdict === 'PASS' ? 'PASS' : 'BLOCK';
+
+  const compare = (field: keyof VerifiedActionChainBinding): ReplayFieldComparison => ({
+    field,
+    receipt: receipt.chain[field],
+    replay: fresh[field],
+    match: receipt.chain[field] === fresh[field],
+  });
+
+  const fields = REPRODUCIBLE_CHAIN_FIELDS.map(compare);
+  const runScopedFields = RUN_SCOPED_CHAIN_FIELDS.map(compare);
+
+  const mismatchedFields = fields.filter((entry) => !entry.match);
+  const verdictMatch = receipt.verdict === freshVerdict;
+  const replayMatch = integrity.intact && verdictMatch && mismatchedFields.length === 0;
+
+  let reason: string;
+  if (!integrity.intact) {
+    reason = integrity.reason;
+  } else if (mismatchedFields.length > 0) {
+    reason = `Replay diverged on ${mismatchedFields.length} of ${fields.length} reproducible chain hashes: ${mismatchedFields
+      .map((entry) => entry.field)
+      .join(', ')}.`;
+  } else if (!verdictMatch) {
+    reason = `Replay verdict ${freshVerdict} does not match receipt verdict ${receipt.verdict}.`;
+  } else {
+    reason = `Replay reproduced all ${fields.length} reproducible chain hashes and the ${receipt.verdict} verdict.`;
+  }
+
+  return {
+    replayMatch,
+    receiptIntact: integrity.intact,
+    verdictMatch,
+    comparedFields: fields.length,
+    mismatchedFields,
+    fields,
+    runScopedFields,
+    reason,
+  };
+}

--- a/lib/dsg-one/verified-action-request.ts
+++ b/lib/dsg-one/verified-action-request.ts
@@ -1,0 +1,226 @@
+import type { VerifiedActionSurface } from './verified-action-receipt';
+
+/**
+ * Request contract for POST /api/dsg/v1/actions/verify.
+ *
+ * The caller's runtime performs the action. DSG receives what the runtime
+ * observed and verifies it against the canonical chain, so this payload always
+ * carries an already-produced simulation witness and execution result. A caller
+ * that omits them is asking DSG to execute, which this product does not do.
+ */
+
+export interface VerifiedActionSimulationInput {
+  ok: boolean;
+  witnessHash: string;
+  reason?: string;
+}
+
+export interface VerifiedActionExecutionInput {
+  status: 'SUCCESS' | 'FAILED' | 'PARTIAL';
+  observations: Record<string, unknown>;
+  evidence: Array<{
+    fact: string;
+    observerRole: 'verifier';
+    hash: string;
+    [key: string]: unknown;
+  }>;
+  observedResultHash: string;
+  evidenceItemIds: string[];
+}
+
+export interface VerifiedActionRequest {
+  idempotencyKey: string;
+  surface: VerifiedActionSurface;
+  sessionId: string;
+  agentId?: string;
+  agentName?: string;
+  planContractVerified?: boolean;
+  optimization: Record<string, unknown>;
+  actionSolution: {
+    database?: 'supabase';
+    runtime?: 'render' | 'netlify';
+    environment: string;
+    commitSha: string;
+  };
+  approval?: {
+    requestId?: string;
+    decision?: 'approved' | 'rejected' | 'pending';
+    approvedBy?: string;
+    approvedAt?: string;
+  };
+  audit?: {
+    preAuditEventId?: string;
+    ledgerId?: string;
+    chainHeadHash?: string;
+  };
+  evidence?: {
+    evidenceManifestId?: string;
+    policySnapshotHash?: string;
+    runtimeBindingHash?: string;
+  };
+  observed: {
+    simulation: VerifiedActionSimulationInput;
+    execution: VerifiedActionExecutionInput;
+  };
+}
+
+export interface ValidationDetail {
+  field: string;
+  message: string;
+}
+
+/**
+ * Flat rather than a discriminated union: this project compiles with
+ * `strict: false`, so narrowing on a boolean literal discriminant does not
+ * apply. `details` is always an array and is empty when `ok` is true.
+ */
+export interface VerifiedActionValidation {
+  ok: boolean;
+  value?: VerifiedActionRequest;
+  details: ValidationDetail[];
+}
+
+const SURFACES: readonly VerifiedActionSurface[] = ['api', 'unify', 'trinity-mcp'];
+const EXECUTION_STATUSES = ['SUCCESS', 'FAILED', 'PARTIAL'] as const;
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function validateVerifiedActionRequest(input: unknown): VerifiedActionValidation {
+  const details: ValidationDetail[] = [];
+  const body = record(input);
+  if (!body) {
+    return { ok: false, details: [{ field: 'body', message: 'must be a JSON object' }] };
+  }
+
+  if (!nonEmptyString(body.idempotencyKey)) {
+    details.push({ field: 'idempotencyKey', message: 'required' });
+  }
+  if (!nonEmptyString(body.sessionId)) {
+    details.push({ field: 'sessionId', message: 'required' });
+  }
+
+  const surface = body.surface ?? 'api';
+  if (!SURFACES.includes(surface as VerifiedActionSurface)) {
+    details.push({ field: 'surface', message: `must be one of ${SURFACES.join(', ')}` });
+  }
+
+  const optimization = record(body.optimization);
+  if (!optimization) {
+    details.push({ field: 'optimization', message: 'required' });
+  } else {
+    if (!nonEmptyString(optimization.problemId)) {
+      details.push({ field: 'optimization.problemId', message: 'required' });
+    }
+    if (!Array.isArray(optimization.tasks) || optimization.tasks.length === 0) {
+      details.push({ field: 'optimization.tasks', message: 'must be a non-empty array' });
+    }
+    if (!Array.isArray(optimization.agentCapacities) || optimization.agentCapacities.length === 0) {
+      details.push({ field: 'optimization.agentCapacities', message: 'must be a non-empty array' });
+    }
+    // The canonical chain only compiles an Action IR from VERIFIED_GLOBAL_OPTIMUM,
+    // which the pipeline only emits for an explicitly bound business objective.
+    // Rejecting here gives a precise 400 instead of a confusing downstream BLOCK.
+    const objective = record(optimization.objective);
+    if (!objective) {
+      details.push({
+        field: 'optimization.objective',
+        message: 'required — global optimality is never claimed for an unbound objective',
+      });
+    } else {
+      if (!nonEmptyString(objective.version)) {
+        details.push({ field: 'optimization.objective.version', message: 'required' });
+      }
+      if (!record(objective.assignmentCosts)) {
+        details.push({ field: 'optimization.objective.assignmentCosts', message: 'required' });
+      }
+    }
+  }
+
+  const actionSolution = record(body.actionSolution);
+  if (!actionSolution) {
+    details.push({ field: 'actionSolution', message: 'required' });
+  } else {
+    if (!nonEmptyString(actionSolution.environment)) {
+      details.push({ field: 'actionSolution.environment', message: 'required' });
+    }
+    if (!nonEmptyString(actionSolution.commitSha)) {
+      details.push({ field: 'actionSolution.commitSha', message: 'required' });
+    }
+  }
+
+  const observed = record(body.observed);
+  if (!observed) {
+    details.push({
+      field: 'observed',
+      message: 'required — DSG verifies an executed action, it does not execute one',
+    });
+  } else {
+    const simulation = record(observed.simulation);
+    if (!simulation) {
+      details.push({ field: 'observed.simulation', message: 'required' });
+    } else {
+      if (typeof simulation.ok !== 'boolean') {
+        details.push({ field: 'observed.simulation.ok', message: 'must be a boolean' });
+      }
+      if (typeof simulation.witnessHash !== 'string' || !HEX_64.test(simulation.witnessHash)) {
+        details.push({
+          field: 'observed.simulation.witnessHash',
+          message: 'must be a 64-character lowercase hex sha256',
+        });
+      }
+    }
+
+    const execution = record(observed.execution);
+    if (!execution) {
+      details.push({ field: 'observed.execution', message: 'required' });
+    } else {
+      if (!EXECUTION_STATUSES.includes(execution.status as (typeof EXECUTION_STATUSES)[number])) {
+        details.push({
+          field: 'observed.execution.status',
+          message: `must be one of ${EXECUTION_STATUSES.join(', ')}`,
+        });
+      }
+      if (!record(execution.observations)) {
+        details.push({ field: 'observed.execution.observations', message: 'required' });
+      }
+      if (!Array.isArray(execution.evidence) || execution.evidence.length === 0) {
+        details.push({
+          field: 'observed.execution.evidence',
+          message: 'must be a non-empty array — no evidence means no receipt',
+        });
+      }
+      if (
+        typeof execution.observedResultHash !== 'string' ||
+        !HEX_64.test(execution.observedResultHash)
+      ) {
+        details.push({
+          field: 'observed.execution.observedResultHash',
+          message: 'must be a 64-character lowercase hex sha256',
+        });
+      }
+      if (!Array.isArray(execution.evidenceItemIds) || execution.evidenceItemIds.length === 0) {
+        details.push({ field: 'observed.execution.evidenceItemIds', message: 'must be a non-empty array' });
+      }
+    }
+  }
+
+  if (details.length > 0) return { ok: false, details };
+
+  return {
+    ok: true,
+    details,
+    value: {
+      ...(body as unknown as VerifiedActionRequest),
+      surface: surface as VerifiedActionSurface,
+    },
+  };
+}

--- a/lib/dsg-one/verified-action-request.ts
+++ b/lib/dsg-one/verified-action-request.ts
@@ -84,6 +84,26 @@ const SURFACES: readonly VerifiedActionSurface[] = ['api', 'unify', 'trinity-mcp
 const EXECUTION_STATUSES = ['SUCCESS', 'FAILED', 'PARTIAL'] as const;
 const HEX_64 = /^[0-9a-f]{64}$/;
 
+/**
+ * Problem-size ceilings.
+ *
+ * buildQUBOMatrix allocates a dense numVariables x numVariables matrix, where
+ * numVariables = tasks * agentCapacities, and it applies no ceiling of its own.
+ * Without a bound here a caller within the route's 64 KB body limit can still
+ * request, say, 200 tasks against 200 agents — 40,000 variables, so a 1.6
+ * billion cell matrix — and exhaust the process before any gate runs. The
+ * product is what matters; the per-list caps just keep the error specific.
+ *
+ * CodeQL alert #79 (Resource exhaustion, lib/dsg-one/ising-optimizer.ts:230)
+ * reports the same class of problem at the request-timeout sink.
+ */
+const MAX_TASKS = 64;
+const MAX_AGENT_CAPACITIES = 64;
+const MAX_QUBO_VARIABLES = 1024;
+
+/** callLiveIsingSolver clamps with Math.min, which passes NaN through. */
+const MAX_TIMEOUT_MS = 30_000;
+
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -120,11 +140,52 @@ export function validateVerifiedActionRequest(input: unknown): VerifiedActionVal
     if (!nonEmptyString(optimization.problemId)) {
       details.push({ field: 'optimization.problemId', message: 'required' });
     }
-    if (!Array.isArray(optimization.tasks) || optimization.tasks.length === 0) {
+    const tasks = optimization.tasks;
+    const agents = optimization.agentCapacities;
+
+    if (!Array.isArray(tasks) || tasks.length === 0) {
       details.push({ field: 'optimization.tasks', message: 'must be a non-empty array' });
+    } else if (tasks.length > MAX_TASKS) {
+      details.push({
+        field: 'optimization.tasks',
+        message: `must contain at most ${MAX_TASKS} entries`,
+      });
     }
-    if (!Array.isArray(optimization.agentCapacities) || optimization.agentCapacities.length === 0) {
+
+    if (!Array.isArray(agents) || agents.length === 0) {
       details.push({ field: 'optimization.agentCapacities', message: 'must be a non-empty array' });
+    } else if (agents.length > MAX_AGENT_CAPACITIES) {
+      details.push({
+        field: 'optimization.agentCapacities',
+        message: `must contain at most ${MAX_AGENT_CAPACITIES} entries`,
+      });
+    }
+
+    // The dense QUBO matrix is allocated from the product, so bound it even
+    // when each list is individually acceptable.
+    if (Array.isArray(tasks) && Array.isArray(agents)) {
+      const variables = tasks.length * agents.length;
+      if (variables > MAX_QUBO_VARIABLES) {
+        details.push({
+          field: 'optimization',
+          message: `tasks x agentCapacities must not exceed ${MAX_QUBO_VARIABLES} QUBO variables (got ${variables})`,
+        });
+      }
+    }
+
+    if (optimization.timeout !== undefined) {
+      const timeout = optimization.timeout;
+      if (
+        typeof timeout !== 'number' ||
+        !Number.isFinite(timeout) ||
+        timeout <= 0 ||
+        timeout > MAX_TIMEOUT_MS
+      ) {
+        details.push({
+          field: 'optimization.timeout',
+          message: `must be a finite number between 1 and ${MAX_TIMEOUT_MS}`,
+        });
+      }
     }
     // The canonical chain only compiles an Action IR from VERIFIED_GLOBAL_OPTIMUM,
     // which the pipeline only emits for an explicitly bound business objective.

--- a/lib/dsg-one/verified-optimization-pipeline.ts
+++ b/lib/dsg-one/verified-optimization-pipeline.ts
@@ -108,7 +108,7 @@ function sha256(value: unknown): string {
 function vectorToSolution(qubo: QUBOMatrix, mask: bigint): Record<string, number> {
   const solution: Record<string, number> = {};
   for (let i = 0; i < qubo.numVariables; i++) {
-    solution[qubo.variables[i].id] = Number((mask >> BigInt(i)) & 1n);
+    solution[qubo.variables[i].id] = Number((mask >> BigInt(i)) & BigInt(1));
   }
   return solution;
 }
@@ -138,10 +138,10 @@ function exactGlobalQuboProof(
     };
   }
 
-  const totalStates = 1n << BigInt(qubo.numVariables);
+  const totalStates = BigInt(1) << BigInt(qubo.numVariables);
   let bestEnergy = Number.POSITIVE_INFINITY;
   let statesChecked = 0;
-  for (let mask = 0n; mask < totalStates; mask += 1n) {
+  for (let mask = BigInt(0); mask < totalStates; mask += BigInt(1)) {
     const energy = calculateQUBOEnergy(qubo, vectorToSolution(qubo, mask));
     if (energy < bestEnergy) bestEnergy = energy;
     statesChecked += 1;

--- a/lib/dsg-one/verified-optimization-pipeline.ts
+++ b/lib/dsg-one/verified-optimization-pipeline.ts
@@ -14,6 +14,17 @@ export type OptimizationVerdict =
   | 'BLOCKED_INFEASIBLE'
   | 'BLOCKED_NOT_GLOBAL_OPTIMUM';
 
+export interface OptimizationObjective {
+  /** Stable semantic version for the business objective. */
+  version: string;
+  /**
+   * Sparse additive cost per canonical QUBO assignment variable.
+   * Keys are the builder variable ids, e.g. task_<taskId>_agent_<agentId>.
+   * Lower total cost is better. Missing variables have cost 0.
+   */
+  assignmentCosts: Record<string, number>;
+}
+
 export interface VerifiedOptimizationRequest {
   problemId: string;
   tasks: Task[];
@@ -22,6 +33,13 @@ export interface VerifiedOptimizationRequest {
   useMock?: boolean;
   timeout?: number;
   exactProofMaxVariables?: number;
+  /**
+   * Optional explicit business objective. Without one, DSG may prove feasibility
+   * and even the minimum penalty state of the feasibility QUBO, but MUST NOT
+   * market or emit VERIFIED_GLOBAL_OPTIMUM for a business objective.
+   */
+  objective?: OptimizationObjective;
+  constraintVersion?: string;
 }
 
 export interface ExactQuboProof {
@@ -40,6 +58,14 @@ export interface VerifiedOptimizationResult {
   executionAllowed: false;
   problemId: string;
   quboHash: string;
+  canonicalProblem: {
+    baseFeasibilityHash: string;
+    objectiveVersion: string;
+    objectiveHash: string;
+    constraintVersion: string;
+    constraintHash: string;
+    businessObjectiveBound: boolean;
+  };
   candidate: {
     solution: Record<string, number | boolean>;
     solutionHash: string;
@@ -138,8 +164,82 @@ function exactGlobalQuboProof(
     candidateIsGlobal,
     proofHash: sha256(material),
     reason: candidateIsGlobal
-      ? 'Exhaustive deterministic enumeration proved no QUBO assignment has lower energy.'
-      : 'Exact enumeration found a QUBO assignment with lower energy than the Ising candidate.',
+      ? 'Exhaustive deterministic enumeration proved no assignment has lower energy for this exact canonical QUBO.'
+      : 'Exact enumeration found an assignment with lower energy than the Ising candidate.',
+  };
+}
+
+function bindCanonicalProblem(
+  baseQubo: QUBOMatrix,
+  req: VerifiedOptimizationRequest,
+): {
+  qubo: QUBOMatrix;
+  objectiveVersion: string;
+  objectiveHash: string;
+  constraintVersion: string;
+  constraintHash: string;
+  businessObjectiveBound: boolean;
+} {
+  const constraintVersion = req.constraintVersion?.trim() || 'assignment-capacity-v1';
+  const constraintMaterial = {
+    version: constraintVersion,
+    tasks: [...req.tasks]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map((task) => ({ id: task.id })),
+    agents: [...req.agentCapacities]
+      .sort((a, b) => a.agentId - b.agentId)
+      .map((agent) => ({
+        agentId: agent.agentId,
+        maxTotalTasks: agent.maxTotalTasks,
+      })),
+  };
+  const constraintHash = sha256(constraintMaterial);
+
+  const businessObjectiveBound = Boolean(req.objective);
+  const objectiveVersion = req.objective?.version?.trim() || 'feasibility-only-v1';
+  if (!objectiveVersion) throw new Error('objective.version must be non-empty');
+
+  const knownVariables = new Set(baseQubo.variables.map((variable) => variable.id));
+  const assignmentCosts = req.objective?.assignmentCosts ?? {};
+  for (const [variableId, cost] of Object.entries(assignmentCosts)) {
+    if (!knownVariables.has(variableId)) {
+      throw new Error(`objective references unknown QUBO variable: ${variableId}`);
+    }
+    if (!Number.isFinite(cost)) {
+      throw new Error(`objective cost must be finite for variable: ${variableId}`);
+    }
+  }
+
+  const objectiveMaterial = {
+    version: objectiveVersion,
+    assignmentCosts,
+  };
+  const objectiveHash = sha256(objectiveMaterial);
+
+  const linear = [...baseQubo.linear];
+  for (const [variableId, cost] of Object.entries(assignmentCosts)) {
+    const index = baseQubo.variableMap.get(variableId);
+    if (index !== undefined) linear[index] += cost;
+  }
+
+  const canonicalProblemHash = sha256({
+    schemaVersion: 'dsg-canonical-optimization-problem/1.0',
+    baseFeasibilityHash: baseQubo.problemHash,
+    objectiveHash,
+    constraintHash,
+  });
+
+  return {
+    qubo: {
+      ...baseQubo,
+      linear,
+      problemHash: canonicalProblemHash,
+    },
+    objectiveVersion,
+    objectiveHash,
+    constraintVersion,
+    constraintHash,
+    businessObjectiveBound,
   };
 }
 
@@ -154,10 +254,11 @@ export async function runVerifiedOptimizationPipeline(
     tasks: req.tasks,
     agentCapacities: req.agentCapacities,
   });
+  const canonical = bindCanonicalProblem(built.qubo, req);
 
   const candidate = await optimizeWithIsing({
     problemId: req.problemId,
-    quboMatrix: built.qubo,
+    quboMatrix: canonical.qubo,
     seed: req.seed ?? 0,
     useMock: req.useMock,
     timeout: req.timeout,
@@ -165,29 +266,43 @@ export async function runVerifiedOptimizationPipeline(
 
   const z3 = await verifyIsingWithZ3({
     isingAssignment: candidate.solution,
-    quboMatrix: built.qubo,
+    quboMatrix: canonical.qubo,
     tasks: req.tasks,
     agentCapacities: req.agentCapacities,
     timeout: req.timeout,
   });
 
   const exact = exactGlobalQuboProof(
-    built.qubo,
+    canonical.qubo,
     candidate.energy,
     Math.max(1, Math.min(req.exactProofMaxVariables ?? 18, 22)),
   );
 
   let verdict: OptimizationVerdict;
   if (!z3.isValid) verdict = 'BLOCKED_INFEASIBLE';
-  else if (exact.complete && exact.candidateIsGlobal === true) verdict = 'VERIFIED_GLOBAL_OPTIMUM';
-  else if (exact.complete && exact.candidateIsGlobal === false) verdict = 'BLOCKED_NOT_GLOBAL_OPTIMUM';
+  else if (
+    canonical.businessObjectiveBound &&
+    exact.complete &&
+    exact.candidateIsGlobal === true
+  ) verdict = 'VERIFIED_GLOBAL_OPTIMUM';
+  else if (
+    canonical.businessObjectiveBound &&
+    exact.complete &&
+    exact.candidateIsGlobal === false
+  ) verdict = 'BLOCKED_NOT_GLOBAL_OPTIMUM';
   else verdict = 'VERIFIED_FEASIBLE';
 
   const solutionHash = sha256(Object.entries(candidate.solution).sort());
   const proofMaterial = {
-    schemaVersion: 'dsg-verified-optimization/1.0',
+    schemaVersion: 'dsg-verified-optimization/1.1',
     problemId: req.problemId,
-    quboHash: built.qubo.problemHash,
+    quboHash: canonical.qubo.problemHash,
+    baseFeasibilityHash: built.qubo.problemHash,
+    objectiveVersion: canonical.objectiveVersion,
+    objectiveHash: canonical.objectiveHash,
+    constraintVersion: canonical.constraintVersion,
+    constraintHash: canonical.constraintHash,
+    businessObjectiveBound: canonical.businessObjectiveBound,
     solutionHash,
     candidateEnergy: candidate.energy,
     z3ProofHash: z3.proofHash,
@@ -201,7 +316,15 @@ export async function runVerifiedOptimizationPipeline(
     verdict,
     executionAllowed: false,
     problemId: req.problemId,
-    quboHash: built.qubo.problemHash,
+    quboHash: canonical.qubo.problemHash,
+    canonicalProblem: {
+      baseFeasibilityHash: built.qubo.problemHash,
+      objectiveVersion: canonical.objectiveVersion,
+      objectiveHash: canonical.objectiveHash,
+      constraintVersion: canonical.constraintVersion,
+      constraintHash: canonical.constraintHash,
+      businessObjectiveBound: canonical.businessObjectiveBound,
+    },
     candidate: {
       solution: candidate.solution,
       solutionHash,
@@ -224,6 +347,8 @@ export async function runVerifiedOptimizationPipeline(
     nextGate:
       verdict === 'VERIFIED_GLOBAL_OPTIMUM'
         ? 'Bind this proofHash to the Verified Action Compiler, then require DSG plan/scope ALLOW before execution.'
-        : 'Execution remains blocked. VERIFIED_FEASIBLE is not a global-optimum claim and is not execution permission.',
+        : canonical.businessObjectiveBound
+          ? 'Execution remains blocked. The business objective was bound, but global optimality was not proven.'
+          : 'Execution remains blocked. No explicit business objective was bound, so DSG reports VERIFIED_FEASIBLE rather than a false global-optimum claim.',
   };
 }

--- a/lib/dsg-one/verified-optimization-pipeline.ts
+++ b/lib/dsg-one/verified-optimization-pipeline.ts
@@ -1,0 +1,229 @@
+import { createHash } from 'node:crypto';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+import {
+  buildQUBOMatrix,
+  calculateQUBOEnergy,
+  type QUBOMatrix,
+} from './qubo-builder';
+import { optimizeWithIsing } from './ising-optimizer';
+import { verifyIsingWithZ3 } from './ising-to-z3-verifier';
+
+export type OptimizationVerdict =
+  | 'VERIFIED_GLOBAL_OPTIMUM'
+  | 'VERIFIED_FEASIBLE'
+  | 'BLOCKED_INFEASIBLE'
+  | 'BLOCKED_NOT_GLOBAL_OPTIMUM';
+
+export interface VerifiedOptimizationRequest {
+  problemId: string;
+  tasks: Task[];
+  agentCapacities: AgentCapacity[];
+  seed?: number;
+  useMock?: boolean;
+  timeout?: number;
+  exactProofMaxVariables?: number;
+}
+
+export interface ExactQuboProof {
+  attempted: boolean;
+  complete: boolean;
+  statesChecked: number;
+  bestEnergy: number | null;
+  candidateEnergy: number;
+  candidateIsGlobal: boolean | null;
+  proofHash: string;
+  reason: string;
+}
+
+export interface VerifiedOptimizationResult {
+  verdict: OptimizationVerdict;
+  executionAllowed: false;
+  problemId: string;
+  quboHash: string;
+  candidate: {
+    solution: Record<string, number | boolean>;
+    solutionHash: string;
+    energy: number;
+    solverMode: string;
+    solverVersion: string;
+  };
+  z3: {
+    status: string;
+    feasible: boolean;
+    proofHash: string;
+    version: string;
+  };
+  exact: ExactQuboProof;
+  proof: {
+    proofHash: string;
+    receiptHash: string;
+    deterministic: true;
+  };
+  nextGate: string;
+}
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((out, key) => {
+        out[key] = stable((value as Record<string, unknown>)[key]);
+        return out;
+      }, {});
+  }
+  return value;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
+
+function vectorToSolution(qubo: QUBOMatrix, mask: bigint): Record<string, number> {
+  const solution: Record<string, number> = {};
+  for (let i = 0; i < qubo.numVariables; i++) {
+    solution[qubo.variables[i].id] = Number((mask >> BigInt(i)) & 1n);
+  }
+  return solution;
+}
+
+function exactGlobalQuboProof(
+  qubo: QUBOMatrix,
+  candidateEnergy: number,
+  maxVariables: number,
+): ExactQuboProof {
+  if (qubo.numVariables > maxVariables) {
+    const material = {
+      quboHash: qubo.problemHash,
+      candidateEnergy,
+      numVariables: qubo.numVariables,
+      maxVariables,
+      complete: false,
+    };
+    return {
+      attempted: false,
+      complete: false,
+      statesChecked: 0,
+      bestEnergy: null,
+      candidateEnergy,
+      candidateIsGlobal: null,
+      proofHash: sha256(material),
+      reason: `Exact proof skipped: ${qubo.numVariables} variables exceeds deterministic exhaustive bound ${maxVariables}.`,
+    };
+  }
+
+  const totalStates = 1n << BigInt(qubo.numVariables);
+  let bestEnergy = Number.POSITIVE_INFINITY;
+  let statesChecked = 0;
+  for (let mask = 0n; mask < totalStates; mask += 1n) {
+    const energy = calculateQUBOEnergy(qubo, vectorToSolution(qubo, mask));
+    if (energy < bestEnergy) bestEnergy = energy;
+    statesChecked += 1;
+  }
+
+  const candidateIsGlobal = Math.abs(candidateEnergy - bestEnergy) <= 1e-9;
+  const material = {
+    quboHash: qubo.problemHash,
+    candidateEnergy,
+    bestEnergy,
+    statesChecked,
+    candidateIsGlobal,
+  };
+  return {
+    attempted: true,
+    complete: true,
+    statesChecked,
+    bestEnergy,
+    candidateEnergy,
+    candidateIsGlobal,
+    proofHash: sha256(material),
+    reason: candidateIsGlobal
+      ? 'Exhaustive deterministic enumeration proved no QUBO assignment has lower energy.'
+      : 'Exact enumeration found a QUBO assignment with lower energy than the Ising candidate.',
+  };
+}
+
+export async function runVerifiedOptimizationPipeline(
+  req: VerifiedOptimizationRequest,
+): Promise<VerifiedOptimizationResult> {
+  if (!req.problemId || req.tasks.length === 0 || req.agentCapacities.length === 0) {
+    throw new Error('problemId, tasks, and agentCapacities are required');
+  }
+
+  const built = await buildQUBOMatrix({
+    tasks: req.tasks,
+    agentCapacities: req.agentCapacities,
+  });
+
+  const candidate = await optimizeWithIsing({
+    problemId: req.problemId,
+    quboMatrix: built.qubo,
+    seed: req.seed ?? 0,
+    useMock: req.useMock,
+    timeout: req.timeout,
+  });
+
+  const z3 = await verifyIsingWithZ3({
+    isingAssignment: candidate.solution,
+    quboMatrix: built.qubo,
+    tasks: req.tasks,
+    agentCapacities: req.agentCapacities,
+    timeout: req.timeout,
+  });
+
+  const exact = exactGlobalQuboProof(
+    built.qubo,
+    candidate.energy,
+    Math.max(1, Math.min(req.exactProofMaxVariables ?? 18, 22)),
+  );
+
+  let verdict: OptimizationVerdict;
+  if (!z3.isValid) verdict = 'BLOCKED_INFEASIBLE';
+  else if (exact.complete && exact.candidateIsGlobal === true) verdict = 'VERIFIED_GLOBAL_OPTIMUM';
+  else if (exact.complete && exact.candidateIsGlobal === false) verdict = 'BLOCKED_NOT_GLOBAL_OPTIMUM';
+  else verdict = 'VERIFIED_FEASIBLE';
+
+  const solutionHash = sha256(Object.entries(candidate.solution).sort());
+  const proofMaterial = {
+    schemaVersion: 'dsg-verified-optimization/1.0',
+    problemId: req.problemId,
+    quboHash: built.qubo.problemHash,
+    solutionHash,
+    candidateEnergy: candidate.energy,
+    z3ProofHash: z3.proofHash,
+    exactProofHash: exact.proofHash,
+    verdict,
+  };
+  const proofHash = sha256(proofMaterial);
+  const receiptHash = sha256({ ...proofMaterial, proofHash });
+
+  return {
+    verdict,
+    executionAllowed: false,
+    problemId: req.problemId,
+    quboHash: built.qubo.problemHash,
+    candidate: {
+      solution: candidate.solution,
+      solutionHash,
+      energy: candidate.energy,
+      solverMode: candidate.mode,
+      solverVersion: candidate.solverVersion,
+    },
+    z3: {
+      status: z3.isSAT,
+      feasible: z3.isValid,
+      proofHash: z3.proofHash,
+      version: z3.z3Version,
+    },
+    exact,
+    proof: {
+      proofHash,
+      receiptHash,
+      deterministic: true,
+    },
+    nextGate:
+      verdict === 'VERIFIED_GLOBAL_OPTIMUM'
+        ? 'Bind this proofHash to the Verified Action Compiler, then require DSG plan/scope ALLOW before execution.'
+        : 'Execution remains blocked. VERIFIED_FEASIBLE is not a global-optimum claim and is not execution permission.',
+  };
+}

--- a/lib/dsg/gate-entitlement.ts
+++ b/lib/dsg/gate-entitlement.ts
@@ -23,7 +23,8 @@ import {
 export type DsgMeteredGateRoute =
   | 'gates/evaluate'
   | 'proofs/prove'
-  | 'encoding/prove';
+  | 'encoding/prove'
+  | 'actions/verify';
 
 export interface DsgGateTier {
   tier: GateTier;

--- a/lib/mcp/canonical-action-adapter.ts
+++ b/lib/mcp/canonical-action-adapter.ts
@@ -1,0 +1,117 @@
+import type { UnifiedAuthContext } from './unified-auth';
+import {
+  runCanonicalActionE2E,
+  type CanonicalActionE2ERequest,
+  type ControlledExecutionResult,
+  type PreExecutionSimulationResult,
+} from '@/lib/dsg-one/canonical-action-e2e';
+import type { ActionPlan } from './verified-action-tools';
+
+export type CanonicalActionAdapterSurface = 'unify' | 'trinity-mcp';
+
+export type CanonicalActionAdapterHooks = {
+  simulate: (plan: ActionPlan) => Promise<PreExecutionSimulationResult>;
+  execute: (plan: ActionPlan) => Promise<ControlledExecutionResult>;
+};
+
+export type CanonicalActionAdapterRequest = Omit<
+  CanonicalActionE2ERequest,
+  'simulate' | 'execute' | 'gate'
+> & {
+  surface: CanonicalActionAdapterSurface;
+  sessionId: string;
+  agentId?: string;
+  agentName?: string;
+  planContractVerified?: boolean;
+  approval?: {
+    requestId?: string;
+    decision?: 'approved' | 'rejected' | 'pending';
+    approvedBy?: string;
+    approvedAt?: string;
+  };
+  audit?: {
+    preAuditEventId?: string;
+    ledgerId?: string;
+    chainHeadHash?: string;
+  };
+  evidence?: {
+    evidenceManifestId?: string;
+    policySnapshotHash?: string;
+    runtimeBindingHash?: string;
+  };
+};
+
+function executionPermissions(auth: UnifiedAuthContext): string[] {
+  const canOperate = auth.roles.includes('operator') || auth.roles.includes('org_admin');
+  if (!canOperate) return [];
+  return [
+    'tool:execute_low',
+    'tool:execute_medium',
+    'tool:execute_high',
+    'tool:execute_critical',
+  ];
+}
+
+/**
+ * Transport adapter for both Unify Desktop and Trinity MCP.
+ *
+ * This adapter intentionally contains no independent ALLOW/BLOCK logic. It maps
+ * authenticated transport context into the canonical DSG ONE chain and returns
+ * the canonical hashes/receipts produced there.
+ */
+export async function runCanonicalActionFromSurface(
+  input: CanonicalActionAdapterRequest,
+  auth: UnifiedAuthContext,
+  hooks: CanonicalActionAdapterHooks,
+) {
+  const agentId = input.agentId?.trim() || auth.actorId;
+  const approval = input.approval ?? {};
+  const audit = input.audit ?? {};
+  const evidence = input.evidence ?? {};
+
+  const result = await runCanonicalActionE2E({
+    optimization: input.optimization,
+    actionSolution: input.actionSolution,
+    gate: {
+      workspaceId: auth.orgId,
+      runtime: {
+        agentId,
+        agentName: input.agentName ?? `${input.surface}:${agentId}`,
+        agentType: input.surface === 'unify' ? 'external-agent' : 'ai-agent',
+        sessionId: input.sessionId,
+        agentWillExecuteAction: true,
+        requiresResultCallback: true,
+      },
+      rbac: {
+        actorId: auth.actorId,
+        role: auth.roles.includes('org_admin') ? 'admin' : auth.roles.includes('operator') ? 'operator' : 'viewer',
+        permissions: executionPermissions(auth),
+        approvalRequestId: approval.requestId,
+        approvalDecision: approval.decision,
+        approvedBy: approval.approvedBy,
+        approvedAt: approval.approvedAt,
+      },
+      audit: {
+        preAuditEventId: audit.preAuditEventId ?? '',
+        ledgerId: audit.ledgerId ?? '',
+        chainHeadHash: audit.chainHeadHash ?? '',
+      },
+      evidence: {
+        evidenceManifestId: evidence.evidenceManifestId ?? '',
+        policySnapshotHash: evidence.policySnapshotHash ?? '',
+        runtimeBindingHash: evidence.runtimeBindingHash,
+      },
+      planContractVerified: input.planContractVerified === true,
+    },
+    simulate: hooks.simulate,
+    execute: hooks.execute,
+  });
+
+  return {
+    surface: input.surface,
+    canonical: true as const,
+    result,
+    boundary:
+      'Unify and Trinity MCP are transport/executor surfaces only. They do not create a second authorization or verification engine; the canonical DSG ONE chain remains authoritative.',
+  };
+}

--- a/lib/mcp/canonical-action-adapter.ts
+++ b/lib/mcp/canonical-action-adapter.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/dsg-one/canonical-action-e2e';
 import type { ActionPlan } from './verified-action-tools';
 
-export type CanonicalActionAdapterSurface = 'unify' | 'trinity-mcp';
+export type CanonicalActionAdapterSurface = 'api' | 'unify' | 'trinity-mcp';
 
 export type CanonicalActionAdapterHooks = {
   simulate: (plan: ActionPlan) => Promise<PreExecutionSimulationResult>;

--- a/lib/runtime/makk8-z3-verifier.ts
+++ b/lib/runtime/makk8-z3-verifier.ts
@@ -1,0 +1,134 @@
+import { createHash } from 'node:crypto';
+import { init } from 'z3-solver';
+import {
+  MAKK8_INVARIANT_SET,
+  MAKK8_VERSION,
+  Makk8Arbiter,
+  type Makk8ActionData,
+  type Makk8InvariantSnapshot,
+} from './makk8-arbiter';
+
+export type Makk8Z3Status = 'SAT' | 'UNSAT' | 'UNKNOWN';
+
+export interface Makk8Z3VerificationResult {
+  ok: boolean;
+  decision: 'ALLOW' | 'BLOCK';
+  status: Makk8Z3Status;
+  reason: 'SAMMA_Z3_VERIFIED' | 'PATH_CONFLICT' | 'Z3_UNKNOWN';
+  invariantSet: string;
+  makk8Version: string;
+  artifact: Makk8InvariantSnapshot;
+  constraintsHash: string;
+  proofHash: string;
+  evaluationTimeMs: number;
+}
+
+const INVARIANT_NAMES: Array<keyof Makk8InvariantSnapshot> = [
+  'rightView',
+  'rightResolve',
+  'rightSpeech',
+  'rightConduct',
+  'rightLivelihood',
+  'rightEffort',
+  'rightMindfulness',
+  'rightSamadhi',
+];
+
+/**
+ * Formal Makk-8 verification using the actual z3-solver runtime.
+ *
+ * The boolean Makk-8 snapshot is bound into SMT-LIB, then Z3 must satisfy
+ * the conjunction of all eight invariants. This prevents the runtime from
+ * calling a plain boolean check "Z3 verification" without invoking Z3.
+ */
+export async function verifyMakk8WithZ3(
+  actionData: Makk8ActionData,
+  timeoutMs = 5_000,
+): Promise<Makk8Z3VerificationResult> {
+  const startedAt = Date.now();
+  const logical = new Makk8Arbiter().verifyPathIntegrity(actionData);
+  const smt2 = buildMakk8Smt2(logical.artifact);
+  const constraintsHash = sha256(smt2);
+
+  let status: Makk8Z3Status = 'UNKNOWN';
+
+  try {
+    const { Context } = await init();
+    const ctx = Context('makk8-desktop-gate');
+    const solver = new ctx.Solver();
+
+    try {
+      solver.set('timeout', timeoutMs);
+    } catch {
+      // Keep verification functional on Z3 builds that do not expose timeout configuration.
+    }
+
+    solver.fromString(smt2);
+    const rawStatus = await solver.check();
+    status = rawStatus === 'sat' ? 'SAT' : rawStatus === 'unsat' ? 'UNSAT' : 'UNKNOWN';
+  } catch {
+    status = 'UNKNOWN';
+  }
+
+  const ok = logical.ok && status === 'SAT';
+  const reason: Makk8Z3VerificationResult['reason'] =
+    ok ? 'SAMMA_Z3_VERIFIED' : status === 'UNKNOWN' ? 'Z3_UNKNOWN' : 'PATH_CONFLICT';
+
+  const proofHash = sha256({
+    makk8Version: MAKK8_VERSION,
+    invariantSet: MAKK8_INVARIANT_SET,
+    artifact: logical.artifact,
+    status,
+    constraintsHash,
+  });
+
+  return {
+    ok,
+    decision: ok ? 'ALLOW' : 'BLOCK',
+    status,
+    reason,
+    invariantSet: MAKK8_INVARIANT_SET,
+    makk8Version: MAKK8_VERSION,
+    artifact: logical.artifact,
+    constraintsHash,
+    proofHash,
+    evaluationTimeMs: Date.now() - startedAt,
+  };
+}
+
+export function buildMakk8Smt2(artifact: Makk8InvariantSnapshot): string {
+  const declarations = INVARIANT_NAMES.map((name) => `(declare-const ${name} Bool)`).join('\n');
+  const bindings = INVARIANT_NAMES.map(
+    (name) => `(assert (= ${name} ${artifact[name] ? 'true' : 'false'}))`,
+  ).join('\n');
+  const conjunction = `(assert (and ${INVARIANT_NAMES.join(' ')}))`;
+
+  return [
+    '(set-logic QF_UF)',
+    declarations,
+    bindings,
+    conjunction,
+  ].join('\n');
+}
+
+function sha256(value: unknown): string {
+  const payload = typeof value === 'string' ? value : stableJson(value);
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortStable(value));
+}
+
+function sortStable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortStable);
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortStable((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}

--- a/lib/unify/desktop-dsg-bridge.ts
+++ b/lib/unify/desktop-dsg-bridge.ts
@@ -1,0 +1,350 @@
+import { createHash } from 'node:crypto';
+import type {
+  AgentActionResultRequest,
+  AgentActionResultReceipt,
+  AgentCommandGateRequest,
+  AgentCommandGateResult,
+} from '@/lib/dsg/agent-command-gate';
+
+export type UnifyExecutionTarget = 'desktop' | 'browser' | 'shell';
+
+export interface UnifyFormalContext {
+  is_grounded: boolean;
+  is_api_clean: boolean;
+  source_verified: boolean;
+  has_audit_trail: boolean;
+  nonce_lock: boolean;
+  value: number;
+  intent_score: number;
+  compute_cost: number;
+}
+
+export interface UnifyExecutionRequest {
+  target: UnifyExecutionTarget;
+  action: string;
+  args?: Record<string, unknown>;
+  formalContext: UnifyFormalContext;
+  gateRequest: AgentCommandGateRequest;
+}
+
+export interface UnifyExecutorResult {
+  status: 'SUCCESS' | 'FAILED' | 'PARTIAL' | 'BLOCKED_BY_TARGET';
+  output: unknown;
+  targetReceiptId?: string;
+  errorClass?: string;
+  errorMessage?: string;
+}
+
+export interface UnifyExecutor {
+  execute(input: {
+    target: UnifyExecutionTarget;
+    action: string;
+    args?: Record<string, unknown>;
+    envelope: NonNullable<AgentCommandGateResult['actionEnvelope']>;
+  }): Promise<UnifyExecutorResult>;
+}
+
+export interface UnifyEvidenceStore {
+  save(evidence: UnifyLocalEvidence): Promise<void>;
+}
+
+export interface UnifyBridgeTransportOptions {
+  baseUrl: string;
+  bearerToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface UnifyLocalEvidence {
+  schemaVersion: 'unify-dsg-evidence-v1';
+  target: UnifyExecutionTarget;
+  action: string;
+  actionArgsHash: string;
+  commandId: string;
+  commandHash: string;
+  gateDecision: 'PASS';
+  gateDecisionHash: string;
+  envelopeId: string;
+  formalProofHash: string;
+  formalConstraintsHash: string;
+  formalStatus: 'SAT';
+  executionStatus: UnifyExecutorResult['status'];
+  observedResultHash: string;
+  startedAt: string;
+  completedAt: string;
+  evidenceHash: string;
+}
+
+export interface UnifyReplayResult {
+  ok: boolean;
+  integrityMatch: boolean;
+  formalProofMatch: boolean;
+  reason: 'REPLAY_VERIFIED' | 'EVIDENCE_HASH_MISMATCH' | 'FORMAL_PROOF_MISMATCH' | 'FORMAL_REPLAY_BLOCKED';
+}
+
+export type UnifyGovernedExecutionResult =
+  | {
+      decision: 'BLOCK';
+      stage: 'MAKK8_Z3' | 'DSG_ONE_GATE';
+      executed: false;
+      formal?: FormalApiResult;
+      gate?: AgentCommandGateResult;
+    }
+  | {
+      decision: 'ALLOW';
+      stage: 'COMPLETE';
+      executed: true;
+      formal: FormalApiResult;
+      gate: AgentCommandGateResult;
+      execution: UnifyExecutorResult;
+      receipt: AgentActionResultReceipt | null;
+      evidence: UnifyLocalEvidence;
+      replay: UnifyReplayResult;
+    };
+
+interface FormalApiResult {
+  ok: boolean;
+  decision: 'ALLOW' | 'BLOCK';
+  makk8: {
+    ok: boolean;
+    decision: 'ALLOW' | 'BLOCK';
+    status: 'SAT' | 'UNSAT' | 'UNKNOWN';
+    reason: string;
+    proofHash: string;
+    constraintsHash: string;
+  };
+}
+
+interface GateApiResponse {
+  ok: boolean;
+  result: AgentCommandGateResult;
+}
+
+interface ResultApiResponse {
+  ok?: boolean;
+  receipt?: AgentActionResultReceipt;
+  result?: AgentActionResultReceipt;
+}
+
+/**
+ * Unify Desktop Assistant governed execution chain:
+ * Makk-8/Z3 -> DSG ONE command gate -> injected local executor -> local evidence -> replay.
+ *
+ * This module never executes OS/browser/shell actions by itself. Execution is only
+ * performed by the caller-provided executor after both verifier stages return ALLOW/PASS.
+ */
+export class UnifyDesktopDsgBridge {
+  private readonly baseUrl: string;
+  private readonly bearerToken?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: UnifyBridgeTransportOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.bearerToken = options.bearerToken;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async execute(
+    request: UnifyExecutionRequest,
+    executor: UnifyExecutor,
+    evidenceStore?: UnifyEvidenceStore,
+  ): Promise<UnifyGovernedExecutionResult> {
+    const formal = await this.verifyFormal(request.formalContext);
+    if (!formal.ok || formal.decision !== 'ALLOW' || formal.makk8.status !== 'SAT') {
+      return { decision: 'BLOCK', stage: 'MAKK8_Z3', executed: false, formal };
+    }
+
+    const gateResponse = await this.postJson<GateApiResponse>(
+      '/api/dsg/agent-command-gate',
+      request.gateRequest,
+      true,
+    );
+    const gate = gateResponse.result;
+    if (!gateResponse.ok || !gate.canAgentExecute || gate.decision !== 'PASS' || !gate.actionEnvelope) {
+      return { decision: 'BLOCK', stage: 'DSG_ONE_GATE', executed: false, formal, gate };
+    }
+
+    const startedAt = new Date().toISOString();
+    const execution = await executor.execute({
+      target: request.target,
+      action: request.action,
+      args: request.args,
+      envelope: gate.actionEnvelope,
+    });
+    const completedAt = new Date().toISOString();
+    const observedResultHash = sha256(execution.output);
+
+    const evidence = buildLocalEvidence({
+      request,
+      formal,
+      gate,
+      execution,
+      observedResultHash,
+      startedAt,
+      completedAt,
+    });
+
+    await evidenceStore?.save(evidence);
+
+    const resultPayload: AgentActionResultRequest = {
+      workspaceId: request.gateRequest.workspaceId,
+      agentId: request.gateRequest.runtime.agentId,
+      sessionId: request.gateRequest.runtime.sessionId,
+      commandId: request.gateRequest.command.commandId,
+      envelopeId: gate.actionEnvelope.envelopeId,
+      decisionHash: gate.decisionHash,
+      status: execution.status,
+      startedAt,
+      completedAt,
+      observedResultHash,
+      evidenceItemIds: [`unify-local:${evidence.evidenceHash}`],
+      targetSystemReceiptId: execution.targetReceiptId,
+      errorClass: execution.errorClass,
+      errorMessage: execution.errorMessage,
+      planHash: request.gateRequest.command.planHash,
+      scopeHash: request.gateRequest.command.scopeHash,
+    };
+
+    let receipt: AgentActionResultReceipt | null = null;
+    try {
+      const resultResponse = await this.postJson<ResultApiResponse>(
+        gate.actionEnvelope.mustReturnResultTo,
+        resultPayload,
+        true,
+      );
+      receipt = resultResponse.receipt ?? resultResponse.result ?? null;
+    } catch {
+      // Local evidence remains valid even if remote receipt delivery is temporarily unavailable.
+      // The caller can retry result delivery using the same evidence hash/idempotent command context.
+    }
+
+    const replay = await this.replay(evidence, request.formalContext);
+
+    return {
+      decision: 'ALLOW',
+      stage: 'COMPLETE',
+      executed: true,
+      formal,
+      gate,
+      execution,
+      receipt,
+      evidence,
+      replay,
+    };
+  }
+
+  async replay(evidence: UnifyLocalEvidence, formalContext: UnifyFormalContext): Promise<UnifyReplayResult> {
+    const integrityMatch = verifyLocalEvidenceIntegrity(evidence);
+    if (!integrityMatch) {
+      return {
+        ok: false,
+        integrityMatch: false,
+        formalProofMatch: false,
+        reason: 'EVIDENCE_HASH_MISMATCH',
+      };
+    }
+
+    const formal = await this.verifyFormal(formalContext);
+    if (!formal.ok || formal.makk8.status !== 'SAT') {
+      return {
+        ok: false,
+        integrityMatch: true,
+        formalProofMatch: false,
+        reason: 'FORMAL_REPLAY_BLOCKED',
+      };
+    }
+
+    const formalProofMatch = formal.makk8.proofHash === evidence.formalProofHash;
+    return {
+      ok: formalProofMatch,
+      integrityMatch: true,
+      formalProofMatch,
+      reason: formalProofMatch ? 'REPLAY_VERIFIED' : 'FORMAL_PROOF_MISMATCH',
+    };
+  }
+
+  async verifyFormal(context: UnifyFormalContext): Promise<FormalApiResult> {
+    return this.postJson<FormalApiResult>('/api/dsg/makk8-z3/verify', { context }, false);
+  }
+
+  private async postJson<T>(path: string, body: unknown, requireAuth: boolean): Promise<T> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.bearerToken) headers.Authorization = `Bearer ${this.bearerToken}`;
+    if (requireAuth && !this.bearerToken) {
+      // Browser/session deployments may authenticate through cookies, so do not block locally.
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers,
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+
+    const payload = (await response.json()) as T;
+    if (!response.ok && response.status !== 409) {
+      throw new Error(`DSG bridge request failed: ${path} (${response.status})`);
+    }
+    return payload;
+  }
+}
+
+export function verifyLocalEvidenceIntegrity(evidence: UnifyLocalEvidence): boolean {
+  const { evidenceHash, ...unsigned } = evidence;
+  return sha256(unsigned) === evidenceHash;
+}
+
+function buildLocalEvidence(input: {
+  request: UnifyExecutionRequest;
+  formal: FormalApiResult;
+  gate: AgentCommandGateResult;
+  execution: UnifyExecutorResult;
+  observedResultHash: string;
+  startedAt: string;
+  completedAt: string;
+}): UnifyLocalEvidence {
+  if (!input.gate.actionEnvelope || input.gate.decision !== 'PASS' || input.formal.makk8.status !== 'SAT') {
+    throw new Error('Cannot build ALLOW evidence without SAT formal proof and PASS action envelope');
+  }
+
+  const unsigned = {
+    schemaVersion: 'unify-dsg-evidence-v1' as const,
+    target: input.request.target,
+    action: input.request.action,
+    actionArgsHash: sha256(input.request.args ?? {}),
+    commandId: input.request.gateRequest.command.commandId,
+    commandHash: input.gate.commandHash,
+    gateDecision: 'PASS' as const,
+    gateDecisionHash: input.gate.decisionHash,
+    envelopeId: input.gate.actionEnvelope.envelopeId,
+    formalProofHash: input.formal.makk8.proofHash,
+    formalConstraintsHash: input.formal.makk8.constraintsHash,
+    formalStatus: 'SAT' as const,
+    executionStatus: input.execution.status,
+    observedResultHash: input.observedResultHash,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+  };
+
+  return { ...unsigned, evidenceHash: sha256(unsigned) };
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortStable(value));
+}
+
+function sortStable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortStable);
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortStable((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}

--- a/scripts/resolve-vercel-routing.mjs
+++ b/scripts/resolve-vercel-routing.mjs
@@ -122,12 +122,17 @@ export function loadRoutingConfig(path = '.github/vercel-routing.json') {
 }
 
 async function main() {
+  // A CI bootstrap may create/link the new Vercel project before routing is resolved.
+  // Prefer those IDs when present; otherwise use the repository secrets.
+  const newTeamId = process.env.BOOTSTRAP_VERCEL_ORG_ID || process.env.NEW_VERCEL_ORG_ID;
+  const newProjectId = process.env.BOOTSTRAP_VERCEL_PROJECT_ID || process.env.NEW_VERCEL_PROJECT_ID;
+
   const routing = resolveVercelRouting({
     config: loadRoutingConfig(process.env.VERCEL_ROUTING_CONFIG),
     legacyToken: process.env.LEGACY_VERCEL_TOKEN,
     newToken: process.env.NEW_VERCEL_TOKEN,
-    newTeamId: process.env.NEW_VERCEL_ORG_ID,
-    newProjectId: process.env.NEW_VERCEL_PROJECT_ID,
+    newTeamId,
+    newProjectId,
   });
 
   writeGitHubEnvironment('VERCEL_ACCOUNT_MODE', routing.accountMode);

--- a/scripts/resolve-vercel-routing.mjs
+++ b/scripts/resolve-vercel-routing.mjs
@@ -39,7 +39,20 @@ function requireAccount(config, name, { allowEmpty = false } = {}) {
   return { teamId, projectId, projectName };
 }
 
-export function resolveVercelRouting({ config, legacyToken, newToken }) {
+function requireNewSecretId(value, label, pattern) {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new VercelRoutingError(`${label} is missing or invalid`);
+  }
+  return value;
+}
+
+export function resolveVercelRouting({
+  config,
+  legacyToken,
+  newToken,
+  newTeamId = '',
+  newProjectId = '',
+}) {
   if (config?.schemaVersion !== 1) {
     throw new VercelRoutingError('Unsupported Vercel routing schema version');
   }
@@ -48,12 +61,20 @@ export function resolveVercelRouting({ config, legacyToken, newToken }) {
   }
 
   const legacy = requireAccount(config, 'legacy');
-  const next = requireAccount(config, 'new', {
-    allowEmpty: config.activeAccount === 'legacy',
+  const configuredNext = requireAccount(config, 'new', {
+    allowEmpty: true,
   });
   if (legacy.teamId !== LEGACY_TEAM_ID || legacy.projectId !== LEGACY_PROJECT_ID) {
     throw new VercelRoutingError('Legacy Vercel rollback identity was changed');
   }
+
+  const next = config.activeAccount === 'new'
+    ? {
+        teamId: requireNewSecretId(newTeamId, 'VERCEL_ORG_ID_NEW', TEAM_ID_PATTERN),
+        projectId: requireNewSecretId(newProjectId, 'VERCEL_PROJECT_ID_NEW', PROJECT_ID_PATTERN),
+        projectName: configuredNext.projectName,
+      }
+    : configuredNext;
 
   const account = config.activeAccount === 'new' ? next : legacy;
   const token = config.activeAccount === 'new' ? newToken : legacyToken;
@@ -105,6 +126,8 @@ async function main() {
     config: loadRoutingConfig(process.env.VERCEL_ROUTING_CONFIG),
     legacyToken: process.env.LEGACY_VERCEL_TOKEN,
     newToken: process.env.NEW_VERCEL_TOKEN,
+    newTeamId: process.env.NEW_VERCEL_ORG_ID,
+    newProjectId: process.env.NEW_VERCEL_PROJECT_ID,
   });
 
   writeGitHubEnvironment('VERCEL_ACCOUNT_MODE', routing.accountMode);

--- a/supabase/migrations/20260815180000_dsg_gate_verified_action_route.sql
+++ b/supabase/migrations/20260815180000_dsg_gate_verified_action_route.sql
@@ -1,0 +1,142 @@
+-- Extend the atomic DSG Gate usage ledger to the Verified Agent Action product.
+--
+-- This migration is additive and follows the same shape as the encoding/prove
+-- extension (20260812163842): it drops and reinstates the route CHECK, then
+-- replaces the usage RPC with an identical body whose route allow-list also
+-- accepts 'actions/verify'. Serialization, idempotency per (org_id, eval_id),
+-- and the subscription-period usage position are unchanged.
+
+BEGIN;
+
+DO $$
+DECLARE
+  constraint_name TEXT;
+BEGIN
+  FOR constraint_name IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.dsg_gate_usage'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%route%'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.dsg_gate_usage DROP CONSTRAINT IF EXISTS %I',
+      constraint_name
+    );
+  END LOOP;
+END $$;
+
+ALTER TABLE public.dsg_gate_usage
+  ADD CONSTRAINT dsg_gate_usage_route_check
+  CHECK (route IN ('gates/evaluate', 'proofs/prove', 'encoding/prove', 'actions/verify'));
+
+CREATE OR REPLACE FUNCTION public.record_dsg_gate_usage(
+  p_org_id TEXT,
+  p_eval_id TEXT,
+  p_route TEXT,
+  p_gate_status TEXT,
+  p_duration_ms INTEGER
+)
+RETURNS TABLE (
+  usage_id UUID,
+  created BOOLEAN,
+  billed BOOLEAN,
+  meter_event_id TEXT,
+  usage_position INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing public.dsg_gate_usage%ROWTYPE;
+  v_period_start TIMESTAMPTZ;
+  v_period_end TIMESTAMPTZ;
+  v_position INTEGER;
+  v_inserted public.dsg_gate_usage%ROWTYPE;
+BEGIN
+  IF p_org_id IS NULL OR btrim(p_org_id) = '' THEN
+    RAISE EXCEPTION 'org_id is required';
+  END IF;
+  IF p_eval_id IS NULL OR btrim(p_eval_id) = '' THEN
+    RAISE EXCEPTION 'eval_id is required';
+  END IF;
+  IF p_route NOT IN ('gates/evaluate', 'proofs/prove', 'encoding/prove', 'actions/verify') THEN
+    RAISE EXCEPTION 'unsupported route: %', p_route;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_org_id, 0));
+
+  SELECT *
+  INTO v_existing
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.eval_id = p_eval_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN QUERY SELECT
+      v_existing.id,
+      FALSE,
+      v_existing.billed,
+      v_existing.meter_event_id,
+      v_existing.usage_position;
+    RETURN;
+  END IF;
+
+  SELECT
+    COALESCE(entitlement.current_period_start, date_trunc('month', now())),
+    COALESCE(entitlement.current_period_end, date_trunc('month', now()) + INTERVAL '1 month')
+  INTO v_period_start, v_period_end
+  FROM public.dsg_gate_entitlements entitlement
+  WHERE entitlement.org_id = p_org_id;
+
+  IF NOT FOUND THEN
+    v_period_start := date_trunc('month', now());
+    v_period_end := v_period_start + INTERVAL '1 month';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER + 1
+  INTO v_position
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.created_at >= v_period_start
+    AND usage.created_at < v_period_end;
+
+  INSERT INTO public.dsg_gate_usage (
+    org_id,
+    eval_id,
+    route,
+    gate_status,
+    duration_ms,
+    billed,
+    usage_position
+  ) VALUES (
+    p_org_id,
+    p_eval_id,
+    p_route,
+    p_gate_status,
+    p_duration_ms,
+    FALSE,
+    v_position
+  )
+  RETURNING * INTO v_inserted;
+
+  RETURN QUERY SELECT
+    v_inserted.id,
+    TRUE,
+    v_inserted.billed,
+    v_inserted.meter_event_id,
+    v_inserted.usage_position;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  TO service_role;
+
+COMMENT ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER) IS
+  'Idempotently records one DSG Gate/Proof/Encoding/Verified-Action evaluation and assigns a serialized subscription-period usage position.';
+
+COMMIT;

--- a/tests/e2e/start-funnel.spec.ts
+++ b/tests/e2e/start-funnel.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('DSG ONE start funnel', () => {
+  test('shows truthful connection states and routes to pricing', async ({ page }) => {
+    await page.goto('/start');
+
+    await expect(page.getByRole('heading', { name: /Connect.*verify.*execute.*evidence/i })).toBeVisible();
+    await expect(page.getByText('Web demo')).toBeVisible();
+    await expect(page.getByText('DSG Gate API')).toBeVisible();
+    await expect(page.getByText('MCP server')).toBeVisible();
+    await expect(page.getByText('GitHub integration')).toBeVisible();
+    await expect(page.getByText('Vercel integration')).toBeVisible();
+
+    await expect(page.getByText('Ready now')).toHaveCount(2);
+    await expect(page.getByText('Guided install')).toHaveCount(1);
+    await expect(page.getByText('Access request')).toHaveCount(2);
+
+    await expect(page.getByRole('link', { name: /Choose plan/i })).toHaveAttribute('href', '/pricing');
+  });
+
+  test('pricing exposes the connection/install funnel', async ({ page }) => {
+    await page.goto('/pricing');
+    await expect(page.getByRole('link', { name: /connection and install paths/i })).toHaveAttribute('href', '/start');
+  });
+});

--- a/tests/integration/api/install-manifest.test.ts
+++ b/tests/integration/api/install-manifest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from '@/app/api/install/manifest/route';
+
+describe('GET /api/install/manifest', () => {
+  it('publishes only supported installation states', async () => {
+    const response = GET();
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+    expect(body.version).toBe(1);
+    expect(Array.isArray(body.channels)).toBe(true);
+
+    const byId = Object.fromEntries(
+      body.channels.map((channel: { id: string }) => [channel.id, channel]),
+    );
+
+    expect(byId.web.status).toBe('ready');
+    expect(byId.web.installMode).toBe('one-click');
+    expect(byId.web.href).toBe('/demo');
+
+    expect(byId.api.status).toBe('ready');
+    expect(byId.api.href).toBe('/dashboard/api-keys');
+
+    expect(byId.mcp.status).toBe('guided');
+    expect(byId.mcp.installMode).toBe('manual');
+
+    expect(byId.github.status).toBe('planned');
+    expect(byId.github.installMode).not.toBe('one-click');
+
+    expect(byId.vercel.status).toBe('planned');
+    expect(byId.vercel.installMode).not.toBe('one-click');
+  });
+
+  it('never exposes an empty install destination', async () => {
+    const body = await GET().json();
+    for (const channel of body.channels) {
+      expect(channel.href).toEqual(expect.any(String));
+      expect(channel.href.trim().length).toBeGreaterThan(0);
+      expect(channel.firstValue.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/dsg-one/canonical-action-e2e.test.ts
+++ b/tests/unit/dsg-one/canonical-action-e2e.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runCanonicalActionE2E } from '@/lib/dsg-one/canonical-action-e2e';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+
+const tasks: Task[] = [
+  {
+    id: 'deploy-task',
+    name: 'Deploy verified release',
+    domain: 'deployment',
+    operation: 'deploy',
+    target: 'render',
+    dataSensitivity: 'medium',
+    externalEffect: true,
+    reversibility: 'reversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: true,
+  } as Task,
+];
+
+const agents: AgentCapacity[] = [
+  {
+    agentId: 1,
+    maxConcurrentTasks: 1,
+    maxTotalTasks: 1,
+    resourceAvailable: { cpu: 1 },
+  },
+];
+
+function request(execute = vi.fn(async () => ({
+  status: 'SUCCESS' as const,
+  observations: {
+    'deployment.status': 'LIVE',
+    'deployment.ref': 'abc123',
+    'health.status': 'PASS',
+  },
+  evidence: [
+    { fact: 'deployment.status', observerRole: 'verifier' as const, hash: 'a'.repeat(64) },
+    { fact: 'deployment.ref', observerRole: 'verifier' as const, hash: 'b'.repeat(64) },
+    { fact: 'health.status', observerRole: 'verifier' as const, hash: 'c'.repeat(64) },
+  ],
+  observedResultHash: 'd'.repeat(64),
+  evidenceItemIds: ['ev-deploy', 'ev-ref', 'ev-health'],
+}))) {
+  return {
+    optimization: {
+      problemId: 'deploy-opt-1',
+      tasks,
+      agentCapacities: agents,
+      useMock: true,
+      seed: 7,
+      exactProofMaxVariables: 4,
+      objective: {
+        version: 'deployment-risk-cost-v1',
+        assignmentCosts: {
+          'task_deploy-task_agent_1': 1,
+        },
+      },
+      constraintVersion: 'assignment-capacity-v1',
+    },
+    actionSolution: {
+      runtime: 'render' as const,
+      environment: 'preview',
+      commitSha: 'abc123',
+    },
+    gate: {
+      workspaceId: 'org-1',
+      runtime: {
+        agentId: 'unify-1',
+        agentType: 'code-agent' as const,
+        sessionId: 'session-1',
+        agentWillExecuteAction: true as const,
+        requiresResultCallback: true as const,
+      },
+      rbac: {
+        actorId: 'user-1',
+        role: 'approver' as const,
+        permissions: ['tool:execute_high'],
+        approvalRequestId: 'approval-1',
+        approvalDecision: 'approved' as const,
+        approvedBy: 'user-1',
+        approvedAt: '2026-08-15T00:00:00.000Z',
+      },
+      audit: {
+        preAuditEventId: 'audit-1',
+        ledgerId: 'ledger-1',
+        chainHeadHash: 'e'.repeat(64),
+      },
+      evidence: {
+        evidenceManifestId: 'manifest-1',
+        policySnapshotHash: 'f'.repeat(64),
+      },
+      planContractVerified: false,
+    },
+    simulate: vi.fn(async () => ({ ok: true, witnessHash: '1'.repeat(64) })),
+    execute,
+  };
+}
+
+describe('DSG ONE canonical action E2E', () => {
+  it('runs the executor only after global proof, Action IR, DSG ALLOW, and simulation', async () => {
+    const input = request();
+    const result = await runCanonicalActionE2E(input);
+
+    expect(result.verdict).toBe('PASS');
+    expect(result.executionPerformed).toBe(true);
+    expect(input.simulate).toHaveBeenCalledTimes(1);
+    expect(input.execute).toHaveBeenCalledTimes(1);
+    if ('replay' in result) {
+      expect(result.replay.replayable).toBe(true);
+      expect(result.deterministicReceiptHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('never invokes the executor when the DSG gate blocks', async () => {
+    const execute = vi.fn(async () => ({
+      status: 'SUCCESS' as const,
+      observations: {},
+      evidence: [],
+      observedResultHash: 'd'.repeat(64),
+      evidenceItemIds: ['ev'],
+    }));
+    const input = request(execute);
+    input.gate.rbac.permissions = [];
+
+    const result = await runCanonicalActionE2E(input);
+
+    expect(result.verdict).toBe('BLOCK');
+    expect(result.executionPerformed).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dsg-one/canonical-e2e-pipeline.test.ts
+++ b/tests/unit/dsg-one/canonical-e2e-pipeline.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildCanonicalSimulationWitness } from '@/lib/dsg-one/canonical-e2e-pipeline';
+
+const request = {
+  problemId: 'canonical-e2e-test',
+  tasks: [
+    { id: 'task-1', requiredCapabilities: ['code'], estimatedTokens: 100, priority: 1 },
+  ],
+  agentCapacities: [
+    { agentId: 'agent-1', capabilities: ['code'], maxConcurrentTasks: 1, maxTotalTasks: 1 },
+  ],
+  seed: 7,
+};
+
+describe('canonical DSG ONE E2E pipeline', () => {
+  it('produces the same simulation witness for the same normalized input', () => {
+    const a = buildCanonicalSimulationWitness(request as any);
+    const b = buildCanonicalSimulationWitness(request as any);
+    expect(a).toEqual(b);
+    expect(a.deterministic).toBe(true);
+  });
+
+  it('changes the witness when the optimization problem changes', () => {
+    const a = buildCanonicalSimulationWitness(request as any);
+    const b = buildCanonicalSimulationWitness({
+      ...request,
+      seed: 8,
+    } as any);
+    expect(a.inputHash).not.toBe(b.inputHash);
+    expect(a.scenarioHash).not.toBe(b.scenarioHash);
+  });
+});

--- a/tests/unit/dsg-one/verified-action-receipt.test.ts
+++ b/tests/unit/dsg-one/verified-action-receipt.test.ts
@@ -266,6 +266,73 @@ describe('verified action request validation', () => {
     }
   });
 
+  it('rejects a problem large enough to exhaust the dense QUBO matrix', () => {
+    // buildQUBOMatrix allocates numVariables x numVariables, so 64 x 64 = 4096
+    // variables would be a ~16.8M cell matrix. Each list is individually within
+    // its own cap here — only the product catches it.
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: {
+        ...optimization,
+        tasks: Array.from({ length: 64 }, (_, i) => ({ id: `task-${i}` })),
+        agentCapacities: Array.from({ length: 64 }, (_, i) => ({ agentId: i })),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const problem = result.details.find((detail) => detail.field === 'optimization');
+      expect(problem?.message).toContain('QUBO variables');
+      expect(result.details.map((detail) => detail.field)).not.toContain('optimization.tasks');
+    }
+  });
+
+  it('rejects oversized task and agent lists individually', () => {
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: {
+        ...optimization,
+        tasks: Array.from({ length: 65 }, (_, i) => ({ id: `task-${i}` })),
+        agentCapacities: Array.from({ length: 65 }, (_, i) => ({ agentId: i })),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const fields = result.details.map((detail) => detail.field);
+      expect(fields).toContain('optimization.tasks');
+      expect(fields).toContain('optimization.agentCapacities');
+    }
+  });
+
+  it.each([
+    ['not a number', 'soon'],
+    ['NaN, which Math.min passes through', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['zero', 0],
+    ['negative', -1],
+    ['above the 30s ceiling', 30_001],
+  ])('rejects a request timeout that is %s', (_label, timeout) => {
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: { ...optimization, timeout },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain('optimization.timeout');
+    }
+  });
+
+  it('accepts a timeout inside the ceiling', () => {
+    expect(
+      validateVerifiedActionRequest({
+        ...baseRequest,
+        optimization: { ...optimization, timeout: 30_000 },
+      }).ok,
+    ).toBe(true);
+  });
+
   it('rejects an execution result carrying no evidence', () => {
     const result = validateVerifiedActionRequest({
       ...baseRequest,

--- a/tests/unit/dsg-one/verified-action-receipt.test.ts
+++ b/tests/unit/dsg-one/verified-action-receipt.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import {
+  buildVerifiedActionReceipt,
+  checkReceiptIntegrity,
+  replayVerifiedAction,
+  REPRODUCIBLE_CHAIN_FIELDS,
+  RUN_SCOPED_CHAIN_FIELDS,
+  VERIFIED_ACTION_RECEIPT_SCHEMA,
+} from '@/lib/dsg-one/verified-action-receipt';
+import { validateVerifiedActionRequest } from '@/lib/dsg-one/verified-action-request';
+
+const auth: UnifiedAuthContext = {
+  source: 'api-key',
+  actorId: 'key-1',
+  orgId: 'org-1',
+  roles: ['operator'],
+};
+
+const optimization = {
+  problemId: 'verified-action-receipt',
+  tasks: [
+    {
+      id: 'task-1',
+      requiredCapabilities: ['code'],
+      estimatedTokens: 100,
+      priority: 1,
+    },
+  ],
+  agentCapacities: [
+    {
+      agentId: 1,
+      capabilities: ['code'],
+      maxConcurrentTasks: 1,
+      maxTotalTasks: 1,
+    },
+  ],
+  seed: 1,
+  useMock: true,
+  exactProofMaxVariables: 8,
+  objective: {
+    version: 'test-cost-v1',
+    assignmentCosts: { 'task_task-1_agent_1': 0 },
+  },
+};
+
+const observed = {
+  simulation: { ok: true, witnessHash: 'c'.repeat(64) },
+  execution: {
+    status: 'SUCCESS' as const,
+    observations: {
+      'deployment.status': 'LIVE',
+      'deployment.ref': '0123456789abcdef0123456789abcdef01234567',
+      'health.status': 'PASS',
+    },
+    evidence: [
+      { fact: 'deployment.status', observerRole: 'verifier' as const, hash: 'd'.repeat(64) },
+      { fact: 'deployment.ref', observerRole: 'verifier' as const, hash: 'e'.repeat(64) },
+      { fact: 'health.status', observerRole: 'verifier' as const, hash: 'f'.repeat(64) },
+    ],
+    observedResultHash: '1'.repeat(64),
+    evidenceItemIds: ['ev-1', 'ev-2', 'ev-3'],
+  },
+};
+
+const baseRequest = {
+  idempotencyKey: 'idem-1',
+  surface: 'api' as const,
+  sessionId: 'session-1',
+  optimization,
+  actionSolution: {
+    runtime: 'render' as const,
+    environment: 'staging',
+    commitSha: '0123456789abcdef0123456789abcdef01234567',
+  },
+  approval: { requestId: 'approval-1', decision: 'approved' as const },
+  audit: { preAuditEventId: 'audit-1', ledgerId: 'ledger-1', chainHeadHash: 'a'.repeat(64) },
+  evidence: { evidenceManifestId: 'manifest-1', policySnapshotHash: 'b'.repeat(64) },
+  observed,
+};
+
+async function runChain() {
+  return runCanonicalActionFromSurface(
+    {
+      surface: 'api',
+      sessionId: baseRequest.sessionId,
+      optimization: baseRequest.optimization as never,
+      actionSolution: baseRequest.actionSolution,
+      approval: baseRequest.approval,
+      audit: baseRequest.audit,
+      evidence: baseRequest.evidence,
+    },
+    auth,
+    {
+      simulate: async () => observed.simulation,
+      execute: async () => observed.execution,
+    },
+  );
+}
+
+describe('verified action receipt', () => {
+  it('issues a receipt bound to the canonical chain hashes', async () => {
+    const chain = await runChain();
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    expect(receipt.schema).toBe(VERIFIED_ACTION_RECEIPT_SCHEMA);
+    expect(receipt.receiptId).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.workspaceId).toBe('org-1');
+    expect(receipt.chain.canonicalChainHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.chain.optimizationProofHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // The receipt must never soften the repository's standing claim boundary.
+    expect(receipt.boundary.certificationClaim).toBe(false);
+    expect(receipt.boundary.independentAuditClaim).toBe(false);
+    expect(receipt.boundary.externalZ3SolverInvoked).toBe(false);
+    expect(receipt.boundary.executedByDsg).toBe(false);
+  });
+
+  it('addresses the same chain run by the same receiptId regardless of issue time', async () => {
+    const chain = await runChain();
+    const first = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+      issuedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const second = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+      issuedAt: '2026-06-30T12:00:00.000Z',
+    });
+
+    expect(second.receiptId).toBe(first.receiptId);
+    expect(second.issuedAt).not.toBe(first.issuedAt);
+  });
+
+  it('detects a receipt whose verdict was edited after issue', async () => {
+    const chain = await runChain();
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    expect(checkReceiptIntegrity(receipt).intact).toBe(true);
+
+    const forged = {
+      ...receipt,
+      chain: { ...receipt.chain, actionPlanHash: '0'.repeat(64) },
+    };
+    const integrity = checkReceiptIntegrity(forged);
+    expect(integrity.intact).toBe(false);
+    if (!integrity.intact) {
+      expect(integrity.presentedReceiptId).toBe(receipt.receiptId);
+      expect(integrity.expectedReceiptId).not.toBe(receipt.receiptId);
+    }
+  });
+
+  it('reports replayMatch when the chain reproduces every hash', async () => {
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: (await runChain()).result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    const replay = replayVerifiedAction(receipt, (await runChain()).result);
+
+    expect(replay.replayMatch).toBe(true);
+    expect(replay.receiptIntact).toBe(true);
+    expect(replay.verdictMatch).toBe(true);
+    expect(replay.mismatchedFields).toEqual([]);
+    expect(replay.comparedFields).toBe(REPRODUCIBLE_CHAIN_FIELDS.length);
+  });
+
+  it('never asserts the timestamped hashes reproduce, and says which they are', async () => {
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: (await runChain()).result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    const replay = replayVerifiedAction(receipt, (await runChain()).result);
+
+    // evaluateAgentCommandGate and buildAgentActionResultReceipt both hash a
+    // wall-clock timestamp, so these three differ on every run of the same
+    // action. A replay must stay green regardless.
+    expect(replay.replayMatch).toBe(true);
+    expect(replay.runScopedFields.map((entry) => entry.field)).toEqual(RUN_SCOPED_CHAIN_FIELDS);
+    expect(replay.runScopedFields.some((entry) => !entry.match)).toBe(true);
+    expect(REPRODUCIBLE_CHAIN_FIELDS).not.toContain('deterministicReceiptHash');
+  });
+
+  it('reports which chain hashes diverged when inputs change underneath a receipt', async () => {
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: (await runChain()).result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    // Same action, different target environment — the drift a stale receipt
+    // must not hide.
+    const drifted = await runCanonicalActionFromSurface(
+      {
+        surface: 'api',
+        sessionId: baseRequest.sessionId,
+        optimization: baseRequest.optimization as never,
+        actionSolution: { ...baseRequest.actionSolution, environment: 'production' },
+        approval: baseRequest.approval,
+        audit: baseRequest.audit,
+        evidence: baseRequest.evidence,
+      },
+      auth,
+      {
+        simulate: async () => observed.simulation,
+        execute: async () => observed.execution,
+      },
+    );
+
+    const replay = replayVerifiedAction(receipt, drifted.result);
+
+    expect(replay.replayMatch).toBe(false);
+    expect(replay.receiptIntact).toBe(true);
+    expect(replay.mismatchedFields.length).toBeGreaterThan(0);
+    expect(replay.reason).toContain('diverged');
+  });
+});
+
+describe('verified action request validation', () => {
+  it('accepts a complete request', () => {
+    expect(validateVerifiedActionRequest(baseRequest).ok).toBe(true);
+  });
+
+  it('rejects a request with no bound business objective', () => {
+    const { objective: _objective, ...withoutObjective } = optimization;
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: withoutObjective,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain('optimization.objective');
+    }
+  });
+
+  it('rejects a request that asks DSG to execute rather than verify', () => {
+    const { observed: _observed, ...withoutObserved } = baseRequest;
+    const result = validateVerifiedActionRequest(withoutObserved);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain('observed');
+    }
+  });
+
+  it('rejects an execution result carrying no evidence', () => {
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      observed: {
+        ...observed,
+        execution: { ...observed.execution, evidence: [] },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain(
+        'observed.execution.evidence',
+      );
+    }
+  });
+});

--- a/tests/unit/dsg-one/verified-optimization-pipeline.test.ts
+++ b/tests/unit/dsg-one/verified-optimization-pipeline.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
+import { runVerifiedOptimizationPipeline } from '@/lib/dsg-one/verified-optimization-pipeline';
+
+function task(id: string): Task {
+  return {
+    id,
+    name: id,
+    domain: 'test',
+    operation: 'test',
+    target: 'test-target',
+    dataSensitivity: 'low',
+    externalEffect: false,
+    reversibility: 'reversible',
+    userAuthorized: true,
+    planAllowed: true,
+    hasFreshEvidence: true,
+    hasRollback: true,
+  } as Task;
+}
+
+function agent(agentId: number, maxTotalTasks: number): AgentCapacity {
+  return {
+    agentId,
+    maxConcurrentTasks: maxTotalTasks,
+    maxTotalTasks,
+    resourceAvailable: { cpu: 1, memory: 1 },
+  };
+}
+
+describe('verified optimization pipeline', () => {
+  it('emits VERIFIED_GLOBAL_OPTIMUM only after Z3 SAT and complete exact proof', async () => {
+    const result = await runVerifiedOptimizationPipeline({
+      problemId: 'one-task-one-agent',
+      tasks: [task('t1')],
+      agentCapacities: [agent(1, 1)],
+      seed: 7,
+      useMock: true,
+      exactProofMaxVariables: 8,
+    });
+
+    expect(result.verdict).toBe('VERIFIED_GLOBAL_OPTIMUM');
+    expect(result.z3.feasible).toBe(true);
+    expect(result.z3.status).toBe('sat');
+    expect(result.exact.complete).toBe(true);
+    expect(result.exact.candidateIsGlobal).toBe(true);
+    expect(result.exact.statesChecked).toBe(2);
+    expect(result.executionAllowed).toBe(false);
+    expect(result.proof.proofHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.proof.receiptHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('does not claim global optimum when exact proof bound is insufficient', async () => {
+    const result = await runVerifiedOptimizationPipeline({
+      problemId: 'one-task-two-agents',
+      tasks: [task('t1')],
+      agentCapacities: [agent(1, 1), agent(2, 1)],
+      seed: 7,
+      useMock: true,
+      exactProofMaxVariables: 1,
+    });
+
+    expect(result.z3.feasible).toBe(true);
+    expect(result.exact.complete).toBe(false);
+    expect(result.exact.candidateIsGlobal).toBeNull();
+    expect(result.verdict).toBe('VERIFIED_FEASIBLE');
+    expect(result.executionAllowed).toBe(false);
+  });
+
+  it('produces the same deterministic receipt for identical inputs', async () => {
+    const input = {
+      problemId: 'deterministic-receipt',
+      tasks: [task('t1')],
+      agentCapacities: [agent(1, 1)],
+      seed: 42,
+      useMock: true,
+      exactProofMaxVariables: 8,
+    } as const;
+
+    const first = await runVerifiedOptimizationPipeline(input);
+    const second = await runVerifiedOptimizationPipeline(input);
+
+    expect(second.quboHash).toBe(first.quboHash);
+    expect(second.candidate.solutionHash).toBe(first.candidate.solutionHash);
+    expect(second.z3.proofHash).toBe(first.z3.proofHash);
+    expect(second.exact.proofHash).toBe(first.exact.proofHash);
+    expect(second.proof.proofHash).toBe(first.proof.proofHash);
+    expect(second.proof.receiptHash).toBe(first.proof.receiptHash);
+  });
+});

--- a/tests/unit/dsg-one/verified-optimization-pipeline.test.ts
+++ b/tests/unit/dsg-one/verified-optimization-pipeline.test.ts
@@ -37,8 +37,16 @@ describe('verified optimization pipeline', () => {
       seed: 7,
       useMock: true,
       exactProofMaxVariables: 8,
+      // VERIFIED_GLOBAL_OPTIMUM is only emitted for an explicitly bound business
+      // objective. Without this the pipeline correctly degrades to
+      // VERIFIED_FEASIBLE rather than claiming optimality it cannot support.
+      objective: {
+        version: 'test-cost-v1',
+        assignmentCosts: { 'task_t1_agent_1': -1 },
+      },
     });
 
+    expect(result.canonicalProblem.businessObjectiveBound).toBe(true);
     expect(result.verdict).toBe('VERIFIED_GLOBAL_OPTIMUM');
     expect(result.z3.feasible).toBe(true);
     expect(result.z3.status).toBe('sat');
@@ -58,8 +66,17 @@ describe('verified optimization pipeline', () => {
       seed: 7,
       useMock: true,
       exactProofMaxVariables: 1,
+      // Objective is bound here too, so the VERIFIED_FEASIBLE verdict below is
+      // caused by the incomplete exact proof and nothing else. Costs stay at 0
+      // so binding the objective does not perturb the capacity penalties that
+      // decide feasibility across the two candidate agents.
+      objective: {
+        version: 'test-cost-v1',
+        assignmentCosts: { 'task_t1_agent_1': 0, 'task_t1_agent_2': 0 },
+      },
     });
 
+    expect(result.canonicalProblem.businessObjectiveBound).toBe(true);
     expect(result.z3.feasible).toBe(true);
     expect(result.exact.complete).toBe(false);
     expect(result.exact.candidateIsGlobal).toBeNull();

--- a/tests/unit/mcp/canonical-action-adapter.test.ts
+++ b/tests/unit/mcp/canonical-action-adapter.test.ts
@@ -34,7 +34,7 @@ const baseInput = {
     exactProofMaxVariables: 8,
     objective: {
       version: 'test-cost-v1',
-      assignmentCosts: { task_task-1_agent_1: 0 },
+      assignmentCosts: { 'task_task-1_agent_1': 0 },
     },
   },
   actionSolution: {

--- a/tests/unit/mcp/canonical-action-adapter.test.ts
+++ b/tests/unit/mcp/canonical-action-adapter.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+
+const auth: UnifiedAuthContext = {
+  source: 'session',
+  actorId: 'actor-1',
+  orgId: 'org-1',
+  roles: ['operator'],
+};
+
+const baseInput = {
+  sessionId: 'session-1',
+  optimization: {
+    problemId: 'adapter-test',
+    tasks: [
+      {
+        id: 'task-1',
+        requiredCapabilities: ['code'],
+        estimatedTokens: 100,
+        priority: 1,
+      },
+    ],
+    agentCapacities: [
+      {
+        agentId: 1,
+        capabilities: ['code'],
+        maxConcurrentTasks: 1,
+        maxTotalTasks: 1,
+      },
+    ],
+    seed: 1,
+    useMock: true,
+    exactProofMaxVariables: 8,
+    objective: {
+      version: 'test-cost-v1',
+      assignmentCosts: { task_task-1_agent_1: 0 },
+    },
+  },
+  actionSolution: {
+    runtime: 'render' as const,
+    environment: 'staging',
+    commitSha: '0123456789abcdef0123456789abcdef01234567',
+  },
+  approval: {
+    requestId: 'approval-1',
+    decision: 'approved' as const,
+  },
+  audit: {
+    preAuditEventId: 'audit-1',
+    ledgerId: 'ledger-1',
+    chainHeadHash: 'a'.repeat(64),
+  },
+  evidence: {
+    evidenceManifestId: 'manifest-1',
+    policySnapshotHash: 'b'.repeat(64),
+  },
+};
+
+function hooks() {
+  return {
+    simulate: async () => ({ ok: true, witnessHash: 'c'.repeat(64) }),
+    execute: async () => ({
+      status: 'SUCCESS' as const,
+      observations: {
+        'deployment.status': 'LIVE',
+        'deployment.ref': baseInput.actionSolution.commitSha,
+        'health.status': 'PASS',
+      },
+      evidence: [
+        { fact: 'deployment.status', observerRole: 'verifier' as const, hash: 'd'.repeat(64) },
+        { fact: 'deployment.ref', observerRole: 'verifier' as const, hash: 'e'.repeat(64) },
+        { fact: 'health.status', observerRole: 'verifier' as const, hash: 'f'.repeat(64) },
+      ],
+      observedResultHash: '1'.repeat(64),
+      evidenceItemIds: ['ev-1', 'ev-2', 'ev-3'],
+    }),
+  };
+}
+
+describe('canonical action surface adapter', () => {
+  it('keeps Unify as a transport surface over the canonical chain', async () => {
+    const result = await runCanonicalActionFromSurface(
+      { ...baseInput, surface: 'unify' },
+      auth,
+      hooks(),
+    );
+    expect(result.surface).toBe('unify');
+    expect(result.canonical).toBe(true);
+    expect(result.boundary).toContain('do not create a second authorization');
+  });
+
+  it('keeps Trinity MCP on the same canonical chain', async () => {
+    const result = await runCanonicalActionFromSurface(
+      { ...baseInput, surface: 'trinity-mcp' },
+      auth,
+      hooks(),
+    );
+    expect(result.surface).toBe('trinity-mcp');
+    expect(result.canonical).toBe(true);
+    expect(result.boundary).toContain('canonical DSG ONE chain remains authoritative');
+  });
+});

--- a/tests/unit/runtime/makk8-z3-verifier.test.ts
+++ b/tests/unit/runtime/makk8-z3-verifier.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildMakk8Smt2, verifyMakk8WithZ3 } from '@/lib/runtime/makk8-z3-verifier';
+
+const validAction = {
+  value: 1,
+  is_grounded: true,
+  intent_score: 1,
+  is_api_clean: true,
+  source_verified: true,
+  compute_cost: 10,
+  has_audit_trail: true,
+  nonce_lock: true,
+};
+
+describe('Makk-8 Z3 verifier', () => {
+  it('returns SAT/ALLOW when all eight invariants are true', async () => {
+    const result = await verifyMakk8WithZ3(validAction);
+
+    expect(result.status).toBe('SAT');
+    expect(result.ok).toBe(true);
+    expect(result.decision).toBe('ALLOW');
+    expect(result.reason).toBe('SAMMA_Z3_VERIFIED');
+    expect(result.proofHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.constraintsHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns UNSAT/BLOCK when a required path invariant is false', async () => {
+    const result = await verifyMakk8WithZ3({ ...validAction, source_verified: false });
+
+    expect(result.status).toBe('UNSAT');
+    expect(result.ok).toBe(false);
+    expect(result.decision).toBe('BLOCK');
+    expect(result.artifact.rightLivelihood).toBe(false);
+  });
+
+  it('builds the conjunction of all eight named invariants', () => {
+    const smt2 = buildMakk8Smt2({
+      rightView: true,
+      rightResolve: true,
+      rightSpeech: true,
+      rightConduct: true,
+      rightLivelihood: true,
+      rightEffort: true,
+      rightMindfulness: true,
+      rightSamadhi: true,
+    });
+
+    expect(smt2).toContain('(declare-const rightView Bool)');
+    expect(smt2).toContain('(declare-const rightSamadhi Bool)');
+    expect(smt2).toContain('(assert (and rightView rightResolve rightSpeech rightConduct rightLivelihood rightEffort rightMindfulness rightSamadhi))');
+  });
+});

--- a/tests/unit/scripts/vercel-routing.test.ts
+++ b/tests/unit/scripts/vercel-routing.test.ts
@@ -9,20 +9,19 @@ const legacy = {
   projectName: 'tdealer01-crypto-dsg-control-plane',
 };
 
+const blankNew = {
+  teamId: '',
+  projectId: '',
+  projectName: 'tdealer01-crypto-dsg-control-plane',
+};
+
 describe('Vercel routing configuration', () => {
-  it('keeps legacy routing active until a verified config commit switches it', () => {
+  it('keeps legacy routing available as the rollback identity', () => {
     const result = resolveVercelRouting({
       config: {
         schemaVersion: 1,
         activeAccount: 'legacy',
-        accounts: {
-          legacy,
-          new: {
-            teamId: '',
-            projectId: '',
-            projectName: 'tdealer01-crypto-dsg-control-plane',
-          },
-        },
+        accounts: { legacy, new: blankNew },
       },
       legacyToken: 'legacy-token',
       newToken: '',
@@ -38,22 +37,17 @@ describe('Vercel routing configuration', () => {
     });
   });
 
-  it('selects only a distinct, fully configured new account', () => {
+  it('routes to a distinct new account using protected secret IDs', () => {
     const result = resolveVercelRouting({
       config: {
         schemaVersion: 1,
         activeAccount: 'new',
-        accounts: {
-          legacy,
-          new: {
-            teamId: 'team_newAccount123',
-            projectId: 'prj_newProject123',
-            projectName: 'tdealer01-crypto-dsg-control-plane',
-          },
-        },
+        accounts: { legacy, new: blankNew },
       },
       legacyToken: 'legacy-token',
       newToken: 'new-token',
+      newTeamId: 'team_newAccount123',
+      newProjectId: 'prj_newProject123',
     });
 
     expect(result.accountMode).toBe('new');
@@ -63,24 +57,35 @@ describe('Vercel routing configuration', () => {
     expect(result.token).toBe('new-token');
   });
 
-  it('blocks new routing when IDs or credentials are incomplete', () => {
+  it('blocks new routing when protected IDs or credentials are incomplete', () => {
     expect(() =>
       resolveVercelRouting({
         config: {
           schemaVersion: 1,
           activeAccount: 'new',
-          accounts: {
-            legacy,
-            new: {
-              teamId: '',
-              projectId: '',
-              projectName: 'tdealer01-crypto-dsg-control-plane',
-            },
-          },
+          accounts: { legacy, new: blankNew },
         },
         legacyToken: 'legacy-token',
         newToken: '',
+        newTeamId: '',
+        newProjectId: '',
       }),
-    ).toThrow('new Vercel team ID is invalid');
+    ).toThrow('VERCEL_ORG_ID_NEW is missing or invalid');
+  });
+
+  it('blocks accidental reuse of the legacy destination under new routing', () => {
+    expect(() =>
+      resolveVercelRouting({
+        config: {
+          schemaVersion: 1,
+          activeAccount: 'new',
+          accounts: { legacy, new: blankNew },
+        },
+        legacyToken: 'legacy-token',
+        newToken: 'new-token',
+        newTeamId: legacy.teamId,
+        newProjectId: 'prj_newProject123',
+      }),
+    ).toThrow('New-account routing resolves to the legacy account');
   });
 });

--- a/tests/unit/scripts/vercel-routing.test.ts
+++ b/tests/unit/scripts/vercel-routing.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // @ts-expect-error The production helper is intentionally a native ESM module.
@@ -88,4 +90,42 @@ describe('Vercel routing configuration', () => {
       }),
     ).toThrow('New-account routing resolves to the legacy account');
   });
+});
+
+describe('workflows that resolve Vercel routing', () => {
+  const workflowDir = join(process.cwd(), '.github', 'workflows');
+
+  // Under activeAccount: "new", resolveVercelRouting reads the destination IDs
+  // from NEW_VERCEL_ORG_ID / NEW_VERCEL_PROJECT_ID and throws when either is
+  // absent. A workflow that only forwards the token therefore fails at the
+  // routing step, which is how the migration to the rebuilt Vercel project
+  // silently broke production-readiness, promoted-production-deploy, and
+  // set-stripe-price-env. This pins the full trio for every caller.
+  const routingSteps = readdirSync(workflowDir)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .flatMap((name) => {
+      const content = readFileSync(join(workflowDir, name), 'utf8');
+      // Split on step boundaries so each block carries its own env: keys.
+      // `node --check <path>` is a syntax check, not an invocation, and does
+      // not match this exact command string.
+      return content
+        .split(/\n(?=\s*- )/)
+        .filter((step) => step.includes('node scripts/resolve-vercel-routing.mjs'))
+        .map((step) => ({ workflow: name, step }));
+    });
+
+  it('finds every workflow step that invokes the routing resolver', () => {
+    expect(routingSteps.length).toBeGreaterThan(0);
+  });
+
+  it.each(['NEW_VERCEL_ORG_ID', 'NEW_VERCEL_PROJECT_ID', 'NEW_VERCEL_TOKEN', 'LEGACY_VERCEL_TOKEN'])(
+    'forwards %s in every routing step',
+    (variable) => {
+      const missing = routingSteps
+        .filter(({ step }) => !step.includes(`${variable}:`))
+        .map(({ workflow }) => workflow);
+
+      expect(missing).toEqual([]);
+    },
+  );
 });

--- a/tests/unit/unify/desktop-dsg-bridge.test.ts
+++ b/tests/unit/unify/desktop-dsg-bridge.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  UnifyDesktopDsgBridge,
+  verifyLocalEvidenceIntegrity,
+  type UnifyExecutionRequest,
+} from '@/lib/unify/desktop-dsg-bridge';
+
+const formalContext = {
+  is_grounded: true,
+  is_api_clean: true,
+  source_verified: true,
+  has_audit_trail: true,
+  nonce_lock: true,
+  value: 1,
+  intent_score: 1,
+  compute_cost: 10,
+};
+
+const request: UnifyExecutionRequest = {
+  target: 'shell',
+  action: 'run-approved-command',
+  args: { command: 'echo', args: ['verified'] },
+  formalContext,
+  gateRequest: {
+    workspaceId: 'org-1',
+    runtime: {
+      agentId: 'unify-desktop',
+      agentType: 'external-agent',
+      sessionId: 'session-1',
+      agentWillExecuteAction: true,
+      requiresResultCallback: true,
+    },
+    command: {
+      commandId: 'cmd-1',
+      actionType: 'write',
+      targetSystemId: 'local-shell',
+      operationName: 'run-approved-command',
+      riskLevel: 'low',
+      dataClasses: [],
+      idempotencyKey: 'idem-1',
+      rollbackPlanId: 'rollback-1',
+    },
+    rbac: {
+      actorId: 'user-1',
+      role: 'operator',
+      permissions: ['tool:execute_low'],
+    },
+    audit: {
+      preAuditEventId: 'audit-1',
+      ledgerId: 'ledger-1',
+      chainHeadHash: 'a'.repeat(64),
+    },
+    evidence: {
+      evidenceManifestId: 'manifest-1',
+      policySnapshotHash: 'b'.repeat(64),
+    },
+  },
+};
+
+const formalAllow = {
+  ok: true,
+  decision: 'ALLOW',
+  makk8: {
+    ok: true,
+    decision: 'ALLOW',
+    status: 'SAT',
+    reason: 'SAMMA_Z3_VERIFIED',
+    proofHash: 'c'.repeat(64),
+    constraintsHash: 'd'.repeat(64),
+  },
+};
+
+const gateAllow = {
+  ok: true,
+  result: {
+    gateVersion: 'dsg-agent-command-gate-v1.0',
+    decision: 'PASS',
+    canAgentExecute: true,
+    status: 'AGENT_ACTION_ALLOWED',
+    reasons: ['decision_pass'],
+    invariantChecks: [],
+    commandHash: 'e'.repeat(64),
+    decisionHash: 'f'.repeat(64),
+    generatedAt: '2026-08-15T00:00:00.000Z',
+    truthBoundary: 'allowed',
+    actionEnvelope: {
+      envelopeId: 'envelope-1',
+      workspaceId: 'org-1',
+      agentId: 'unify-desktop',
+      sessionId: 'session-1',
+      commandId: 'cmd-1',
+      decisionHash: 'f'.repeat(64),
+      allowedAction: 'write',
+      targetSystemId: 'local-shell',
+      operationName: 'run-approved-command',
+      actionScope: ['local-shell', 'run-approved-command', 'write'],
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      mustReturnResultTo: '/api/dsg/agent-command-gate/result',
+      requiredResultFields: [],
+    },
+  },
+};
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('UnifyDesktopDsgBridge', () => {
+  it('does not execute when Makk-8/Z3 blocks', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response({ ...formalAllow, ok: false, decision: 'BLOCK', makk8: { ...formalAllow.makk8, ok: false, decision: 'BLOCK', status: 'UNSAT' } }, 409),
+    );
+    const executor = { execute: vi.fn() };
+    const bridge = new UnifyDesktopDsgBridge({ baseUrl: 'https://dsg.example', fetchImpl: fetchImpl as typeof fetch });
+
+    const result = await bridge.execute(request, executor);
+
+    expect(result.decision).toBe('BLOCK');
+    expect(result.stage).toBe('MAKK8_Z3');
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('does not execute when DSG ONE command gate blocks', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response(formalAllow))
+      .mockResolvedValueOnce(response({ ok: false, result: { ...gateAllow.result, decision: 'BLOCK', canAgentExecute: false, status: 'AGENT_ACTION_BLOCKED', actionEnvelope: undefined } }, 409));
+    const executor = { execute: vi.fn() };
+    const bridge = new UnifyDesktopDsgBridge({ baseUrl: 'https://dsg.example', fetchImpl: fetchImpl as typeof fetch });
+
+    const result = await bridge.execute(request, executor);
+
+    expect(result.decision).toBe('BLOCK');
+    expect(result.stage).toBe('DSG_ONE_GATE');
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('executes only after both gates, stores evidence, records receipt, and replays formal proof', async () => {
+    const receipt = {
+      gateVersion: 'dsg-agent-command-gate-v1.0',
+      accepted: true,
+      workspaceId: 'org-1',
+      agentId: 'unify-desktop',
+      commandId: 'cmd-1',
+      envelopeId: 'envelope-1',
+      status: 'SUCCESS',
+      resultHash: '1'.repeat(64),
+      receiptHash: '2'.repeat(64),
+      reasons: ['agent_result_record_accepted'],
+      recordedAt: '2026-08-15T00:00:01.000Z',
+    };
+
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response(formalAllow))
+      .mockResolvedValueOnce(response(gateAllow))
+      .mockResolvedValueOnce(response({ ok: true, receipt }))
+      .mockResolvedValueOnce(response(formalAllow));
+
+    const executor = {
+      execute: vi.fn(async () => ({ status: 'SUCCESS' as const, output: { stdout: 'verified' } })),
+    };
+    const store = { save: vi.fn(async () => undefined) };
+    const bridge = new UnifyDesktopDsgBridge({ baseUrl: 'https://dsg.example', fetchImpl: fetchImpl as typeof fetch });
+
+    const result = await bridge.execute(request, executor, store);
+
+    expect(result.decision).toBe('ALLOW');
+    if (result.decision !== 'ALLOW') throw new Error('expected ALLOW');
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(store.save).toHaveBeenCalledTimes(1);
+    expect(result.receipt?.accepted).toBe(true);
+    expect(result.replay.ok).toBe(true);
+    expect(result.replay.reason).toBe('REPLAY_VERIFIED');
+    expect(verifyLocalEvidenceIntegrity(result.evidence)).toBe(true);
+    expect(result.evidence.evidenceHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('detects tampered local evidence', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(response(formalAllow))
+      .mockResolvedValueOnce(response(gateAllow))
+      .mockResolvedValueOnce(response({ ok: true, receipt: null }))
+      .mockResolvedValueOnce(response(formalAllow));
+    const executor = {
+      execute: vi.fn(async () => ({ status: 'SUCCESS' as const, output: 'ok' })),
+    };
+    const bridge = new UnifyDesktopDsgBridge({ baseUrl: 'https://dsg.example', fetchImpl: fetchImpl as typeof fetch });
+    const result = await bridge.execute(request, executor);
+    if (result.decision !== 'ALLOW') throw new Error('expected ALLOW');
+
+    const tampered = { ...result.evidence, action: 'changed-after-execution' };
+    expect(verifyLocalEvidenceIntegrity(tampered)).toBe(false);
+  });
+});

--- a/trinity-mcp-server/package.json
+++ b/trinity-mcp-server/package.json
@@ -8,6 +8,7 @@
     "dev": "node --loader ts-node/esm src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "start:dsg-one": "node dist/dsg-one.js",
     "inspector": "npx @modelcontextprotocol/inspector node dist/index.js",
     "test": "npm run build && node --test test/*.test.mjs"
   },

--- a/trinity-mcp-server/package.json
+++ b/trinity-mcp-server/package.json
@@ -6,10 +6,13 @@
   "type": "module",
   "scripts": {
     "dev": "node --loader ts-node/esm src/index.ts",
+    "dev:unify": "node --loader ts-node/esm src/unify-dsg.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "start:dsg-one": "node dist/dsg-one.js",
+    "start:unify": "node dist/unify-dsg.js",
     "inspector": "npx @modelcontextprotocol/inspector node dist/index.js",
+    "inspector:unify": "npx @modelcontextprotocol/inspector node dist/unify-dsg.js",
     "test": "npm run build && node --test test/*.test.mjs"
   },
   "dependencies": {

--- a/trinity-mcp-server/src/client.ts
+++ b/trinity-mcp-server/src/client.ts
@@ -42,7 +42,8 @@ export class TrinityClient {
   constructor(config: TrinityClientConfig) {
     this.apiUrl = config.apiUrl.replace(/\/$/, '');
     this.jwtToken = config.jwtToken;
-    this.backendMode = config.backendMode ?? 'trinity';
+    this.backendMode =
+      config.backendMode ?? (process.env.DSG_ONE_API_URL ? 'dsg-one' : 'trinity');
   }
 
   private async request<T>(path: string, options: RequestInit = {}): Promise<T> {

--- a/trinity-mcp-server/src/client.ts
+++ b/trinity-mcp-server/src/client.ts
@@ -1,34 +1,61 @@
 /**
- * Trinity API Client
- * Handles all communication with Trinity Backend API
+ * Trinity / DSG ONE API Client
+ * Supports the legacy Trinity backend contract and a DSG ONE-native adapter mode.
  */
+
+export type TrinityBackendMode = 'trinity' | 'dsg-one';
 
 export interface TrinityClientConfig {
   apiUrl: string;
   jwtToken?: string;
+  backendMode?: TrinityBackendMode;
+}
+
+export interface AgentStatusItem {
+  id: string;
+  name: string;
+  role?: string;
+  status: 'running' | 'idle' | 'error' | 'stopped';
+  uptime?: string;
+  reliability?: number;
+  jobsProcessed?: number;
+  cpuUsage?: number;
+  mode?: 'sandbox' | 'live';
+}
+
+export interface TaskExecutionResult {
+  success: boolean;
+  result: string;
+  duration: number;
+  planHash?: string;
+  gateDecision?: string;
+  gateDecisionHash?: string;
+  violations?: Array<{ message?: string; [key: string]: unknown }>;
+  evidence?: Array<{ type: string; id: string; hash: string; timestamp: number }>;
 }
 
 export class TrinityClient {
   private apiUrl: string;
   private jwtToken?: string;
+  private backendMode: TrinityBackendMode;
 
   constructor(config: TrinityClientConfig) {
-    this.apiUrl = config.apiUrl;
+    this.apiUrl = config.apiUrl.replace(/\/$/, '');
     this.jwtToken = config.jwtToken;
+    this.backendMode = config.backendMode ?? 'trinity';
   }
 
   private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...(options.headers as Record<string, string> || {}),
+      ...((options.headers as Record<string, string>) || {}),
     };
 
     if (this.jwtToken) {
-      headers['Authorization'] = `Bearer ${this.jwtToken}`;
+      headers.Authorization = `Bearer ${this.jwtToken}`;
     }
 
-    const url = `${this.apiUrl}${path}`;
-    const response = await fetch(url, {
+    const response = await fetch(`${this.apiUrl}${path}`, {
       ...options,
       headers,
     });
@@ -36,11 +63,19 @@ export class TrinityClient {
     if (!response.ok) {
       const error = await response.text();
       throw new Error(
-        `Trinity API Error (${response.status}): ${response.statusText} - ${error}`
+        `Trinity API Error (${response.status}): ${response.statusText} - ${error}`,
       );
     }
 
     return response.json() as Promise<T>;
+  }
+
+  private requireLegacyRoute(feature: string) {
+    if (this.backendMode === 'dsg-one') {
+      throw new Error(
+        `${feature} is not mapped to a verified DSG ONE route yet; refusing to emulate it.`,
+      );
+    }
   }
 
   async health() {
@@ -53,25 +88,53 @@ export class TrinityClient {
     }>('/api/health');
   }
 
-  async getAgentStatus() {
+  async getAgentStatus(): Promise<{
+    agents: AgentStatusItem[];
+    total: number;
+    healthy: number;
+  }> {
+    if (this.backendMode === 'dsg-one') {
+      const response = await this.request<{
+        items: Array<{
+          agent_id: string;
+          name: string;
+          status: string;
+          usage_this_month?: number;
+        }>;
+        pagination?: { total?: number };
+      }>('/api/agents?per_page=50');
+
+      const agents: AgentStatusItem[] = response.items.map((agent) => ({
+        id: String(agent.agent_id),
+        name: agent.name,
+        role: 'DSG ONE agent',
+        status:
+          agent.status === 'disabled'
+            ? 'stopped'
+            : agent.status === 'error'
+              ? 'error'
+              : agent.status === 'active'
+                ? 'running'
+                : 'idle',
+        jobsProcessed: agent.usage_this_month,
+      }));
+
+      return {
+        agents,
+        total: response.pagination?.total ?? agents.length,
+        healthy: agents.filter((agent) => agent.status === 'running').length,
+      };
+    }
+
     return this.request<{
-      agents: Array<{
-        id: string;
-        name: string;
-        role: string;
-        status: 'running' | 'idle' | 'error' | 'stopped';
-        uptime: string;
-        reliability: number;
-        jobsProcessed: number;
-        cpuUsage: number;
-        mode: 'sandbox' | 'live';
-      }>;
+      agents: AgentStatusItem[];
       total: number;
       healthy: number;
     }>('/api/agents/status');
   }
 
   async setAgentMode(agentId: string, mode: 'sandbox' | 'live') {
+    this.requireLegacyRoute('Agent mode switching');
     return this.request<{
       success: boolean;
       previousMode: string;
@@ -82,18 +145,52 @@ export class TrinityClient {
     });
   }
 
-  async executeTask(agentId: string, task: string) {
-    return this.request<{
-      success: boolean;
-      result: string;
-      duration: number;
-    }>('/api/agents/execute', {
+  async executeTask(agentId: string, task: string): Promise<TaskExecutionResult> {
+    if (this.backendMode === 'dsg-one') {
+      const startedAt = Date.now();
+      const response = await this.request<{
+        success: boolean;
+        planHash: string;
+        gateDecision?: string;
+        gateDecisionHash?: string;
+        violations?: Array<{ message?: string; [key: string]: unknown }>;
+        result?: {
+          success: boolean;
+          executedCommands?: Array<{ command: string; args: string[] }>;
+          fileChanges?: Array<{ path: string; operation: string }>;
+          evidence?: Array<{ type: string; id: string; hash: string; timestamp: number }>;
+        };
+        message: string;
+      }>('/api/dsg/brain/execute', {
+        method: 'POST',
+        body: JSON.stringify({ input: task }),
+      });
+
+      const evidence = response.result?.evidence ?? [];
+      const commandSummary = (response.result?.executedCommands ?? [])
+        .map((entry) => [entry.command, ...entry.args].join(' '))
+        .join('; ');
+
+      return {
+        success: response.success,
+        result: commandSummary || response.message,
+        duration: Date.now() - startedAt,
+        planHash: response.planHash,
+        gateDecision: response.gateDecision,
+        gateDecisionHash: response.gateDecisionHash,
+        violations: response.violations ?? [],
+        evidence,
+      };
+    }
+
+    return this.request<TaskExecutionResult>('/api/agents/execute', {
       method: 'POST',
       body: JSON.stringify({ agentId, task }),
     });
   }
 
   async chatWithAgent(agentId: string, message: string) {
+    this.requireLegacyRoute('Agent chat');
     return this.request<{
       response: string;
       agentId: string;
@@ -105,6 +202,7 @@ export class TrinityClient {
   }
 
   async getCostTracker(period: '1h' | '24h' | '7d' = '24h') {
+    this.requireLegacyRoute('Legacy Trinity cost tracker');
     return this.request<{
       total_usd: number;
       budget: {
@@ -120,6 +218,7 @@ export class TrinityClient {
   }
 
   async getSecurityAudit(limit: number = 10) {
+    this.requireLegacyRoute('Legacy Trinity security audit');
     return this.request<{
       entries: Array<{
         id: string;
@@ -134,6 +233,7 @@ export class TrinityClient {
   }
 
   async getStateContinuity() {
+    this.requireLegacyRoute('Legacy Trinity state continuity');
     return this.request<{
       all_agents_running: boolean;
       context_sharing: number;
@@ -143,6 +243,7 @@ export class TrinityClient {
   }
 
   async login(username: string, password: string) {
+    this.requireLegacyRoute('Legacy Trinity login');
     return this.request<{
       token: string;
       expiresIn: string;

--- a/trinity-mcp-server/src/dsg-one.ts
+++ b/trinity-mcp-server/src/dsg-one.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/**
+ * DSG ONE launcher for the Trinity MCP server.
+ *
+ * This keeps the legacy Trinity backend contract available while allowing
+ * the same MCP package to target a deployed DSG ONE control plane.
+ */
+async function main() {
+  const dsgOneUrl = process.env.DSG_ONE_API_URL?.trim();
+  if (!dsgOneUrl) {
+    throw new Error('DSG_ONE_API_URL is required');
+  }
+
+  process.env.TRINITY_API_URL = dsgOneUrl.replace(/\/$/, '');
+  await import('./index.js');
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[Trinity DSG ONE launcher] ${message}`);
+  process.exit(1);
+});

--- a/trinity-mcp-server/src/index.ts
+++ b/trinity-mcp-server/src/index.ts
@@ -191,10 +191,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: `## Trinity Agents Status\n\nTotal Agents: ${result.total}\nHealthy (Running): ${result.healthy}\n\n### Agents:\n${result.agents
-                .map(
-                  (agent) =>
-                    `- **${agent.name}** (${agent.role})\n  - Status: ${agent.status}\n  - Reliability: ${(agent.reliability * 100).toFixed(1)}%\n  - Jobs: ${agent.jobsProcessed}\n  - CPU: ${agent.cpuUsage.toFixed(1)}%\n  - Mode: ${agent.mode}\n  - Uptime: ${agent.uptime}`
-                )
+                .map((agent) => {
+                  const reliability =
+                    typeof agent.reliability === 'number'
+                      ? `${(agent.reliability * 100).toFixed(1)}%`
+                      : 'Unknown';
+                  const cpuUsage =
+                    typeof agent.cpuUsage === 'number'
+                      ? `${agent.cpuUsage.toFixed(1)}%`
+                      : 'Unknown';
+                  return `- **${agent.name}** (${agent.role})\n  - Status: ${agent.status}\n  - Reliability: ${reliability}\n  - Jobs: ${agent.jobsProcessed}\n  - CPU: ${cpuUsage}\n  - Mode: ${agent.mode}\n  - Uptime: ${agent.uptime}`;
+                })
                 .join('\n\n')}`,
             },
             {

--- a/trinity-mcp-server/src/unify-dsg.ts
+++ b/trinity-mcp-server/src/unify-dsg.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const DSG_ONE_API_URL = (process.env.DSG_ONE_API_URL || process.env.TRINITY_API_URL || '').replace(/\/$/, '');
+const DSG_ONE_TOKEN = process.env.DSG_ONE_TOKEN || process.env.TRINITY_JWT_TOKEN;
+
+if (!DSG_ONE_API_URL) {
+  throw new Error('DSG_ONE_API_URL or TRINITY_API_URL is required');
+}
+
+const server = new Server(
+  { name: 'trinity-unify-dsg-mcp', version: '1.0.0' },
+  { capabilities: { tools: {} } },
+);
+
+const tools = [
+  {
+    name: 'unify_verify_action',
+    description:
+      'Verify an Unify Desktop Assistant action through the real Makk-8/Z3 verifier and then the DSG ONE agent command gate. Returns ALLOW only when both stages pass. This tool does not execute desktop, browser, or shell actions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        formalContext: {
+          type: 'object',
+          properties: {
+            is_grounded: { type: 'boolean' },
+            is_api_clean: { type: 'boolean' },
+            source_verified: { type: 'boolean' },
+            has_audit_trail: { type: 'boolean' },
+            nonce_lock: { type: 'boolean' },
+            value: { type: 'number' },
+            intent_score: { type: 'number' },
+            compute_cost: { type: 'number' },
+          },
+          required: [
+            'is_grounded',
+            'is_api_clean',
+            'source_verified',
+            'has_audit_trail',
+            'nonce_lock',
+            'value',
+            'intent_score',
+            'compute_cost',
+          ],
+        },
+        gateRequest: {
+          type: 'object',
+          description: 'Complete AgentCommandGateRequest accepted by /api/dsg/agent-command-gate.',
+        },
+      },
+      required: ['formalContext', 'gateRequest'],
+    },
+  },
+  {
+    name: 'unify_record_result',
+    description:
+      'Record the observed result of an already ALLOWed Unify action. The result must carry the envelopeId, decisionHash, observedResultHash, and local evidence item id from the governed execution.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        result: {
+          type: 'object',
+          description: 'AgentActionResultRequest for /api/dsg/agent-command-gate/result.',
+        },
+      },
+      required: ['result'],
+    },
+  },
+  {
+    name: 'unify_replay_evidence',
+    description:
+      'Replay Unify local evidence: verify its canonical SHA-256 evidence hash and re-run the same Makk-8/Z3 formal context. Returns REPLAY_VERIFIED only if both evidence integrity and the formal proof hash match.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        evidence: { type: 'object' },
+        formalContext: { type: 'object' },
+      },
+      required: ['evidence', 'formalContext'],
+    },
+  },
+  {
+    name: 'unify_chain_status',
+    description:
+      'Return the enforced Unify governed execution order and the truth boundary between verification and local execution.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+  },
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: rawArgs } = request.params;
+  const args = (rawArgs || {}) as Record<string, unknown>;
+
+  try {
+    if (name === 'unify_verify_action') {
+      const formalContext = asRecord(args.formalContext, 'formalContext');
+      const gateRequest = asRecord(args.gateRequest, 'gateRequest');
+      const formal = await postDecision('/api/dsg/makk8-z3/verify', { context: formalContext });
+      const formalAllowed = formal.ok === true && formal.decision === 'ALLOW' && asRecord(formal.makk8, 'makk8').status === 'SAT';
+
+      if (!formalAllowed) {
+        return jsonToolResult({
+          decision: 'BLOCK',
+          stage: 'MAKK8_Z3',
+          executed: false,
+          formal,
+          boundary: 'No local execution is authorized from this result.',
+        });
+      }
+
+      const gate = await postDecision('/api/dsg/agent-command-gate', gateRequest);
+      const gateResult = asRecord(gate.result, 'result');
+      const allowed = gate.ok === true && gateResult.canAgentExecute === true && gateResult.decision === 'PASS' && Boolean(gateResult.actionEnvelope);
+
+      return jsonToolResult({
+        decision: allowed ? 'ALLOW' : 'BLOCK',
+        stage: allowed ? 'DSG_ONE_GATE_PASS' : 'DSG_ONE_GATE',
+        executed: false,
+        formal,
+        gate,
+        actionEnvelope: allowed ? gateResult.actionEnvelope : null,
+        boundary: allowed
+          ? 'Verification passed. The Unify desktop process may execute only the action envelope scope, then must return observed result evidence.'
+          : 'DSG ONE did not authorize local execution.',
+      });
+    }
+
+    if (name === 'unify_record_result') {
+      const result = asRecord(args.result, 'result');
+      const receipt = await postDecision('/api/dsg/agent-command-gate/result', result);
+      return jsonToolResult(receipt);
+    }
+
+    if (name === 'unify_replay_evidence') {
+      const evidence = asRecord(args.evidence, 'evidence');
+      const formalContext = asRecord(args.formalContext, 'formalContext');
+      const claimedEvidenceHash = stringValue(evidence.evidenceHash);
+      const claimedProofHash = stringValue(evidence.formalProofHash);
+      const unsignedEvidence = { ...evidence };
+      delete unsignedEvidence.evidenceHash;
+      const calculatedEvidenceHash = sha256(unsignedEvidence);
+      const integrityMatch = Boolean(claimedEvidenceHash) && calculatedEvidenceHash === claimedEvidenceHash;
+
+      if (!integrityMatch) {
+        return jsonToolResult({
+          ok: false,
+          reason: 'EVIDENCE_HASH_MISMATCH',
+          integrityMatch: false,
+          formalProofMatch: false,
+          calculatedEvidenceHash,
+        }, true);
+      }
+
+      const formal = await postDecision('/api/dsg/makk8-z3/verify', { context: formalContext });
+      const makk8 = asRecord(formal.makk8, 'makk8');
+      const formalAllowed = formal.ok === true && makk8.status === 'SAT';
+      const formalProofMatch = formalAllowed && stringValue(makk8.proofHash) === claimedProofHash;
+
+      return jsonToolResult({
+        ok: formalProofMatch,
+        reason: formalProofMatch ? 'REPLAY_VERIFIED' : formalAllowed ? 'FORMAL_PROOF_MISMATCH' : 'FORMAL_REPLAY_BLOCKED',
+        integrityMatch: true,
+        formalProofMatch,
+        formal,
+      }, !formalProofMatch);
+    }
+
+    if (name === 'unify_chain_status') {
+      return jsonToolResult({
+        chain: [
+          'Unify Desktop Assistant intent',
+          'Makk-8 invariants',
+          'Z3 SAT/UNSAT verification',
+          'DSG ONE agent command gate',
+          'ALLOW/BLOCK',
+          'Desktop/Browser/Shell execution by local Unify executor only when ALLOW',
+          'Local SHA-256 evidence',
+          'Agent result receipt',
+          'Replay of evidence integrity + formal proof',
+          'Trinity MCP inspection/control surface',
+        ],
+        executionBoundary: 'Trinity MCP and DSG ONE verify/authorize; the local Unify executor performs OS/browser/shell actions.',
+      });
+    }
+
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true,
+    };
+  }
+});
+
+async function postDecision(path: string, body: unknown): Promise<Record<string, unknown>> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (DSG_ONE_TOKEN) headers.Authorization = `Bearer ${DSG_ONE_TOKEN}`;
+
+  const response = await fetch(`${DSG_ONE_API_URL}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new Error(`DSG ONE returned non-JSON from ${path}: HTTP ${response.status}`);
+  }
+
+  // 409 is the intentional decision status for a BLOCK result.
+  if (!response.ok && response.status !== 409 && response.status !== 422) {
+    throw new Error(`DSG ONE request failed ${path}: HTTP ${response.status}`);
+  }
+  return payload;
+}
+
+function jsonToolResult(value: unknown, isError = false) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2), mimeType: 'application/json' }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function asRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortStable(value));
+}
+
+function sortStable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortStable);
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortStable((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`[Trinity Unify DSG MCP] Connected to ${DSG_ONE_API_URL}`);
+}
+
+main().catch((error) => {
+  console.error('[Trinity Unify DSG MCP] Fatal:', error);
+  process.exit(1);
+});

--- a/trinity-mcp-server/test/dsg-one-adapter.test.mjs
+++ b/trinity-mcp-server/test/dsg-one-adapter.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { TrinityClient } from '../dist/client.js';
+
+test('DSG ONE mode maps agent listing and governed execution to native routes', async () => {
+  const previous = process.env.DSG_ONE_API_URL;
+  process.env.DSG_ONE_API_URL = 'https://dsg-one.example';
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+
+    if (String(url).endsWith('/api/agents?per_page=50')) {
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              agent_id: 'agent-1',
+              name: 'Hermes',
+              status: 'active',
+              usage_this_month: 7,
+            },
+          ],
+          pagination: { total: 1 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+
+    if (String(url).endsWith('/api/dsg/brain/execute')) {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          planHash: 'plan-hash',
+          gateDecision: 'ALLOW',
+          gateDecisionHash: 'gate-hash',
+          violations: [],
+          result: {
+            success: true,
+            executedCommands: [{ command: 'echo', args: ['verified'] }],
+            evidence: [
+              { type: 'execution', id: 'ev-1', hash: 'proof-hash', timestamp: 1 },
+            ],
+          },
+          message: 'Execution completed within constraints',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+
+    return new Response('not found', { status: 404 });
+  };
+
+  try {
+    const client = new TrinityClient({
+      apiUrl: 'https://dsg-one.example',
+      jwtToken: 'test-token',
+    });
+
+    const status = await client.getAgentStatus();
+    assert.equal(status.total, 1);
+    assert.equal(status.healthy, 1);
+    assert.equal(status.agents[0].jobsProcessed, 7);
+
+    const execution = await client.executeTask('agent-1', 'verify deployment');
+    assert.equal(execution.success, true);
+    assert.equal(execution.planHash, 'plan-hash');
+    assert.equal(execution.gateDecision, 'ALLOW');
+    assert.equal(execution.result, 'echo verified');
+    assert.equal(execution.evidence?.[0]?.hash, 'proof-hash');
+
+    assert.equal(calls[0].url, 'https://dsg-one.example/api/agents?per_page=50');
+    assert.equal(calls[1].url, 'https://dsg-one.example/api/dsg/brain/execute');
+    assert.equal(calls[1].options.method, 'POST');
+    assert.deepEqual(JSON.parse(calls[1].options.body), { input: 'verify deployment' });
+    assert.equal(calls[1].options.headers.Authorization, 'Bearer test-token');
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previous === undefined) delete process.env.DSG_ONE_API_URL;
+    else process.env.DSG_ONE_API_URL = previous;
+  }
+});
+
+test('DSG ONE mode refuses to fake unmapped mutation routes', async () => {
+  const previous = process.env.DSG_ONE_API_URL;
+  process.env.DSG_ONE_API_URL = 'https://dsg-one.example';
+
+  try {
+    const client = new TrinityClient({ apiUrl: 'https://dsg-one.example' });
+    await assert.rejects(
+      client.setAgentMode('agent-1', 'live'),
+      /not mapped to a verified DSG ONE route yet/,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.DSG_ONE_API_URL;
+    else process.env.DSG_ONE_API_URL = previous;
+  }
+});

--- a/vercel.preview.json
+++ b/vercel.preview.json
@@ -1,0 +1,14 @@
+{
+  "buildCommand": "next build",
+  "outputDirectory": ".next",
+  "git": {
+    "deploymentEnabled": {
+      "*": false
+    }
+  },
+  "github": {
+    "autoAlias": false,
+    "silent": false,
+    "autoJobCancelation": true
+  }
+}

--- a/vercel.preview.json
+++ b/vercel.preview.json
@@ -10,5 +10,6 @@
     "autoAlias": false,
     "silent": false,
     "autoJobCancelation": true
-  }
+  },
+  "crons": []
 }


### PR DESCRIPTION
## Goal
Create one clear funnel from discovery to first value to paid usage without claiming automation that is not actually wired.

## What changed
- Added `/start` connection/install page covering Web, API, MCP, GitHub, and Vercel paths.
- Added `GET /api/install/manifest` as the product truth source for channel readiness.
- Updated `/pricing` to route users into `/start` and removed unsupported universal competitor claims from pricing copy.
- Added integration test for install-manifest truth boundaries.
- Added Playwright smoke coverage for `/start` and pricing-to-start conversion.
- Added E2E funnel contract and provenance notes.

## Truth boundary
- Web demo: ready / one-click.
- API: ready / guided API-key setup.
- MCP: guided / repository install and environment configuration.
- GitHub and Vercel managed installs: not advertised as one-click until production registration/callback flows are verified.

## User benefit
`Discover -> Start -> Connect -> Verify -> Execute when authorized -> Evidence -> Upgrade`

## Required before merge
- Typecheck
- Production build
- install-manifest integration test
- start funnel E2E smoke where CI supports Playwright
