### PR TITLE
ci: verify protected Vercel preview behind authentication

### DIFF
--- a/.github/workflows/verify-new-vercel-protected-preview.yml
+++ b/.github/workflows/verify-new-vercel-protected-preview.yml
@@ -1,0 +1,88 @@
+name: Verify New Vercel Protected Preview
+
+on:
+  workflow_run:
+    workflows: ["Bootstrap New Vercel Runtime ENV"]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: verify-new-vercel-protected-preview
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_CLI_VERSION: 58.0.0
+  VERCEL_ORG_ID: team_6pEhvA6GmVXYajBuJ2PUPFcs
+  VERCEL_PROJECT_ID: prj_EsrB0dLrqbDKPDTMiKFGadZMny5M
+
+jobs:
+  verify:
+    name: Deploy and Verify Protected Preview
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: "Production – dsg-qubo-api"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Validate new-account authorization
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+        run: |
+          set -euo pipefail
+          test -n "$VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN_NEW"; exit 1; }
+          test "$VERCEL_ORG_ID" != "team_n189mlAdVHR6cGGiaAwsKzQ0" || exit 1
+          test "$VERCEL_PROJECT_ID" != "prj_k02PTNzCJRBN5CcRtg6hFdd0HjuW" || exit 1
+
+      - name: Pull destination preview configuration
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+        run: npx --yes "vercel@$VERCEL_CLI_VERSION" pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Deploy current main to protected preview
+        id: preview
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+        run: |
+          set -euo pipefail
+          cp vercel.json "$RUNNER_TEMP/vercel.production.json"
+          trap 'cp "$RUNNER_TEMP/vercel.production.json" vercel.json' EXIT
+          cp vercel.preview.json vercel.json
+
+          PREVIEW_URL=$(npx --yes "vercel@$VERCEL_CLI_VERSION" deploy --yes --token="$VERCEL_TOKEN" \
+            --meta=protected_health_proof=true \
+            --meta=commit="$(git rev-parse HEAD)")
+          test -n "$PREVIEW_URL"
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify application health behind Vercel Authentication
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_NEW }}
+          VERCEL_SCOPE: thanawats-projects-336871dc
+        run: bash scripts/verify-vercel-health.sh "${{ steps.preview.outputs.preview_url }}" /api/health
+
+      - name: Record proof
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
+        run: |
+          {
+            echo "## Protected preview health proof"
+            echo ""
+            echo "- Team: $VERCEL_ORG_ID"
+            echo "- Project: $VERCEL_PROJECT_ID"
+            echo "- Preview: $PREVIEW_URL"
+            echo "- Deployment Protection: accessed through authenticated Vercel CLI"
+            echo "- Application health: HTTP 200 + JSON ok=true"
+            echo "- Production deploy: not performed"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/verify-vercel-health.sh
+++ b/scripts/verify-vercel-health.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOYMENT_URL="${1:-}"
+HEALTH_PATH="${2:-/api/health}"
+VERCEL_CLI_VERSION="${VERCEL_CLI_VERSION:-58.0.0}"
+
+if [[ -z "$DEPLOYMENT_URL" ]]; then
+  echo "Usage: scripts/verify-vercel-health.sh <deployment-url> [health-path]" >&2
+  exit 2
+fi
+
+: "${VERCEL_TOKEN:?VERCEL_TOKEN is required}"
+
+BODY_FILE="$(mktemp)"
+cleanup() { rm -f "$BODY_FILE"; }
+trap cleanup EXIT
+
+cmd=(
+  npx --yes "vercel@${VERCEL_CLI_VERSION}" curl "$HEALTH_PATH"
+  --deployment "$DEPLOYMENT_URL"
+  --token "$VERCEL_TOKEN"
+)
+
+if [[ -n "${VERCEL_SCOPE:-}" ]]; then
+  cmd+=(--scope "$VERCEL_SCOPE")
+fi
+
+# vercel curl automatically handles Vercel Deployment Protection for the
+# authenticated project. curl's output is separated so HTTP status and JSON
+# payload can be independently asserted.
+cmd+=(--silent --show-error --output "$BODY_FILE" --write-out '%{http_code}')
+
+HTTP_STATUS="$("${cmd[@]}")"
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "Vercel health verification failed closed: expected HTTP 200, got ${HTTP_STATUS}" >&2
+  exit 1
+fi
+
+node - "$BODY_FILE" <<'NODE'
+const fs = require('fs');
+const path = process.argv[2];
+let payload;
+try {
+  payload = JSON.parse(fs.readFileSync(path, 'utf8'));
+} catch {
+  console.error('Vercel health verification failed closed: response is not valid JSON');
+  process.exit(1);
+}
+if (payload?.ok !== true) {
+  const reason = payload?.error ?? payload?.status ?? 'health_payload_not_ok';
+  console.error(`Vercel health verification failed closed: ${String(reason)}`);
+  process.exit(1);
+}
+console.log('Vercel health verified: protected deployment bypassed, HTTP 200 + JSON ok=true');
+NODE


### PR DESCRIPTION
Follow-up to #1122.

Vercel preview deployments are protected by Vercel Authentication, so an unauthenticated HTTP probe can return a login redirect even when the application is healthy. This adds a separate proof workflow that uses authenticated `vercel curl`, which Vercel documents for CI testing of protected deployments.

The workflow:
- is pinned to the verified NEW team/project
- rejects the legacy IDs
- deploys current main as a preview only
- uses Vercel-authenticated curl to bypass only Deployment Protection
- requires application HTTP 200 and JSON `ok:true`
- does not deploy production

This keeps DSG's application health fail-closed while removing Vercel login redirects from the health signal.