### PR TITLE
Verified Agent Action API + optimization fixture contract fix

### DIFF
--- a/.github/workflows/dsg-secure-deploy-gate.yml
+++ b/.github/workflows/dsg-secure-deploy-gate.yml
@@ -10,10 +10,15 @@ jobs:
   dsg-gate:
     runs-on: ubuntu-latest
     steps:
+      # The origin is a repository variable so it can follow the production
+      # deployment without a code change — set DSG_PRODUCTION_ORIGIN once a
+      # custom domain exists. The default is the rebuilt Vercel project; the
+      # previous hardcoded host belonged to the retired project and answers 402
+      # DEPLOYMENT_DISABLED, so the gate was reporting on a dead origin.
       - uses: tdealer01-crypto/dsg-secure-deploy-gate-action@v1
         with:
-          readiness_url: "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/finance-governance/readiness"
+          readiness_url: "${{ vars.DSG_PRODUCTION_ORIGIN || 'https://tdealer01-crypto-dsg-control-plane-thanawats-projects-336871dc.vercel.app' }}/api/finance-governance/readiness"
           expected_status: "200"
           require_json_ok: "true"
-          protected_url: "https://tdealer01-crypto-dsg-control-plane.vercel.app/api/api-keys"
+          protected_url: "${{ vars.DSG_PRODUCTION_ORIGIN || 'https://tdealer01-crypto-dsg-control-plane-thanawats-projects-336871dc.vercel.app' }}/api/api-keys"
           protected_expected: "401,403"

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Check available secrets
@@ -83,6 +85,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Install Vercel CLI

--- a/.github/workflows/promoted-production-deploy.yml
+++ b/.github/workflows/promoted-production-deploy.yml
@@ -105,6 +105,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Verify required release configuration

--- a/.github/workflows/set-stripe-price-env.yml
+++ b/.github/workflows/set-stripe-price-env.yml
@@ -72,6 +72,8 @@ jobs:
         env:
           LEGACY_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           NEW_VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW || secrets.VERCEL_TOKEN }}
+          NEW_VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_NEW }}
+          NEW_VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_NEW }}
         run: node scripts/resolve-vercel-routing.mjs
 
       - name: Validate required secrets

