### PR TITLE
ci: retrigger production bootstrap on Vercel config changes

### DIFF
--- a/.github/workflows/bootstrap-new-vercel-production.yml
+++ b/.github/workflows/bootstrap-new-vercel-production.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/bootstrap-new-vercel-production.yml
       - scripts/verify-vercel-health.sh
+      - vercel.json
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Add `vercel.json` to the production bootstrap workflow path trigger. This keeps the bootstrap narrowly scoped while ensuring Vercel deployment-configuration fixes (such as the Hobby-compatible cron schedules in #1127) automatically re-run the governed production build/deploy verification.

No application logic changes in this PR.