### PR TITLE
fix(dsg-one): bound problem size on the verified-action request

### DIFF
--- a/lib/dsg-one/verified-action-request.ts
+++ b/lib/dsg-one/verified-action-request.ts
@@ -84,6 +84,26 @@ const SURFACES: readonly VerifiedActionSurface[] = ['api', 'unify', 'trinity-mcp
 const EXECUTION_STATUSES = ['SUCCESS', 'FAILED', 'PARTIAL'] as const;
 const HEX_64 = /^[0-9a-f]{64}$/;
 
+/**
+ * Problem-size ceilings.
+ *
+ * buildQUBOMatrix allocates a dense numVariables x numVariables matrix, where
+ * numVariables = tasks * agentCapacities, and it applies no ceiling of its own.
+ * Without a bound here a caller within the route's 64 KB body limit can still
+ * request, say, 200 tasks against 200 agents — 40,000 variables, so a 1.6
+ * billion cell matrix — and exhaust the process before any gate runs. The
+ * product is what matters; the per-list caps just keep the error specific.
+ *
+ * CodeQL alert #79 (Resource exhaustion, lib/dsg-one/ising-optimizer.ts:230)
+ * reports the same class of problem at the request-timeout sink.
+ */
+const MAX_TASKS = 64;
+const MAX_AGENT_CAPACITIES = 64;
+const MAX_QUBO_VARIABLES = 1024;
+
+/** callLiveIsingSolver clamps with Math.min, which passes NaN through. */
+const MAX_TIMEOUT_MS = 30_000;
+
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -120,11 +140,52 @@ export function validateVerifiedActionRequest(input: unknown): VerifiedActionVal
     if (!nonEmptyString(optimization.problemId)) {
       details.push({ field: 'optimization.problemId', message: 'required' });
     }
-    if (!Array.isArray(optimization.tasks) || optimization.tasks.length === 0) {
+    const tasks = optimization.tasks;
+    const agents = optimization.agentCapacities;
+
+    if (!Array.isArray(tasks) || tasks.length === 0) {
       details.push({ field: 'optimization.tasks', message: 'must be a non-empty array' });
+    } else if (tasks.length > MAX_TASKS) {
+      details.push({
+        field: 'optimization.tasks',
+        message: `must contain at most ${MAX_TASKS} entries`,
+      });
     }
-    if (!Array.isArray(optimization.agentCapacities) || optimization.agentCapacities.length === 0) {
+
+    if (!Array.isArray(agents) || agents.length === 0) {
       details.push({ field: 'optimization.agentCapacities', message: 'must be a non-empty array' });
+    } else if (agents.length > MAX_AGENT_CAPACITIES) {
+      details.push({
+        field: 'optimization.agentCapacities',
+        message: `must contain at most ${MAX_AGENT_CAPACITIES} entries`,
+      });
+    }
+
+    // The dense QUBO matrix is allocated from the product, so bound it even
+    // when each list is individually acceptable.
+    if (Array.isArray(tasks) && Array.isArray(agents)) {
+      const variables = tasks.length * agents.length;
+      if (variables > MAX_QUBO_VARIABLES) {
+        details.push({
+          field: 'optimization',
+          message: `tasks x agentCapacities must not exceed ${MAX_QUBO_VARIABLES} QUBO variables (got ${variables})`,
+        });
+      }
+    }
+
+    if (optimization.timeout !== undefined) {
+      const timeout = optimization.timeout;
+      if (
+        typeof timeout !== 'number' ||
+        !Number.isFinite(timeout) ||
+        timeout <= 0 ||
+        timeout > MAX_TIMEOUT_MS
+      ) {
+        details.push({
+          field: 'optimization.timeout',
+          message: `must be a finite number between 1 and ${MAX_TIMEOUT_MS}`,
+        });
+      }
     }
     // The canonical chain only compiles an Action IR from VERIFIED_GLOBAL_OPTIMUM,
     // which the pipeline only emits for an explicitly bound business objective.

--- a/tests/unit/dsg-one/verified-action-receipt.test.ts
+++ b/tests/unit/dsg-one/verified-action-receipt.test.ts
@@ -266,6 +266,73 @@ describe('verified action request validation', () => {
     }
   });
 
+  it('rejects a problem large enough to exhaust the dense QUBO matrix', () => {
+    // buildQUBOMatrix allocates numVariables x numVariables, so 64 x 64 = 4096
+    // variables would be a ~16.8M cell matrix. Each list is individually within
+    // its own cap here — only the product catches it.
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: {
+        ...optimization,
+        tasks: Array.from({ length: 64 }, (_, i) => ({ id: `task-${i}` })),
+        agentCapacities: Array.from({ length: 64 }, (_, i) => ({ agentId: i })),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const problem = result.details.find((detail) => detail.field === 'optimization');
+      expect(problem?.message).toContain('QUBO variables');
+      expect(result.details.map((detail) => detail.field)).not.toContain('optimization.tasks');
+    }
+  });
+
+  it('rejects oversized task and agent lists individually', () => {
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: {
+        ...optimization,
+        tasks: Array.from({ length: 65 }, (_, i) => ({ id: `task-${i}` })),
+        agentCapacities: Array.from({ length: 65 }, (_, i) => ({ agentId: i })),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const fields = result.details.map((detail) => detail.field);
+      expect(fields).toContain('optimization.tasks');
+      expect(fields).toContain('optimization.agentCapacities');
+    }
+  });
+
+  it.each([
+    ['not a number', 'soon'],
+    ['NaN, which Math.min passes through', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['zero', 0],
+    ['negative', -1],
+    ['above the 30s ceiling', 30_001],
+  ])('rejects a request timeout that is %s', (_label, timeout) => {
+    const result = validateVerifiedActionRequest({
+      ...baseRequest,
+      optimization: { ...optimization, timeout },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.details.map((detail) => detail.field)).toContain('optimization.timeout');
+    }
+  });
+
+  it('accepts a timeout inside the ceiling', () => {
+    expect(
+      validateVerifiedActionRequest({
+        ...baseRequest,
+        optimization: { ...optimization, timeout: 30_000 },
+      }).ok,
+    ).toBe(true);
+  });
+
   it('rejects an execution result carrying no evidence', () => {
     const result = validateVerifiedActionRequest({
       ...baseRequest,


### PR DESCRIPTION
Goal:

Close a resource-exhaustion hole that `POST /api/dsg/v1/actions/verify` opened, found while running down CodeQL alert **#79**.

Files changed:

- `lib/dsg-one/verified-action-request.ts` — bound the optimization problem size and the request timeout.
- `tests/unit/dsg-one/verified-action-receipt.test.ts` — cover the new bounds.

## What the alert actually was

CodeQL reported two high alerts on #1115. #81 is the traced false positive on `verified-action-receipt.ts:93`. **#79 is `Resource exhaustion` at `lib/dsg-one/ising-optimizer.ts:230`** — the abort timer in `callLiveIsingSolver`, whose duration comes from the caller's `req.timeout`.

That sink on its own is mild: `Math.min(req.timeout ?? 5000, 30000)` bounds it at 30s. But following it upstream found a much larger version of the same problem, and one this PR's own route opened.

## The reachable problem

`buildQUBOMatrix` allocates a **dense `numVariables × numVariables` matrix**, where `numVariables = tasks × agentCapacities`, and applies no ceiling of its own (`lib/dsg-one/qubo-builder.ts:95-100`). The validator added with the route required `tasks` and `agentCapacities` to be non-empty and checked nothing else.

The route's `readJsonBody` limit is 64 KB, which is not a meaningful bound here — a caller can fit roughly 200 minimal task objects and 200 agent objects in that budget. 200 × 200 = 40,000 variables, so a **1.6 billion cell matrix**, roughly 12 GB at 8 bytes per cell. The process dies before the DSG gate ever runs. Authentication does not help: any org with a valid key can send it.

## The fix

Validation at the trust boundary, where the untrusted input enters:

| Bound | Value | Why |
|---|---|---|
| `optimization.tasks` | ≤ 64 | keeps the error specific |
| `optimization.agentCapacities` | ≤ 64 | keeps the error specific |
| `tasks × agentCapacities` | ≤ 1024 variables | **the bound that matters** — each list can be individually fine while the product is not |
| `optimization.timeout` | finite, 1..30000 ms | `callLiveIsingSolver` clamps with `Math.min`, which passes `NaN` straight through |

Verification:

- [x] `npx vitest run tests/unit/dsg-one/ tests/unit/mcp/` — `Test Files 6 passed`, `Tests 35 passed`. New cases include a 64×64 request that both per-list caps accept and only the product rule rejects, oversized lists rejected individually, and six rejected timeout values (`'soon'`, `NaN`, `Infinity`, `0`, `-1`, `30001`) plus an accepted `30000`.
- [x] `npm run typecheck` — passed, no output.
- [ ] Load test proving the previous payload actually OOMs — **Not run.** The arithmetic above is from reading `qubo-builder.ts`; no attempt was made to crash a real deployment.

Known limits:

- **`buildQUBOMatrix` still has no internal ceiling.** Any other caller reaching it remains unprotected. A defence-in-depth guard belongs there too, but it is shared code with existing callers whose problem sizes I have not surveyed, so changing it is out of scope here.
- The 1024-variable ceiling is a judgement call, not a measured limit. It is generous against current usage — every test in the repo uses 1–2 variables, and the exhaustive proof path is already capped at 22 variables by the pipeline — but nothing profiled where the real cliff is.
- This does not change `ising-optimizer.ts`, so alert #79 stays open at its original location even though the reachable path through this route is now bounded. Whether the clamped 30s timer is worth dismissing or fixing separately is a call for whoever owns that file.
- Alert #81 is unrelated and still needs dismissing as a false positive.

User-visible benefit:

An authenticated caller can no longer take the control plane down with one oversized verify request, and gets a precise 400 naming the ceiling it crossed instead of a dead process.

Next step:

Consider the same ceiling inside `buildQUBOMatrix` so the guarantee holds for every caller rather than this route alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaSRuE6GLCSSh2vmsXVSnB)_