--- a/app/api/dsg/v1/actions/replay/route.ts
+++ b/app/api/dsg/v1/actions/replay/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from 'next/server';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import { validateVerifiedActionRequest } from '@/lib/dsg-one/verified-action-request';
+import {
+  checkReceiptIntegrity,
+  replayVerifiedAction,
+  VERIFIED_ACTION_RECEIPT_SCHEMA,
+  type VerifiedActionReceipt,
+} from '@/lib/dsg-one/verified-action-receipt';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import {
+  requireDsgAuth,
+  dsgAuthError,
+  logDsgApiCall,
+} from '@/lib/dsg/auth/require-dsg-auth';
+
+export const dynamic = 'force-dynamic';
+
+function isReceipt(value: unknown): value is VerifiedActionReceipt {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.schema === VERIFIED_ACTION_RECEIPT_SCHEMA &&
+    typeof candidate.receiptId === 'string' &&
+    typeof candidate.chain === 'object' &&
+    candidate.chain !== null
+  );
+}
+
+/**
+ * POST /api/dsg/v1/actions/replay — independently re-verify a receipt.
+ *
+ * Two modes, both free of charge because replay is what makes a receipt worth
+ * paying for and charging to check your own evidence would defeat that:
+ *
+ *   1. receipt only            -> integrity check (was the document altered?)
+ *   2. receipt + original request -> full replay (does the chain still produce
+ *                                    the same hashes and the same verdict?)
+ *
+ * Mode 2 is the measurable claim: provider, model, or orchestration drift shows
+ * up as a per-field hash mismatch instead of silently passing.
+ */
+export async function POST(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const startMs = Date.now();
+
+  const rateLimitResult = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-action-replay:${caller.orgId}`),
+    limit: 60,
+    windowMs: 60_000,
+  });
+  const rateLimitHeaders = buildRateLimitHeaders(rateLimitResult, 60);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limit_exceeded' },
+      { status: 429, headers: rateLimitHeaders },
+    );
+  }
+
+  const body = await readJsonBody(request, { maxBytes: 96_000 });
+  if (!body.ok) {
+    return NextResponse.json(
+      { ok: false, error: body.error },
+      { status: body.status, headers: rateLimitHeaders },
+    );
+  }
+
+  const payload = body.value as Record<string, unknown>;
+  if (!isReceipt(payload?.receipt)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'validation_failed',
+        details: [
+          { field: 'receipt', message: `must be a ${VERIFIED_ACTION_RECEIPT_SCHEMA} document` },
+        ],
+      },
+      { status: 400, headers: rateLimitHeaders },
+    );
+  }
+
+  const receipt = payload.receipt;
+  const integrity = checkReceiptIntegrity(receipt);
+
+  // Mode 1: no original request supplied — report integrity only, and say so
+  // rather than letting the caller read it as a full replay.
+  if (payload.request === undefined) {
+    const durationMs = Date.now() - startMs;
+    void logDsgApiCall({
+      orgId: caller.orgId,
+      actorType: caller.actorType,
+      apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+      userId: caller.actorType === 'user' ? caller.userId : undefined,
+      route: 'actions/replay',
+      statusCode: 200,
+      gateStatus: integrity.intact ? 'INTACT' : 'ALTERED',
+      proofId: receipt.receiptId,
+      durationMs,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        type: 'dsg-verified-action-integrity',
+        mode: 'integrity-only',
+        receiptId: receipt.receiptId,
+        receiptIntact: integrity.intact,
+        reason: integrity.intact
+          ? 'Receipt contents hash to the presented receiptId.'
+          : integrity.reason,
+        replayPerformed: false,
+        note: 'Supply the original verify request as `request` to replay the chain and compare every hash.',
+      },
+      { headers: rateLimitHeaders },
+    );
+  }
+
+  const validated = validateVerifiedActionRequest(payload.request);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'validation_failed', details: validated.details },
+      { status: 400, headers: rateLimitHeaders },
+    );
+  }
+
+  const req = validated.value;
+  const auth: UnifiedAuthContext = {
+    source: caller.actorType === 'api_key' ? 'api-key' : 'session',
+    actorId: caller.actorType === 'api_key' ? caller.apiKeyId : caller.userId,
+    orgId: caller.orgId,
+    roles: ['operator'],
+  };
+
+  const fresh = await runCanonicalActionFromSurface(
+    {
+      surface: req.surface,
+      sessionId: req.sessionId,
+      agentId: req.agentId,
+      agentName: req.agentName,
+      planContractVerified: req.planContractVerified,
+      optimization: req.optimization as never,
+      actionSolution: req.actionSolution,
+      approval: req.approval,
+      audit: req.audit,
+      evidence: req.evidence,
+    },
+    auth,
+    {
+      simulate: async () => req.observed.simulation,
+      execute: async () => req.observed.execution,
+    },
+  );
+
+  const replay = replayVerifiedAction(receipt, fresh.result);
+  const durationMs = Date.now() - startMs;
+
+  void logDsgApiCall({
+    orgId: caller.orgId,
+    actorType: caller.actorType,
+    apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+    userId: caller.actorType === 'user' ? caller.userId : undefined,
+    route: 'actions/replay',
+    statusCode: 200,
+    gateStatus: replay.replayMatch ? 'REPLAY_MATCH' : 'REPLAY_MISMATCH',
+    proofId: receipt.receiptId,
+    durationMs,
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      type: 'dsg-verified-action-replay',
+      mode: 'full-replay',
+      receiptId: receipt.receiptId,
+      replayMatch: replay.replayMatch,
+      receiptIntact: replay.receiptIntact,
+      verdictMatch: replay.verdictMatch,
+      comparedFields: replay.comparedFields,
+      mismatchedFields: replay.mismatchedFields,
+      fields: replay.fields,
+      reason: replay.reason,
+      boundary:
+        'Replay re-runs the canonical chain over the same inputs and compares hashes. It does not re-execute the action against any live system.',
+    },
+    { headers: rateLimitHeaders },
+  );
+}

--- a/app/api/dsg/v1/actions/verify/route.ts
+++ b/app/api/dsg/v1/actions/verify/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import { validateVerifiedActionRequest } from '@/lib/dsg-one/verified-action-request';
+import { buildVerifiedActionReceipt } from '@/lib/dsg-one/verified-action-receipt';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import {
+  requireDsgAuth,
+  dsgAuthError,
+  logDsgApiCall,
+} from '@/lib/dsg/auth/require-dsg-auth';
+import {
+  checkGateEntitlement,
+  recordGateEvaluation,
+} from '@/lib/dsg/gate-entitlement';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/dsg/v1/actions/verify — Verified Agent Action.
+ *
+ * The first HTTP surface over the canonical DSG chain
+ * (QUBO -> Ising -> Z3 -> exact proof -> Action IR -> DSG gate ->
+ * pre-execution simulation -> evidence -> receipt/replay).
+ *
+ * Boundary: the caller's runtime executes the action and submits what it
+ * observed. This route verifies that observation against the chain and issues a
+ * receipt. It never executes anything, so the simulate/execute hooks below are
+ * bound to the submitted evidence rather than to any live executor.
+ */
+export async function POST(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const startMs = Date.now();
+
+  const rateLimitResult = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-verified-action:${caller.orgId}`),
+    limit: 60,
+    windowMs: 60_000,
+  });
+  const rateLimitHeaders = buildRateLimitHeaders(rateLimitResult, 60);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { ok: false, error: 'rate_limit_exceeded' },
+      { status: 429, headers: rateLimitHeaders },
+    );
+  }
+
+  const entitlement = await checkGateEntitlement(caller.orgId);
+  if (!entitlement.allowed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: entitlement.message,
+        requiresUpgrade: entitlement.requiresPayment,
+        tier: entitlement.tier,
+        accessMode: entitlement.accessMode,
+        upgradeUrl: entitlement.upgradeUrl,
+      },
+      {
+        status: entitlement.requiresPayment ? 402 : 503,
+        headers: rateLimitHeaders,
+      },
+    );
+  }
+
+  const body = await readJsonBody(request, { maxBytes: 64_000 });
+  if (!body.ok) {
+    return NextResponse.json(
+      { ok: false, error: body.error },
+      { status: body.status, headers: rateLimitHeaders },
+    );
+  }
+
+  const validated = validateVerifiedActionRequest(body.value);
+  if (!validated.ok) {
+    return NextResponse.json(
+      { ok: false, error: 'validation_failed', details: validated.details },
+      { status: 400, headers: rateLimitHeaders },
+    );
+  }
+
+  const req = validated.value;
+
+  const auth: UnifiedAuthContext = {
+    source: caller.actorType === 'api_key' ? 'api-key' : 'session',
+    actorId: caller.actorType === 'api_key' ? caller.apiKeyId : caller.userId,
+    orgId: caller.orgId,
+    roles: ['operator'],
+  };
+
+  const canonicalResult = await runCanonicalActionFromSurface(
+    {
+      surface: req.surface,
+      sessionId: req.sessionId,
+      agentId: req.agentId,
+      agentName: req.agentName,
+      planContractVerified: req.planContractVerified,
+      optimization: req.optimization as never,
+      actionSolution: req.actionSolution,
+      approval: req.approval,
+      audit: req.audit,
+      evidence: req.evidence,
+    },
+    auth,
+    {
+      simulate: async () => req.observed.simulation,
+      execute: async () => req.observed.execution,
+    },
+  );
+
+  const problemId = String(
+    (req.optimization as Record<string, unknown>).problemId ?? '',
+  );
+  const receipt = buildVerifiedActionReceipt({
+    canonicalResult: canonicalResult.result,
+    surface: req.surface,
+    workspaceId: caller.orgId,
+    problemId,
+  });
+
+  const durationMs = Date.now() - startMs;
+
+  // Metered on every verified action, PASS or BLOCK: a BLOCK receipt is the
+  // product working, not a failed request, and the caller keeps the evidence.
+  const usage = await recordGateEvaluation(
+    req.idempotencyKey,
+    caller.orgId,
+    'actions/verify',
+    receipt.verdict,
+    durationMs,
+  );
+
+  if (!usage.recorded) {
+    const accessMode = usage.error?.startsWith('delivery_blocked:')
+      ? usage.error.slice('delivery_blocked:'.length)
+      : 'billing_unavailable';
+    const requiresUpgrade =
+      accessMode === 'quota_exceeded' || accessMode === 'subscription_inactive';
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'usage_evidence_unavailable',
+        accessMode,
+        requiresUpgrade,
+        message:
+          'Receipt withheld because usage evidence could not be recorded safely.',
+        upgradeUrl: '/pricing#dsg-gate',
+      },
+      { status: requiresUpgrade ? 402 : 503, headers: rateLimitHeaders },
+    );
+  }
+
+  const response = NextResponse.json(
+    {
+      ok: true,
+      type: 'dsg-verified-action',
+      receipt,
+      canonical: canonicalResult.canonical,
+      surface: canonicalResult.surface,
+      entitlement: {
+        tier: entitlement.tier,
+        evalsRemaining: entitlement.evalsRemaining,
+        accessMode: entitlement.accessMode,
+      },
+      caller: { orgId: caller.orgId, actorType: caller.actorType },
+      replayWith: '/api/dsg/v1/actions/replay',
+      boundary: canonicalResult.boundary,
+    },
+    { headers: rateLimitHeaders },
+  );
+
+  void logDsgApiCall({
+    orgId: caller.orgId,
+    actorType: caller.actorType,
+    apiKeyId: caller.actorType === 'api_key' ? caller.apiKeyId : undefined,
+    userId: caller.actorType === 'user' ? caller.userId : undefined,
+    route: 'actions/verify',
+    statusCode: 200,
+    gateStatus: receipt.verdict,
+    proofId: receipt.receiptId,
+    durationMs,
+  });
+
+  return response;
+}

