### PR TITLE
fix(prod): unblock Vercel build and Hobby cron limits

### DIFF
--- a/lib/trinity/real-jobs.ts
+++ b/lib/trinity/real-jobs.ts
@@ -3,14 +3,41 @@
  * Replaces mock data with live job platforms and governance
  */
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+// Do not construct the Supabase client at module evaluation time. Next.js
+// evaluates route imports while collecting page data during production builds;
+// a malformed runtime URL must not crash the entire build. Runtime operations
+// still fail closed when the database configuration is missing or invalid.
+let supabaseClient: SupabaseClient | null | undefined;
 
-const supabase = supabaseUrl && supabaseServiceKey
-  ? createClient(supabaseUrl, supabaseServiceKey)
-  : null;
+function getSupabaseClient(): SupabaseClient | null {
+  if (supabaseClient !== undefined) {
+    return supabaseClient;
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    supabaseClient = null;
+    return supabaseClient;
+  }
+
+  try {
+    const parsed = new URL(supabaseUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      supabaseClient = null;
+      return supabaseClient;
+    }
+
+    supabaseClient = createClient(supabaseUrl, supabaseServiceKey);
+  } catch {
+    supabaseClient = null;
+  }
+
+  return supabaseClient;
+}
 
 // Cache for API results (5 minutes)
 const cache = new Map<string, { data: any; expiry: number }>();
@@ -113,7 +140,8 @@ export async function discoverJobsReal(
       jobs.push(...solanaGrants);
     }
 
-    // Load internal DSG jobs from Supabase if connected
+    // Load internal DSG jobs from Supabase if connected.
+    const supabase = getSupabaseClient();
     if (supabase) {
       try {
         const { data: dsgJobs } = await supabase
@@ -184,6 +212,7 @@ export async function executeJobReal(
   _executionTimeTarget?: number
 ): Promise<any> {
   try {
+    const supabase = getSupabaseClient();
     if (!supabase) {
       return { error: 'Database not configured' };
     }
@@ -244,6 +273,7 @@ export async function verifyDeliverableReal(
   qualityCriteria?: string
 ): Promise<any> {
   try {
+    const supabase = getSupabaseClient();
     if (!supabase) {
       return { error: 'Database not configured' };
     }
@@ -326,6 +356,7 @@ export async function settlePaymentReal(
   amountSol: number
 ): Promise<any> {
   try {
+    const supabase = getSupabaseClient();
     if (!supabase) {
       return { error: 'Database not configured' };
     }
@@ -380,6 +411,7 @@ export async function validateGovernanceReal(
   constraints?: Record<string, any>
 ): Promise<any> {
   try {
+    const supabase = getSupabaseClient();
     if (!supabase) {
       return { error: 'Database not configured' };
     }

--- a/vercel.json
+++ b/vercel.json
@@ -14,11 +14,11 @@
   "crons": [
     {
       "path": "/api/cron/flush-meter-outbox",
-      "schedule": "*/10 * * * *"
+      "schedule": "10 0 * * *"
     },
     {
       "path": "/api/cron/reconcile-meter",
-      "schedule": "0 * * * *"
+      "schedule": "20 0 * * *"
     },
     {
       "path": "/api/cron/usage-alerts",


### PR DESCRIPTION
Fixes the two production blockers confirmed on the new Vercel project.

1. `lib/trinity/real-jobs.ts`
   - removes Supabase client construction from module evaluation
   - validates `NEXT_PUBLIC_SUPABASE_URL` lazily at runtime
   - preserves fail-closed behavior (`Database not configured`) instead of crashing `next build`

2. `vercel.json`
   - changes the two sub-daily cron schedules to daily schedules compatible with the Vercel Hobby plan
   - confirmed production deployment `tdealer01-crypto-dsg-control-plane-2vkzlc9bi.vercel.app` currently fails with `cron_jobs_limits_reached`

Truth boundary: this PR removes known build/deployment blockers; production is not claimed READY until the bootstrap workflow and live route probes pass after merge. Meter flush/reconcile cadence is temporarily reduced to daily on Hobby and should be restored only after moving to a scheduler/plan that supports sub-daily jobs.