### PR TITLE
fix(api): stop echoing raw error messages from optimization verify

### DIFF
--- a/app/api/dsg-one/optimization/verify/route.ts
+++ b/app/api/dsg-one/optimization/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireOrgPermission } from '@/lib/auth/require-org-permission';
+import { handleApiError } from '@/lib/security/api-error';
 import { runVerifiedOptimizationPipeline } from '@/lib/dsg-one/verified-optimization-pipeline';
 import type { Task, AgentCapacity } from '@/lib/dsg/multi-agent/types';
 
@@ -55,13 +56,13 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: 'DSG_VERIFIED_OPTIMIZATION_FAILED',
-        message: error instanceof Error ? error.message : 'Unknown optimization error',
-      },
-      { status: 400 },
-    );
+    // The raw message was echoed to the client here, which
+    // scripts/check-error-handlers.sh fails as error-message leakage: this
+    // catch also receives internal failures, not just the pipeline's input
+    // validation. 400 is kept because the throws that reach it are dominated
+    // by bad request payloads, so the status is unchanged and only the
+    // message stops crossing the boundary. handleApiError still logs the real
+    // error server-side with redaction.
+    return handleApiError('api/dsg-one/optimization/verify', error, { status: 400 });
   }
 }


### PR DESCRIPTION
Goal:

Clear the `security` check on PR #1115, which fails with `FAILED: 1 route(s) with potential leakage`.

Files changed:

- `app/api/dsg-one/optimization/verify/route.ts` — route the catch through `handleApiError` instead of returning the raw error message.

The flagged route is not from the #1117 merge. `git log` puts it at `7415b12 feat: expose authenticated verified optimization endpoint` on `feat/e2e-install-sales-funnel`, and it does not exist on `main`, so the defect predates that merge and ships with #1115.

Its catch returned `error instanceof Error ? error.message : 'Unknown optimization error'` directly to the client. That catch does not only receive the pipeline's input-validation throws — anything failing inside `runVerifiedOptimizationPipeline` lands there too — so an internal message could cross the trust boundary. `docs/ops/ERROR_HANDLING_POLICY.md` §2 prohibits exactly this, and `scripts/check-error-handlers.sh` hard-fails on the `instanceof Error ? error.message` pattern.

`handleApiError` logs the real error server-side with redaction (and Sentry for 5xx) and returns a safe body. The **400 status is deliberately unchanged**: the throws that reach this catch are dominated by bad request payloads, so keeping it preserves the route's existing client-visible status and limits the change to the message itself.

Verification:

- [x] `bash scripts/check-error-handlers.sh` — before: `ERROR: potential error-message leakage in app/api/dsg-one/optimization/verify/route.ts` / `FAILED: 1 route(s) with potential leakage.` After: `OK: no direct error-message leakage patterns detected in app/api routes.`
- [x] `npm run typecheck` — passed, no output.
- [x] `npx vitest run tests/unit/dsg-one/` — `Test Files 4 passed`, `Tests 17 passed`.
- [x] Checked for consumers of the old error shape: the only references to `DSG_VERIFIED_OPTIMIZATION_FAILED` or to this route path are generated `.next` artifacts. No test or client code depends on it.
- [ ] `npm run build` — Not run. Single-route catch-block change; typecheck covers the import and signature.

Known limits:

- Callers that previously received the specific reason (for example `objective references unknown QUBO variable: X`) now get the generic safe body. That detail is genuinely useful for debugging, so the better long-term fix is explicit up-front validation of the objective and capacity inputs returning precise 400s, leaving `handleApiError` for what escapes. That is a larger change to this route's contract and is out of scope for unblocking the check.
- This clears only the `security` check. `dsg-gate` and `CodeQL` on #1115 remain red for the reasons recorded on that PR.
- The `security` workflow still emits ~200 `WARN: missing centralized error helper` lines for other routes. Those are warnings by design during migration and are untouched here.

User-visible benefit:

An authenticated caller hitting an internal failure on `/api/dsg-one/optimization/verify` no longer receives the raw internal message, and the branch clears one of the checks blocking it.

Next step:

Merge into `feat/e2e-install-sales-funnel` so #1115's `security` check goes green, then continue with the remaining two red checks there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaSRuE6GLCSSh2vmsXVSnB)_