--- a/lib/dsg-one/verified-action-receipt.ts
+++ b/lib/dsg-one/verified-action-receipt.ts
@@ -1,0 +1,333 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Verified Agent Action receipt.
+ *
+ * The sellable unit of the canonical DSG chain: one action, verified after it
+ * was authorized, bound to the hashes that produced the verdict, and checkable
+ * again later by someone who did not run it.
+ *
+ * Claim boundary — this file does NOT do any of the following, and no caller
+ * may describe it as doing them:
+ *   - it does not execute anything (the customer runtime executes; DSG verifies);
+ *   - it does not invoke an external Z3 solver;
+ *   - it is not a certification and not an independent third-party audit.
+ * A receipt proves that a specific chain of hashes produced a specific verdict,
+ * and that a later run either reproduced those hashes or did not.
+ */
+
+export const VERIFIED_ACTION_RECEIPT_SCHEMA = 'dsg-verified-action-receipt/1.0';
+
+export type VerifiedActionSurface = 'api' | 'unify' | 'trinity-mcp';
+
+/**
+ * Hashes lifted from one canonical chain run. Every field is either a hash the
+ * chain produced or null when that stage was never reached, so a BLOCK receipt
+ * still records exactly how far the action got.
+ *
+ * These hashes split into two groups, and conflating them would make the replay
+ * claim false:
+ *
+ *   - Reproducible: derived only from the request inputs. A later run over the
+ *     same inputs must produce identical values, so these are what replayMatch
+ *     is computed from.
+ *   - Run-scoped: derived partly from wall-clock time, because
+ *     evaluateAgentCommandGate and buildAgentActionResultReceipt both hash a
+ *     timestamp (an audit receipt is supposed to record when it happened).
+ *     These are recorded and reported, but never asserted to reproduce.
+ *
+ * deterministicReceiptHash is run-scoped despite its name: it folds in the two
+ * timestamped hashes above, so it changes between runs of the same action.
+ */
+export interface VerifiedActionChainBinding {
+  canonicalChainHash: string | null;
+  optimizationProofHash: string | null;
+  actionPlanHash: string | null;
+  gateDecisionHash: string | null;
+  simulationWitnessHash: string | null;
+  resultReceiptHash: string | null;
+  acceptanceHash: string | null;
+  finalReceiptHash: string | null;
+  deterministicReceiptHash: string | null;
+}
+
+export interface VerifiedActionReceipt {
+  schema: typeof VERIFIED_ACTION_RECEIPT_SCHEMA;
+  receiptId: string;
+  issuedAt: string;
+  surface: VerifiedActionSurface;
+  workspaceId: string;
+  problemId: string;
+  verdict: 'PASS' | 'BLOCK';
+  stage: string;
+  executionPerformed: boolean;
+  replayable: boolean;
+  reason: string | null;
+  chain: VerifiedActionChainBinding;
+  boundary: {
+    certificationClaim: false;
+    independentAuditClaim: false;
+    externalZ3SolverInvoked: false;
+    executedByDsg: false;
+    statement: string;
+  };
+}
+
+const BOUNDARY_STATEMENT =
+  'DSG verified an action that the caller authorized and executed. This receipt binds a verdict to a chain of hashes; it is not a certification, not an independent audit, and does not assert that an external Z3 solver was invoked.';
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, stable(record[key])]),
+    );
+  }
+  return value;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
+
+function hashOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * The receiptId covers everything a verifier must not be able to change without
+ * detection: the verdict, the stage it stopped at, and every chain hash. It
+ * deliberately excludes issuedAt so the same chain run is addressable by the
+ * same id.
+ */
+function computeReceiptId(
+  receipt: Omit<VerifiedActionReceipt, 'receiptId' | 'issuedAt'>,
+): string {
+  return sha256({
+    schema: receipt.schema,
+    surface: receipt.surface,
+    workspaceId: receipt.workspaceId,
+    problemId: receipt.problemId,
+    verdict: receipt.verdict,
+    stage: receipt.stage,
+    executionPerformed: receipt.executionPerformed,
+    replayable: receipt.replayable,
+    reason: receipt.reason,
+    chain: receipt.chain,
+  });
+}
+
+/**
+ * Lift the chain hashes out of a canonical-chain result. The result shape is a
+ * discriminated union whose BLOCK arms omit later stages, so every field is
+ * read defensively rather than assumed present.
+ */
+export function extractChainBinding(canonicalResult: unknown): VerifiedActionChainBinding {
+  const result = asRecord(canonicalResult);
+  const upstream = asRecord(result?.upstream);
+  const binding = asRecord(upstream?.binding);
+  const stages = asRecord(upstream?.stages);
+  const optimization = asRecord(stages?.optimization);
+  const optimizationProof = asRecord(optimization?.proof);
+  const gate = asRecord(result?.gate);
+  const simulation = asRecord(result?.simulation);
+  const resultReceipt = asRecord(result?.resultReceipt);
+  const acceptance = asRecord(result?.acceptance);
+  const compilation = asRecord(result?.compilation);
+  const plan = asRecord(compilation?.plan);
+
+  return {
+    canonicalChainHash: hashOrNull(binding?.chainHash),
+    optimizationProofHash: hashOrNull(optimizationProof?.proofHash),
+    actionPlanHash: hashOrNull(plan?.actionPlanHash),
+    gateDecisionHash: hashOrNull(gate?.decisionHash),
+    simulationWitnessHash: hashOrNull(simulation?.witnessHash),
+    resultReceiptHash: hashOrNull(resultReceipt?.receiptHash),
+    acceptanceHash: hashOrNull(acceptance?.acceptanceHash),
+    finalReceiptHash: hashOrNull(acceptance?.finalReceiptHash),
+    deterministicReceiptHash: hashOrNull(result?.deterministicReceiptHash),
+  };
+}
+
+export function buildVerifiedActionReceipt(input: {
+  canonicalResult: unknown;
+  surface: VerifiedActionSurface;
+  workspaceId: string;
+  problemId: string;
+  issuedAt?: string;
+}): VerifiedActionReceipt {
+  const result = asRecord(input.canonicalResult);
+  const replay = asRecord(result?.replay);
+  const verdict = result?.verdict === 'PASS' ? 'PASS' : 'BLOCK';
+
+  const body = {
+    schema: VERIFIED_ACTION_RECEIPT_SCHEMA,
+    surface: input.surface,
+    workspaceId: input.workspaceId,
+    problemId: input.problemId,
+    verdict,
+    stage: String(result?.stage ?? 'unknown'),
+    executionPerformed: result?.executionPerformed === true,
+    replayable: replay?.replayable === true,
+    reason: typeof result?.reason === 'string' ? result.reason : null,
+    chain: extractChainBinding(input.canonicalResult),
+    boundary: {
+      certificationClaim: false,
+      independentAuditClaim: false,
+      externalZ3SolverInvoked: false,
+      executedByDsg: false,
+      statement: BOUNDARY_STATEMENT,
+    },
+  } as const satisfies Omit<VerifiedActionReceipt, 'receiptId' | 'issuedAt'>;
+
+  return {
+    ...body,
+    receiptId: computeReceiptId(body),
+    issuedAt: input.issuedAt ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Flat rather than a discriminated union: this project compiles with
+ * `strict: false`, so narrowing on a boolean literal discriminant does not
+ * apply and every field has to be readable without it.
+ */
+export interface ReceiptIntegrityResult {
+  intact: boolean;
+  presentedReceiptId: string;
+  expectedReceiptId: string;
+  reason: string;
+}
+
+/**
+ * Recompute a receipt's id from its own contents. This detects a receipt whose
+ * verdict, stage, or any chain hash was edited after issue. It is an integrity
+ * check on the document, not a re-run of the action — use replayVerifiedAction
+ * for that.
+ */
+export function checkReceiptIntegrity(receipt: VerifiedActionReceipt): ReceiptIntegrityResult {
+  if (receipt.schema !== VERIFIED_ACTION_RECEIPT_SCHEMA) {
+    return {
+      intact: false,
+      presentedReceiptId: receipt.receiptId,
+      expectedReceiptId: '',
+      reason: `Unsupported receipt schema: ${String(receipt.schema)}`,
+    };
+  }
+
+  const { receiptId, issuedAt: _issuedAt, ...body } = receipt;
+  const expected = computeReceiptId(body);
+  const intact = expected === receiptId;
+  return {
+    intact,
+    presentedReceiptId: receiptId,
+    expectedReceiptId: expected,
+    reason: intact
+      ? 'Receipt contents hash to the presented receiptId.'
+      : 'Receipt contents do not hash to the presented receiptId.',
+  };
+}
+
+export interface ReplayFieldComparison {
+  field: keyof VerifiedActionChainBinding;
+  receipt: string | null;
+  replay: string | null;
+  match: boolean;
+}
+
+export interface ReplayVerificationResult {
+  replayMatch: boolean;
+  receiptIntact: boolean;
+  verdictMatch: boolean;
+  comparedFields: number;
+  mismatchedFields: ReplayFieldComparison[];
+  fields: ReplayFieldComparison[];
+  /** Timestamped hashes, reported for audit but excluded from replayMatch. */
+  runScopedFields: ReplayFieldComparison[];
+  reason: string;
+}
+
+/** Input-determined. A replay over the same inputs must reproduce all of these. */
+export const REPRODUCIBLE_CHAIN_FIELDS: Array<keyof VerifiedActionChainBinding> = [
+  'canonicalChainHash',
+  'optimizationProofHash',
+  'actionPlanHash',
+  'simulationWitnessHash',
+  'acceptanceHash',
+  'finalReceiptHash',
+];
+
+/** Time-dependent by design. Recorded, never asserted to reproduce. */
+export const RUN_SCOPED_CHAIN_FIELDS: Array<keyof VerifiedActionChainBinding> = [
+  'gateDecisionHash',
+  'resultReceiptHash',
+  'deterministicReceiptHash',
+];
+
+/**
+ * Independently re-verify a receipt against a fresh canonical-chain run.
+ *
+ * This is the measurable claim the product is sold on: given the same inputs,
+ * does the chain still produce the same input-determined hashes and the same
+ * verdict? A mismatch is reported per field so the caller can see which stage
+ * drifted — provider, model, and orchestration changes surface here rather than
+ * silently passing.
+ *
+ * Run-scoped hashes are compared and returned separately. They are expected to
+ * differ between runs and a difference there is not a replay failure.
+ */
+export function replayVerifiedAction(
+  receipt: VerifiedActionReceipt,
+  freshCanonicalResult: unknown,
+): ReplayVerificationResult {
+  const integrity = checkReceiptIntegrity(receipt);
+  const fresh = extractChainBinding(freshCanonicalResult);
+  const freshVerdict = asRecord(freshCanonicalResult)?.verdict === 'PASS' ? 'PASS' : 'BLOCK';
+
+  const compare = (field: keyof VerifiedActionChainBinding): ReplayFieldComparison => ({
+    field,
+    receipt: receipt.chain[field],
+    replay: fresh[field],
+    match: receipt.chain[field] === fresh[field],
+  });
+
+  const fields = REPRODUCIBLE_CHAIN_FIELDS.map(compare);
+  const runScopedFields = RUN_SCOPED_CHAIN_FIELDS.map(compare);
+
+  const mismatchedFields = fields.filter((entry) => !entry.match);
+  const verdictMatch = receipt.verdict === freshVerdict;
+  const replayMatch = integrity.intact && verdictMatch && mismatchedFields.length === 0;
+
+  let reason: string;
+  if (!integrity.intact) {
+    reason = integrity.reason;
+  } else if (mismatchedFields.length > 0) {
+    reason = `Replay diverged on ${mismatchedFields.length} of ${fields.length} reproducible chain hashes: ${mismatchedFields
+      .map((entry) => entry.field)
+      .join(', ')}.`;
+  } else if (!verdictMatch) {
+    reason = `Replay verdict ${freshVerdict} does not match receipt verdict ${receipt.verdict}.`;
+  } else {
+    reason = `Replay reproduced all ${fields.length} reproducible chain hashes and the ${receipt.verdict} verdict.`;
+  }
+
+  return {
+    replayMatch,
+    receiptIntact: integrity.intact,
+    verdictMatch,
+    comparedFields: fields.length,
+    mismatchedFields,
+    fields,
+    runScopedFields,
+    reason,
+  };
+}

--- a/lib/dsg-one/verified-action-request.ts
+++ b/lib/dsg-one/verified-action-request.ts
@@ -1,0 +1,226 @@
+import type { VerifiedActionSurface } from './verified-action-receipt';
+
+/**
+ * Request contract for POST /api/dsg/v1/actions/verify.
+ *
+ * The caller's runtime performs the action. DSG receives what the runtime
+ * observed and verifies it against the canonical chain, so this payload always
+ * carries an already-produced simulation witness and execution result. A caller
+ * that omits them is asking DSG to execute, which this product does not do.
+ */
+
+export interface VerifiedActionSimulationInput {
+  ok: boolean;
+  witnessHash: string;
+  reason?: string;
+}
+
+export interface VerifiedActionExecutionInput {
+  status: 'SUCCESS' | 'FAILED' | 'PARTIAL';
+  observations: Record<string, unknown>;
+  evidence: Array<{
+    fact: string;
+    observerRole: 'verifier';
+    hash: string;
+    [key: string]: unknown;
+  }>;
+  observedResultHash: string;
+  evidenceItemIds: string[];
+}
+
+export interface VerifiedActionRequest {
+  idempotencyKey: string;
+  surface: VerifiedActionSurface;
+  sessionId: string;
+  agentId?: string;
+  agentName?: string;
+  planContractVerified?: boolean;
+  optimization: Record<string, unknown>;
+  actionSolution: {
+    database?: 'supabase';
+    runtime?: 'render' | 'netlify';
+    environment: string;
+    commitSha: string;
+  };
+  approval?: {
+    requestId?: string;
+    decision?: 'approved' | 'rejected' | 'pending';
+    approvedBy?: string;
+    approvedAt?: string;
+  };
+  audit?: {
+    preAuditEventId?: string;
+    ledgerId?: string;
+    chainHeadHash?: string;
+  };
+  evidence?: {
+    evidenceManifestId?: string;
+    policySnapshotHash?: string;
+    runtimeBindingHash?: string;
+  };
+  observed: {
+    simulation: VerifiedActionSimulationInput;
+    execution: VerifiedActionExecutionInput;
+  };
+}
+
+export interface ValidationDetail {
+  field: string;
+  message: string;
+}
+
+/**
+ * Flat rather than a discriminated union: this project compiles with
+ * `strict: false`, so narrowing on a boolean literal discriminant does not
+ * apply. `details` is always an array and is empty when `ok` is true.
+ */
+export interface VerifiedActionValidation {
+  ok: boolean;
+  value?: VerifiedActionRequest;
+  details: ValidationDetail[];
+}
+
+const SURFACES: readonly VerifiedActionSurface[] = ['api', 'unify', 'trinity-mcp'];
+const EXECUTION_STATUSES = ['SUCCESS', 'FAILED', 'PARTIAL'] as const;
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function validateVerifiedActionRequest(input: unknown): VerifiedActionValidation {
+  const details: ValidationDetail[] = [];
+  const body = record(input);
+  if (!body) {
+    return { ok: false, details: [{ field: 'body', message: 'must be a JSON object' }] };
+  }
+
+  if (!nonEmptyString(body.idempotencyKey)) {
+    details.push({ field: 'idempotencyKey', message: 'required' });
+  }
+  if (!nonEmptyString(body.sessionId)) {
+    details.push({ field: 'sessionId', message: 'required' });
+  }
+
+  const surface = body.surface ?? 'api';
+  if (!SURFACES.includes(surface as VerifiedActionSurface)) {
+    details.push({ field: 'surface', message: `must be one of ${SURFACES.join(', ')}` });
+  }
+
+  const optimization = record(body.optimization);
+  if (!optimization) {
+    details.push({ field: 'optimization', message: 'required' });
+  } else {
+    if (!nonEmptyString(optimization.problemId)) {
+      details.push({ field: 'optimization.problemId', message: 'required' });
+    }
+    if (!Array.isArray(optimization.tasks) || optimization.tasks.length === 0) {
+      details.push({ field: 'optimization.tasks', message: 'must be a non-empty array' });
+    }
+    if (!Array.isArray(optimization.agentCapacities) || optimization.agentCapacities.length === 0) {
+      details.push({ field: 'optimization.agentCapacities', message: 'must be a non-empty array' });
+    }
+    // The canonical chain only compiles an Action IR from VERIFIED_GLOBAL_OPTIMUM,
+    // which the pipeline only emits for an explicitly bound business objective.
+    // Rejecting here gives a precise 400 instead of a confusing downstream BLOCK.
+    const objective = record(optimization.objective);
+    if (!objective) {
+      details.push({
+        field: 'optimization.objective',
+        message: 'required — global optimality is never claimed for an unbound objective',
+      });
+    } else {
+      if (!nonEmptyString(objective.version)) {
+        details.push({ field: 'optimization.objective.version', message: 'required' });
+      }
+      if (!record(objective.assignmentCosts)) {
+        details.push({ field: 'optimization.objective.assignmentCosts', message: 'required' });
+      }
+    }
+  }
+
+  const actionSolution = record(body.actionSolution);
+  if (!actionSolution) {
+    details.push({ field: 'actionSolution', message: 'required' });
+  } else {
+    if (!nonEmptyString(actionSolution.environment)) {
+      details.push({ field: 'actionSolution.environment', message: 'required' });
+    }
+    if (!nonEmptyString(actionSolution.commitSha)) {
+      details.push({ field: 'actionSolution.commitSha', message: 'required' });
+    }
+  }
+
+  const observed = record(body.observed);
+  if (!observed) {
+    details.push({
+      field: 'observed',
+      message: 'required — DSG verifies an executed action, it does not execute one',
+    });
+  } else {
+    const simulation = record(observed.simulation);
+    if (!simulation) {
+      details.push({ field: 'observed.simulation', message: 'required' });
+    } else {
+      if (typeof simulation.ok !== 'boolean') {
+        details.push({ field: 'observed.simulation.ok', message: 'must be a boolean' });
+      }
+      if (typeof simulation.witnessHash !== 'string' || !HEX_64.test(simulation.witnessHash)) {
+        details.push({
+          field: 'observed.simulation.witnessHash',
+          message: 'must be a 64-character lowercase hex sha256',
+        });
+      }
+    }
+
+    const execution = record(observed.execution);
+    if (!execution) {
+      details.push({ field: 'observed.execution', message: 'required' });
+    } else {
+      if (!EXECUTION_STATUSES.includes(execution.status as (typeof EXECUTION_STATUSES)[number])) {
+        details.push({
+          field: 'observed.execution.status',
+          message: `must be one of ${EXECUTION_STATUSES.join(', ')}`,
+        });
+      }
+      if (!record(execution.observations)) {
+        details.push({ field: 'observed.execution.observations', message: 'required' });
+      }
+      if (!Array.isArray(execution.evidence) || execution.evidence.length === 0) {
+        details.push({
+          field: 'observed.execution.evidence',
+          message: 'must be a non-empty array — no evidence means no receipt',
+        });
+      }
+      if (
+        typeof execution.observedResultHash !== 'string' ||
+        !HEX_64.test(execution.observedResultHash)
+      ) {
+        details.push({
+          field: 'observed.execution.observedResultHash',
+          message: 'must be a 64-character lowercase hex sha256',
+        });
+      }
+      if (!Array.isArray(execution.evidenceItemIds) || execution.evidenceItemIds.length === 0) {
+        details.push({ field: 'observed.execution.evidenceItemIds', message: 'must be a non-empty array' });
+      }
+    }
+  }
+
+  if (details.length > 0) return { ok: false, details };
+
+  return {
+    ok: true,
+    details,
+    value: {
+      ...(body as unknown as VerifiedActionRequest),
+      surface: surface as VerifiedActionSurface,
+    },
+  };
+}

--- a/lib/dsg/gate-entitlement.ts
+++ b/lib/dsg/gate-entitlement.ts
@@ -23,7 +23,8 @@ import {
 export type DsgMeteredGateRoute =
   | 'gates/evaluate'
   | 'proofs/prove'
-  | 'encoding/prove';
+  | 'encoding/prove'
+  | 'actions/verify';
 
 export interface DsgGateTier {
   tier: GateTier;

--- a/lib/mcp/canonical-action-adapter.ts
+++ b/lib/mcp/canonical-action-adapter.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/dsg-one/canonical-action-e2e';
 import type { ActionPlan } from './verified-action-tools';
 
-export type CanonicalActionAdapterSurface = 'unify' | 'trinity-mcp';
+export type CanonicalActionAdapterSurface = 'api' | 'unify' | 'trinity-mcp';
 
 export type CanonicalActionAdapterHooks = {
   simulate: (plan: ActionPlan) => Promise<PreExecutionSimulationResult>;

--- a/supabase/migrations/20260815180000_dsg_gate_verified_action_route.sql
+++ b/supabase/migrations/20260815180000_dsg_gate_verified_action_route.sql
@@ -1,0 +1,142 @@
+-- Extend the atomic DSG Gate usage ledger to the Verified Agent Action product.
+--
+-- This migration is additive and follows the same shape as the encoding/prove
+-- extension (20260812163842): it drops and reinstates the route CHECK, then
+-- replaces the usage RPC with an identical body whose route allow-list also
+-- accepts 'actions/verify'. Serialization, idempotency per (org_id, eval_id),
+-- and the subscription-period usage position are unchanged.
+
+BEGIN;
+
+DO $$
+DECLARE
+  constraint_name TEXT;
+BEGIN
+  FOR constraint_name IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.dsg_gate_usage'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%route%'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.dsg_gate_usage DROP CONSTRAINT IF EXISTS %I',
+      constraint_name
+    );
+  END LOOP;
+END $$;
+
+ALTER TABLE public.dsg_gate_usage
+  ADD CONSTRAINT dsg_gate_usage_route_check
+  CHECK (route IN ('gates/evaluate', 'proofs/prove', 'encoding/prove', 'actions/verify'));
+
+CREATE OR REPLACE FUNCTION public.record_dsg_gate_usage(
+  p_org_id TEXT,
+  p_eval_id TEXT,
+  p_route TEXT,
+  p_gate_status TEXT,
+  p_duration_ms INTEGER
+)
+RETURNS TABLE (
+  usage_id UUID,
+  created BOOLEAN,
+  billed BOOLEAN,
+  meter_event_id TEXT,
+  usage_position INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing public.dsg_gate_usage%ROWTYPE;
+  v_period_start TIMESTAMPTZ;
+  v_period_end TIMESTAMPTZ;
+  v_position INTEGER;
+  v_inserted public.dsg_gate_usage%ROWTYPE;
+BEGIN
+  IF p_org_id IS NULL OR btrim(p_org_id) = '' THEN
+    RAISE EXCEPTION 'org_id is required';
+  END IF;
+  IF p_eval_id IS NULL OR btrim(p_eval_id) = '' THEN
+    RAISE EXCEPTION 'eval_id is required';
+  END IF;
+  IF p_route NOT IN ('gates/evaluate', 'proofs/prove', 'encoding/prove', 'actions/verify') THEN
+    RAISE EXCEPTION 'unsupported route: %', p_route;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_org_id, 0));
+
+  SELECT *
+  INTO v_existing
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.eval_id = p_eval_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN QUERY SELECT
+      v_existing.id,
+      FALSE,
+      v_existing.billed,
+      v_existing.meter_event_id,
+      v_existing.usage_position;
+    RETURN;
+  END IF;
+
+  SELECT
+    COALESCE(entitlement.current_period_start, date_trunc('month', now())),
+    COALESCE(entitlement.current_period_end, date_trunc('month', now()) + INTERVAL '1 month')
+  INTO v_period_start, v_period_end
+  FROM public.dsg_gate_entitlements entitlement
+  WHERE entitlement.org_id = p_org_id;
+
+  IF NOT FOUND THEN
+    v_period_start := date_trunc('month', now());
+    v_period_end := v_period_start + INTERVAL '1 month';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER + 1
+  INTO v_position
+  FROM public.dsg_gate_usage usage
+  WHERE usage.org_id = p_org_id
+    AND usage.created_at >= v_period_start
+    AND usage.created_at < v_period_end;
+
+  INSERT INTO public.dsg_gate_usage (
+    org_id,
+    eval_id,
+    route,
+    gate_status,
+    duration_ms,
+    billed,
+    usage_position
+  ) VALUES (
+    p_org_id,
+    p_eval_id,
+    p_route,
+    p_gate_status,
+    p_duration_ms,
+    FALSE,
+    v_position
+  )
+  RETURNING * INTO v_inserted;
+
+  RETURN QUERY SELECT
+    v_inserted.id,
+    TRUE,
+    v_inserted.billed,
+    v_inserted.meter_event_id,
+    v_inserted.usage_position;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER)
+  TO service_role;
+
+COMMENT ON FUNCTION public.record_dsg_gate_usage(TEXT, TEXT, TEXT, TEXT, INTEGER) IS
+  'Idempotently records one DSG Gate/Proof/Encoding/Verified-Action evaluation and assigns a serialized subscription-period usage position.';
+
+COMMIT;

--- a/tests/unit/dsg-one/verified-action-receipt.test.ts
+++ b/tests/unit/dsg-one/verified-action-receipt.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest';
+import { runCanonicalActionFromSurface } from '@/lib/mcp/canonical-action-adapter';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import {
+  buildVerifiedActionReceipt,
+  checkReceiptIntegrity,
+  replayVerifiedAction,
+  REPRODUCIBLE_CHAIN_FIELDS,
+  RUN_SCOPED_CHAIN_FIELDS,
+  VERIFIED_ACTION_RECEIPT_SCHEMA,
+} from '@/lib/dsg-one/verified-action-receipt';
+import { validateVerifiedActionRequest } from '@/lib/dsg-one/verified-action-request';
+
+const auth: UnifiedAuthContext = {
+  source: 'api-key',
+  actorId: 'key-1',
+  orgId: 'org-1',
+  roles: ['operator'],
+};
+
+const optimization = {
+  problemId: 'verified-action-receipt',
+  tasks: [
+    {
+      id: 'task-1',
+      requiredCapabilities: ['code'],
+      estimatedTokens: 100,
+      priority: 1,
+    },
+  ],
+  agentCapacities: [
+    {
+      agentId: 1,
+      capabilities: ['code'],
+      maxConcurrentTasks: 1,
+      maxTotalTasks: 1,
+    },
+  ],
+  seed: 1,
+  useMock: true,
+  exactProofMaxVariables: 8,
+  objective: {
+    version: 'test-cost-v1',
+    assignmentCosts: { 'task_task-1_agent_1': 0 },
+  },
+};
+
+const observed = {
+  simulation: { ok: true, witnessHash: 'c'.repeat(64) },
+  execution: {
+    status: 'SUCCESS' as const,
+    observations: {
+      'deployment.status': 'LIVE',
+      'deployment.ref': '0123456789abcdef0123456789abcdef01234567',
+      'health.status': 'PASS',
+    },
+    evidence: [
+      { fact: 'deployment.status', observerRole: 'verifier' as const, hash: 'd'.repeat(64) },
+      { fact: 'deployment.ref', observerRole: 'verifier' as const, hash: 'e'.repeat(64) },
+      { fact: 'health.status', observerRole: 'verifier' as const, hash: 'f'.repeat(64) },
+    ],
+    observedResultHash: '1'.repeat(64),
+    evidenceItemIds: ['ev-1', 'ev-2', 'ev-3'],
+  },
+};
+
+const baseRequest = {
+  idempotencyKey: 'idem-1',
+  surface: 'api' as const,
+  sessionId: 'session-1',
+  optimization,
+  actionSolution: {
+    runtime: 'render' as const,
+    environment: 'staging',
+    commitSha: '0123456789abcdef0123456789abcdef01234567',
+  },
+  approval: { requestId: 'approval-1', decision: 'approved' as const },
+  audit: { preAuditEventId: 'audit-1', ledgerId: 'ledger-1', chainHeadHash: 'a'.repeat(64) },
+  evidence: { evidenceManifestId: 'manifest-1', policySnapshotHash: 'b'.repeat(64) },
+  observed,
+};
+
+async function runChain() {
+  return runCanonicalActionFromSurface(
+    {
+      surface: 'api',
+      sessionId: baseRequest.sessionId,
+      optimization: baseRequest.optimization as never,
+      actionSolution: baseRequest.actionSolution,
+      approval: baseRequest.approval,
+      audit: baseRequest.audit,
+      evidence: baseRequest.evidence,
+    },
+    auth,
+    {
+      simulate: async () => observed.simulation,
+      execute: async () => observed.execution,
+    },
+  );
+}
+
+describe('verified action receipt', () => {
+  it('issues a receipt bound to the canonical chain hashes', async () => {
+    const chain = await runChain();
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    expect(receipt.schema).toBe(VERIFIED_ACTION_RECEIPT_SCHEMA);
+    expect(receipt.receiptId).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.workspaceId).toBe('org-1');
+    expect(receipt.chain.canonicalChainHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(receipt.chain.optimizationProofHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // The receipt must never soften the repository's standing claim boundary.
+    expect(receipt.boundary.certificationClaim).toBe(false);
+    expect(receipt.boundary.independentAuditClaim).toBe(false);
+    expect(receipt.boundary.externalZ3SolverInvoked).toBe(false);
+    expect(receipt.boundary.executedByDsg).toBe(false);
+  });
+
+  it('addresses the same chain run by the same receiptId regardless of issue time', async () => {
+    const chain = await runChain();
+    const first = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+      issuedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const second = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+      issuedAt: '2026-06-30T12:00:00.000Z',
+    });
+
+    expect(second.receiptId).toBe(first.receiptId);
+    expect(second.issuedAt).not.toBe(first.issuedAt);
+  });
+
+  it('detects a receipt whose verdict was edited after issue', async () => {
+    const chain = await runChain();
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: chain.result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    expect(checkReceiptIntegrity(receipt).intact).toBe(true);
+
+    const forged = {
+      ...receipt,
+      chain: { ...receipt.chain, actionPlanHash: '0'.repeat(64) },
+    };
+    const integrity = checkReceiptIntegrity(forged);
+    expect(integrity.intact).toBe(false);
+    if (!integrity.intact) {
+      expect(integrity.presentedReceiptId).toBe(receipt.receiptId);
+      expect(integrity.expectedReceiptId).not.toBe(receipt.receiptId);
+    }
+  });
+
+  it('reports replayMatch when the chain reproduces every hash', async () => {
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: (await runChain()).result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    const replay = replayVerifiedAction(receipt, (await runChain()).result);
+
+    expect(replay.replayMatch).toBe(true);
+    expect(replay.receiptIntact).toBe(true);
+    expect(replay.verdictMatch).toBe(true);
+    expect(replay.mismatchedFields).toEqual([]);
+    expect(replay.comparedFields).toBe(REPRODUCIBLE_CHAIN_FIELDS.length);
+  });
+
+  it('never asserts the timestamped hashes reproduce, and says which they are', async () => {
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: (await runChain()).result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    const replay = replayVerifiedAction(receipt, (await runChain()).result);
+
+    // evaluateAgentCommandGate and buildAgentActionResultReceipt both hash a
+    // wall-clock timestamp, so these three differ on every run of the same
+    // action. A replay must stay green regardless.
+    expect(replay.replayMatch).toBe(true);
+    expect(replay.runScopedFields.map((entry) => entry.field)).toEqual(RUN_SCOPED_CHAIN_FIELDS);
+    expect(replay.runScopedFields.some((entry) => !entry.match)).toBe(true);
+    expect(REPRODUCIBLE_CHAIN_FIELDS).not.toContain('deterministicReceiptHash');
+  });
+
+  it('reports which chain hashes diverged when inputs change underneath a receipt', async () => {
+    const receipt = buildVerifiedActionReceipt({
+      canonicalResult: (await runChain()).result,
+      surface: 'api',
+      workspaceId: 'org-1',
+      problemId: optimization.problemId,
+    });
+
+    // Same action, different target environment — the drift a stale receipt
+    // must not hide.
+    const drifted = await runCanonicalActionFromSurface(
+      {
+        surface: 'api',
+        sessionId: baseRequest.sessionId,
+        optimization: baseRequest.optimization as never,
+        actionSolution: { ...baseRequest.actionSolution, environment: 'production' },
+        approval: baseRequest.approval,
+        audit: baseRequest.audit,
+        evidence: baseRequest.evidence,
+      },
+      auth,
+      {
+        simulate: async () => observed.simulation,
+        execute: async () => observed.execution,
+      },
+    );
+
+    const replay = replayVerifiedAction(receipt, drifted.result);
+
+    expect(replay.replayMatch).toBe(false);
+    expect(replay.receiptIntact).toBe(true);
+    expect(replay.mismatchedFields.length).toBeGreaterThan(0);
+    expect(replay.reason).toContain('diverged');
+  });
+});
+
+describe('verified action request validation', () => {
+  it('accepts a complete request', () => {
+    expect(validateVerifiedActionRequest(baseRequest).ok).toBe(true);
+  });
+
+  it('rejects a request with no bound business objective', () => {
+    const { objective: _objective, ...withoutObjective } = optimization;
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: withoutObjective,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain('optimization.objective');
+    }
+  });
+
+  it('rejects a request that asks DSG to execute rather than verify', () => {
+    const { observed: _observed, ...withoutObserved } = baseRequest;
+    const result = validateVerifiedActionRequest(withoutObserved);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain('observed');
+    }
+  });
+
+  it('rejects an execution result carrying no evidence', () => {
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      observed: {
+        ...observed,
+        execution: { ...observed.execution, evidence: [] },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain(
+        'observed.execution.evidence',
+      );
+    }
+  });
+});

