### PR TITLE
fix(ci): separate preview access proof from production health

### DIFF
--- a/.github/workflows/bootstrap-new-vercel-production.yml
+++ b/.github/workflows/bootstrap-new-vercel-production.yml
@@ -65,7 +65,7 @@ jobs:
             "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&state=READY&limit=20&teamId=$VERCEL_ORG_ID")
           PREVIEW_HOST=$(echo "$RESPONSE" | jq -r '.deployments[] | select(.target != "production" and .state == "READY") | .url' | head -n 1)
           test -n "$PREVIEW_HOST" && test "$PREVIEW_HOST" != "null" || { echo "No READY preview found on destination project"; exit 1; }
-          bash scripts/verify-vercel-health.sh "https://$PREVIEW_HOST" /api/health
+          bash scripts/verify-vercel-health.sh "https://$PREVIEW_HOST" /api/health access
 
       - name: Install exact dependencies
         run: npm ci --ignore-scripts
@@ -124,7 +124,7 @@ jobs:
         run: |
           set -euo pipefail
           for route in /api/dsg/v1/actions/verify /api/dsg/v1/actions/replay; do
-            STATUS=$(npx --yes "vercel@$VERCEL_CLI_VERSION" --token "$VERCEL_TOKEN" curl "$route" \
+            STATUS=$(npx --yes "vercel@$VERCEL_CLI_VERSION" curl "$route" \
               --deployment "$PRODUCTION_URL" \
               --silent --show-error --output /tmp/dsg-route-body.json --write-out '%{http_code}' \
               --request POST --header 'content-type: application/json' --data '{}')

--- a/scripts/verify-vercel-health.sh
+++ b/scripts/verify-vercel-health.sh
@@ -3,10 +3,16 @@ set -euo pipefail
 
 DEPLOYMENT_URL="${1:-}"
 HEALTH_PATH="${2:-/api/health}"
+VERIFY_MODE="${3:-health}"
 VERCEL_CLI_VERSION="${VERCEL_CLI_VERSION:-58.0.0}"
 
 if [[ -z "$DEPLOYMENT_URL" ]]; then
-  echo "Usage: scripts/verify-vercel-health.sh <deployment-url> [health-path]" >&2
+  echo "Usage: scripts/verify-vercel-health.sh <deployment-url> [health-path] [health|access]" >&2
+  exit 2
+fi
+
+if [[ "$VERIFY_MODE" != "health" && "$VERIFY_MODE" != "access" ]]; then
+  echo "Invalid verification mode: $VERIFY_MODE (expected health or access)" >&2
   exit 2
 fi
 
@@ -35,6 +41,33 @@ cmd=(
 cmd+=(--silent --show-error --output "$BODY_FILE" --write-out '%{http_code}')
 
 HTTP_STATUS="$("${cmd[@]}")"
+
+if [[ "$VERIFY_MODE" == "access" ]]; then
+  # Preview deployments can be READY while their preview-only runtime env is
+  # intentionally incomplete. For this preflight we prove only that Vercel
+  # Authentication was bypassed and the request reached DSG itself; production
+  # health remains strict below. An SSO redirect/body cannot satisfy this JSON
+  # identity check.
+  node - "$BODY_FILE" "$HTTP_STATUS" <<'NODE'
+const fs = require('fs');
+const path = process.argv[2];
+const status = process.argv[3];
+let payload;
+try {
+  payload = JSON.parse(fs.readFileSync(path, 'utf8'));
+} catch {
+  console.error(`Vercel access verification failed closed: app JSON not reached (HTTP ${status})`);
+  process.exit(1);
+}
+if (payload?.service !== 'dsg-control-plane') {
+  console.error(`Vercel access verification failed closed: unexpected app identity (HTTP ${status})`);
+  process.exit(1);
+}
+console.log(`Vercel access verified: protection bypassed and DSG app reached (HTTP ${status})`);
+NODE
+  exit 0
+fi
+
 if [[ "$HTTP_STATUS" != "200" ]]; then
   echo "Vercel health verification failed closed: expected HTTP 200, got ${HTTP_STATUS}" >&2
   exit 1


### PR DESCRIPTION
Follow-up to #1125 after live verification of the newest protected preview.

Evidence found:
- Vercel Authentication is still enabled.
- After bypass, the newest READY preview reaches the DSG app but `/api/health` returns 503 because preview runtime env is incomplete.
- Therefore requiring preview `health=200` blocks production for the wrong reason.
- The verify/replay smoke step also still used explicit `--token` with beta `vercel curl`, which would reproduce the same CLI forwarding bug later.

Changes:
1. Add `access` mode to `scripts/verify-vercel-health.sh`.
   - `access` proves Deployment Protection was bypassed and the response is DSG app JSON (`service=dsg-control-plane`).
   - it does not claim runtime readiness.
   - SSO redirects fail closed because they are not valid DSG JSON.
2. Use `access` only for the existing READY preview preflight.
3. Keep production verification strict: HTTP 200 + JSON `ok=true`.
4. Remove explicit `--token` from verify/replay `vercel curl` probes and rely on the supported `VERCEL_TOKEN` environment variable.

Truth boundary remains unchanged: production is only READY after target=production/state=READY + strict health pass; route probes only prove deployment + app-auth denial, not full authenticated canonical execution.