### PR TITLE
fix(ci): use VERCEL_TOKEN env for protected curl

### DIFF
--- a/scripts/verify-vercel-health.sh
+++ b/scripts/verify-vercel-health.sh
@@ -16,19 +16,15 @@ BODY_FILE="$(mktemp)"
 cleanup() { rm -f "$BODY_FILE"; }
 trap cleanup EXIT
 
-# --token and --scope are Vercel CLI global options. They must appear before
-# the `curl` subcommand; when placed after it, Vercel forwards them to the
-# underlying curl process and curl fails with "option --token: is unknown".
+# Vercel CLI officially supports VERCEL_TOKEN as an environment variable.
+# Do not pass --token (or other Vercel-global flags) on this `vercel curl`
+# command: in CLI 58.0.0 the beta curl command can forward those flags to the
+# underlying system curl process, which then fails with
+# "curl: option --token: is unknown". The linked .vercel/project.json plus
+# VERCEL_ORG_ID / VERCEL_PROJECT_ID keep this request bound to the destination
+# project while VERCEL_TOKEN authenticates the CLI itself.
 cmd=(
   npx --yes "vercel@${VERCEL_CLI_VERSION}"
-  --token "$VERCEL_TOKEN"
-)
-
-if [[ -n "${VERCEL_SCOPE:-}" ]]; then
-  cmd+=(--scope "$VERCEL_SCOPE")
-fi
-
-cmd+=(
   curl "$HEALTH_PATH"
   --deployment "$DEPLOYMENT_URL"
 )


### PR DESCRIPTION
Fix the remaining Vercel protected-preview bootstrap blocker seen in workflow run 31926779670.

Root cause: `vercel curl` in CLI 58.0.0 is beta and forwarded the explicit `--token` flag to the underlying system curl, producing `curl: option --token: is unknown` even when the flag was placed before the subcommand.

Change:
- keep `VERCEL_TOKEN` required
- rely on the officially supported `VERCEL_TOKEN` environment variable for Vercel CLI authentication
- remove explicit Vercel-global flags from `vercel curl`
- preserve strict HTTP 200 + JSON `ok=true` fail-closed verification
- preserve destination binding via linked `.vercel/project.json` and `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`

Merging this touches `scripts/verify-vercel-health.sh`, which intentionally retriggers `Bootstrap New Vercel Production` on main.

Truth boundary: this change only fixes protected deployment access. Production is not claimed READY until the bootstrap workflow proves `target=production`, `state=READY`, health=200/ok=true, and verify/replay routes return application-auth denial when unauthenticated.