--- a/tests/unit/dsg-one/verified-optimization-pipeline.test.ts
+++ b/tests/unit/dsg-one/verified-optimization-pipeline.test.ts
@@ -37,8 +37,16 @@ describe('verified optimization pipeline', () => {
       seed: 7,
       useMock: true,
       exactProofMaxVariables: 8,
+      // VERIFIED_GLOBAL_OPTIMUM is only emitted for an explicitly bound business
+      // objective. Without this the pipeline correctly degrades to
+      // VERIFIED_FEASIBLE rather than claiming optimality it cannot support.
+      objective: {
+        version: 'test-cost-v1',
+        assignmentCosts: { 'task_t1_agent_1': -1 },
+      },
     });
 
+    expect(result.canonicalProblem.businessObjectiveBound).toBe(true);
     expect(result.verdict).toBe('VERIFIED_GLOBAL_OPTIMUM');
     expect(result.z3.feasible).toBe(true);
     expect(result.z3.status).toBe('sat');
@@ -58,8 +66,17 @@ describe('verified optimization pipeline', () => {
       seed: 7,
       useMock: true,
       exactProofMaxVariables: 1,
+      // Objective is bound here too, so the VERIFIED_FEASIBLE verdict below is
+      // caused by the incomplete exact proof and nothing else. Costs stay at 0
+      // so binding the objective does not perturb the capacity penalties that
+      // decide feasibility across the two candidate agents.
+      objective: {
+        version: 'test-cost-v1',
+        assignmentCosts: { 'task_t1_agent_1': 0, 'task_t1_agent_2': 0 },
+      },
     });
 
