### PR TITLE
ci: trigger current-main production bootstrap

### DIFF
--- a/.github/workflows/bootstrap-new-vercel-production.yml
+++ b/.github/workflows/bootstrap-new-vercel-production.yml
@@ -1,3 +1,4 @@
+# Manual production bootstrap trigger: current main, 2026-08-16
 name: Bootstrap New Vercel Production
 
 on:


### PR DESCRIPTION
Triggers the existing audited Vercel production bootstrap from the current main lineage. No application behavior change; only a workflow comment is added so the main push matches the workflow path filter and deploys the corrected Hobby-compatible cron configuration.