### PR TITLE
ops: verify current Vercel new-account routing

### DIFF
--- a/docs/ops/VERCEL_NEW_ACCOUNT_ROUTING_VERIFICATION_2026-08-16.md
+++ b/docs/ops/VERCEL_NEW_ACCOUNT_ROUTING_VERIFICATION_2026-08-16.md
@@ -1,0 +1,13 @@
+# Vercel new-account routing verification — 2026-08-16
+
+Purpose: trigger the current pull-request deployment workflow from the latest `main` so GitHub Actions proves which Vercel account routing is actually selected after the account migration work.
+
+Acceptance evidence:
+
+- `Resolve audited Vercel routing` must report `Vercel routing resolved to new account.`
+- `VERCEL_USE_NEW_ACCOUNT` must be `true`.
+- The selected org/project must not equal the legacy IDs guarded by `scripts/resolve-vercel-routing.mjs`.
+- `vercel pull` must succeed against the selected project.
+- Preview deployment must reach a usable URL and `/api/health` must pass.
+
+This file contains no credentials or secret values. A failed run is diagnostic evidence and must not be converted into a production-ready claim.


### PR DESCRIPTION
## Goal
Trigger the current PR deployment workflow from latest `main` to verify the new Vercel account secrets/routing actually selected by CI.

## Evidence required
- resolver prints `Vercel routing resolved to new account.`
- `VERCEL_USE_NEW_ACCOUNT=true`
- selected org/project differ from legacy guarded IDs
- `vercel pull` succeeds
- preview deploy succeeds and `/api/health` passes

No credentials are stored in this PR. A failure is diagnostic evidence, not production-ready proof.