+    expect(result.canonicalProblem.businessObjectiveBound).toBe(true);
     expect(result.z3.feasible).toBe(true);
     expect(result.exact.complete).toBe(false);
     expect(result.exact.candidateIsGlobal).toBeNull();

--- a/tests/unit/mcp/canonical-action-adapter.test.ts
+++ b/tests/unit/mcp/canonical-action-adapter.test.ts
@@ -34,7 +34,7 @@ const baseInput = {
     exactProofMaxVariables: 8,
     objective: {
       version: 'test-cost-v1',
-      assignmentCosts: { task_task-1_agent_1: 0 },
+      assignmentCosts: { 'task_task-1_agent_1': 0 },
     },
   },
   actionSolution: {

--- a/tests/unit/scripts/vercel-routing.test.ts
+++ b/tests/unit/scripts/vercel-routing.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // @ts-expect-error The production helper is intentionally a native ESM module.
@@ -88,4 +90,42 @@ describe('Vercel routing configuration', () => {
       }),
     ).toThrow('New-account routing resolves to the legacy account');
   });
+});
+
+describe('workflows that resolve Vercel routing', () => {
+  const workflowDir = join(process.cwd(), '.github', 'workflows');
+
+  // Under activeAccount: "new", resolveVercelRouting reads the destination IDs
+  // from NEW_VERCEL_ORG_ID / NEW_VERCEL_PROJECT_ID and throws when either is
+  // absent. A workflow that only forwards the token therefore fails at the
+  // routing step, which is how the migration to the rebuilt Vercel project
+  // silently broke production-readiness, promoted-production-deploy, and
+  // set-stripe-price-env. This pins the full trio for every caller.
+  const routingSteps = readdirSync(workflowDir)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .flatMap((name) => {
+      const content = readFileSync(join(workflowDir, name), 'utf8');
+      // Split on step boundaries so each block carries its own env: keys.
+      // `node --check <path>` is a syntax check, not an invocation, and does
+      // not match this exact command string.
+      return content
+        .split(/\n(?=\s*- )/)
+        .filter((step) => step.includes('node scripts/resolve-vercel-routing.mjs'))
+        .map((step) => ({ workflow: name, step }));
+    });
+
+  it('finds every workflow step that invokes the routing resolver', () => {
+    expect(routingSteps.length).toBeGreaterThan(0);
+  });
+
+  it.each(['NEW_VERCEL_ORG_ID', 'NEW_VERCEL_PROJECT_ID', 'NEW_VERCEL_TOKEN', 'LEGACY_VERCEL_TOKEN'])(
+    'forwards %s in every routing step',
+    (variable) => {
+      const missing = routingSteps
+        .filter(({ step }) => !step.includes(`${variable}:`))
+        .map(({ workflow }) => workflow);
+
+      expect(missing).toEqual([]);
+    },
+  );
 });


### PR DESCRIPTION
Goal:

Four things, in the order they were found. Fix the two fixtures failing the DSG Proof Gate on PR #1115; give the canonical chain an HTTP surface so it can be sold; then repair the CI wiring to the rebuilt Vercel account, which turned out to be broken in two separate places.

## Part 1 — fixture contract fix

Correction to the working assumption: the failing job (`95027494195`, run `31891150903`, merge commit `11f9ecc`) contains no `tests/unit/plan-gating.test.ts`, no `goal_requires_executable_task_payload`, and no 44/4-of-48 result. The raw log shows `Test Files 2 failed | 365 passed | 21 skipped (388)` and `Tests 1 failed | 4613 passed | 184 skipped (4798)`, from two different files.

- `tests/unit/mcp/canonical-action-adapter.test.ts` — quoted the QUBO variable key `task_task-1_agent_1`. The task id contains a hyphen, so the unquoted object key was a syntax error; esbuild failed the whole-file transform at 37:34 and neither test was collected. That was the failed *suite*, not a failed assertion.
- `tests/unit/dsg-one/verified-optimization-pipeline.test.ts` — bound an explicit business objective in both fixtures and asserted `canonicalProblem.businessObjectiveBound`.

`runVerifiedOptimizationPipeline` emits `VERIFIED_GLOBAL_OPTIMUM` only when `businessObjectiveBound && exact.complete && exact.candidateIsGlobal === true` (`lib/dsg-one/verified-optimization-pipeline.ts:283-293`), and `businessObjectiveBound = Boolean(req.objective)` (line 198). The fixture sent no `objective`, so the pipeline correctly degraded to `VERIFIED_FEASIBLE` rather than claiming optimality for an objective nobody bound. Z3 SAT and the exact enumeration were both fine. The second case was passing for the wrong reason — it asserted `VERIFIED_FEASIBLE` with the objective unbound, so it never exercised the incomplete-exact-proof branch it is named for. It now binds a zero-cost objective there.

## Part 2 — Verified Agent Action API

`runCanonicalActionFromSurface` was reachable only from a unit test, so nothing a customer could call exercised the canonical chain.

- `POST /api/dsg/v1/actions/verify` — runs the chain over submitted inputs and issues a receipt. The caller's runtime executes the action and submits what it observed; the `simulate`/`execute` hooks are bound to that submitted evidence, so this route never executes anything itself. Metered through the existing `checkGateEntitlement` / `recordGateEvaluation` path on PASS *and* BLOCK.
- `POST /api/dsg/v1/actions/replay` — free re-verification: receipt alone gives a tamper check; receipt plus the original request replays the chain and compares every hash field by field.
- `lib/dsg-one/verified-action-receipt.ts`, `lib/dsg-one/verified-action-request.ts` — receipt construction, integrity check, replay comparison, request validation.
- `lib/dsg/gate-entitlement.ts` + `supabase/migrations/20260815180000_dsg_gate_verified_action_route.sql` — adds `actions/verify` as a metered route, mirroring the `encoding/prove` extension (`20260812163842`). Serialization and per-`(org_id, eval_id)` idempotency unchanged.

### Finding: three chain hashes are not reproducible, including one named "deterministic"

`gateDecisionHash`, `resultReceiptHash`, and `deterministicReceiptHash` all fold in a wall-clock timestamp — `evaluateAgentCommandGate` and `buildAgentActionResultReceipt` each default `now` to `new Date()` (`lib/dsg/agent-command-gate.ts:153,199`) — so they differ on every run of the same action. Measured: two identical runs agree on 6 of 9 hashes and differ on exactly those 3. That is correct for an audit receipt; the error would be claiming they replay. `replayMatch` is therefore computed from the six input-determined hashes plus the verdict, and the three timestamped ones are returned separately as `runScopedFields`. A test pins this so a future change cannot quietly fold a timestamped hash into the replay claim.

## Part 3 — new-account routing was never reaching three workflows

`.github/vercel-routing.json` already sets `activeAccount: "new"`, and in that mode `resolveVercelRouting` reads the destination from `NEW_VERCEL_ORG_ID` / `NEW_VERCEL_PROJECT_ID` and throws `VERCEL_ORG_ID_NEW is missing or invalid` when either is absent. Only `deploy.yml` forwarded them. `production-readiness.yml` (two call sites), `promoted-production-deploy.yml`, and `set-stripe-price-env.yml` passed the token alone and failed at the routing step. Each now forwards the same trio, without a legacy fallback — under new-account routing the resolver already rejects a destination resolving to the legacy team or project, so a fallback would only trade a precise "secret missing" message for a confusing one. `sync-vercel-envs.yml` is untouched; it only runs `node --check` and bootstraps its destination through its own migration flow.

A test walks `.github/workflows`, isolates every step that actually invokes the resolver, and asserts all four routing variables are forwarded.

## Part 4 — the gate was judging a retired origin

`dsg-secure-deploy-gate.yml` hardcoded `tdealer01-crypto-dsg-control-plane.vercel.app`, which belongs to the retired Vercel project and answers 402 `DEPLOYMENT_DISABLED` on every path. Both probe URLs now come from the `DSG_PRODUCTION_ORIGIN` repository variable, defaulting to the rebuilt project's domain, so the gate can follow production to a custom domain without a code change.

Verification:

- [x] `npx vitest run tests/unit/dsg-one/verified-action-receipt.test.ts` — `10 passed (10)`.
- [x] `npx vitest run tests/unit/scripts/vercel-routing.test.ts` — `9 passed (9)`. Verified non-vacuous: removing one env line makes it fail and name the offending workflow.
- [x] `npm run typecheck` — passed, no output.
- [x] `NODE_ENV=test npm run test` — `368 passed | 19 skipped (389)` files, `4629 passed | 156 skipped (4812)` tests. The 27 failures are all `ECONNREFUSED 127.0.0.1:3000` in two integration files needing a dev server; confirmed pre-existing by `git stash` + re-run at unmodified PR-1115 head (identical `27 failed | 1 passed`), and both files are skipped in CI.
- [x] `npm run build` — `✓ Compiled successfully in 40s`; both new routes present as `ƒ /api/dsg/v1/actions/verify` and `ƒ /api/dsg/v1/actions/replay`.
- [x] `node scripts/verify-deterministic-module.mjs` — `"ok": true`, `"failures": []`.
- [x] `node scripts/verify-production-manifest.mjs` — `✓ 186 paths present`.
- [x] CI: `test`, `verify` (both jobs), `fast-gate`, `smoke-test`, `stripe-app-typecheck`, `npm audit`, SBOM, Gitleaks all green.
- [x] Part 4 confirmed live: `dsg-gate` moved from `readiness_status_expected_200_got_402` to `..._got_404`, proving it now probes the rebuilt project rather than the retired one.
- [ ] Migration applied — **Not run.** Status is `migration file exists`, not `live DB ready`.
- [ ] Live request against either new route — **Not run.** No production deployment exists to send one to.

## Merging over two red checks

Merged on explicit instruction with both failures understood and neither caused by this diff:

- **`CodeQL`** — one high alert on the new `sha256` helper claiming a password from `resolveApiKey` is hashed insecurely. False positive on two counts: `resolveApiKey` returns `apiKeyId: String(data.id)`, an `api_keys` row UUID, while the real secret `rawKey` is never returned; and the flagged helper's single caller hashes receipt metadata whose values are all 64-character digests, so the id never reaches it. Full trace in the PR thread. Needs dismissing in the Security tab.
- **`dsg-gate`** — NO-GO because the rebuilt Vercel project has no successful production deployment. Its only production-target build errored after `Deploying outputs...` during the account-disabled window; the READY builds are previews. Vercel Authentication is also enabled for all non-custom domains, so an anonymous probe of any `*.vercel.app` host returns 302 even once a production deployment exists. Not touched here — disabling a security control is a separate, explicit decision.

Known limits:

- The metering path is untested against a live database. `actions/verify` only passes the `dsg_gate_usage` route CHECK once the migration is applied.
- No pricing or Stripe product for `actions/verify`; it consumes the existing gate entitlement quota, so today it bills as a gate evaluation rather than its own SKU.
- No UI. The routes are API-only.
- 49 files under `.github/workflows` and `scripts/` still reference the retired host. None is a failing check and none can be verified until a production deployment exists.
- The `-1` assignment cost in the global-optimum fixture is safe because that fixture has a single QUBO variable; it is not a general claim that arbitrary costs preserve feasibility.

User-visible benefit:

A customer can send one authorized, already-executed agent action and get back a receipt someone else can re-verify — as a tamper check or as a full chain replay naming exactly which hash diverged. That answers "can this action be independently verified and replayed?" concretely, and sits after the caller's own authorization rather than competing with it. CI can now reach the rebuilt Vercel account, and the deploy gate reports on the live project instead of a retired one. The truth boundary holds: `VERIFIED_GLOBAL_OPTIMUM` still requires a bound objective, the receipt carries `certificationClaim: false`, `independentAuditClaim: false`, `externalZ3SolverInvoked: false`, `executedByDsg: false`, and the replay claim covers only hashes that genuinely reproduce.

Next step:

Merge onward to `main` so a production deployment can run on the rebuilt account, apply the migration and verify the route CHECK with a query, then decide the custom-domain or bypass route for Vercel Authentication so `dsg-gate` can reach 200.