### PR TITLE
feat(dsg-one): DSG ONE — Verified Execution product layer

### DIFF
--- a/app/api/dsg/v1/runs/[runId]/approve/route.ts
+++ b/app/api/dsg/v1/runs/[runId]/approve/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { applyRunEvent } from '@/lib/dsg-one/run/state-machine';
+import { advanceRun } from '@/lib/dsg-one/run/orchestrator';
+import { getRun, saveRun } from '@/lib/dsg-one/run/repository';
+import { isRunTransitionError, runPhase } from '@/lib/dsg-one/run/types';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import { requireDsgAuth, dsgAuthError, logDsgApiCall } from '@/lib/dsg/auth/require-dsg-auth';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+const RATE_LIMIT = 60;
+
+function actorId(caller: { actorType: 'user' | 'api_key'; userId?: string; apiKeyId?: string }) {
+  return caller.actorType === 'api_key' ? `key:${caller.apiKeyId}` : `user:${caller.userId}`;
+}
+
+/**
+ * POST /api/dsg/v1/runs/:runId/approve — Approve & Run.
+ *
+ * The single approval in the product. It freezes the planHash and then, per
+ * layer 3 of the spec, immediately verifies and dispatches the first step
+ * rather than asking again. `{ decision: 'reject' }` cancels the run instead.
+ *
+ * The response carries `dispatch`: the step the caller should now execute. When
+ * it is null the run already settled — the gate blocked something, or every
+ * step needs review — and the caller has nothing to do.
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ runId: string }> }) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const { runId } = await params;
+  const startMs = Date.now();
+
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-one-approve:${caller.orgId}`),
+    limit: RATE_LIMIT,
+    windowMs: 60_000,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, RATE_LIMIT);
+  if (!rateLimit.allowed) {
+    return NextResponse.json({ ok: false, error: 'rate_limit_exceeded' }, { status: 429, headers });
+  }
+
+  const body = await readJsonBody<{ decision?: unknown }>(request, { maxBytes: 4_000 });
+  if (!body.ok) {
+    return NextResponse.json({ ok: false, error: body.error }, { status: body.status, headers });
+  }
+  const reject = body.value?.decision === 'reject';
+
+  try {
+    const run = await getRun(runId, caller.orgId);
+    if (!run) {
+      return NextResponse.json({ ok: false, error: 'run_not_found' }, { status: 404, headers });
+    }
+
+    const at = new Date().toISOString();
+    const decided = reject
+      ? applyRunEvent(run, { type: 'REJECT', at })
+      : applyRunEvent(run, { type: 'APPROVE', approvedBy: actorId(caller), at });
+
+    if (isRunTransitionError(decided)) {
+      return NextResponse.json(
+        { ok: false, error: decided.code, message: decided.message },
+        { status: 409, headers },
+      );
+    }
+
+    if (reject) {
+      await saveRun(decided.run);
+      return NextResponse.json(
+        { ok: true, run: decided.run, dispatch: null, phase: runPhase(decided.run) },
+        { headers },
+      );
+    }
+
+    // Layer 3: no second gate in front of work the user just approved.
+    const advanced = await advanceRun(decided.run, {
+      connectedSystems: decided.run.connectedSystems,
+      auditAvailable: decided.run.auditAvailable,
+    });
+
+    await saveRun(advanced.run);
+
+    await logDsgApiCall({
+      route: 'runs/approve',
+      orgId: caller.orgId,
+      actorType: caller.actorType,
+      userId: caller.userId,
+      apiKeyId: caller.apiKeyId,
+      statusCode: 200,
+      durationMs: Date.now() - startMs,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        run: advanced.run,
+        planHash: advanced.run.planHash,
+        dispatch: advanced.dispatch,
+        phase: runPhase(advanced.run),
+      },
+      { headers },
+    );
+  } catch (error) {
+    return handleApiError('dsg-one/runs:approve', error, { headers });
+  }
+}

--- a/app/api/dsg/v1/runs/[runId]/receipt/route.ts
+++ b/app/api/dsg/v1/runs/[runId]/receipt/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { applyRunEvent } from '@/lib/dsg-one/run/state-machine';
+import { buildRunReceipt, replayRunReceipt } from '@/lib/dsg-one/run/receipt';
+import { getRun, saveRun } from '@/lib/dsg-one/run/repository';
+import { isTerminal } from '@/lib/dsg-one/run/types';
+import { requireDsgAuth, dsgAuthError } from '@/lib/dsg/auth/require-dsg-auth';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dsg/v1/runs/:runId/receipt — Proof Receipt (product layer 5).
+ *
+ * Issues the receipt for a settled run, and replays it in the same call so the
+ * caller never sees a receipt whose replay status is unknown. Replay is free
+ * and unmetered: charging someone to check their own evidence would defeat the
+ * point of issuing it.
+ *
+ * A CANCELLED run has no receipt — the user rejected the plan, so no work was
+ * approved and there is nothing to prove.
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ runId: string }> }) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const { runId } = await params;
+
+  try {
+    const run = await getRun(runId, caller.orgId);
+    if (!run) {
+      return NextResponse.json({ ok: false, error: 'run_not_found' }, { status: 404 });
+    }
+
+    if (!isTerminal(run.status)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'run_not_settled',
+          message: 'This run is still going. A receipt is issued once it finishes.',
+          status: run.status,
+        },
+        { status: 409 },
+      );
+    }
+
+    if (run.status === 'CANCELLED') {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: 'run_cancelled',
+          message: 'The plan was rejected, so nothing ran and there is nothing to prove.',
+        },
+        { status: 409 },
+      );
+    }
+
+    const receipt = buildRunReceipt(run, new Date().toISOString());
+    const replay = replayRunReceipt(receipt, run);
+
+    // Record the receipt id on first issuance so Activity can link to it. The
+    // id is derived from the chain, so re-issuing yields the same value.
+    if (run.receiptId !== receipt.receiptId) {
+      const stamped = applyRunEvent(run, {
+        type: 'RECEIPT_ISSUED',
+        receiptId: receipt.receiptId,
+        at: receipt.issuedAt,
+      });
+      if (stamped.ok) await saveRun(stamped.run);
+    }
+
+    return NextResponse.json({ ok: true, receipt, replay });
+  } catch (error) {
+    return handleApiError('dsg-one/runs:receipt', error);
+  }
+}

--- a/app/api/dsg/v1/runs/[runId]/route.ts
+++ b/app/api/dsg/v1/runs/[runId]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getRun } from '@/lib/dsg-one/run/repository';
+import { runPhase } from '@/lib/dsg-one/run/types';
+import { requireDsgAuth, dsgAuthError } from '@/lib/dsg/auth/require-dsg-auth';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dsg/v1/runs/:runId — Live Verification (product layer 4).
+ *
+ * The polling endpoint behind the progress display. It returns the run, the
+ * single phase word to show, and — when a step is waiting on the executor —
+ * which step that is.
+ *
+ * `blockedReason` is the plain sentence the spec requires: when something
+ * fails, say what failed and what to fix, not "some checks may have issues".
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ runId: string }> }) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const { runId } = await params;
+
+  try {
+    const run = await getRun(runId, caller.orgId);
+    if (!run) {
+      return NextResponse.json({ ok: false, error: 'run_not_found' }, { status: 404 });
+    }
+
+    const awaiting = run.steps.find((step) => step.status === 'DISPATCHED') ?? null;
+    const failed = run.steps.find(
+      (step) => step.status === 'BLOCKED' || step.status === 'REVIEW',
+    );
+
+    return NextResponse.json({
+      ok: true,
+      run,
+      phase: runPhase(run),
+      awaitingStepId: awaiting?.stepId ?? null,
+      blockedReason: failed?.judgement?.message ?? null,
+    });
+  } catch (error) {
+    return handleApiError('dsg-one/runs:get', error);
+  }
+}

--- a/app/api/dsg/v1/runs/[runId]/steps/[stepId]/observe/route.ts
+++ b/app/api/dsg/v1/runs/[runId]/steps/[stepId]/observe/route.ts
@@ -1,0 +1,142 @@
+import { NextResponse } from 'next/server';
+import { applyRunEvent, judgeObservation } from '@/lib/dsg-one/run/state-machine';
+import { advanceRun } from '@/lib/dsg-one/run/orchestrator';
+import { getRun, saveRun } from '@/lib/dsg-one/run/repository';
+import { isRunTransitionError, runPhase, type StepObservation } from '@/lib/dsg-one/run/types';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import { requireDsgAuth, dsgAuthError, logDsgApiCall } from '@/lib/dsg/auth/require-dsg-auth';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+const RATE_LIMIT = 120;
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+/**
+ * POST /api/dsg/v1/runs/:runId/steps/:stepId/observe — Observe (layer 4).
+ *
+ * The client executor reports what it actually did. DSG judges that report
+ * against the locked plan and either advances to the next step or stops the run.
+ *
+ * The executor's own `outcome` is never taken at face value: an observation
+ * carrying the wrong planHash, touching a system outside the approved scope, or
+ * producing no evidence is stopped regardless of what it claims about itself.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ runId: string; stepId: string }> },
+) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const { runId, stepId } = await params;
+  const startMs = Date.now();
+
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-one-observe:${caller.orgId}`),
+    limit: RATE_LIMIT,
+    windowMs: 60_000,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, RATE_LIMIT);
+  if (!rateLimit.allowed) {
+    return NextResponse.json({ ok: false, error: 'rate_limit_exceeded' }, { status: 429, headers });
+  }
+
+  const body = await readJsonBody<Record<string, unknown>>(request, { maxBytes: 64_000 });
+  if (!body.ok) {
+    return NextResponse.json({ ok: false, error: body.error }, { status: body.status, headers });
+  }
+
+  const raw = body.value ?? {};
+  if (typeof raw.planHash !== 'string' || raw.planHash.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: 'validation_failed', details: ['planHash is required'] },
+      { status: 400, headers },
+    );
+  }
+  if (raw.outcome !== 'SUCCEEDED' && raw.outcome !== 'FAILED') {
+    return NextResponse.json(
+      { ok: false, error: 'validation_failed', details: ["outcome must be 'SUCCEEDED' or 'FAILED'"] },
+      { status: 400, headers },
+    );
+  }
+
+  const observation: StepObservation = {
+    planHash: raw.planHash,
+    executedCommands: toStringArray(raw.executedCommands),
+    changedPaths: toStringArray(raw.changedPaths),
+    evidenceIds: toStringArray(raw.evidenceIds),
+    outcome: raw.outcome,
+    detail: typeof raw.detail === 'string' ? raw.detail : undefined,
+  };
+
+  try {
+    const run = await getRun(runId, caller.orgId);
+    if (!run) {
+      return NextResponse.json({ ok: false, error: 'run_not_found' }, { status: 404, headers });
+    }
+
+    const step = run.steps.find((candidate) => candidate.stepId === stepId);
+    if (!step) {
+      return NextResponse.json({ ok: false, error: 'step_not_found' }, { status: 404, headers });
+    }
+
+    const at = new Date().toISOString();
+    const judgement = judgeObservation(run, step, observation);
+
+    const observed = applyRunEvent(run, { type: 'STEP_OBSERVED', stepId, judgement, at });
+    if (isRunTransitionError(observed)) {
+      return NextResponse.json(
+        { ok: false, error: observed.code, message: observed.message },
+        { status: 409, headers },
+      );
+    }
+
+    // Keep the raw observation on the step so the receipt and any later replay
+    // can show what was reported, not only how it was judged.
+    const withObservation = {
+      ...observed.run,
+      steps: observed.run.steps.map((candidate) =>
+        candidate.stepId === stepId ? { ...candidate, observation } : candidate,
+      ),
+    };
+
+    const advanced = await advanceRun(withObservation, {
+      connectedSystems: run.connectedSystems,
+      auditAvailable: run.auditAvailable,
+    });
+
+    await saveRun(advanced.run);
+
+    await logDsgApiCall({
+      route: 'runs/observe',
+      orgId: caller.orgId,
+      actorType: caller.actorType,
+      userId: caller.userId,
+      apiKeyId: caller.apiKeyId,
+      statusCode: 200,
+      durationMs: Date.now() - startMs,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        run: advanced.run,
+        judgement,
+        dispatch: advanced.dispatch,
+        phase: runPhase(advanced.run),
+      },
+      { headers },
+    );
+  } catch (error) {
+    return handleApiError('dsg-one/runs:observe', error, { headers });
+  }
+}

--- a/app/api/dsg/v1/runs/route.ts
+++ b/app/api/dsg/v1/runs/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server';
+import { compilePlan, listSupportedIntents } from '@/lib/dsg-one/run/plan-lock';
+import { computePlanHash } from '@/lib/dsg-one/run/state-machine';
+import { createRun, listRuns } from '@/lib/dsg-one/run/repository';
+import { runPhase } from '@/lib/dsg-one/run/types';
+import type { VerifiedActionSurface } from '@/lib/dsg-one/verified-action-receipt';
+import {
+  applyRateLimit,
+  buildRateLimitHeaders,
+  getRateLimitKey,
+} from '@/lib/security/rate-limit';
+import { readJsonBody } from '@/lib/security/request-json';
+import { requireDsgAuth, dsgAuthError, logDsgApiCall } from '@/lib/dsg/auth/require-dsg-auth';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+const RATE_LIMIT = 60;
+const RATE_WINDOW_MS = 60_000;
+const SURFACES: VerifiedActionSurface[] = ['api', 'unify', 'trinity-mcp'];
+
+function actorId(caller: { actorType: 'user' | 'api_key'; userId?: string; apiKeyId?: string }) {
+  return caller.actorType === 'api_key' ? `key:${caller.apiKeyId}` : `user:${caller.userId}`;
+}
+
+/**
+ * POST /api/dsg/v1/runs — Plan Lock (product layer 1).
+ *
+ * Compiles an intent into a checkable plan and stores it as a DRAFT run. No
+ * planHash is frozen here and nothing is dispatched: the run is inert until the
+ * user approves it, which is what makes the approval mean something.
+ *
+ * The response includes the hash the plan *would* freeze to, so a client can
+ * show the user exactly what they are about to commit to.
+ */
+export async function POST(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const startMs = Date.now();
+
+  const rateLimit = await applyRateLimit({
+    key: getRateLimitKey(request, `dsg-one-runs:${caller.orgId}`),
+    limit: RATE_LIMIT,
+    windowMs: RATE_WINDOW_MS,
+  });
+  const headers = buildRateLimitHeaders(rateLimit, RATE_LIMIT);
+  if (!rateLimit.allowed) {
+    return NextResponse.json({ ok: false, error: 'rate_limit_exceeded' }, { status: 429, headers });
+  }
+
+  const body = await readJsonBody<{
+    intent?: unknown;
+    surface?: unknown;
+    connectedSystems?: unknown;
+    auditAvailable?: unknown;
+  }>(request, { maxBytes: 16_000 });
+  if (!body.ok) {
+    return NextResponse.json({ ok: false, error: body.error }, { status: body.status, headers });
+  }
+
+  const intent = typeof body.value?.intent === 'string' ? body.value.intent : '';
+  const surfaceInput = body.value?.surface;
+  const surface: VerifiedActionSurface =
+    typeof surfaceInput === 'string' && SURFACES.includes(surfaceInput as VerifiedActionSurface)
+      ? (surfaceInput as VerifiedActionSurface)
+      : 'api';
+
+  const connectedSystems = Array.isArray(body.value?.connectedSystems)
+    ? body.value.connectedSystems.filter((value): value is string => typeof value === 'string')
+    : [];
+  const auditAvailable = body.value?.auditAvailable === true;
+
+  const compiled = compilePlan(intent);
+  if (!compiled.ok || !compiled.plan) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'plan_not_compilable',
+        message: compiled.reason,
+        supportedIntents: listSupportedIntents(),
+      },
+      { status: 422, headers },
+    );
+  }
+
+  try {
+    const run = await createRun({
+      orgId: caller.orgId,
+      actorId: actorId(caller),
+      surface,
+      plan: compiled.plan,
+      templateId: compiled.templateId,
+      connectedSystems,
+      auditAvailable,
+    });
+
+    await logDsgApiCall({
+      route: 'runs/create',
+      orgId: caller.orgId,
+      actorType: caller.actorType,
+      userId: caller.userId,
+      apiKeyId: caller.apiKeyId,
+      statusCode: 201,
+      durationMs: Date.now() - startMs,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        run,
+        // What approving would freeze. Shown next to the Approve & Run button so
+        // the user can see the plan identity before they commit to it.
+        pendingPlanHash: computePlanHash(run.plan),
+        phase: runPhase(run),
+      },
+      { status: 201, headers },
+    );
+  } catch (error) {
+    return handleApiError('dsg-one/runs:create', error, { headers });
+  }
+}
+
+/** GET /api/dsg/v1/runs — Activity. Recent runs for the caller's org. */
+export async function GET(request: Request) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) return dsgAuthError(caller as typeof caller & { ok: false });
+
+  const limitParam = new URL(request.url).searchParams.get('limit');
+  const limit = limitParam ? Number.parseInt(limitParam, 10) : 25;
+
+  try {
+    const runs = await listRuns(caller.orgId, Number.isFinite(limit) ? limit : 25);
+    return NextResponse.json({
+      ok: true,
+      runs: runs.map((run) => ({
+        runId: run.runId,
+        status: run.status,
+        phase: runPhase(run),
+        intent: run.plan.intent,
+        planHash: run.planHash,
+        receiptId: run.receiptId,
+        stepCount: run.steps.length,
+        createdAt: run.createdAt,
+        updatedAt: run.updatedAt,
+      })),
+    });
+  } catch (error) {
+    return handleApiError('dsg-one/runs:list', error);
+  }
+}

--- a/app/one/_components/OneNav.tsx
+++ b/app/one/_components/OneNav.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+/**
+ * The five destinations of DSG ONE. Not four, not twenty.
+ * See docs/product/DSG_ONE_VERIFIED_EXECUTION.md §3.
+ */
+const NAV = [
+  { href: '/one', label: 'Run', exact: true },
+  { href: '/one/activity', label: 'Activity' },
+  { href: '/one/proofs', label: 'Proofs' },
+  { href: '/one/policies', label: 'Policies' },
+  { href: '/one/integrations', label: 'Integrations' },
+] as const;
+
+function isActive(pathname: string, href: string, exact?: boolean) {
+  if (exact) return pathname === href;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export default function OneNav() {
+  const pathname = usePathname() ?? '/one';
+
+  return (
+    <nav aria-label="DSG ONE" className="flex items-center gap-1">
+      {NAV.map((item) => {
+        const active = isActive(pathname, item.href, 'exact' in item ? item.exact : undefined);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={active ? 'page' : undefined}
+            className={[
+              'rounded-md px-3 py-1.5 text-sm transition-colors',
+              active
+                ? 'bg-white/10 font-medium text-white'
+                : 'text-slate-400 hover:bg-white/5 hover:text-slate-200',
+            ].join(' ')}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/one/_components/Verdict.tsx
+++ b/app/one/_components/Verdict.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+/**
+ * The one result the user reads. Three states, no fourth.
+ * See docs/product/DSG_ONE_VERIFIED_EXECUTION.md §2.
+ */
+export type VerdictValue = 'VERIFIED' | 'NEEDS_REVIEW' | 'BLOCKED';
+
+const STYLES: Record<VerdictValue, { mark: string; label: string; className: string }> = {
+  VERIFIED: {
+    mark: '✓',
+    label: 'VERIFIED',
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  },
+  NEEDS_REVIEW: {
+    mark: '△',
+    label: 'NEEDS REVIEW',
+    className: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-300',
+  },
+  BLOCKED: {
+    mark: '✕',
+    label: 'BLOCKED',
+    className: 'border-red-500/30 bg-red-500/10 text-red-300',
+  },
+};
+
+export function toVerdict(status: string): VerdictValue | null {
+  if (status === 'VERIFIED') return 'VERIFIED';
+  if (status === 'NEEDS_REVIEW') return 'NEEDS_REVIEW';
+  if (status === 'BLOCKED' || status === 'CANCELLED') return 'BLOCKED';
+  return null;
+}
+
+export default function Verdict({
+  value,
+  size = 'md',
+}: {
+  value: VerdictValue;
+  size?: 'sm' | 'md' | 'lg';
+}) {
+  const style = STYLES[value];
+  const sizing =
+    size === 'lg'
+      ? 'px-4 py-2 text-lg'
+      : size === 'sm'
+        ? 'px-2 py-0.5 text-xs'
+        : 'px-3 py-1 text-sm';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border font-semibold tracking-wide ${style.className} ${sizing}`}
+    >
+      <span aria-hidden="true">{style.mark}</span>
+      {style.label}
+    </span>
+  );
+}

--- a/app/one/_components/types.ts
+++ b/app/one/_components/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Client-side view of the run API payloads.
+ *
+ * Structurally mirrors lib/dsg-one/run/types.ts but is declared separately so
+ * the browser bundle never pulls in the server module (which reaches into
+ * node:crypto and the Supabase admin client).
+ */
+
+export interface RunPlanStepView {
+  stepId: string;
+  ordinal: number;
+  summary: string;
+  actionType: string;
+  targetSystem: string;
+  operation: string;
+  riskLevel: 'low' | 'medium' | 'high' | 'critical';
+  phase: string;
+}
+
+export interface RunStepView extends RunPlanStepView {
+  status: 'PENDING' | 'VERIFIED' | 'DISPATCHED' | 'PASSED' | 'REVIEW' | 'BLOCKED' | 'SKIPPED';
+  gateVerdict: 'PASS' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED' | null;
+  judgement: { status: string; reasons: string[]; message: string | null } | null;
+  dispatchedAt: string | null;
+  settledAt: string | null;
+}
+
+export interface RunPlanView {
+  intent: string;
+  steps: RunPlanStepView[];
+  allowedTargetSystems: string[];
+  allowedOperations: string[];
+  maxRiskLevel: string;
+  exclusions: string[];
+  policyVersion: string;
+}
+
+export interface RunView {
+  runId: string;
+  status: 'DRAFT' | 'LOCKED' | 'RUNNING' | 'VERIFIED' | 'NEEDS_REVIEW' | 'BLOCKED' | 'CANCELLED';
+  plan: RunPlanView;
+  planHash: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  expiresAt: string | null;
+  steps: RunStepView[];
+  receiptId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RunSummaryView {
+  runId: string;
+  status: RunView['status'];
+  phase: string;
+  intent: string;
+  planHash: string | null;
+  receiptId: string | null;
+  stepCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReceiptCheckView {
+  label: string;
+  status: 'PASS' | 'REVIEW' | 'BLOCK' | 'SKIPPED';
+  detail: string | null;
+}
+
+export interface RunReceiptView {
+  receiptId: string;
+  runId: string;
+  issuedAt: string;
+  result: 'VERIFIED' | 'NEEDS_REVIEW' | 'BLOCKED';
+  requestedAction: string;
+  checks: ReceiptCheckView[];
+  evidenceCount: number;
+  chain: {
+    planHash: string;
+    outcomeHash: string;
+    evidenceHash: string;
+    receiptHash: string;
+  };
+  boundary: {
+    executedByDsg: boolean;
+    externalZ3SolverInvoked: boolean;
+    certificationClaim: boolean;
+    independentAuditClaim: boolean;
+    note: string;
+  };
+}
+
+export interface ReplayView {
+  replayMatch: boolean;
+  receiptIntact: boolean;
+  verdictMatch: boolean;
+  mismatchedFields: Array<{ field: string; receipt: string; replay: string; match: boolean }>;
+  reason: string;
+}
+
+/** Short hash for display: 7f28...91ac */
+export function shortHash(value: string | null | undefined): string {
+  if (!value) return '—';
+  return value.length <= 12 ? value : `${value.slice(0, 4)}...${value.slice(-4)}`;
+}

--- a/app/one/activity/page.tsx
+++ b/app/one/activity/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import Verdict, { toVerdict } from '../_components/Verdict';
+import { shortHash, type RunSummaryView } from '../_components/types';
+
+function when(value: string) {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+/** Activity — runs in flight and recent runs. */
+export default function ActivityPage() {
+  const [runs, setRuns] = useState<RunSummaryView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/dsg/v1/runs?limit=25', { cache: 'no-store' })
+      .then(async (response) => ({ ok: response.ok, payload: await response.json() }))
+      .then(({ ok, payload }) => {
+        if (!alive) return;
+        if (!ok || !payload.ok) throw new Error(payload.error || 'Could not load activity.');
+        setRuns(payload.runs);
+      })
+      .catch((err) => {
+        if (alive) setError(err instanceof Error ? err.message : 'Could not load activity.');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold">Activity</h1>
+      <p className="mt-1 text-sm text-slate-400">Runs in flight and recently finished.</p>
+
+      {error && (
+        <div role="alert" className="mt-6 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      {loading && <p className="mt-6 text-sm text-slate-400">Loading…</p>}
+
+      {!loading && !error && runs.length === 0 && (
+        <div className="mt-6 rounded-xl border border-slate-800 bg-slate-900/50 px-5 py-8 text-center">
+          <p className="text-sm text-slate-400">No runs yet.</p>
+          <Link href="/one" className="mt-3 inline-block text-sm text-slate-200 underline underline-offset-4">
+            Start one
+          </Link>
+        </div>
+      )}
+
+      <ul className="mt-6 space-y-2">
+        {runs.map((run) => {
+          const verdict = toVerdict(run.status);
+          return (
+            <li key={run.runId}>
+              <Link
+                href={`/one/runs/${run.runId}`}
+                className="flex items-center gap-4 rounded-lg border border-slate-800 bg-slate-900/50 px-4 py-3 transition-colors hover:border-slate-700 hover:bg-slate-900"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm text-slate-200">{run.intent}</p>
+                  <p className="mt-0.5 text-xs text-slate-500">
+                    {when(run.createdAt)} · {run.stepCount} steps · plan {shortHash(run.planHash)}
+                  </p>
+                </div>
+                {verdict ? (
+                  <Verdict value={verdict} size="sm" />
+                ) : (
+                  <span className="shrink-0 rounded-full border border-slate-700 px-2.5 py-0.5 text-xs text-slate-400">
+                    {run.phase}
+                  </span>
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/app/one/integrations/page.tsx
+++ b/app/one/integrations/page.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Integrations — the systems a plan may touch.
+ *
+ * DSG deliberately uses what the customer already has rather than building a
+ * parallel ecosystem. See docs/product/DSG_ONE_VERIFIED_EXECUTION.md §4.
+ */
+const INTEGRATIONS = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    role: 'Code, pull requests, and CI checks.',
+    operations: ['checks.read', 'branch.push', 'pull_request.create', 'file.read'],
+    settings: '/dashboard/integration',
+  },
+  {
+    id: 'vercel',
+    name: 'Vercel',
+    role: 'Preview and production deployments.',
+    operations: ['deployment.create', 'deployment.promote', 'deployment.health'],
+    settings: '/dashboard/integration',
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    role: 'Data, migrations, and evidence storage.',
+    operations: ['migration.apply', 'schema.read'],
+    settings: '/dashboard/integration',
+  },
+] as const;
+
+export default function IntegrationsPage() {
+  return (
+    <div>
+      <h1 className="text-xl font-semibold">Integrations</h1>
+      <p className="mt-1 text-sm text-slate-400">
+        The systems a plan is allowed to touch. A step targeting anything else is out of plan.
+      </p>
+
+      <ul className="mt-6 space-y-3">
+        {INTEGRATIONS.map((integration) => (
+          <li
+            key={integration.id}
+            className="rounded-xl border border-slate-800 bg-slate-900/50 p-5"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-sm font-semibold">{integration.name}</h2>
+                <p className="mt-0.5 text-sm text-slate-400">{integration.role}</p>
+              </div>
+              <Link
+                href={integration.settings}
+                className="shrink-0 rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-300 transition-colors hover:bg-white/5"
+              >
+                Manage
+              </Link>
+            </div>
+            <ul className="mt-3 flex flex-wrap gap-1.5">
+              {integration.operations.map((operation) => (
+                <li
+                  key={operation}
+                  className="rounded-full border border-slate-700 bg-slate-800/50 px-2.5 py-0.5 font-mono text-[11px] text-slate-400"
+                >
+                  {operation}
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-6 text-xs leading-relaxed text-slate-500">
+        DSG orchestrates and judges; your own runtime performs the work and reports what it
+        observed. Credentials for these systems stay where they are today — DSG does not hold them
+        on your behalf.
+      </p>
+    </div>
+  );
+}

--- a/app/one/layout.tsx
+++ b/app/one/layout.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import OneNav from './_components/OneNav';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'DSG ONE — Verified Execution',
+  description:
+    'Approve a plan once. DSG proves every action matches it, and holds evidence that it ran.',
+};
+
+/**
+ * DSG ONE application shell.
+ *
+ * Deliberately separate from /dashboard: this is the single-product surface
+ * described in docs/product/DSG_ONE_VERIFIED_EXECUTION.md, and the operator
+ * dashboard keeps its own broader navigation.
+ */
+export default function OneLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-6 px-6 py-3">
+          <Link href="/one" className="flex shrink-0 flex-col leading-tight">
+            <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">DSG ONE</span>
+            <span className="text-sm font-semibold">Verified Execution</span>
+          </Link>
+          <OneNav />
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl px-6 py-10">{children}</main>
+    </div>
+  );
+}

--- a/app/one/page.tsx
+++ b/app/one/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+const EXAMPLES = [
+  'Deploy the latest verified version to production',
+  'Deploy a preview of this branch',
+  'Push this branch and open a pull request',
+  'Apply the pending database migration',
+];
+
+/**
+ * Run — the home screen.
+ *
+ * One field. The user says what they want; DSG compiles it into a plan and
+ * takes them to the approval. Everything else in the product hangs off this.
+ */
+export default function RunPage() {
+  const router = useRouter();
+  const [intent, setIntent] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [supported, setSupported] = useState<string[] | null>(null);
+
+  async function submit(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || busy) return;
+
+    setBusy(true);
+    setError(null);
+    setSupported(null);
+
+    try {
+      const response = await fetch('/api/dsg/v1/runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        cache: 'no-store',
+        body: JSON.stringify({
+          intent: trimmed,
+          surface: 'api',
+          // The browser surface can reach the systems the org has connected
+          // through the control plane's own integrations.
+          connectedSystems: ['github', 'vercel', 'supabase'],
+          auditAvailable: true,
+        }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok || !payload.ok) {
+        setError(payload.message || payload.error || 'Could not build a plan for that.');
+        if (Array.isArray(payload.supportedIntents)) {
+          setSupported(payload.supportedIntents.map((item: { example: string }) => item.example));
+        }
+        return;
+      }
+
+      router.push(`/one/runs/${payload.run.runId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not reach DSG.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl pt-10">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        What do you want your agent to do?
+      </h1>
+      <p className="mt-2 text-sm text-slate-400">
+        DSG turns it into a plan you approve once, then proves every action matched it.
+      </p>
+
+      <form
+        className="mt-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit(intent);
+        }}
+      >
+        <label htmlFor="intent" className="sr-only">
+          What do you want your agent to do?
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="intent"
+            name="intent"
+            type="text"
+            autoComplete="off"
+            autoFocus
+            value={intent}
+            onChange={(event) => setIntent(event.target.value)}
+            placeholder="Deploy the latest verified version to production"
+            disabled={busy}
+            className="flex-1 rounded-lg border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-white placeholder:text-slate-600 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 disabled:opacity-60"
+          />
+          <button
+            type="submit"
+            disabled={busy || intent.trim().length === 0}
+            className="rounded-lg bg-white px-5 py-3 text-sm font-medium text-slate-950 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {busy ? 'Planning…' : 'Plan'}
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="mt-8">
+        <p className="text-xs uppercase tracking-wider text-slate-500">
+          {supported ? 'Supported today' : 'Try'}
+        </p>
+        <ul className="mt-3 space-y-2">
+          {(supported ?? EXAMPLES).map((example) => (
+            <li key={example}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => {
+                  setIntent(example);
+                  void submit(example);
+                }}
+                className="w-full rounded-lg border border-slate-800 bg-slate-900/50 px-4 py-2.5 text-left text-sm text-slate-300 transition-colors hover:border-slate-700 hover:bg-slate-900 disabled:opacity-50"
+              >
+                {example}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/one/policies/page.tsx
+++ b/app/one/policies/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface ManifestConstraint {
+  constraintId: string;
+  name: string;
+  severity: string;
+  message: string;
+}
+
+interface Manifest {
+  policyRef?: string;
+  policyVersion?: string;
+  constraintSetHash?: string;
+  constraints?: ManifestConstraint[];
+}
+
+const SEVERITY_STYLE: Record<string, string> = {
+  critical: 'border-red-500/30 bg-red-500/10 text-red-300',
+  high: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-300',
+  medium: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
+  low: 'border-slate-600 bg-slate-800 text-slate-300',
+};
+
+/**
+ * Policies — what the org allows, and the active policy version.
+ *
+ * Read-only by design: this screen exists so the user can see what the gate
+ * checks before approving a plan, not to become a second policy editor.
+ */
+export default function PoliciesPage() {
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/dsg/v1/policies/manifest', { cache: 'no-store' })
+      .then(async (response) => ({ ok: response.ok, payload: await response.json() }))
+      .then(({ ok, payload }) => {
+        if (!alive) return;
+        if (!ok) throw new Error(payload.error || 'Could not load the policy manifest.');
+        setManifest(payload.manifest ?? payload);
+      })
+      .catch((err) => {
+        if (alive) setError(err instanceof Error ? err.message : 'Could not load policies.');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const constraints = manifest?.constraints ?? [];
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold">Policies</h1>
+      <p className="mt-1 text-sm text-slate-400">
+        Every plan step is checked against these before it may run.
+      </p>
+
+      {error && (
+        <div role="alert" className="mt-6 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      {loading && <p className="mt-6 text-sm text-slate-400">Loading…</p>}
+
+      {manifest && (
+        <>
+          <dl className="mt-6 grid grid-cols-2 gap-4 rounded-xl border border-slate-800 bg-slate-900/50 p-5 text-sm sm:grid-cols-3">
+            <div>
+              <dt className="text-xs text-slate-500">Policy</dt>
+              <dd className="mt-0.5 text-slate-200">{manifest.policyRef ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-slate-500">Version</dt>
+              <dd className="mt-0.5 text-slate-200">{manifest.policyVersion ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-slate-500">Constraint set</dt>
+              <dd className="mt-0.5 truncate font-mono text-xs text-slate-300">
+                {manifest.constraintSetHash
+                  ? `${manifest.constraintSetHash.slice(0, 8)}…`
+                  : '—'}
+              </dd>
+            </div>
+          </dl>
+
+          <ul className="mt-4 space-y-2">
+            {constraints.map((constraint) => (
+              <li
+                key={constraint.constraintId}
+                className="flex items-start gap-4 rounded-lg border border-slate-800 bg-slate-900/50 px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-slate-200">{constraint.name}</p>
+                  <p className="mt-0.5 text-xs text-slate-500">{constraint.message}</p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-[11px] ${
+                    SEVERITY_STYLE[constraint.severity] ?? SEVERITY_STYLE.low
+                  }`}
+                >
+                  {constraint.severity}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-6 text-xs leading-relaxed text-slate-500">
+            An undecidable check is never treated as a pass. Low-risk steps fall back to human
+            review; anything above that is blocked.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/one/proofs/[runId]/ReceiptClient.tsx
+++ b/app/one/proofs/[runId]/ReceiptClient.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import Verdict from '../../_components/Verdict';
+import type { ReceiptCheckView, ReplayView, RunReceiptView } from '../../_components/types';
+
+const CHECK_GLYPH: Record<ReceiptCheckView['status'], { mark: string; className: string }> = {
+  PASS: { mark: 'PASS', className: 'text-emerald-400' },
+  REVIEW: { mark: 'REVIEW', className: 'text-yellow-400' },
+  BLOCK: { mark: 'BLOCK', className: 'text-red-400' },
+  SKIPPED: { mark: '—', className: 'text-slate-600' },
+};
+
+/**
+ * Proof Receipt — one job, one receipt.
+ * See docs/product/DSG_ONE_VERIFIED_EXECUTION.md §2 layer 5.
+ */
+export default function ReceiptClient({ runId }: { runId: string }) {
+  const [receipt, setReceipt] = useState<RunReceiptView | null>(null);
+  const [replay, setReplay] = useState<ReplayView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch(`/api/dsg/v1/runs/${runId}/receipt`, { cache: 'no-store' })
+      .then(async (response) => ({ ok: response.ok, payload: await response.json() }))
+      .then(({ ok, payload }) => {
+        if (!alive) return;
+        if (!ok || !payload.ok) {
+          throw new Error(payload.message || payload.error || 'No receipt for this run.');
+        }
+        setReceipt(payload.receipt);
+        setReplay(payload.replay);
+      })
+      .catch((err) => {
+        if (alive) setError(err instanceof Error ? err.message : 'No receipt for this run.');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [runId]);
+
+  function exportProof() {
+    if (!receipt) return;
+    // The viewer sandbox blocks page-initiated downloads, so open the raw
+    // receipt JSON in a new tab and let the user save it from there.
+    window.open(`/api/dsg/v1/runs/${runId}/receipt`, '_blank', 'noopener');
+  }
+
+  if (loading) return <p className="text-sm text-slate-400">Loading receipt…</p>;
+
+  if (error) {
+    return (
+      <div>
+        <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error}
+        </div>
+        <Link href="/one/activity" className="mt-4 inline-block text-sm text-slate-300 underline underline-offset-4">
+          Back to activity
+        </Link>
+      </div>
+    );
+  }
+
+  if (!receipt) return null;
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+        <div className="flex items-start justify-between gap-4 border-b border-slate-800 pb-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+              DSG Execution Receipt
+            </p>
+            <h1 className="mt-1 text-lg font-semibold">{receipt.requestedAction}</h1>
+          </div>
+          <Verdict value={receipt.result} size="lg" />
+        </div>
+
+        <dl className="mt-4 space-y-2.5">
+          {receipt.checks.map((check, index) => {
+            const glyph = CHECK_GLYPH[check.status];
+            return (
+              <div key={`${check.label}-${index}`} className="flex items-baseline gap-4 text-sm">
+                <dt className="min-w-0 flex-1 truncate text-slate-300">{check.label}</dt>
+                <dd className={`shrink-0 font-mono text-xs ${glyph.className}`}>{glyph.mark}</dd>
+              </div>
+            );
+          })}
+
+          <div className="flex items-baseline gap-4 border-t border-slate-800 pt-3 text-sm">
+            <dt className="flex-1 text-slate-300">Evidence</dt>
+            <dd className="shrink-0 text-slate-400">{receipt.evidenceCount} artifacts</dd>
+          </div>
+          <div className="flex items-baseline gap-4 text-sm">
+            <dt className="flex-1 text-slate-300">Replay</dt>
+            <dd
+              className={`shrink-0 font-mono text-xs ${
+                replay?.replayMatch ? 'text-emerald-400' : 'text-red-400'
+              }`}
+            >
+              {replay?.replayMatch ? 'MATCH' : 'MISMATCH'}
+            </dd>
+          </div>
+          <div className="flex items-baseline gap-4 text-sm">
+            <dt className="flex-1 text-slate-300">Proof</dt>
+            <dd className="shrink-0 font-mono text-xs text-slate-400">
+              {receipt.chain.receiptHash.slice(0, 4)}…{receipt.chain.receiptHash.slice(-4)}
+            </dd>
+          </div>
+        </dl>
+
+        {replay && !replay.replayMatch && (
+          <p className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {replay.reason}
+          </p>
+        )}
+
+        <div className="mt-6 flex flex-wrap gap-2">
+          <Link
+            href={`/one/runs/${receipt.runId}`}
+            className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-white/5"
+          >
+            View evidence
+          </Link>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-white/5"
+          >
+            Replay
+          </button>
+          <button
+            type="button"
+            onClick={exportProof}
+            className="rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-white/5"
+          >
+            Export proof
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-4 text-xs leading-relaxed text-slate-500">{receipt.boundary.note}</p>
+    </div>
+  );
+}

--- a/app/one/proofs/[runId]/page.tsx
+++ b/app/one/proofs/[runId]/page.tsx
@@ -1,0 +1,8 @@
+import ReceiptClient from './ReceiptClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ReceiptPage({ params }: { params: Promise<{ runId: string }> }) {
+  const { runId } = await params;
+  return <ReceiptClient runId={runId} />;
+}

--- a/app/one/proofs/page.tsx
+++ b/app/one/proofs/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import Verdict, { toVerdict } from '../_components/Verdict';
+import { shortHash, type RunSummaryView } from '../_components/types';
+
+function when(value: string) {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+/** Proofs — receipts for settled runs. A run only appears once it has a verdict. */
+export default function ProofsPage() {
+  const [runs, setRuns] = useState<RunSummaryView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/dsg/v1/runs?limit=50', { cache: 'no-store' })
+      .then(async (response) => ({ ok: response.ok, payload: await response.json() }))
+      .then(({ ok, payload }) => {
+        if (!alive) return;
+        if (!ok || !payload.ok) throw new Error(payload.error || 'Could not load proofs.');
+        // CANCELLED runs never ran, so they have nothing to prove.
+        setRuns(
+          (payload.runs as RunSummaryView[]).filter((run) =>
+            ['VERIFIED', 'NEEDS_REVIEW', 'BLOCKED'].includes(run.status),
+          ),
+        );
+      })
+      .catch((err) => {
+        if (alive) setError(err instanceof Error ? err.message : 'Could not load proofs.');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold">Proofs</h1>
+      <p className="mt-1 text-sm text-slate-400">
+        One receipt per finished run. Each one replays to the same verdict, or says why not.
+      </p>
+
+      {error && (
+        <div role="alert" className="mt-6 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      {loading && <p className="mt-6 text-sm text-slate-400">Loading…</p>}
+
+      {!loading && !error && runs.length === 0 && (
+        <div className="mt-6 rounded-xl border border-slate-800 bg-slate-900/50 px-5 py-8 text-center">
+          <p className="text-sm text-slate-400">No finished runs yet.</p>
+          <Link href="/one" className="mt-3 inline-block text-sm text-slate-200 underline underline-offset-4">
+            Start one
+          </Link>
+        </div>
+      )}
+
+      <ul className="mt-6 space-y-2">
+        {runs.map((run) => (
+          <li key={run.runId}>
+            <Link
+              href={`/one/proofs/${run.runId}`}
+              className="flex items-center gap-4 rounded-lg border border-slate-800 bg-slate-900/50 px-4 py-3 transition-colors hover:border-slate-700 hover:bg-slate-900"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm text-slate-200">{run.intent}</p>
+                <p className="mt-0.5 text-xs text-slate-500">
+                  {when(run.updatedAt)} · plan {shortHash(run.planHash)}
+                </p>
+              </div>
+              <Verdict value={toVerdict(run.status)!} size="sm" />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/one/runs/[runId]/RunClient.tsx
+++ b/app/one/runs/[runId]/RunClient.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Verdict, { toVerdict } from '../../_components/Verdict';
+import { shortHash, type RunView } from '../../_components/types';
+
+const LIVE_POLL_MS = 2_000;
+
+const RISK_LABEL: Record<string, string> = {
+  low: 'low risk',
+  medium: 'medium risk',
+  high: 'high risk',
+  critical: 'critical risk',
+};
+
+function StepIcon({ status }: { status: RunStepStatus }) {
+  const glyph =
+    status === 'PASSED'
+      ? '✓'
+      : status === 'BLOCKED'
+        ? '✕'
+        : status === 'REVIEW'
+          ? '△'
+          : status === 'DISPATCHED'
+            ? '●'
+            : status === 'SKIPPED'
+              ? '–'
+              : '○';
+
+  const color =
+    status === 'PASSED'
+      ? 'text-emerald-400'
+      : status === 'BLOCKED'
+        ? 'text-red-400'
+        : status === 'REVIEW'
+          ? 'text-yellow-400'
+          : status === 'DISPATCHED'
+            ? 'animate-pulse text-white'
+            : 'text-slate-600';
+
+  return (
+    <span aria-hidden="true" className={`w-4 shrink-0 text-center ${color}`}>
+      {glyph}
+    </span>
+  );
+}
+
+type RunStepStatus = RunView['steps'][number]['status'];
+
+export default function RunClient({ runId }: { runId: string }) {
+  const [run, setRun] = useState<RunView | null>(null);
+  const [phase, setPhase] = useState<string>('Planning');
+  const [blockedReason, setBlockedReason] = useState<string | null>(null);
+  const [pendingPlanHash, setPendingPlanHash] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [approving, setApproving] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // Kept in a ref so the poll effect does not restart on every status change.
+  const statusRef = useRef<string>('DRAFT');
+
+  const load = useCallback(async () => {
+    const response = await fetch(`/api/dsg/v1/runs/${runId}`, { cache: 'no-store' });
+    const payload = await response.json();
+    if (!response.ok || !payload.ok) {
+      throw new Error(payload.message || payload.error || 'Could not load this run.');
+    }
+    setRun(payload.run);
+    setPhase(payload.phase);
+    setBlockedReason(payload.blockedReason ?? null);
+    statusRef.current = payload.run.status;
+  }, [runId]);
+
+  useEffect(() => {
+    let alive = true;
+    load()
+      .catch((err) => {
+        if (alive) setError(err instanceof Error ? err.message : 'Could not load this run.');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [load]);
+
+  // Live Verification: poll only while the run is actually moving.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (statusRef.current !== 'LOCKED' && statusRef.current !== 'RUNNING') return;
+      void load().catch(() => {
+        /* transient; the next tick retries */
+      });
+    }, LIVE_POLL_MS);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  async function decide(decision: 'approve' | 'reject') {
+    setApproving(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/dsg/v1/runs/${runId}/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.message || payload.error || 'Could not record your decision.');
+      }
+      setRun(payload.run);
+      setPhase(payload.phase);
+      statusRef.current = payload.run.status;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not record your decision.');
+    } finally {
+      setApproving(false);
+    }
+  }
+
+  useEffect(() => {
+    if (run?.status !== 'DRAFT') return;
+    // Show the hash the approval will freeze, so the user can see the plan
+    // identity before committing to it.
+    setPendingPlanHash(run.planHash);
+  }, [run]);
+
+  if (loading) {
+    return <p className="text-sm text-slate-400">Loading run…</p>;
+  }
+
+  if (error && !run) {
+    return (
+      <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+        {error}
+      </div>
+    );
+  }
+
+  if (!run) return null;
+
+  const verdict = toVerdict(run.status);
+  const isDraft = run.status === 'DRAFT';
+  const isLive = run.status === 'LOCKED' || run.status === 'RUNNING';
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <p className="text-xs uppercase tracking-wider text-slate-500">Requested action</p>
+        <h1 className="mt-1 text-xl font-semibold">{run.plan.intent}</h1>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      {/* ── Layer 1: Plan Lock ─────────────────────────────────────────── */}
+      {isDraft && (
+        <section className="rounded-xl border border-slate-800 bg-slate-900/50 p-5">
+          <h2 className="text-sm font-semibold">The agent will</h2>
+          <ol className="mt-3 space-y-2">
+            {run.plan.steps.map((step) => (
+              <li key={step.stepId} className="flex gap-3 text-sm">
+                <span className="w-4 shrink-0 text-slate-600">{step.ordinal}.</span>
+                <span className="flex-1">
+                  {step.summary}
+                  <span className="ml-2 text-xs text-slate-500">
+                    {step.targetSystem} · {RISK_LABEL[step.riskLevel] ?? step.riskLevel}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ol>
+
+          <h2 className="mt-5 text-sm font-semibold">It will not</h2>
+          <ul className="mt-2 space-y-1.5">
+            {run.plan.exclusions.map((exclusion) => (
+              <li key={exclusion} className="flex gap-3 text-sm text-slate-400">
+                <span aria-hidden="true" className="w-4 shrink-0 text-center">
+                  ✕
+                </span>
+                <span>{exclusion}</span>
+              </li>
+            ))}
+          </ul>
+
+          <dl className="mt-5 grid grid-cols-2 gap-x-6 gap-y-2 border-t border-slate-800 pt-4 text-xs">
+            <div>
+              <dt className="text-slate-500">Systems</dt>
+              <dd className="mt-0.5 text-slate-300">{run.plan.allowedTargetSystems.join(', ')}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Policy</dt>
+              <dd className="mt-0.5 text-slate-300">v{run.plan.policyVersion}</dd>
+            </div>
+          </dl>
+
+          <div className="mt-5 flex items-center gap-3">
+            <button
+              type="button"
+              disabled={approving}
+              onClick={() => void decide('approve')}
+              className="rounded-lg bg-white px-5 py-2.5 text-sm font-medium text-slate-950 transition-opacity hover:opacity-90 disabled:opacity-40"
+            >
+              {approving ? 'Starting…' : 'Approve & Run'}
+            </button>
+            <button
+              type="button"
+              disabled={approving}
+              onClick={() => void decide('reject')}
+              className="rounded-lg border border-slate-700 px-4 py-2.5 text-sm text-slate-300 transition-colors hover:bg-white/5 disabled:opacity-40"
+            >
+              Cancel
+            </button>
+            <p className="ml-auto text-xs text-slate-500">
+              DSG will not ask again unless the agent leaves this plan.
+            </p>
+          </div>
+        </section>
+      )}
+
+      {/* ── Layer 4: Live Verification ─────────────────────────────────── */}
+      {!isDraft && (
+        <section className="rounded-xl border border-slate-800 bg-slate-900/50 p-5">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-sm font-semibold">
+              {isLive ? phase : 'Result'}
+              {isLive && <span className="ml-2 animate-pulse text-slate-500">…</span>}
+            </h2>
+            {verdict && <Verdict value={verdict} />}
+          </div>
+
+          <ol className="mt-4 space-y-2.5">
+            {run.steps.map((step) => (
+              <li key={step.stepId} className="flex gap-3 text-sm">
+                <StepIcon status={step.status} />
+                <div className="flex-1">
+                  <span
+                    className={
+                      step.status === 'SKIPPED' || step.status === 'PENDING'
+                        ? 'text-slate-500'
+                        : 'text-slate-200'
+                    }
+                  >
+                    {step.summary}
+                  </span>
+                  {step.judgement?.message && (
+                    <p className="mt-1 text-xs text-slate-400">{step.judgement.message}</p>
+                  )}
+                </div>
+                {step.status === 'DISPATCHED' && (
+                  <span className="shrink-0 text-xs text-slate-500">{step.phase}</span>
+                )}
+              </li>
+            ))}
+          </ol>
+
+          {blockedReason && (
+            <p className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              {blockedReason}
+            </p>
+          )}
+
+          <dl className="mt-5 grid grid-cols-3 gap-4 border-t border-slate-800 pt-4 text-xs">
+            <div>
+              <dt className="text-slate-500">Plan</dt>
+              <dd className="mt-0.5 font-mono text-slate-300">
+                {shortHash(run.planHash ?? pendingPlanHash)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Approved by</dt>
+              <dd className="mt-0.5 truncate text-slate-300">{run.approvedBy ?? '—'}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Steps</dt>
+              <dd className="mt-0.5 text-slate-300">
+                {run.steps.filter((step) => step.status === 'PASSED').length} / {run.steps.length}{' '}
+                passed
+              </dd>
+            </div>
+          </dl>
+
+          {verdict && run.status !== 'CANCELLED' && (
+            <Link
+              href={`/one/proofs/${run.runId}`}
+              className="mt-5 inline-block rounded-lg border border-slate-700 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-white/5"
+            >
+              View proof receipt
+            </Link>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/one/runs/[runId]/page.tsx
+++ b/app/one/runs/[runId]/page.tsx
@@ -1,0 +1,12 @@
+import RunClient from './RunClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function RunDetailPage({
+  params,
+}: {
+  params: Promise<{ runId: string }>;
+}) {
+  const { runId } = await params;
+  return <RunClient runId={runId} />;
+}

--- a/docs/product/DSG_ONE_VERIFIED_EXECUTION.md
+++ b/docs/product/DSG_ONE_VERIFIED_EXECUTION.md
@@ -1,0 +1,253 @@
+# DSG ONE — Verified Execution
+
+**Status:** product/UX layer locked. Architecture, API, and Z3 schema serve this document, not the reverse.
+
+---
+
+## 1. The one product
+
+DSG ONE ships **one** product: **Verified Execution**.
+
+> Before an AI agent does the work, DSG proves that what it is about to do matches
+> the plan you approved. After the work is done, DSG holds evidence that it did
+> that and nothing else.
+
+The user never needs to understand Z3, SMT, Ising, QUBO, or proof hashes. Those
+are the engine. The user reads one verdict and one receipt.
+
+Product model in one sentence:
+
+> **DSG ONE lets AI do real work, where every action must match what the user
+> approved, and every outcome must be provable.**
+
+---
+
+## 2. The five layers
+
+Everything the product does is one of five layers. Anything that is not one of
+these five is not part of DSG ONE.
+
+```
+User states intent
+     ↓
+Agent proposes a plan
+     ↓
+User sees the plan and approves once
+     ↓
+┌──────────────────────────┐
+│ DSG VERIFIED EXECUTION   │
+│                          │
+│ 1. PLAN LOCK             │
+│ 2. VERIFY                │
+│ 3. EXECUTE               │
+│ 4. OBSERVE               │
+│ 5. PROVE                 │
+└──────────────────────────┘
+     ↓
+One verdict
+
+  ✓ VERIFIED
+  △ NEEDS REVIEW
+  ✕ BLOCKED
+     ↓
+Evidence + Replay + Proof
+```
+
+### Layer 1 — Plan Lock
+
+Turn an instruction into a plan that can be checked. The user sees what the
+agent will do, which systems it will touch, and what it explicitly will not do.
+The user presses **Approve & Run** once.
+
+After approval DSG must not ask again without a stated reason. The only
+legitimate reasons to re-prompt are:
+
+- the agent proposes an action outside the approved plan scope;
+- the plan expired;
+- a policy version changed under the running plan.
+
+Each of those is shown to the user as a named reason, never as a bare
+re-confirmation dialog.
+
+The approval freezes a `planHash`. Every later action carries that hash. A
+mismatch is not a warning — it stops that action.
+
+### Layer 2 — Verified Action Compiler
+
+This is the core IP:
+
+```
+Approved Plan → Action → Policy/Permission → Constraint → Z3 → PASS / BLOCK
+```
+
+Optimization and Ising may **select candidates**. They are never the authority
+on correctness. Z3 decides. This boundary is load-bearing: if optimization ever
+becomes the decider, the product's claim collapses.
+
+`UNSUPPORTED` is never `PASS`:
+
+| Gate result | Risk | Verdict |
+|---|---|---|
+| `PASS` | any | proceed |
+| `UNSUPPORTED` | low | `NEEDS REVIEW` |
+| `UNSUPPORTED` | medium / high / critical | `BLOCKED` |
+| `BLOCK` | any | `BLOCKED` |
+
+### Layer 3 — Controlled Execution
+
+Once an action passes, the agent runs it immediately. DSG does not put a gate in
+front of work the user has already approved. Approval fatigue is the failure
+mode this layer exists to avoid.
+
+DSG interrupts only when an agent steps outside the plan, and then it stops
+**that action only** — not the run.
+
+### Layer 4 — Live Verification
+
+The user should never have to open logs. They see plain progress:
+
+```
+Deploying → Testing → Checking production → Verified
+```
+
+When something fails, DSG says so directly and says what to fix:
+
+> **BLOCKED — deployment succeeded but health check failed**
+> `/api/health` returned 503. Fix the health check or roll back to the previous
+> release, then re-run.
+
+No hedging, no "some checks may have issues."
+
+### Layer 5 — Proof Receipt
+
+The differentiator. One job produces one receipt:
+
+```
+DSG EXECUTION RECEIPT
+
+Result             VERIFIED ✓
+Requested action   Deploy release
+Plan alignment     PASS
+Permission         PASS
+Constraints        PASS
+Tests              128 / 128 PASS
+Production check   PASS
+Evidence           14 artifacts
+Replay             MATCH
+Proof              7f28...91ac
+
+[ View Evidence ]   [ Replay ]   [ Export Proof ]
+```
+
+Replay is what makes the receipt worth anything: re-running the chain must
+reproduce the same hashes and the same verdict. Drift shows up as a per-field
+mismatch rather than passing silently.
+
+---
+
+## 3. Navigation
+
+Five destinations. Not twenty.
+
+| Nav | Purpose |
+|---|---|
+| **Run** | Command bar. The default screen. |
+| **Activity** | Runs in flight and recent runs. |
+| **Proofs** | Receipts, replay, export. |
+| **Policies** | What the org allows, and the active policy version. |
+| **Integrations** | Connected systems the plan may touch. |
+
+The home screen is a single input:
+
+> **What do you want your agent to do?**
+> `Deploy the latest verified version to production`
+
+From that one field DSG runs Plan → Verify → Execute → Prove in one workflow.
+
+---
+
+## 4. Integrations
+
+Use what the customer already has. Do not build a parallel ecosystem.
+
+| System | Role |
+|---|---|
+| GitHub | code, PRs, checks |
+| Vercel | deployments |
+| Supabase | data and evidence |
+
+---
+
+## 5. Explicitly out of scope
+
+These are rejected because they add surface area without adding to the core
+claim:
+
+- our own agent marketplace;
+- a new monitoring platform;
+- a generic chatbot;
+- a second approval system;
+- a dashboard of technical metrics.
+
+---
+
+## 6. Execution boundary
+
+DSG **orchestrates**; the caller's runtime **executes**.
+
+```
+DSG ONE control plane          Client executor
+─────────────────────          ───────────────
+plan lock                 →
+verify step               →
+                          →    dispatch
+                          ←    observation
+conformance check         ←
+receipt                   →
+```
+
+Supported executor surfaces are already modelled in
+`lib/dsg-one/verified-action-receipt.ts` as
+`VerifiedActionSurface = 'api' | 'unify' | 'trinity-mcp'`:
+
+- `api` — direct API callers and the GitHub Action;
+- `unify` — the Unify desktop assistant (`agent-service/src/dsgGate.ts`);
+- `trinity-mcp` — the Trinity MCP server.
+
+DSG does not hold the executor's credentials for these surfaces, and it does not
+run the customer's deploy itself. That is a deliberate blast-radius decision, not
+a limitation to be quietly removed later.
+
+---
+
+## 7. Claim boundary
+
+Per `CLAUDE.md` §1, this document does not license any of the following. Each
+needs separate, current evidence:
+
+- `production-ready`, `enterprise-ready`, `certified compliance`;
+- `third-party audited`, `WORM-certified storage`;
+- `external production Z3 solver invocation` — `/api/dsg/v1/gates/evaluate` is a
+  DSG-native deterministic gate adapter and does not call an external Z3 solver;
+- any user, revenue, or TVL number.
+
+What this document *does* support, when the code is deployed and verified:
+
+- `deterministic gate scaffold`;
+- `evidence-ready`, `audit-ready`;
+- `governance-enabling`.
+
+---
+
+## 8. What "done" means for this layer
+
+A run is complete when all five hold:
+
+1. the user approved exactly one plan, and its `planHash` is frozen;
+2. every executed step carries that `planHash`;
+3. every step verdict came from the gate, never from the optimizer;
+4. the run ended in exactly one of `VERIFIED` / `NEEDS_REVIEW` / `BLOCKED`;
+5. a receipt exists and replays to the same verdict.
+
+If any of the five is missing, the run is not `VERIFIED`. There is no partial
+credit.

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4577,6 +4577,137 @@ export type Database = {
         }
         Relationships: []
       }
+      dsg_one_run_steps: {
+        Row: {
+          action_type: string
+          created_at: string
+          dispatched_at: string | null
+          gate_verdict: string | null
+          judgement: Json | null
+          observation: Json | null
+          operation: string
+          ordinal: number
+          org_id: string
+          phase: string
+          risk_level: string
+          run_id: string
+          settled_at: string | null
+          status: string
+          step_id: string
+          summary: string
+          target_system: string
+          updated_at: string
+        }
+        Insert: {
+          action_type: string
+          created_at?: string
+          dispatched_at?: string | null
+          gate_verdict?: string | null
+          judgement?: Json | null
+          observation?: Json | null
+          operation: string
+          ordinal: number
+          org_id: string
+          phase: string
+          risk_level: string
+          run_id: string
+          settled_at?: string | null
+          status?: string
+          step_id?: string
+          summary: string
+          target_system: string
+          updated_at?: string
+        }
+        Update: {
+          action_type?: string
+          created_at?: string
+          dispatched_at?: string | null
+          gate_verdict?: string | null
+          judgement?: Json | null
+          observation?: Json | null
+          operation?: string
+          ordinal?: number
+          org_id?: string
+          phase?: string
+          risk_level?: string
+          run_id?: string
+          settled_at?: string | null
+          status?: string
+          step_id?: string
+          summary?: string
+          target_system?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "dsg_one_run_steps_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "dsg_one_runs"
+            referencedColumns: ["run_id"]
+          },
+        ]
+      }
+      dsg_one_runs: {
+        Row: {
+          actor_id: string
+          approved_at: string | null
+          approved_by: string | null
+          audit_available: boolean
+          connected_systems: Json
+          created_at: string
+          expires_at: string | null
+          intent: string
+          org_id: string
+          plan: Json
+          plan_hash: string | null
+          receipt_id: string | null
+          run_id: string
+          status: string
+          surface: string
+          template_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          actor_id: string
+          approved_at?: string | null
+          approved_by?: string | null
+          audit_available?: boolean
+          connected_systems?: Json
+          created_at?: string
+          expires_at?: string | null
+          intent: string
+          org_id: string
+          plan: Json
+          plan_hash?: string | null
+          receipt_id?: string | null
+          run_id?: string
+          status?: string
+          surface?: string
+          template_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          actor_id?: string
+          approved_at?: string | null
+          approved_by?: string | null
+          audit_available?: boolean
+          connected_systems?: Json
+          created_at?: string
+          expires_at?: string | null
+          intent?: string
+          org_id?: string
+          plan?: Json
+          plan_hash?: string | null
+          receipt_id?: string | null
+          run_id?: string
+          status?: string
+          surface?: string
+          template_id?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       dsg_organizations: {
         Row: {
           created_at: string
@@ -6758,6 +6889,24 @@ export type Database = {
           status?: string
           updated_at?: string
           webhook_url?: string | null
+        }
+        Relationships: []
+      }
+      integration_test: {
+        Row: {
+          created_at: string | null
+          id: number
+          test_name: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: number
+          test_name: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: number
+          test_name?: string
         }
         Relationships: []
       }

--- a/lib/dsg-one/run/orchestrator.ts
+++ b/lib/dsg-one/run/orchestrator.ts
@@ -1,0 +1,107 @@
+/**
+ * DSG ONE — run orchestration (product layers 3 and 4).
+ *
+ * Drives a locked run forward until it either needs the client executor to do
+ * something or has settled. DSG never executes: the furthest it goes is telling
+ * the caller "this step is verified, you may run it now".
+ *
+ * The loop is deliberately small:
+ *
+ *   while the run is live:
+ *     next PENDING step -> verify through the gate
+ *       not VERIFIED  -> the state machine settles the run, stop
+ *       VERIFIED      -> mark DISPATCHED, hand it to the caller, stop
+ *     no PENDING step and one DISPATCHED -> waiting on an observation, stop
+ *
+ * Layer 3 of the spec says DSG must not gate work the user already approved.
+ * That is why a VERIFIED step is dispatched immediately in the same call rather
+ * than surfacing a second confirmation.
+ */
+
+import { applyRunEvent } from './state-machine';
+import { verifyStep, type VerifyStepContext } from './verify-step';
+import { isTerminal, type Run, type RunStep } from './types';
+
+export interface AdvanceResult {
+  run: Run;
+  /**
+   * The step the caller should now execute, or null when the run is settled or
+   * already waiting on an observation.
+   */
+  dispatch: RunStep | null;
+  /** True when the run is waiting for an observation it has already requested. */
+  awaitingObservation: boolean;
+}
+
+/** Guard against a malformed plan spinning the loop. */
+const MAX_STEPS_PER_ADVANCE = 64;
+
+/**
+ * Advance a locked run as far as it can go without the client.
+ *
+ * Verification failures are not thrown: the gate saying no is a normal outcome
+ * that the state machine turns into a settled run, and the caller needs the
+ * updated run back so it can be persisted and shown.
+ */
+export async function advanceRun(
+  run: Run,
+  context: VerifyStepContext,
+  now: () => string = () => new Date().toISOString(),
+): Promise<AdvanceResult> {
+  let current = run;
+
+  for (let guard = 0; guard < MAX_STEPS_PER_ADVANCE; guard += 1) {
+    if (isTerminal(current.status)) {
+      return { run: current, dispatch: null, awaitingObservation: false };
+    }
+
+    const dispatched = current.steps.find((step) => step.status === 'DISPATCHED');
+    if (dispatched) {
+      return { run: current, dispatch: null, awaitingObservation: true };
+    }
+
+    const pending = current.steps.find((step) => step.status === 'PENDING');
+    if (!pending) {
+      return { run: current, dispatch: null, awaitingObservation: false };
+    }
+
+    const verification = await verifyStep(current, pending, context);
+
+    const verified = applyRunEvent(current, {
+      type: 'STEP_VERIFIED',
+      stepId: pending.stepId,
+      verdict: verification.verdict,
+      at: now(),
+    });
+    if (!verified.ok) {
+      // The plan expired, or the run went terminal underneath us. Either way
+      // the current run is the truth; report it rather than forcing a state.
+      return { run: current, dispatch: null, awaitingObservation: false };
+    }
+    current = verified.run;
+
+    const settledStep = current.steps.find((step) => step.stepId === pending.stepId)!;
+    if (settledStep.status !== 'VERIFIED') {
+      // Gate said REVIEW or BLOCK; the state machine has already rolled that up.
+      continue;
+    }
+
+    const dispatchEvent = applyRunEvent(current, {
+      type: 'STEP_DISPATCHED',
+      stepId: pending.stepId,
+      at: now(),
+    });
+    if (!dispatchEvent.ok) {
+      return { run: current, dispatch: null, awaitingObservation: false };
+    }
+    current = dispatchEvent.run;
+
+    return {
+      run: current,
+      dispatch: current.steps.find((step) => step.stepId === pending.stepId)!,
+      awaitingObservation: true,
+    };
+  }
+
+  throw new Error(`advanceRun exceeded ${MAX_STEPS_PER_ADVANCE} steps for run ${run.runId}`);
+}

--- a/lib/dsg-one/run/plan-lock.ts
+++ b/lib/dsg-one/run/plan-lock.ts
@@ -1,0 +1,256 @@
+/**
+ * DSG ONE — Plan Lock (product layer 1).
+ *
+ * Turns a plain-language intent into a plan the user can check and the gate can
+ * enforce. The user sees what the agent will do, which systems it will touch,
+ * and what it explicitly will not do, then approves once.
+ *
+ * Claim boundary: this is a deterministic compiler, not an LLM planner. It maps
+ * a recognised intent shape onto a template plan. That is a real limitation and
+ * is stated in the API response as `planner: 'deterministic'` rather than
+ * papered over — an unrecognised intent yields no plan instead of a guess.
+ */
+
+import { randomUUID } from 'crypto';
+import { DETERMINISTIC_POLICY_VERSION } from '../../dsg/deterministic/policy-manifest';
+import type { RunPlan, RunPlanStep, RunRiskLevel } from './types';
+
+/** Integrations a plan may name. Deliberately the customer's existing systems. */
+export const SUPPORTED_TARGET_SYSTEMS = ['github', 'vercel', 'supabase'] as const;
+
+export type SupportedTargetSystem = (typeof SUPPORTED_TARGET_SYSTEMS)[number];
+
+export function isSupportedTargetSystem(value: string): value is SupportedTargetSystem {
+  return (SUPPORTED_TARGET_SYSTEMS as readonly string[]).includes(value);
+}
+
+interface StepTemplate {
+  summary: string;
+  actionType: string;
+  targetSystem: SupportedTargetSystem;
+  operation: string;
+  riskLevel: RunRiskLevel;
+  phase: RunPlanStep['phase'];
+}
+
+interface PlanTemplate {
+  id: string;
+  /** Lower-cased keywords; all of `requires` must appear in the intent. */
+  requires: string[][];
+  maxRiskLevel: RunRiskLevel;
+  exclusions: string[];
+  steps: StepTemplate[];
+}
+
+/**
+ * Templates are ordered; the first whose keywords all match wins. Keep the
+ * narrowest template first so "deploy to production" does not fall into the
+ * broader "deploy" case.
+ */
+const PLAN_TEMPLATES: PlanTemplate[] = [
+  {
+    id: 'deploy-release',
+    requires: [['deploy', 'release', 'ship'], ['production', 'prod', 'live']],
+    maxRiskLevel: 'high',
+    exclusions: [
+      'Will not change environment variables or secrets',
+      'Will not run database migrations',
+      'Will not delete or roll back existing deployments',
+    ],
+    steps: [
+      {
+        summary: 'Confirm the release commit is green on CI',
+        actionType: 'READ',
+        targetSystem: 'github',
+        operation: 'checks.read',
+        riskLevel: 'low',
+        phase: 'Verifying',
+      },
+      {
+        summary: 'Promote the verified build to production',
+        actionType: 'DEPLOY',
+        targetSystem: 'vercel',
+        operation: 'deployment.promote',
+        riskLevel: 'high',
+        phase: 'Executing',
+      },
+      {
+        summary: 'Check production health after the deploy',
+        actionType: 'READ',
+        targetSystem: 'vercel',
+        operation: 'deployment.health',
+        riskLevel: 'low',
+        phase: 'Checking',
+      },
+    ],
+  },
+  {
+    id: 'deploy-preview',
+    requires: [['deploy', 'preview', 'ship']],
+    maxRiskLevel: 'medium',
+    exclusions: [
+      'Will not touch the production deployment',
+      'Will not change environment variables or secrets',
+    ],
+    steps: [
+      {
+        summary: 'Build a preview deployment from the current branch',
+        actionType: 'DEPLOY',
+        targetSystem: 'vercel',
+        operation: 'deployment.create',
+        riskLevel: 'medium',
+        phase: 'Executing',
+      },
+      {
+        summary: 'Check the preview responds',
+        actionType: 'READ',
+        targetSystem: 'vercel',
+        operation: 'deployment.health',
+        riskLevel: 'low',
+        phase: 'Checking',
+      },
+    ],
+  },
+  {
+    id: 'open-pull-request',
+    requires: [['pull request', 'pr', 'branch'], ['open', 'create', 'raise', 'push']],
+    maxRiskLevel: 'medium',
+    exclusions: [
+      'Will not merge the pull request',
+      'Will not push to the default branch',
+      'Will not modify repository settings',
+    ],
+    steps: [
+      {
+        summary: 'Push the working branch',
+        actionType: 'WRITE',
+        targetSystem: 'github',
+        operation: 'branch.push',
+        riskLevel: 'medium',
+        phase: 'Executing',
+      },
+      {
+        summary: 'Open a pull request for review',
+        actionType: 'WRITE',
+        targetSystem: 'github',
+        operation: 'pull_request.create',
+        riskLevel: 'low',
+        phase: 'Executing',
+      },
+    ],
+  },
+  {
+    id: 'apply-migration',
+    requires: [['migration', 'schema', 'database'], ['apply', 'run', 'migrate']],
+    maxRiskLevel: 'critical',
+    exclusions: [
+      'Will not drop tables or columns',
+      'Will not disable row level security',
+      'Will not modify data outside the migration',
+    ],
+    steps: [
+      {
+        summary: 'Check the migration is idempotent and non-destructive',
+        actionType: 'READ',
+        targetSystem: 'github',
+        operation: 'file.read',
+        riskLevel: 'low',
+        phase: 'Verifying',
+      },
+      {
+        summary: 'Apply the migration to the target database',
+        actionType: 'WRITE',
+        targetSystem: 'supabase',
+        operation: 'migration.apply',
+        riskLevel: 'critical',
+        phase: 'Executing',
+      },
+      {
+        summary: 'Confirm the expected schema objects exist',
+        actionType: 'READ',
+        targetSystem: 'supabase',
+        operation: 'schema.read',
+        riskLevel: 'low',
+        phase: 'Checking',
+      },
+    ],
+  },
+];
+
+function matches(intent: string, template: PlanTemplate): boolean {
+  const haystack = intent.toLowerCase();
+  return template.requires.every((group) => group.some((word) => haystack.includes(word)));
+}
+
+export interface CompilePlanResult {
+  ok: boolean;
+  templateId: string | null;
+  plan: RunPlan | null;
+  /** Why no plan was produced. Shown to the user verbatim. */
+  reason: string | null;
+}
+
+/**
+ * Compile an intent into a lockable plan.
+ *
+ * Returns `ok: false` when no template matches. That is the honest outcome: a
+ * plan the user cannot check is worse than no plan, because approving it would
+ * freeze a planHash over steps nobody agreed to.
+ */
+export function compilePlan(intent: string): CompilePlanResult {
+  const trimmed = intent.trim();
+
+  if (trimmed.length < 4) {
+    return {
+      ok: false,
+      templateId: null,
+      plan: null,
+      reason: 'Tell DSG what you want the agent to do, in a sentence.',
+    };
+  }
+
+  const template = PLAN_TEMPLATES.find((candidate) => matches(trimmed, candidate));
+  if (!template) {
+    return {
+      ok: false,
+      templateId: null,
+      plan: null,
+      reason:
+        'DSG cannot build a checkable plan for that yet. Supported today: deploy a release, ' +
+        'create a preview deployment, open a pull request, or apply a database migration.',
+    };
+  }
+
+  const steps: RunPlanStep[] = template.steps.map((step, index) => ({
+    stepId: randomUUID(),
+    ordinal: index + 1,
+    summary: step.summary,
+    actionType: step.actionType,
+    targetSystem: step.targetSystem,
+    operation: step.operation,
+    riskLevel: step.riskLevel,
+    phase: step.phase,
+  }));
+
+  const plan: RunPlan = {
+    intent: trimmed,
+    steps,
+    allowedTargetSystems: [...new Set(steps.map((step) => step.targetSystem))].sort(),
+    allowedOperations: [...new Set(steps.map((step) => step.operation))].sort(),
+    maxRiskLevel: template.maxRiskLevel,
+    exclusions: template.exclusions,
+    policyVersion: DETERMINISTIC_POLICY_VERSION,
+  };
+
+  return { ok: true, templateId: template.id, plan, reason: null };
+}
+
+/** Intent shapes the planner currently understands, for the empty Run screen. */
+export function listSupportedIntents(): Array<{ id: string; example: string }> {
+  return [
+    { id: 'deploy-release', example: 'Deploy the latest verified version to production' },
+    { id: 'deploy-preview', example: 'Deploy a preview of this branch' },
+    { id: 'open-pull-request', example: 'Push this branch and open a pull request' },
+    { id: 'apply-migration', example: 'Apply the pending database migration' },
+  ];
+}

--- a/lib/dsg-one/run/receipt.ts
+++ b/lib/dsg-one/run/receipt.ts
@@ -1,0 +1,267 @@
+/**
+ * DSG ONE — Proof Receipt (product layer 5).
+ *
+ * One settled run produces one receipt. The receipt is the product's whole
+ * claim in a single document: this is what you approved, this is what ran, and
+ * here is the hash chain that lets anyone re-derive the same verdict.
+ *
+ * Replay is what makes it worth anything. `replayRunReceipt` recomputes every
+ * hash from the run and reports a per-field comparison, so provider drift,
+ * orchestration changes, or an edited plan show up as a named mismatch instead
+ * of silently still saying VERIFIED.
+ *
+ * Deliberately independent of lib/dsg-one/verified-action-receipt.ts: that
+ * receipt binds a single externally-observed action, this one binds a
+ * multi-step run. They share the replay idea, not a schema.
+ */
+
+import { sha256Hash } from '../../dsg/brain/hash-utils';
+import { computePlanHash } from './state-machine';
+import type { Run, RunStep } from './types';
+
+export const DSG_ONE_RUN_RECEIPT_SCHEMA = 'dsg-one-run-receipt/1.0';
+
+export type ReceiptResult = 'VERIFIED' | 'NEEDS_REVIEW' | 'BLOCKED';
+
+/** Hashes that must reproduce on replay. */
+export interface RunReceiptChain {
+  /** Hash of the plan the user approved. */
+  planHash: string;
+  /** Hash of the ordered step outcomes. */
+  outcomeHash: string;
+  /** Hash of the evidence ids gathered across the run. */
+  evidenceHash: string;
+  /** Hash binding all of the above plus the run identity. */
+  receiptHash: string;
+}
+
+/** One line in the receipt's check list, as rendered to the user. */
+export interface ReceiptCheck {
+  label: string;
+  status: 'PASS' | 'REVIEW' | 'BLOCK' | 'SKIPPED';
+  detail: string | null;
+}
+
+export interface RunReceipt {
+  schema: typeof DSG_ONE_RUN_RECEIPT_SCHEMA;
+  receiptId: string;
+  runId: string;
+  orgId: string;
+  issuedAt: string;
+
+  result: ReceiptResult;
+  /** The user's original words. */
+  requestedAction: string;
+  checks: ReceiptCheck[];
+  evidenceCount: number;
+  chain: RunReceiptChain;
+
+  boundary: {
+    /**
+     * DSG orchestrated and judged; the client executor performed the work. The
+     * receipt therefore proves conformance of what was reported, not that DSG
+     * itself touched the customer's systems.
+     */
+    executedByDsg: false;
+    externalZ3SolverInvoked: false;
+    certificationClaim: false;
+    independentAuditClaim: false;
+    note: string;
+  };
+}
+
+function stepOutcome(step: RunStep) {
+  return {
+    ordinal: step.ordinal,
+    stepId: step.stepId,
+    operation: step.operation,
+    targetSystem: step.targetSystem,
+    status: step.status,
+    gateVerdict: step.gateVerdict,
+    judgement: step.judgement?.status ?? null,
+    reasons: step.judgement?.reasons ?? [],
+  };
+}
+
+function collectEvidenceIds(run: Run): string[] {
+  return run.steps
+    .flatMap((step) => step.observation?.evidenceIds ?? [])
+    .slice()
+    .sort();
+}
+
+/**
+ * Recompute a run's chain hashes from the run itself.
+ *
+ * Exported so replay and issuance share one derivation — a receipt that was
+ * built by different code than the one that checks it proves nothing.
+ */
+export function computeRunChain(run: Run): RunReceiptChain {
+  const planHash = computePlanHash(run.plan);
+  const outcomeHash = sha256Hash(run.steps.map(stepOutcome));
+  const evidenceHash = sha256Hash(collectEvidenceIds(run));
+
+  return {
+    planHash,
+    outcomeHash,
+    evidenceHash,
+    receiptHash: sha256Hash({
+      schema: DSG_ONE_RUN_RECEIPT_SCHEMA,
+      runId: run.runId,
+      orgId: run.orgId,
+      status: run.status,
+      planHash,
+      outcomeHash,
+      evidenceHash,
+    }),
+  };
+}
+
+function statusToResult(status: Run['status']): ReceiptResult {
+  if (status === 'VERIFIED') return 'VERIFIED';
+  if (status === 'NEEDS_REVIEW') return 'NEEDS_REVIEW';
+  return 'BLOCKED';
+}
+
+function stepCheckStatus(step: RunStep): ReceiptCheck['status'] {
+  switch (step.status) {
+    case 'PASSED':
+      return 'PASS';
+    case 'REVIEW':
+      return 'REVIEW';
+    case 'BLOCKED':
+      return 'BLOCK';
+    default:
+      return 'SKIPPED';
+  }
+}
+
+/**
+ * Issue a receipt for a settled run.
+ *
+ * Throws for a run that is still live: a receipt for an unfinished run would be
+ * a claim about work that has not happened.
+ */
+export function buildRunReceipt(run: Run, issuedAt: string): RunReceipt {
+  if (run.status !== 'VERIFIED' && run.status !== 'NEEDS_REVIEW' && run.status !== 'BLOCKED') {
+    throw new Error(`Cannot issue a receipt for a ${run.status} run`);
+  }
+
+  const chain = computeRunChain(run);
+  const evidenceIds = collectEvidenceIds(run);
+
+  const checks: ReceiptCheck[] = [
+    {
+      label: 'Plan alignment',
+      status: run.steps.every((step) => step.judgement?.reasons.includes('plan_hash_mismatch') !== true)
+        ? 'PASS'
+        : 'BLOCK',
+      detail: run.planHash,
+    },
+    {
+      label: 'Permission',
+      status: run.steps.some((step) =>
+        step.judgement?.reasons.some((reason) => reason.startsWith('target_system_not_in_plan')),
+      )
+        ? 'BLOCK'
+        : 'PASS',
+      detail: run.plan.allowedTargetSystems.join(', '),
+    },
+    {
+      label: 'Constraints',
+      status: run.steps.some((step) => step.gateVerdict === 'BLOCK')
+        ? 'BLOCK'
+        : run.steps.some((step) => step.gateVerdict === 'UNSUPPORTED' || step.gateVerdict === 'REVIEW')
+          ? 'REVIEW'
+          : 'PASS',
+      detail: `policy ${run.plan.policyVersion}`,
+    },
+    ...run.steps.map((step) => ({
+      label: step.summary,
+      status: stepCheckStatus(step),
+      detail: step.judgement?.message ?? null,
+    })),
+  ];
+
+  return {
+    schema: DSG_ONE_RUN_RECEIPT_SCHEMA,
+    receiptId: `rcpt_${chain.receiptHash.slice(0, 32)}`,
+    runId: run.runId,
+    orgId: run.orgId,
+    issuedAt,
+    result: statusToResult(run.status),
+    requestedAction: run.plan.intent,
+    checks,
+    evidenceCount: evidenceIds.length,
+    chain,
+    boundary: {
+      executedByDsg: false,
+      externalZ3SolverInvoked: false,
+      certificationClaim: false,
+      independentAuditClaim: false,
+      note:
+        'DSG orchestrated and judged this run against the approved plan. The client executor ' +
+        'performed the work and reported what it observed. The deterministic gate is DSG-native ' +
+        'and did not invoke an external Z3 solver.',
+    },
+  };
+}
+
+export interface ReceiptFieldComparison {
+  field: keyof RunReceiptChain;
+  receipt: string;
+  replay: string;
+  match: boolean;
+}
+
+export interface RunReplayResult {
+  replayMatch: boolean;
+  /** True when the receipt document has not been altered since issuance. */
+  receiptIntact: boolean;
+  verdictMatch: boolean;
+  fields: ReceiptFieldComparison[];
+  mismatchedFields: ReceiptFieldComparison[];
+  reason: string;
+}
+
+/**
+ * Re-derive a receipt from its run and compare.
+ *
+ * Two independent checks:
+ *   receiptIntact — the receiptId still follows from the chain it carries, so
+ *                   the document was not edited after issuance;
+ *   replayMatch   — recomputing from the run reproduces every hash, so neither
+ *                   the plan nor the outcomes were rewritten underneath it.
+ *
+ * An edited plan fails the second even when the first passes, which is exactly
+ * the case a tamper check needs to catch.
+ */
+export function replayRunReceipt(receipt: RunReceipt, run: Run): RunReplayResult {
+  const expectedId = `rcpt_${receipt.chain.receiptHash.slice(0, 32)}`;
+  const receiptIntact = receipt.receiptId === expectedId;
+
+  const replayChain = computeRunChain(run);
+  const fields = (Object.keys(replayChain) as Array<keyof RunReceiptChain>).map((field) => ({
+    field,
+    receipt: receipt.chain[field],
+    replay: replayChain[field],
+    match: receipt.chain[field] === replayChain[field],
+  }));
+
+  const mismatchedFields = fields.filter((field) => !field.match);
+  const verdictMatch = receipt.result === statusToResult(run.status);
+  const replayMatch = mismatchedFields.length === 0 && verdictMatch && receiptIntact;
+
+  let reason: string;
+  if (!receiptIntact) {
+    reason = 'Receipt document was altered after issuance.';
+  } else if (mismatchedFields.length > 0) {
+    reason = `Replay diverged on: ${mismatchedFields.map((field) => field.field).join(', ')}.`;
+  } else if (!verdictMatch) {
+    reason = `Receipt says ${receipt.result} but the run is now ${statusToResult(run.status)}.`;
+  } else {
+    reason = 'Replay reproduced every hash and the same verdict.';
+  }
+
+  return { replayMatch, receiptIntact, verdictMatch, fields, mismatchedFields, reason };
+}

--- a/lib/dsg-one/run/repository.ts
+++ b/lib/dsg-one/run/repository.ts
@@ -21,6 +21,15 @@ import {
   type StepObservation,
 } from './types';
 import type { VerifiedActionSurface } from '../verified-action-receipt';
+import type { Json } from '../../database.types';
+
+/**
+ * Our run types are precise interfaces; the generated column type for a jsonb
+ * column is `Json`, which requires an index signature. Cast only at the three
+ * jsonb assignment sites rather than casting whole insert/update payloads, so
+ * every other column stays type-checked against the generated schema.
+ */
+const asJson = (value: unknown) => value as Json;
 
 const RUNS_TABLE = 'dsg_one_runs';
 const STEPS_TABLE = 'dsg_one_run_steps';
@@ -126,18 +135,18 @@ export async function createRun(input: CreateRunInput): Promise<Run> {
   const db = getSupabaseAdmin();
 
   const { data: runRow, error: runError } = await db
-    .from(RUNS_TABLE as never)
+    .from(RUNS_TABLE)
     .insert({
       org_id: input.orgId,
       actor_id: input.actorId,
       surface: input.surface,
       status: 'DRAFT',
       intent: input.plan.intent,
-      plan: input.plan,
+      plan: asJson(input.plan),
       template_id: input.templateId,
       connected_systems: input.connectedSystems,
       audit_available: input.auditAvailable,
-    } as never)
+    })
     .select('*')
     .single();
 
@@ -162,14 +171,14 @@ export async function createRun(input: CreateRunInput): Promise<Run> {
   }));
 
   const { data: inserted, error: stepError } = await db
-    .from(STEPS_TABLE as never)
-    .insert(stepRows as never)
+    .from(STEPS_TABLE)
+    .insert(stepRows)
     .select('*');
 
   if (stepError) {
     // Leave no half-built run behind: a run with no steps would read as
     // "nothing to do" and could be approved into a vacuous VERIFIED.
-    await db.from(RUNS_TABLE as never).delete().eq('run_id', row.run_id);
+    await db.from(RUNS_TABLE).delete().eq('run_id', row.run_id);
     throw new Error(`dsg_one_run_steps insert failed: ${stepError.message}`);
   }
 
@@ -181,7 +190,7 @@ export async function getRun(runId: string, orgId: string): Promise<Run | null> 
   const db = getSupabaseAdmin();
 
   const { data: runRow, error: runError } = await db
-    .from(RUNS_TABLE as never)
+    .from(RUNS_TABLE)
     .select('*')
     .eq('run_id', runId)
     .eq('org_id', orgId)
@@ -190,7 +199,7 @@ export async function getRun(runId: string, orgId: string): Promise<Run | null> 
   if (runError || !runRow) return null;
 
   const { data: steps, error: stepError } = await db
-    .from(STEPS_TABLE as never)
+    .from(STEPS_TABLE)
     .select('*')
     .eq('run_id', runId)
     .eq('org_id', orgId)
@@ -209,7 +218,7 @@ export async function listRuns(orgId: string, limit = 25): Promise<Run[]> {
   const capped = Math.min(Math.max(limit, 1), 100);
 
   const { data: runRows, error: runError } = await db
-    .from(RUNS_TABLE as never)
+    .from(RUNS_TABLE)
     .select('*')
     .eq('org_id', orgId)
     .order('created_at', { ascending: false })
@@ -221,7 +230,7 @@ export async function listRuns(orgId: string, limit = 25): Promise<Run[]> {
   if (rows.length === 0) return [];
 
   const { data: stepRows, error: stepError } = await db
-    .from(STEPS_TABLE as never)
+    .from(STEPS_TABLE)
     .select('*')
     .eq('org_id', orgId)
     .in('run_id', rows.map((row) => row.run_id))
@@ -251,7 +260,7 @@ export async function saveRun(run: Run): Promise<void> {
   const db = getSupabaseAdmin();
 
   const { error: runError } = await db
-    .from(RUNS_TABLE as never)
+    .from(RUNS_TABLE)
     .update({
       status: run.status,
       plan_hash: run.planHash,
@@ -259,7 +268,7 @@ export async function saveRun(run: Run): Promise<void> {
       approved_at: run.approvedAt,
       expires_at: run.expiresAt,
       receipt_id: run.receiptId,
-    } as never)
+    })
     .eq('run_id', run.runId)
     .eq('org_id', run.orgId);
 
@@ -267,15 +276,15 @@ export async function saveRun(run: Run): Promise<void> {
 
   for (const step of run.steps) {
     const { error: stepError } = await db
-      .from(STEPS_TABLE as never)
+      .from(STEPS_TABLE)
       .update({
         status: step.status,
         gate_verdict: step.gateVerdict,
-        observation: step.observation,
-        judgement: step.judgement,
+        observation: asJson(step.observation),
+        judgement: asJson(step.judgement),
         dispatched_at: step.dispatchedAt,
         settled_at: step.settledAt,
-      } as never)
+      })
       .eq('step_id', step.stepId)
       .eq('org_id', run.orgId);
 

--- a/lib/dsg-one/run/repository.ts
+++ b/lib/dsg-one/run/repository.ts
@@ -1,0 +1,286 @@
+/**
+ * DSG ONE — Verified Execution run persistence.
+ *
+ * Maps between the pure run model in ./types and the dsg_one_runs /
+ * dsg_one_run_steps tables. All writes go through the service role; RLS grants
+ * browsers read-only access, so the orchestration routes are the only writer.
+ *
+ * Every read is org-scoped at the query level as well as by RLS. Belt and
+ * braces is deliberate here: the API-key path uses the service role, which
+ * bypasses RLS entirely, so the org filter in these queries is the only thing
+ * standing between two customers' runs.
+ */
+
+import { getSupabaseAdmin } from '../../supabase-server';
+import {
+  DSG_ONE_RUN_SCHEMA,
+  type Run,
+  type RunPlan,
+  type RunStep,
+  type StepJudgement,
+  type StepObservation,
+} from './types';
+import type { VerifiedActionSurface } from '../verified-action-receipt';
+
+const RUNS_TABLE = 'dsg_one_runs';
+const STEPS_TABLE = 'dsg_one_run_steps';
+
+type RunRow = {
+  run_id: string;
+  org_id: string;
+  actor_id: string;
+  surface: string;
+  status: string;
+  intent: string;
+  plan: RunPlan;
+  plan_hash: string | null;
+  template_id: string | null;
+  connected_systems: string[] | null;
+  audit_available: boolean | null;
+  approved_by: string | null;
+  approved_at: string | null;
+  expires_at: string | null;
+  receipt_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type StepRow = {
+  step_id: string;
+  run_id: string;
+  org_id: string;
+  ordinal: number;
+  summary: string;
+  action_type: string;
+  target_system: string;
+  operation: string;
+  risk_level: string;
+  phase: string;
+  status: string;
+  gate_verdict: string | null;
+  observation: StepObservation | null;
+  judgement: StepJudgement | null;
+  dispatched_at: string | null;
+  settled_at: string | null;
+};
+
+function toStep(row: StepRow): RunStep {
+  return {
+    stepId: row.step_id,
+    ordinal: row.ordinal,
+    summary: row.summary,
+    actionType: row.action_type,
+    targetSystem: row.target_system,
+    operation: row.operation,
+    riskLevel: row.risk_level as RunStep['riskLevel'],
+    phase: row.phase as RunStep['phase'],
+    status: row.status as RunStep['status'],
+    gateVerdict: row.gate_verdict as RunStep['gateVerdict'],
+    observation: row.observation,
+    judgement: row.judgement,
+    dispatchedAt: row.dispatched_at,
+    settledAt: row.settled_at,
+  };
+}
+
+function toRun(row: RunRow, steps: StepRow[]): Run {
+  return {
+    schema: DSG_ONE_RUN_SCHEMA,
+    runId: row.run_id,
+    orgId: row.org_id,
+    actorId: row.actor_id,
+    surface: row.surface as VerifiedActionSurface,
+    status: row.status as Run['status'],
+    plan: row.plan,
+    planHash: row.plan_hash,
+    approvedBy: row.approved_by,
+    approvedAt: row.approved_at,
+    expiresAt: row.expires_at,
+    steps: steps.sort((a, b) => a.ordinal - b.ordinal).map(toStep),
+    connectedSystems: row.connected_systems ?? [],
+    auditAvailable: row.audit_available ?? false,
+    receiptId: row.receipt_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export interface CreateRunInput {
+  orgId: string;
+  actorId: string;
+  surface: VerifiedActionSurface;
+  plan: RunPlan;
+  templateId: string | null;
+  connectedSystems: string[];
+  auditAvailable: boolean;
+}
+
+/**
+ * Persist a DRAFT run and its PENDING steps.
+ *
+ * The steps are inserted with the ids the planner already assigned so the
+ * planHash the user approves covers the same step identities the executor will
+ * later reference.
+ */
+export async function createRun(input: CreateRunInput): Promise<Run> {
+  const db = getSupabaseAdmin();
+
+  const { data: runRow, error: runError } = await db
+    .from(RUNS_TABLE as never)
+    .insert({
+      org_id: input.orgId,
+      actor_id: input.actorId,
+      surface: input.surface,
+      status: 'DRAFT',
+      intent: input.plan.intent,
+      plan: input.plan,
+      template_id: input.templateId,
+      connected_systems: input.connectedSystems,
+      audit_available: input.auditAvailable,
+    } as never)
+    .select('*')
+    .single();
+
+  if (runError || !runRow) {
+    throw new Error(`dsg_one_runs insert failed: ${runError?.message ?? 'no row returned'}`);
+  }
+
+  const row = runRow as unknown as RunRow;
+
+  const stepRows = input.plan.steps.map((step) => ({
+    step_id: step.stepId,
+    run_id: row.run_id,
+    org_id: input.orgId,
+    ordinal: step.ordinal,
+    summary: step.summary,
+    action_type: step.actionType,
+    target_system: step.targetSystem,
+    operation: step.operation,
+    risk_level: step.riskLevel,
+    phase: step.phase,
+    status: 'PENDING',
+  }));
+
+  const { data: inserted, error: stepError } = await db
+    .from(STEPS_TABLE as never)
+    .insert(stepRows as never)
+    .select('*');
+
+  if (stepError) {
+    // Leave no half-built run behind: a run with no steps would read as
+    // "nothing to do" and could be approved into a vacuous VERIFIED.
+    await db.from(RUNS_TABLE as never).delete().eq('run_id', row.run_id);
+    throw new Error(`dsg_one_run_steps insert failed: ${stepError.message}`);
+  }
+
+  return toRun(row, (inserted ?? []) as unknown as StepRow[]);
+}
+
+/** Load one run, scoped to the caller's org. Returns null when not visible. */
+export async function getRun(runId: string, orgId: string): Promise<Run | null> {
+  const db = getSupabaseAdmin();
+
+  const { data: runRow, error: runError } = await db
+    .from(RUNS_TABLE as never)
+    .select('*')
+    .eq('run_id', runId)
+    .eq('org_id', orgId)
+    .maybeSingle();
+
+  if (runError || !runRow) return null;
+
+  const { data: steps, error: stepError } = await db
+    .from(STEPS_TABLE as never)
+    .select('*')
+    .eq('run_id', runId)
+    .eq('org_id', orgId)
+    .order('ordinal', { ascending: true });
+
+  if (stepError) {
+    throw new Error(`dsg_one_run_steps read failed: ${stepError.message}`);
+  }
+
+  return toRun(runRow as unknown as RunRow, (steps ?? []) as unknown as StepRow[]);
+}
+
+/** Recent runs for the Activity screen, newest first. */
+export async function listRuns(orgId: string, limit = 25): Promise<Run[]> {
+  const db = getSupabaseAdmin();
+  const capped = Math.min(Math.max(limit, 1), 100);
+
+  const { data: runRows, error: runError } = await db
+    .from(RUNS_TABLE as never)
+    .select('*')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(capped);
+
+  if (runError) throw new Error(`dsg_one_runs list failed: ${runError.message}`);
+
+  const rows = (runRows ?? []) as unknown as RunRow[];
+  if (rows.length === 0) return [];
+
+  const { data: stepRows, error: stepError } = await db
+    .from(STEPS_TABLE as never)
+    .select('*')
+    .eq('org_id', orgId)
+    .in('run_id', rows.map((row) => row.run_id))
+    .order('ordinal', { ascending: true });
+
+  if (stepError) throw new Error(`dsg_one_run_steps list failed: ${stepError.message}`);
+
+  const byRun = new Map<string, StepRow[]>();
+  for (const step of (stepRows ?? []) as unknown as StepRow[]) {
+    const bucket = byRun.get(step.run_id);
+    if (bucket) bucket.push(step);
+    else byRun.set(step.run_id, [step]);
+  }
+
+  return rows.map((row) => toRun(row, byRun.get(row.run_id) ?? []));
+}
+
+/**
+ * Write a transitioned run back.
+ *
+ * The state machine has already decided the new state; this only persists it.
+ * The database triggers are the second line of defence — if application code
+ * ever tries to rewrite a locked plan, the write fails rather than succeeding
+ * quietly.
+ */
+export async function saveRun(run: Run): Promise<void> {
+  const db = getSupabaseAdmin();
+
+  const { error: runError } = await db
+    .from(RUNS_TABLE as never)
+    .update({
+      status: run.status,
+      plan_hash: run.planHash,
+      approved_by: run.approvedBy,
+      approved_at: run.approvedAt,
+      expires_at: run.expiresAt,
+      receipt_id: run.receiptId,
+    } as never)
+    .eq('run_id', run.runId)
+    .eq('org_id', run.orgId);
+
+  if (runError) throw new Error(`dsg_one_runs update failed: ${runError.message}`);
+
+  for (const step of run.steps) {
+    const { error: stepError } = await db
+      .from(STEPS_TABLE as never)
+      .update({
+        status: step.status,
+        gate_verdict: step.gateVerdict,
+        observation: step.observation,
+        judgement: step.judgement,
+        dispatched_at: step.dispatchedAt,
+        settled_at: step.settledAt,
+      } as never)
+      .eq('step_id', step.stepId)
+      .eq('org_id', run.orgId);
+
+    if (stepError) {
+      throw new Error(`dsg_one_run_steps update failed for ${step.stepId}: ${stepError.message}`);
+    }
+  }
+}

--- a/lib/dsg-one/run/state-machine.ts
+++ b/lib/dsg-one/run/state-machine.ts
@@ -1,0 +1,366 @@
+/**
+ * DSG ONE — Verified Execution run state machine.
+ *
+ * Pure and deterministic: same run + same event => same result, no clock, no
+ * network, no database. Every timestamp arrives on the event so a run can be
+ * replayed from its event log and land in the same state.
+ *
+ * The invariants this module exists to hold:
+ *
+ *   1. Nothing is dispatched before the user approves (planHash frozen).
+ *   2. Every observation must carry the frozen planHash.
+ *   3. UNSUPPORTED is never PASS.
+ *   4. A run ends in exactly one of VERIFIED / NEEDS_REVIEW / BLOCKED / CANCELLED.
+ *   5. Terminal runs never move again.
+ */
+
+import { sha256Hash } from '../../dsg/brain/hash-utils';
+import {
+  isTerminal,
+  riskExceeds,
+  type GateVerdict,
+  type Run,
+  type RunEvent,
+  type RunPlan,
+  type RunRiskLevel,
+  type RunStep,
+  type RunTransitionResult,
+  type StepJudgement,
+  type StepObservation,
+  type StepStatus,
+} from './types';
+
+/** Default plan lifetime. An approval is consent for now, not forever. */
+export const DEFAULT_PLAN_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Freeze a plan into its planHash.
+ *
+ * Covers everything the user actually consented to: the steps, the scope
+ * boundary, the exclusions, and the policy version in force. Changing any of
+ * them produces a different hash, which is what makes "the agent went outside
+ * the approved plan" mechanically detectable rather than a matter of opinion.
+ */
+export function computePlanHash(plan: RunPlan): string {
+  return sha256Hash({
+    intent: plan.intent,
+    steps: plan.steps.map((step) => ({
+      ordinal: step.ordinal,
+      actionType: step.actionType,
+      targetSystem: step.targetSystem,
+      operation: step.operation,
+      riskLevel: step.riskLevel,
+    })),
+    allowedTargetSystems: [...plan.allowedTargetSystems].sort(),
+    allowedOperations: [...plan.allowedOperations].sort(),
+    maxRiskLevel: plan.maxRiskLevel,
+    exclusions: [...plan.exclusions].sort(),
+    policyVersion: plan.policyVersion,
+  });
+}
+
+/**
+ * Map a gate verdict to a step outcome.
+ *
+ * This is the table from the product spec, and it is the reason the product can
+ * make its claim at all: an indeterminate answer is never allowed to read as
+ * success. Low risk degrades to human review; anything above that stops.
+ */
+export function verdictToStepStatus(
+  verdict: GateVerdict,
+  risk: RunRiskLevel,
+): Extract<StepStatus, 'VERIFIED' | 'REVIEW' | 'BLOCKED'> {
+  if (verdict === 'PASS') return 'VERIFIED';
+  if (verdict === 'BLOCK') return 'BLOCKED';
+  if (verdict === 'REVIEW') return 'REVIEW';
+  // UNSUPPORTED. Deliberately identical to proofToGateStatus in
+  // lib/dsg/deterministic/gate-engine.ts: undecidable is tolerable only when
+  // the blast radius is small.
+  return risk === 'low' ? 'REVIEW' : 'BLOCKED';
+}
+
+/**
+ * Judge one observation against the locked plan.
+ *
+ * Pure counterpart to lib/dsg/brain/conformance-gate.ts: that module checks a
+ * filesystem-level execution result, this one checks the plan-scope claims a
+ * remote executor reported. Both must agree before a step passes.
+ */
+export function judgeObservation(
+  run: Run,
+  step: RunStep,
+  observation: StepObservation,
+): StepJudgement {
+  const reasons: string[] = [];
+
+  if (!run.planHash) {
+    return {
+      status: 'BLOCKED',
+      reasons: ['plan_not_locked'],
+      message: 'This run has no approved plan, so nothing can be verified against it.',
+    };
+  }
+
+  if (observation.planHash !== run.planHash) {
+    return {
+      status: 'BLOCKED',
+      reasons: ['plan_hash_mismatch'],
+      message:
+        'The agent acted under a different plan than the one you approved. That action was stopped.',
+    };
+  }
+
+  if (!run.plan.allowedTargetSystems.includes(step.targetSystem)) {
+    reasons.push(`target_system_not_in_plan:${step.targetSystem}`);
+  }
+
+  if (
+    run.plan.allowedOperations.length > 0 &&
+    !run.plan.allowedOperations.includes(step.operation)
+  ) {
+    reasons.push(`operation_not_in_plan:${step.operation}`);
+  }
+
+  if (riskExceeds(step.riskLevel, run.plan.maxRiskLevel)) {
+    reasons.push(`risk_exceeds_plan:${step.riskLevel}_max_${run.plan.maxRiskLevel}`);
+  }
+
+  if (reasons.length > 0) {
+    return {
+      status: 'BLOCKED',
+      reasons,
+      message: `The agent tried to go outside the approved plan (${reasons[0]}). That action was stopped.`,
+    };
+  }
+
+  // Evidence is mandatory. A step that reports success without producing
+  // anything to check is indistinguishable from a step that did nothing.
+  if (observation.evidenceIds.length === 0) {
+    return {
+      status: 'REVIEW',
+      reasons: ['no_evidence'],
+      message: 'The step reported success but produced no evidence, so it needs a human look.',
+    };
+  }
+
+  if (observation.outcome === 'FAILED') {
+    return {
+      status: 'BLOCKED',
+      reasons: ['execution_failed'],
+      message:
+        observation.detail?.trim() ||
+        `${step.summary} did not complete. Fix the cause and re-run.`,
+    };
+  }
+
+  return { status: 'PASSED', reasons: [], message: null };
+}
+
+/**
+ * Roll individual step outcomes up to a run status.
+ *
+ * Worst outcome wins, and the run only reaches VERIFIED when every step landed
+ * on PASSED. There is no partial credit.
+ */
+export function deriveRunStatus(steps: RunStep[]): Run['status'] {
+  if (steps.some((step) => step.status === 'BLOCKED')) return 'BLOCKED';
+
+  const settled = steps.every(
+    (step) => step.status === 'PASSED' || step.status === 'REVIEW' || step.status === 'SKIPPED',
+  );
+  if (!settled) return 'RUNNING';
+
+  if (steps.some((step) => step.status === 'REVIEW' || step.status === 'SKIPPED')) {
+    return 'NEEDS_REVIEW';
+  }
+  return 'VERIFIED';
+}
+
+function fail(
+  code: Extract<RunTransitionResult, { ok: false }>['code'],
+  message: string,
+): RunTransitionResult {
+  return { ok: false, code, message };
+}
+
+/** First step still awaiting orchestration, or null when the run is settled. */
+function findNextStepId(steps: RunStep[]): string | null {
+  const next = steps.find(
+    (step) =>
+      step.status === 'PENDING' || step.status === 'VERIFIED' || step.status === 'DISPATCHED',
+  );
+  return next ? next.stepId : null;
+}
+
+/** Mark every not-yet-run step SKIPPED once the run has stopped early. */
+function skipRemaining(steps: RunStep[], at: string): RunStep[] {
+  return steps.map((step) =>
+    step.status === 'PENDING' || step.status === 'VERIFIED' || step.status === 'DISPATCHED'
+      ? { ...step, status: 'SKIPPED' as const, settledAt: at }
+      : step,
+  );
+}
+
+/**
+ * Apply one event to a run.
+ *
+ * Returns a new run; the input is never mutated. A rejected event leaves the
+ * caller's run untouched so a bad request cannot half-advance a run.
+ */
+export function applyRunEvent(run: Run, event: RunEvent): RunTransitionResult {
+  if (isTerminal(run.status) && event.type !== 'RECEIPT_ISSUED') {
+    return fail('run_terminal', `Run is ${run.status} and cannot change.`);
+  }
+
+  switch (event.type) {
+    case 'APPROVE': {
+      if (run.status !== 'DRAFT') {
+        return fail('invalid_transition', `Only a DRAFT run can be approved (was ${run.status}).`);
+      }
+      const ttl = event.ttlMs ?? DEFAULT_PLAN_TTL_MS;
+      const next: Run = {
+        ...run,
+        status: 'LOCKED',
+        planHash: computePlanHash(run.plan),
+        approvedBy: event.approvedBy,
+        approvedAt: event.at,
+        expiresAt: new Date(new Date(event.at).getTime() + ttl).toISOString(),
+        updatedAt: event.at,
+      };
+      return { ok: true, run: next, nextStepId: findNextStepId(next.steps) };
+    }
+
+    case 'REJECT': {
+      if (run.status !== 'DRAFT') {
+        return fail('invalid_transition', `Only a DRAFT run can be rejected (was ${run.status}).`);
+      }
+      return {
+        ok: true,
+        run: {
+          ...run,
+          status: 'CANCELLED',
+          steps: skipRemaining(run.steps, event.at),
+          updatedAt: event.at,
+        },
+        nextStepId: null,
+      };
+    }
+
+    case 'STEP_VERIFIED': {
+      if (run.status !== 'LOCKED' && run.status !== 'RUNNING') {
+        return fail('plan_not_locked', 'A plan must be approved before its steps are verified.');
+      }
+      if (run.expiresAt && new Date(event.at) > new Date(run.expiresAt)) {
+        return fail('plan_expired', 'The approved plan expired. Approve it again to continue.');
+      }
+
+      const index = run.steps.findIndex((step) => step.stepId === event.stepId);
+      if (index < 0) return fail('unknown_step', `No step ${event.stepId} in this run.`);
+      if (run.steps[index].status !== 'PENDING') {
+        return fail('step_already_settled', `Step ${event.stepId} is already ${run.steps[index].status}.`);
+      }
+
+      const step = run.steps[index];
+      const status = verdictToStepStatus(event.verdict, step.riskLevel);
+      const settled = status !== 'VERIFIED';
+
+      const judgement: StepJudgement | null = settled
+        ? {
+            status,
+            reasons: [`gate_${event.verdict.toLowerCase()}`],
+            message:
+              event.verdict === 'BLOCK'
+                ? `${step.summary} is not allowed by your policies.`
+                : event.verdict === 'UNSUPPORTED'
+                  ? `${step.summary} could not be decided automatically, so it needs a human look.`
+                  : `${step.summary} needs a human look before it can run.`,
+          }
+        : null;
+
+      let steps = [...run.steps];
+      steps[index] = {
+        ...step,
+        status,
+        gateVerdict: event.verdict,
+        judgement,
+        settledAt: settled ? event.at : null,
+      };
+      if (status === 'BLOCKED') steps = skipRemaining(steps, event.at);
+
+      const nextStatus = deriveRunStatus(steps);
+      return {
+        ok: true,
+        run: { ...run, status: nextStatus, steps, updatedAt: event.at },
+        nextStepId: isTerminal(nextStatus) ? null : findNextStepId(steps),
+      };
+    }
+
+    case 'STEP_DISPATCHED': {
+      const index = run.steps.findIndex((step) => step.stepId === event.stepId);
+      if (index < 0) return fail('unknown_step', `No step ${event.stepId} in this run.`);
+      if (run.steps[index].status !== 'VERIFIED') {
+        return fail(
+          'step_not_dispatchable',
+          `Step ${event.stepId} is ${run.steps[index].status}; only a VERIFIED step may be dispatched.`,
+        );
+      }
+
+      const steps = [...run.steps];
+      steps[index] = { ...steps[index], status: 'DISPATCHED', dispatchedAt: event.at };
+      return {
+        ok: true,
+        run: { ...run, status: 'RUNNING', steps, updatedAt: event.at },
+        nextStepId: event.stepId,
+      };
+    }
+
+    case 'STEP_OBSERVED': {
+      const index = run.steps.findIndex((step) => step.stepId === event.stepId);
+      if (index < 0) return fail('unknown_step', `No step ${event.stepId} in this run.`);
+      if (run.steps[index].status !== 'DISPATCHED') {
+        return fail(
+          'step_already_settled',
+          `Step ${event.stepId} is ${run.steps[index].status}; only a DISPATCHED step accepts an observation.`,
+        );
+      }
+
+      let steps = [...run.steps];
+      steps[index] = {
+        ...steps[index],
+        status: event.judgement.status,
+        judgement: event.judgement,
+        settledAt: event.at,
+      };
+      if (event.judgement.status === 'BLOCKED') steps = skipRemaining(steps, event.at);
+
+      const nextStatus = deriveRunStatus(steps);
+      return {
+        ok: true,
+        run: { ...run, status: nextStatus, steps, updatedAt: event.at },
+        nextStepId: isTerminal(nextStatus) ? null : findNextStepId(steps),
+      };
+    }
+
+    case 'RECEIPT_ISSUED': {
+      if (!isTerminal(run.status)) {
+        return fail('invalid_transition', 'A receipt is only issued for a settled run.');
+      }
+      return {
+        ok: true,
+        run: { ...run, receiptId: event.receiptId, updatedAt: event.at },
+        nextStepId: null,
+      };
+    }
+  }
+}
+
+/** Fold an event log into a run. Used by replay and by the repository. */
+export function replayRunEvents(initial: Run, events: RunEvent[]): RunTransitionResult {
+  let current = initial;
+  for (const event of events) {
+    const result = applyRunEvent(current, event);
+    if (!result.ok) return result;
+    current = result.run;
+  }
+  return { ok: true, run: current, nextStepId: findNextStepId(current.steps) };
+}

--- a/lib/dsg-one/run/types.ts
+++ b/lib/dsg-one/run/types.ts
@@ -1,0 +1,282 @@
+/**
+ * DSG ONE — Verified Execution run model.
+ *
+ * One run is one user intent carried through the five product layers:
+ * PLAN LOCK -> VERIFY -> EXECUTE -> OBSERVE -> PROVE.
+ *
+ * See docs/product/DSG_ONE_VERIFIED_EXECUTION.md for the locked product spec.
+ *
+ * Boundary: DSG orchestrates, the caller's runtime executes. Nothing in this
+ * module runs a customer command; it decides what may run and judges what was
+ * reported back.
+ */
+
+import type { VerifiedActionSurface } from '../verified-action-receipt';
+
+export const DSG_ONE_RUN_SCHEMA = 'dsg-one-run/1.0';
+
+/** Risk ordering is shared with lib/dsg/plan-scope-contract.ts. */
+export type RunRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export const RISK_ORDER: readonly RunRiskLevel[] = ['low', 'medium', 'high', 'critical'];
+
+/**
+ * Run lifecycle.
+ *
+ * DRAFT        plan proposed, awaiting the single Approve & Run
+ * LOCKED       approved; planHash frozen; no step dispatched yet
+ * RUNNING      at least one step verified/dispatched, none terminal-failing
+ * VERIFIED     every step passed and a receipt was issued
+ * NEEDS_REVIEW at least one step landed on REVIEW and none on BLOCK
+ * BLOCKED      at least one step was blocked
+ * CANCELLED    the user rejected the plan, or the run was abandoned
+ */
+export type RunStatus =
+  | 'DRAFT'
+  | 'LOCKED'
+  | 'RUNNING'
+  | 'VERIFIED'
+  | 'NEEDS_REVIEW'
+  | 'BLOCKED'
+  | 'CANCELLED';
+
+export const TERMINAL_RUN_STATUSES: readonly RunStatus[] = [
+  'VERIFIED',
+  'NEEDS_REVIEW',
+  'BLOCKED',
+  'CANCELLED',
+];
+
+/**
+ * Step lifecycle within a locked plan.
+ *
+ * PENDING     not yet reached
+ * VERIFIED    the compiler passed it; safe to dispatch
+ * DISPATCHED  handed to the client executor; awaiting observation
+ * PASSED      observation conformed to the plan
+ * REVIEW      indeterminate; a human must look (never treated as success)
+ * BLOCKED     gate said no, or the observation left the plan
+ * SKIPPED     an earlier step ended the run before this one ran
+ */
+export type StepStatus =
+  | 'PENDING'
+  | 'VERIFIED'
+  | 'DISPATCHED'
+  | 'PASSED'
+  | 'REVIEW'
+  | 'BLOCKED'
+  | 'SKIPPED';
+
+/**
+ * The user-facing phase label for Live Verification (layer 4). This is the only
+ * progress vocabulary the UI is allowed to show — no log tails, no internal
+ * stage names.
+ */
+export type StepPhase =
+  | 'Planning'
+  | 'Verifying'
+  | 'Executing'
+  | 'Checking'
+  | 'Verified'
+  | 'Needs review'
+  | 'Blocked';
+
+/**
+ * Gate verdicts as produced by the deterministic gate adapter. This is the raw
+ * proof status from lib/dsg/deterministic — carried through unchanged so the
+ * risk mapping happens in exactly one place (verdictToStepStatus).
+ */
+export type GateVerdict = 'PASS' | 'BLOCK' | 'REVIEW' | 'UNSUPPORTED';
+
+/** A single planned action inside a locked plan. */
+export interface RunPlanStep {
+  stepId: string;
+  /** 1-based position; also the execution order. */
+  ordinal: number;
+  /** Plain-language description shown in the Plan Lock card. */
+  summary: string;
+  /** Machine action type, checked against the plan scope contract. */
+  actionType: string;
+  /** Integration the step touches, e.g. "github", "vercel", "supabase". */
+  targetSystem: string;
+  /** Named operation within the target system, e.g. "deployment.create". */
+  operation: string;
+  riskLevel: RunRiskLevel;
+  /** User-facing phase to show while this step is in flight. */
+  phase: Exclude<StepPhase, 'Verified' | 'Needs review' | 'Blocked'>;
+}
+
+/**
+ * The immutable plan the user approves. Hashing this object produces the
+ * planHash that every later action must carry.
+ */
+export interface RunPlan {
+  /** Plain-language restatement of what the user asked for. */
+  intent: string;
+  steps: RunPlanStep[];
+  /** Systems the plan is allowed to touch. Anything else is out of plan. */
+  allowedTargetSystems: string[];
+  /** Operations the plan is allowed to perform. Empty means "any within scope". */
+  allowedOperations: string[];
+  /** Highest risk the plan may reach. A step above this is out of plan. */
+  maxRiskLevel: RunRiskLevel;
+  /**
+   * What the agent explicitly will NOT do. Shown to the user at approval time;
+   * this is the half of the plan that makes approval meaningful.
+   */
+  exclusions: string[];
+  /** Policy manifest version in force when the plan was compiled. */
+  policyVersion: string;
+}
+
+/** Per-step observation submitted by the client executor. */
+export interface StepObservation {
+  /** planHash the executor believed it was acting under. */
+  planHash: string;
+  /** Commands the executor actually ran. */
+  executedCommands: string[];
+  /** Paths the executor actually changed. */
+  changedPaths: string[];
+  /** Evidence artifact ids produced by this step. */
+  evidenceIds: string[];
+  /** Executor's own outcome report. Never trusted on its own. */
+  outcome: 'SUCCEEDED' | 'FAILED';
+  /** Free-text detail surfaced verbatim when a step is blocked. */
+  detail?: string;
+}
+
+/** Result of judging one observation against the locked plan. */
+export interface StepJudgement {
+  status: Extract<StepStatus, 'PASSED' | 'REVIEW' | 'BLOCKED'>;
+  /** Machine-readable reasons; the UI renders the first one. */
+  reasons: string[];
+  /** One plain sentence for the user. Required when not PASSED. */
+  message: string | null;
+}
+
+/** A step as persisted, i.e. plan + live state. */
+export interface RunStep extends RunPlanStep {
+  status: StepStatus;
+  gateVerdict: GateVerdict | null;
+  observation: StepObservation | null;
+  judgement: StepJudgement | null;
+  dispatchedAt: string | null;
+  settledAt: string | null;
+}
+
+/** A run as persisted. */
+export interface Run {
+  schema: typeof DSG_ONE_RUN_SCHEMA;
+  runId: string;
+  orgId: string;
+  /** Who created the run. */
+  actorId: string;
+  surface: VerifiedActionSurface;
+  status: RunStatus;
+  plan: RunPlan;
+  /**
+   * Frozen at approval. Null while DRAFT — a run with no planHash has nothing
+   * to enforce, which is why nothing may be dispatched before approval.
+   */
+  planHash: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  expiresAt: string | null;
+  steps: RunStep[];
+  /**
+   * Systems the client executor declared it can reach, captured at creation.
+   * Executor-declared and not verified by DSG — it feeds the gate's permission
+   * constraints so an unreachable target fails closed. The security boundary is
+   * planHash conformance on each observation, not this list.
+   */
+  connectedSystems: string[];
+  auditAvailable: boolean;
+  /** Receipt id once PROVE has run. */
+  receiptId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Events that advance a run. The state machine accepts nothing else. */
+export type RunEvent =
+  | { type: 'APPROVE'; approvedBy: string; at: string; ttlMs?: number }
+  | { type: 'REJECT'; at: string }
+  | { type: 'STEP_VERIFIED'; stepId: string; verdict: GateVerdict; at: string }
+  | { type: 'STEP_DISPATCHED'; stepId: string; at: string }
+  | { type: 'STEP_OBSERVED'; stepId: string; judgement: StepJudgement; at: string }
+  | { type: 'RECEIPT_ISSUED'; receiptId: string; at: string };
+
+/** Rejected transition. Runs are never mutated on a rejected event. */
+export interface RunTransitionError {
+  ok: false;
+  code:
+    | 'run_terminal'
+    | 'invalid_transition'
+    | 'unknown_step'
+    | 'step_not_dispatchable'
+    | 'step_already_settled'
+    | 'plan_not_locked'
+    | 'plan_expired';
+  message: string;
+}
+
+export interface RunTransitionOk {
+  ok: true;
+  run: Run;
+  /** Step the orchestrator should act on next, if any. */
+  nextStepId: string | null;
+}
+
+export type RunTransitionResult = RunTransitionOk | RunTransitionError;
+
+/**
+ * Explicit type guards.
+ *
+ * The repo compiles with `strict: false`, so `strictNullChecks` is off and
+ * TypeScript will not narrow this union from `if (!result.ok)` alone. These
+ * predicates give callers the narrowing without changing the project-wide
+ * compiler settings.
+ */
+export function isRunTransitionError(
+  result: RunTransitionResult,
+): result is RunTransitionError {
+  return result.ok === false;
+}
+
+export function isRunTransitionOk(result: RunTransitionResult): result is RunTransitionOk {
+  return result.ok === true;
+}
+
+export function riskExceeds(actual: RunRiskLevel, max: RunRiskLevel): boolean {
+  return RISK_ORDER.indexOf(actual) > RISK_ORDER.indexOf(max);
+}
+
+export function isTerminal(status: RunStatus): boolean {
+  return TERMINAL_RUN_STATUSES.includes(status);
+}
+
+/**
+ * Map a run to the single phase word shown in Live Verification.
+ * Terminal statuses win; otherwise the in-flight step decides.
+ */
+export function runPhase(run: Run): StepPhase {
+  switch (run.status) {
+    case 'VERIFIED':
+      return 'Verified';
+    case 'NEEDS_REVIEW':
+      return 'Needs review';
+    case 'BLOCKED':
+    case 'CANCELLED':
+      return 'Blocked';
+    case 'DRAFT':
+      return 'Planning';
+    default:
+      break;
+  }
+
+  const active = run.steps.find(
+    (step) => step.status === 'VERIFIED' || step.status === 'DISPATCHED',
+  );
+  if (!active) return 'Verifying';
+  return active.status === 'DISPATCHED' ? active.phase : 'Verifying';
+}

--- a/lib/dsg-one/run/verify-step.ts
+++ b/lib/dsg-one/run/verify-step.ts
@@ -1,0 +1,138 @@
+/**
+ * DSG ONE — Verified Action Compiler (product layer 2).
+ *
+ *   Approved Plan -> Action -> Policy/Permission -> Constraint -> Z3 -> PASS/BLOCK
+ *
+ * This module owns the "Action -> Constraint" half: it turns one locked plan
+ * step into the deterministic gate's constraint context and returns the raw
+ * proof status. The PASS/REVIEW/BLOCK mapping lives in the run state machine so
+ * that the risk table exists in exactly one place.
+ *
+ * Boundary, per docs/product/DSG_ONE_VERIFIED_EXECUTION.md §7 and CLAUDE.md §13:
+ * the gate here is the DSG-native deterministic adapter. It does not invoke an
+ * external production Z3 solver. Optimization and Ising never appear in this
+ * path at all — they may pick candidates elsewhere, but they are not permitted
+ * to decide correctness.
+ */
+
+import { createHash } from 'crypto';
+import { evaluateDeterministicGate } from '../../dsg/deterministic/gate-engine';
+import {
+  DETERMINISTIC_POLICY_REF,
+  DETERMINISTIC_POLICY_VERSION,
+} from '../../dsg/deterministic/policy-manifest';
+import type { DeterministicProof } from '../../dsg/deterministic/types';
+import { isSupportedTargetSystem } from './plan-lock';
+import type { GateVerdict, Run, RunStep } from './types';
+
+/** Integrations the org has actually connected, for the permission constraint. */
+export interface VerifyStepContext {
+  /** Target systems with live credentials, e.g. ['github', 'vercel']. */
+  connectedSystems: string[];
+  /** Whether the org has an audit sink configured. */
+  auditAvailable: boolean;
+}
+
+export interface VerifyStepResult {
+  verdict: GateVerdict;
+  proof: DeterministicProof;
+  /** Constraint ids that failed, for the step's judgement reasons. */
+  failedConstraints: string[];
+}
+
+/**
+ * Derive a stable idempotency key for one step under one locked plan.
+ *
+ * Keyed on planHash + stepId so re-verifying the same step of the same approved
+ * plan reuses the cached proof, while the same step under a re-approved plan is
+ * a genuinely new question.
+ */
+export function stepIdempotencyKey(planHash: string, stepId: string): string {
+  return createHash('sha256').update(`${planHash}:${stepId}`, 'utf8').digest('hex');
+}
+
+/**
+ * Build the constraint context for one step.
+ *
+ * Each key corresponds to an evidenceKey in DETERMINISTIC_POLICY_CONSTRAINTS.
+ * A key that is absent or not exactly `true` counts as unsatisfied — the gate
+ * fails closed, so an integration we cannot confirm blocks rather than passes.
+ */
+export function buildStepContext(
+  run: Run,
+  step: RunStep,
+  context: VerifyStepContext,
+): Record<string, unknown> {
+  const targetConnected = context.connectedSystems.includes(step.targetSystem);
+  const inPlanScope = run.plan.allowedTargetSystems.includes(step.targetSystem);
+  const operationAllowed =
+    run.plan.allowedOperations.length === 0 ||
+    run.plan.allowedOperations.includes(step.operation);
+  const writes = step.actionType !== 'READ';
+
+  return {
+    // The plan named a concrete operation on a concrete system.
+    requirement_clear: step.summary.trim().length > 0 && step.operation.trim().length > 0,
+    // We know how to talk to this system at all.
+    tool_available: isSupportedTargetSystem(step.targetSystem),
+    // The approved plan covers this step, and the org has connected the system.
+    permission_granted: inPlanScope && operationAllowed && targetConnected,
+    // Writes must run under brokered credentials; reads need no secret.
+    secret_bound: writes ? targetConnected : true,
+    // Earlier steps in the plan settled successfully.
+    dependency_resolved: run.steps
+      .filter((other) => other.ordinal < step.ordinal)
+      .every((other) => other.status === 'PASSED'),
+    // The step reports something we can check afterwards.
+    testable: step.phase === 'Checking' || writes,
+    // Deploy steps need their target connected; everything else is vacuously ready.
+    deploy_target_ready: step.actionType === 'DEPLOY' ? targetConnected : true,
+    audit_hook_available: context.auditAvailable,
+
+    // Non-constraint context, carried into the proof's inputHash so a step
+    // verified under one plan cannot have its proof reused under another.
+    planHash: run.planHash,
+    stepId: step.stepId,
+    targetSystem: step.targetSystem,
+    operation: step.operation,
+  };
+}
+
+/**
+ * Run one locked plan step through the deterministic gate.
+ *
+ * Returns the raw proof status. Callers feed it to the state machine as a
+ * STEP_VERIFIED event rather than interpreting it themselves.
+ */
+export async function verifyStep(
+  run: Run,
+  step: RunStep,
+  context: VerifyStepContext,
+): Promise<VerifyStepResult> {
+  if (!run.planHash) {
+    throw new Error('verifyStep requires an approved run: planHash is not frozen');
+  }
+
+  const idempotencyKey = stepIdempotencyKey(run.planHash, step.stepId);
+
+  const decision = await evaluateDeterministicGate(
+    {
+      planId: run.runId,
+      policyRef: DETERMINISTIC_POLICY_REF,
+      policyVersion: DETERMINISTIC_POLICY_VERSION,
+      riskLevel: step.riskLevel,
+      nonce: idempotencyKey,
+      idempotencyKey,
+      context: buildStepContext(run, step, context),
+    },
+    { orgId: run.orgId },
+  );
+
+  return {
+    verdict: decision.proofStatus,
+    proof: decision.proof,
+    failedConstraints: decision.proof.constraints
+      .filter((constraint) => !constraint.passed)
+      .map((constraint) => constraint.constraintId),
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/supabase/migrations/20260816120000_dsg_one_verified_execution_runs.sql
+++ b/supabase/migrations/20260816120000_dsg_one_verified_execution_runs.sql
@@ -99,8 +99,11 @@ CREATE TABLE IF NOT EXISTS public.dsg_one_run_steps (
 
   CONSTRAINT dsg_one_run_steps_status_check
     CHECK (status IN ('PENDING', 'VERIFIED', 'DISPATCHED', 'PASSED', 'REVIEW', 'BLOCKED', 'SKIPPED')),
+  -- Mirrors DeterministicProofStatus in lib/dsg/deterministic/types.ts. The
+  -- raw proof status is stored, not the gate's mapped outcome, so REVIEW must
+  -- be accepted here; the risk mapping happens in verdictToStepStatus.
   CONSTRAINT dsg_one_run_steps_verdict_check
-    CHECK (gate_verdict IS NULL OR gate_verdict IN ('PASS', 'BLOCK', 'UNSUPPORTED')),
+    CHECK (gate_verdict IS NULL OR gate_verdict IN ('PASS', 'BLOCK', 'REVIEW', 'UNSUPPORTED')),
   CONSTRAINT dsg_one_run_steps_risk_check
     CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
   CONSTRAINT dsg_one_run_steps_ordinal_unique UNIQUE (run_id, ordinal)
@@ -187,7 +190,12 @@ CREATE POLICY dsg_one_runs_select_same_org
   TO authenticated
   USING (
     org_id IN (
-      SELECT u.org_id FROM public.users u
+      -- public.users.org_id is uuid; these tables use text org ids to match
+      -- requireDsgAuth (lib/dsg/auth/require-dsg-auth.ts), which resolves an
+      -- org id as a string, and to match the other DSG tables
+      -- (dsg_gate_usage, incidents). The cast is required — without it the
+      -- policy raises "operator does not exist: text = uuid" at evaluation.
+      SELECT u.org_id::text FROM public.users u
       WHERE u.auth_user_id = auth.uid() AND u.is_active = true
     )
   );
@@ -199,7 +207,12 @@ CREATE POLICY dsg_one_run_steps_select_same_org
   TO authenticated
   USING (
     org_id IN (
-      SELECT u.org_id FROM public.users u
+      -- public.users.org_id is uuid; these tables use text org ids to match
+      -- requireDsgAuth (lib/dsg/auth/require-dsg-auth.ts), which resolves an
+      -- org id as a string, and to match the other DSG tables
+      -- (dsg_gate_usage, incidents). The cast is required — without it the
+      -- policy raises "operator does not exist: text = uuid" at evaluation.
+      SELECT u.org_id::text FROM public.users u
       WHERE u.auth_user_id = auth.uid() AND u.is_active = true
     )
   );

--- a/supabase/migrations/20260816120000_dsg_one_verified_execution_runs.sql
+++ b/supabase/migrations/20260816120000_dsg_one_verified_execution_runs.sql
@@ -1,0 +1,212 @@
+-- DSG ONE — Verified Execution runs.
+--
+-- One run carries one user intent through the five product layers:
+-- PLAN LOCK -> VERIFY -> EXECUTE -> OBSERVE -> PROVE.
+-- See docs/product/DSG_ONE_VERIFIED_EXECUTION.md.
+--
+-- Invariants enforced here rather than only in application code, because a run
+-- whose plan can be edited after approval proves nothing:
+--
+--   1. A run cannot leave DRAFT without a frozen plan_hash (approve_check).
+--   2. plan_hash, plan, approved_by and approved_at are immutable once set
+--      (freeze trigger). Re-planning creates a new run, it never rewrites one.
+--   3. Every step belongs to exactly one run and is ordered within it.
+--   4. Terminal runs never change status again (terminal trigger).
+--
+-- This migration is additive and idempotent so it can be applied from the
+-- Supabase dashboard SQL editor during recovery.
+
+BEGIN;
+
+-- ─── Runs ────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.dsg_one_runs (
+  run_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id       TEXT NOT NULL,
+  actor_id     TEXT NOT NULL,
+  surface      TEXT NOT NULL DEFAULT 'api',
+  status       TEXT NOT NULL DEFAULT 'DRAFT',
+
+  intent       TEXT NOT NULL,
+  plan         JSONB NOT NULL,
+  plan_hash    TEXT,
+  template_id  TEXT,
+
+  -- Systems the client executor declared it can reach when the run was created.
+  -- Executor-declared, not verified by DSG: it feeds the gate's permission and
+  -- deploy-target constraints so a step targeting an unreachable system fails
+  -- closed instead of being dispatched into a wall. It is not a security
+  -- boundary — plan_hash conformance on each observation is.
+  connected_systems JSONB NOT NULL DEFAULT '[]'::jsonb,
+  audit_available   BOOLEAN NOT NULL DEFAULT false,
+
+  approved_by  TEXT,
+  approved_at  TIMESTAMPTZ,
+  expires_at   TIMESTAMPTZ,
+
+  receipt_id   TEXT,
+
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT dsg_one_runs_status_check
+    CHECK (status IN ('DRAFT', 'LOCKED', 'RUNNING', 'VERIFIED', 'NEEDS_REVIEW', 'BLOCKED', 'CANCELLED')),
+  CONSTRAINT dsg_one_runs_surface_check
+    CHECK (surface IN ('api', 'unify', 'trinity-mcp')),
+
+  -- A run past DRAFT must carry a frozen plan and a named approver. CANCELLED
+  -- is exempt: a rejected plan is never locked, so it has nothing to freeze.
+  CONSTRAINT dsg_one_runs_approve_check CHECK (
+    status IN ('DRAFT', 'CANCELLED')
+    OR (plan_hash IS NOT NULL AND approved_by IS NOT NULL AND approved_at IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_one_runs_org_created
+  ON public.dsg_one_runs (org_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_one_runs_org_status
+  ON public.dsg_one_runs (org_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_one_runs_plan_hash
+  ON public.dsg_one_runs (plan_hash)
+  WHERE plan_hash IS NOT NULL;
+
+-- ─── Steps ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.dsg_one_run_steps (
+  step_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id         UUID NOT NULL REFERENCES public.dsg_one_runs(run_id) ON DELETE CASCADE,
+  org_id         TEXT NOT NULL,
+  ordinal        INTEGER NOT NULL,
+
+  summary        TEXT NOT NULL,
+  action_type    TEXT NOT NULL,
+  target_system  TEXT NOT NULL,
+  operation      TEXT NOT NULL,
+  risk_level     TEXT NOT NULL,
+  phase          TEXT NOT NULL,
+
+  status         TEXT NOT NULL DEFAULT 'PENDING',
+  gate_verdict   TEXT,
+  observation    JSONB,
+  judgement      JSONB,
+
+  dispatched_at  TIMESTAMPTZ,
+  settled_at     TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT dsg_one_run_steps_status_check
+    CHECK (status IN ('PENDING', 'VERIFIED', 'DISPATCHED', 'PASSED', 'REVIEW', 'BLOCKED', 'SKIPPED')),
+  CONSTRAINT dsg_one_run_steps_verdict_check
+    CHECK (gate_verdict IS NULL OR gate_verdict IN ('PASS', 'BLOCK', 'UNSUPPORTED')),
+  CONSTRAINT dsg_one_run_steps_risk_check
+    CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
+  CONSTRAINT dsg_one_run_steps_ordinal_unique UNIQUE (run_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_one_run_steps_run
+  ON public.dsg_one_run_steps (run_id, ordinal);
+
+CREATE INDEX IF NOT EXISTS idx_dsg_one_run_steps_org
+  ON public.dsg_one_run_steps (org_id, created_at DESC);
+
+-- ─── Immutability triggers ───────────────────────────────────────────────────
+
+-- Once a plan is approved its hash, body and approver are settled facts. A
+-- silent UPDATE here would let an operator widen the scope a user consented to
+-- while keeping the run's VERIFIED verdict, which is the exact failure this
+-- product exists to prevent.
+CREATE OR REPLACE FUNCTION public.dsg_one_freeze_approved_plan()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF OLD.plan_hash IS NOT NULL THEN
+    IF NEW.plan_hash IS DISTINCT FROM OLD.plan_hash THEN
+      RAISE EXCEPTION 'PLAN_HASH_IMMUTABLE: run % already locked plan %', OLD.run_id, OLD.plan_hash;
+    END IF;
+    IF NEW.plan::text IS DISTINCT FROM OLD.plan::text THEN
+      RAISE EXCEPTION 'PLAN_IMMUTABLE: run % plan cannot change after approval', OLD.run_id;
+    END IF;
+    IF NEW.approved_by IS DISTINCT FROM OLD.approved_by
+       OR NEW.approved_at IS DISTINCT FROM OLD.approved_at THEN
+      RAISE EXCEPTION 'APPROVAL_IMMUTABLE: run % approval cannot be reassigned', OLD.run_id;
+    END IF;
+  END IF;
+
+  IF OLD.status IN ('VERIFIED', 'NEEDS_REVIEW', 'BLOCKED', 'CANCELLED')
+     AND NEW.status IS DISTINCT FROM OLD.status THEN
+    RAISE EXCEPTION 'RUN_TERMINAL: run % is % and cannot change status', OLD.run_id, OLD.status;
+  END IF;
+
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_dsg_one_freeze_approved_plan ON public.dsg_one_runs;
+CREATE TRIGGER trg_dsg_one_freeze_approved_plan
+  BEFORE UPDATE ON public.dsg_one_runs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.dsg_one_freeze_approved_plan();
+
+CREATE OR REPLACE FUNCTION public.dsg_one_touch_step()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_dsg_one_touch_step ON public.dsg_one_run_steps;
+CREATE TRIGGER trg_dsg_one_touch_step
+  BEFORE UPDATE ON public.dsg_one_run_steps
+  FOR EACH ROW
+  EXECUTE FUNCTION public.dsg_one_touch_step();
+
+-- ─── Row level security ──────────────────────────────────────────────────────
+--
+-- Reads are org-scoped for authenticated users, matching
+-- 20260323054500_product_loop_rls.sql. Writes go through the service role only:
+-- the orchestration routes are the sole legitimate writer, because a run whose
+-- steps can be written by a browser session is not evidence of anything.
+
+ALTER TABLE public.dsg_one_runs      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.dsg_one_run_steps ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS dsg_one_runs_select_same_org ON public.dsg_one_runs;
+CREATE POLICY dsg_one_runs_select_same_org
+  ON public.dsg_one_runs
+  FOR SELECT
+  TO authenticated
+  USING (
+    org_id IN (
+      SELECT u.org_id FROM public.users u
+      WHERE u.auth_user_id = auth.uid() AND u.is_active = true
+    )
+  );
+
+DROP POLICY IF EXISTS dsg_one_run_steps_select_same_org ON public.dsg_one_run_steps;
+CREATE POLICY dsg_one_run_steps_select_same_org
+  ON public.dsg_one_run_steps
+  FOR SELECT
+  TO authenticated
+  USING (
+    org_id IN (
+      SELECT u.org_id FROM public.users u
+      WHERE u.auth_user_id = auth.uid() AND u.is_active = true
+    )
+  );
+
+GRANT ALL ON public.dsg_one_runs      TO service_role;
+GRANT ALL ON public.dsg_one_run_steps TO service_role;
+GRANT SELECT ON public.dsg_one_runs      TO authenticated;
+GRANT SELECT ON public.dsg_one_run_steps TO authenticated;
+
+COMMIT;

--- a/tests/unit/dsg-one/run-receipt.test.ts
+++ b/tests/unit/dsg-one/run-receipt.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DSG_ONE_RUN_RECEIPT_SCHEMA,
+  buildRunReceipt,
+  computeRunChain,
+  replayRunReceipt,
+} from '../../../lib/dsg-one/run/receipt';
+import { compilePlan } from '../../../lib/dsg-one/run/plan-lock';
+import { applyRunEvent, judgeObservation } from '../../../lib/dsg-one/run/state-machine';
+import { DSG_ONE_RUN_SCHEMA, type Run, type RunStep } from '../../../lib/dsg-one/run/types';
+
+const T0 = '2026-08-16T10:00:00.000Z';
+const ISSUED = '2026-08-16T10:05:00.000Z';
+
+function draftRun(): Run {
+  const plan = compilePlan('Deploy a preview of this branch').plan!;
+  const steps: RunStep[] = plan.steps.map((step) => ({
+    ...step,
+    status: 'PENDING',
+    gateVerdict: null,
+    observation: null,
+    judgement: null,
+    dispatchedAt: null,
+    settledAt: null,
+  }));
+
+  return {
+    schema: DSG_ONE_RUN_SCHEMA,
+    runId: 'run-1',
+    orgId: 'org-1',
+    actorId: 'user-1',
+    surface: 'api',
+    status: 'DRAFT',
+    plan,
+    planHash: null,
+    approvedBy: null,
+    approvedAt: null,
+    expiresAt: null,
+    steps,
+    connectedSystems: ['vercel'],
+    auditAvailable: true,
+    receiptId: null,
+    createdAt: T0,
+    updatedAt: T0,
+  };
+}
+
+/** Drive a run to VERIFIED with every step passing. */
+function verifiedRun(): Run {
+  let run = (applyRunEvent(draftRun(), { type: 'APPROVE', approvedBy: 'user-1', at: T0 }) as {
+    run: Run;
+  }).run;
+
+  for (const step of run.steps) {
+    run = (applyRunEvent(run, {
+      type: 'STEP_VERIFIED',
+      stepId: step.stepId,
+      verdict: 'PASS',
+      at: T0,
+    }) as { run: Run }).run;
+    run = (applyRunEvent(run, { type: 'STEP_DISPATCHED', stepId: step.stepId, at: T0 }) as {
+      run: Run;
+    }).run;
+
+    const observation = {
+      planHash: run.planHash!,
+      executedCommands: ['vercel deploy'],
+      changedPaths: [],
+      evidenceIds: [`ev-${step.ordinal}`],
+      outcome: 'SUCCEEDED' as const,
+    };
+    const judgement = judgeObservation(run, step, observation);
+    run = (applyRunEvent(run, {
+      type: 'STEP_OBSERVED',
+      stepId: step.stepId,
+      judgement,
+      at: T0,
+    }) as { run: Run }).run;
+    run = {
+      ...run,
+      steps: run.steps.map((s) => (s.stepId === step.stepId ? { ...s, observation } : s)),
+    };
+  }
+
+  return run;
+}
+
+describe('buildRunReceipt', () => {
+  it('refuses to issue a receipt for a live run', () => {
+    const draft = draftRun();
+    expect(() => buildRunReceipt(draft, ISSUED)).toThrow(/Cannot issue a receipt/);
+  });
+
+  it('issues a VERIFIED receipt carrying the plan hash and evidence count', () => {
+    const run = verifiedRun();
+    const receipt = buildRunReceipt(run, ISSUED);
+
+    expect(receipt.schema).toBe(DSG_ONE_RUN_RECEIPT_SCHEMA);
+    expect(receipt.result).toBe('VERIFIED');
+    expect(receipt.requestedAction).toBe(run.plan.intent);
+    expect(receipt.chain.planHash).toBe(run.planHash);
+    expect(receipt.evidenceCount).toBe(run.steps.length);
+    expect(receipt.receiptId).toMatch(/^rcpt_[0-9a-f]{32}$/);
+  });
+
+  it('keeps the claim boundary explicit', () => {
+    const receipt = buildRunReceipt(verifiedRun(), ISSUED);
+    expect(receipt.boundary.executedByDsg).toBe(false);
+    expect(receipt.boundary.externalZ3SolverInvoked).toBe(false);
+    expect(receipt.boundary.certificationClaim).toBe(false);
+    expect(receipt.boundary.independentAuditClaim).toBe(false);
+  });
+
+  it('is deterministic for the same run', () => {
+    const run = verifiedRun();
+    expect(buildRunReceipt(run, ISSUED).chain).toEqual(
+      buildRunReceipt(run, '2026-09-01T00:00:00.000Z').chain,
+    );
+  });
+
+  it('reports BLOCKED with the blocking reason in its checks', () => {
+    let run = (applyRunEvent(draftRun(), { type: 'APPROVE', approvedBy: 'user-1', at: T0 }) as {
+      run: Run;
+    }).run;
+    run = (applyRunEvent(run, {
+      type: 'STEP_VERIFIED',
+      stepId: run.steps[0].stepId,
+      verdict: 'BLOCK',
+      at: T0,
+    }) as { run: Run }).run;
+
+    const receipt = buildRunReceipt(run, ISSUED);
+    expect(receipt.result).toBe('BLOCKED');
+    expect(receipt.checks.find((check) => check.label === 'Constraints')!.status).toBe('BLOCK');
+    expect(receipt.checks.some((check) => check.status === 'SKIPPED')).toBe(true);
+  });
+});
+
+describe('replayRunReceipt', () => {
+  it('matches when nothing changed', () => {
+    const run = verifiedRun();
+    const replay = replayRunReceipt(buildRunReceipt(run, ISSUED), run);
+
+    expect(replay.replayMatch).toBe(true);
+    expect(replay.receiptIntact).toBe(true);
+    expect(replay.verdictMatch).toBe(true);
+    expect(replay.mismatchedFields).toHaveLength(0);
+  });
+
+  it('detects an edited receipt document', () => {
+    const run = verifiedRun();
+    const tampered = { ...buildRunReceipt(run, ISSUED), receiptId: 'rcpt_notarealhash' };
+    const replay = replayRunReceipt(tampered, run);
+
+    expect(replay.receiptIntact).toBe(false);
+    expect(replay.replayMatch).toBe(false);
+    expect(replay.reason).toContain('altered after issuance');
+  });
+
+  it('detects a plan widened after the receipt was issued', () => {
+    const run = verifiedRun();
+    const receipt = buildRunReceipt(run, ISSUED);
+
+    const widened: Run = {
+      ...run,
+      plan: { ...run.plan, maxRiskLevel: 'critical', exclusions: [] },
+    };
+    const replay = replayRunReceipt(receipt, widened);
+
+    expect(replay.replayMatch).toBe(false);
+    expect(replay.mismatchedFields.map((field) => field.field)).toContain('planHash');
+    expect(replay.reason).toContain('planHash');
+  });
+
+  it('detects rewritten step outcomes', () => {
+    const run = verifiedRun();
+    const receipt = buildRunReceipt(run, ISSUED);
+
+    const rewritten: Run = {
+      ...run,
+      steps: run.steps.map((step, index) =>
+        index === 0 ? { ...step, gateVerdict: 'UNSUPPORTED' as const } : step,
+      ),
+    };
+    const replay = replayRunReceipt(receipt, rewritten);
+
+    expect(replay.replayMatch).toBe(false);
+    expect(replay.mismatchedFields.map((field) => field.field)).toContain('outcomeHash');
+  });
+
+  it('detects evidence removed after issuance', () => {
+    const run = verifiedRun();
+    const receipt = buildRunReceipt(run, ISSUED);
+
+    const stripped: Run = {
+      ...run,
+      steps: run.steps.map((step) => ({ ...step, observation: null })),
+    };
+    const replay = replayRunReceipt(receipt, stripped);
+
+    expect(replay.replayMatch).toBe(false);
+    expect(replay.mismatchedFields.map((field) => field.field)).toContain('evidenceHash');
+  });
+});
+
+describe('computeRunChain', () => {
+  it('binds the run identity into the receipt hash', () => {
+    const run = verifiedRun();
+    const other = computeRunChain({ ...run, runId: 'run-2' });
+    expect(other.receiptHash).not.toBe(computeRunChain(run).receiptHash);
+    // The component hashes are run-independent; only the binding changes.
+    expect(other.planHash).toBe(computeRunChain(run).planHash);
+  });
+});

--- a/tests/unit/dsg-one/run-state-machine.test.ts
+++ b/tests/unit/dsg-one/run-state-machine.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PLAN_TTL_MS,
+  applyRunEvent,
+  computePlanHash,
+  deriveRunStatus,
+  judgeObservation,
+  replayRunEvents,
+  verdictToStepStatus,
+} from '../../../lib/dsg-one/run/state-machine';
+import { compilePlan } from '../../../lib/dsg-one/run/plan-lock';
+import {
+  DSG_ONE_RUN_SCHEMA,
+  runPhase,
+  type Run,
+  type RunPlan,
+  type RunStep,
+  type StepObservation,
+} from '../../../lib/dsg-one/run/types';
+
+const T0 = '2026-08-16T10:00:00.000Z';
+const T1 = '2026-08-16T10:01:00.000Z';
+const T2 = '2026-08-16T10:02:00.000Z';
+
+function plan(): RunPlan {
+  const compiled = compilePlan('Deploy the latest verified version to production');
+  if (!compiled.plan) throw new Error('fixture plan failed to compile');
+  return compiled.plan;
+}
+
+function draftRun(overrides: Partial<Run> = {}): Run {
+  const runPlan = overrides.plan ?? plan();
+  const steps: RunStep[] = runPlan.steps.map((step) => ({
+    ...step,
+    status: 'PENDING',
+    gateVerdict: null,
+    observation: null,
+    judgement: null,
+    dispatchedAt: null,
+    settledAt: null,
+  }));
+
+  return {
+    schema: DSG_ONE_RUN_SCHEMA,
+    runId: 'run-1',
+    orgId: 'org-1',
+    actorId: 'user-1',
+    surface: 'api',
+    status: 'DRAFT',
+    plan: runPlan,
+    planHash: null,
+    approvedBy: null,
+    approvedAt: null,
+    expiresAt: null,
+    steps,
+    receiptId: null,
+    createdAt: T0,
+    updatedAt: T0,
+    ...overrides,
+  };
+}
+
+function approve(run: Run) {
+  const result = applyRunEvent(run, { type: 'APPROVE', approvedBy: 'user-1', at: T0 });
+  if (!result.ok) throw new Error(`approve failed: ${result.message}`);
+  return result.run;
+}
+
+function observation(planHash: string, overrides: Partial<StepObservation> = {}): StepObservation {
+  return {
+    planHash,
+    executedCommands: ['vercel promote'],
+    changedPaths: [],
+    evidenceIds: ['ev-1'],
+    outcome: 'SUCCEEDED',
+    ...overrides,
+  };
+}
+
+describe('computePlanHash', () => {
+  it('is stable across key ordering of scope arrays', () => {
+    const base = plan();
+    const reordered: RunPlan = {
+      ...base,
+      allowedTargetSystems: [...base.allowedTargetSystems].reverse(),
+      allowedOperations: [...base.allowedOperations].reverse(),
+      exclusions: [...base.exclusions].reverse(),
+    };
+    expect(computePlanHash(reordered)).toBe(computePlanHash(base));
+  });
+
+  it('changes when the scope boundary changes', () => {
+    const base = plan();
+    const widened: RunPlan = { ...base, maxRiskLevel: 'critical' };
+    expect(computePlanHash(widened)).not.toBe(computePlanHash(base));
+  });
+
+  it('changes when an exclusion is dropped', () => {
+    const base = plan();
+    const weakened: RunPlan = { ...base, exclusions: base.exclusions.slice(1) };
+    expect(computePlanHash(weakened)).not.toBe(computePlanHash(base));
+  });
+});
+
+describe('verdictToStepStatus', () => {
+  it('never turns UNSUPPORTED into a pass', () => {
+    for (const risk of ['low', 'medium', 'high', 'critical'] as const) {
+      expect(verdictToStepStatus('UNSUPPORTED', risk)).not.toBe('VERIFIED');
+    }
+  });
+
+  it('maps low-risk UNSUPPORTED to REVIEW and higher risk to BLOCKED', () => {
+    expect(verdictToStepStatus('UNSUPPORTED', 'low')).toBe('REVIEW');
+    expect(verdictToStepStatus('UNSUPPORTED', 'medium')).toBe('BLOCKED');
+    expect(verdictToStepStatus('UNSUPPORTED', 'high')).toBe('BLOCKED');
+    expect(verdictToStepStatus('UNSUPPORTED', 'critical')).toBe('BLOCKED');
+  });
+
+  it('passes PASS and blocks BLOCK', () => {
+    expect(verdictToStepStatus('PASS', 'critical')).toBe('VERIFIED');
+    expect(verdictToStepStatus('BLOCK', 'low')).toBe('BLOCKED');
+  });
+});
+
+describe('APPROVE', () => {
+  it('freezes the planHash and sets an expiry', () => {
+    const run = approve(draftRun());
+    expect(run.status).toBe('LOCKED');
+    expect(run.planHash).toBe(computePlanHash(run.plan));
+    expect(run.approvedBy).toBe('user-1');
+    expect(new Date(run.expiresAt!).getTime() - new Date(T0).getTime()).toBe(DEFAULT_PLAN_TTL_MS);
+  });
+
+  it('refuses to approve twice', () => {
+    const locked = approve(draftRun());
+    const result = applyRunEvent(locked, { type: 'APPROVE', approvedBy: 'user-1', at: T1 });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.code).toBe('invalid_transition');
+  });
+
+  it('does not mutate the input run', () => {
+    const draft = draftRun();
+    approve(draft);
+    expect(draft.status).toBe('DRAFT');
+    expect(draft.planHash).toBeNull();
+  });
+});
+
+describe('dispatch guard', () => {
+  it('refuses to dispatch a step before the plan is approved', () => {
+    const draft = draftRun();
+    const result = applyRunEvent(draft, {
+      type: 'STEP_DISPATCHED',
+      stepId: draft.steps[0].stepId,
+      at: T1,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.code).toBe('step_not_dispatchable');
+  });
+
+  it('refuses to verify a step under an expired plan', () => {
+    const locked = approve(draftRun());
+    const late = new Date(new Date(T0).getTime() + DEFAULT_PLAN_TTL_MS + 1000).toISOString();
+    const result = applyRunEvent(locked, {
+      type: 'STEP_VERIFIED',
+      stepId: locked.steps[0].stepId,
+      verdict: 'PASS',
+      at: late,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.code).toBe('plan_expired');
+  });
+});
+
+describe('judgeObservation', () => {
+  it('blocks an observation carrying a different planHash', () => {
+    const run = approve(draftRun());
+    const judgement = judgeObservation(run, run.steps[0], observation('deadbeef'));
+    expect(judgement.status).toBe('BLOCKED');
+    expect(judgement.reasons).toContain('plan_hash_mismatch');
+  });
+
+  it('blocks a step that leaves the approved target systems', () => {
+    const run = approve(draftRun());
+    const rogue = { ...run.steps[0], targetSystem: 'stripe' };
+    const judgement = judgeObservation(run, rogue, observation(run.planHash!));
+    expect(judgement.status).toBe('BLOCKED');
+    expect(judgement.reasons[0]).toContain('target_system_not_in_plan');
+  });
+
+  it('blocks a step whose risk exceeds the approved ceiling', () => {
+    const base = plan();
+    const run = approve(draftRun({ plan: { ...base, maxRiskLevel: 'low' } }));
+    const risky = { ...run.steps[0], riskLevel: 'critical' as const };
+    const judgement = judgeObservation(run, risky, observation(run.planHash!));
+    expect(judgement.status).toBe('BLOCKED');
+    expect(judgement.reasons[0]).toContain('risk_exceeds_plan');
+  });
+
+  it('sends a success with no evidence to review rather than passing it', () => {
+    const run = approve(draftRun());
+    const judgement = judgeObservation(
+      run,
+      run.steps[0],
+      observation(run.planHash!, { evidenceIds: [] }),
+    );
+    expect(judgement.status).toBe('REVIEW');
+    expect(judgement.reasons).toContain('no_evidence');
+  });
+
+  it('surfaces the executor detail verbatim when a step fails', () => {
+    const run = approve(draftRun());
+    const judgement = judgeObservation(
+      run,
+      run.steps[0],
+      observation(run.planHash!, { outcome: 'FAILED', detail: '/api/health returned 503' }),
+    );
+    expect(judgement.status).toBe('BLOCKED');
+    expect(judgement.message).toBe('/api/health returned 503');
+  });
+
+  it('passes a conforming observation', () => {
+    const run = approve(draftRun());
+    const judgement = judgeObservation(run, run.steps[0], observation(run.planHash!));
+    expect(judgement.status).toBe('PASSED');
+    expect(judgement.message).toBeNull();
+  });
+});
+
+describe('run rollup', () => {
+  it('reaches VERIFIED only when every step passed', () => {
+    let run = approve(draftRun());
+
+    for (const step of run.steps) {
+      const verified = applyRunEvent(run, {
+        type: 'STEP_VERIFIED',
+        stepId: step.stepId,
+        verdict: 'PASS',
+        at: T1,
+      });
+      expect(verified.ok).toBe(true);
+      run = (verified as { run: Run }).run;
+
+      const dispatched = applyRunEvent(run, { type: 'STEP_DISPATCHED', stepId: step.stepId, at: T1 });
+      run = (dispatched as { run: Run }).run;
+
+      const judged = judgeObservation(run, step, observation(run.planHash!));
+      const observed = applyRunEvent(run, {
+        type: 'STEP_OBSERVED',
+        stepId: step.stepId,
+        judgement: judged,
+        at: T2,
+      });
+      run = (observed as { run: Run }).run;
+    }
+
+    expect(run.status).toBe('VERIFIED');
+    expect(runPhase(run)).toBe('Verified');
+  });
+
+  it('blocks the run and skips remaining steps when one step is blocked', () => {
+    let run = approve(draftRun());
+    const [first, ...rest] = run.steps;
+
+    const result = applyRunEvent(run, {
+      type: 'STEP_VERIFIED',
+      stepId: first.stepId,
+      verdict: 'BLOCK',
+      at: T1,
+    });
+    expect(result.ok).toBe(true);
+    run = (result as { run: Run }).run;
+
+    expect(run.status).toBe('BLOCKED');
+    for (const step of rest) {
+      expect(run.steps.find((s) => s.stepId === step.stepId)!.status).toBe('SKIPPED');
+    }
+    expect((result as { nextStepId: string | null }).nextStepId).toBeNull();
+  });
+
+  it('lands on NEEDS_REVIEW when a low-risk step is undecidable', () => {
+    const lowRisk = compilePlan('Deploy a preview of this branch').plan!;
+    let run = approve(draftRun({ plan: lowRisk }));
+
+    // Second step of the preview template is the low-risk health check.
+    const healthStep = run.steps.find((step) => step.riskLevel === 'low')!;
+    const other = run.steps.filter((step) => step.stepId !== healthStep.stepId);
+
+    for (const step of other) {
+      run = (applyRunEvent(run, {
+        type: 'STEP_VERIFIED',
+        stepId: step.stepId,
+        verdict: 'PASS',
+        at: T1,
+      }) as { run: Run }).run;
+      run = (applyRunEvent(run, { type: 'STEP_DISPATCHED', stepId: step.stepId, at: T1 }) as {
+        run: Run;
+      }).run;
+      run = (applyRunEvent(run, {
+        type: 'STEP_OBSERVED',
+        stepId: step.stepId,
+        judgement: judgeObservation(run, step, observation(run.planHash!)),
+        at: T2,
+      }) as { run: Run }).run;
+    }
+
+    const result = applyRunEvent(run, {
+      type: 'STEP_VERIFIED',
+      stepId: healthStep.stepId,
+      verdict: 'UNSUPPORTED',
+      at: T2,
+    });
+    expect(result.ok).toBe(true);
+    expect((result as { run: Run }).run.status).toBe('NEEDS_REVIEW');
+  });
+
+  it('refuses to move a terminal run', () => {
+    let run = approve(draftRun());
+    run = (applyRunEvent(run, {
+      type: 'STEP_VERIFIED',
+      stepId: run.steps[0].stepId,
+      verdict: 'BLOCK',
+      at: T1,
+    }) as { run: Run }).run;
+
+    const result = applyRunEvent(run, {
+      type: 'STEP_DISPATCHED',
+      stepId: run.steps[1].stepId,
+      at: T2,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.code).toBe('run_terminal');
+  });
+
+  it('still accepts a receipt for a settled run', () => {
+    let run = approve(draftRun());
+    run = (applyRunEvent(run, {
+      type: 'STEP_VERIFIED',
+      stepId: run.steps[0].stepId,
+      verdict: 'BLOCK',
+      at: T1,
+    }) as { run: Run }).run;
+
+    const result = applyRunEvent(run, { type: 'RECEIPT_ISSUED', receiptId: 'rcpt-1', at: T2 });
+    expect(result.ok).toBe(true);
+    expect((result as { run: Run }).run.receiptId).toBe('rcpt-1');
+  });
+});
+
+describe('deriveRunStatus', () => {
+  it('reports RUNNING while any step is unsettled', () => {
+    const run = approve(draftRun());
+    expect(deriveRunStatus(run.steps)).toBe('RUNNING');
+  });
+});
+
+describe('replayRunEvents', () => {
+  it('produces the same run as applying events one at a time', () => {
+    const draft = draftRun();
+    const stepId = draft.steps[0].stepId;
+    const events = [
+      { type: 'APPROVE' as const, approvedBy: 'user-1', at: T0 },
+      { type: 'STEP_VERIFIED' as const, stepId, verdict: 'PASS' as const, at: T1 },
+      { type: 'STEP_DISPATCHED' as const, stepId, at: T1 },
+    ];
+
+    const folded = replayRunEvents(draft, events);
+    expect(folded.ok).toBe(true);
+
+    let manual = draft;
+    for (const event of events) {
+      manual = (applyRunEvent(manual, event) as { run: Run }).run;
+    }
+    expect((folded as { run: Run }).run).toEqual(manual);
+  });
+
+  it('stops at the first rejected event', () => {
+    const draft = draftRun();
+    const result = replayRunEvents(draft, [
+      { type: 'APPROVE', approvedBy: 'user-1', at: T0 },
+      { type: 'APPROVE', approvedBy: 'user-1', at: T1 },
+    ]);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('compilePlan', () => {
+  it('refuses to plan an intent it cannot check', () => {
+    const result = compilePlan('make the app better somehow');
+    expect(result.ok).toBe(false);
+    expect(result.plan).toBeNull();
+    expect(result.reason).toContain('cannot build a checkable plan');
+  });
+
+  it('rejects an empty intent', () => {
+    expect(compilePlan('  ').ok).toBe(false);
+  });
+
+  it('scopes a production deploy to the systems its steps touch', () => {
+    const result = compilePlan('Deploy the latest verified version to production');
+    expect(result.ok).toBe(true);
+    expect(result.templateId).toBe('deploy-release');
+    expect(result.plan!.allowedTargetSystems).toEqual(['github', 'vercel']);
+    expect(result.plan!.exclusions.length).toBeGreaterThan(0);
+  });
+
+  it('gives every step a distinct id', () => {
+    const steps = compilePlan('Apply the pending database migration').plan!.steps;
+    expect(new Set(steps.map((step) => step.stepId)).size).toBe(steps.length);
+  });
+});


### PR DESCRIPTION
Goal:

Lock DSG ONE to a single product — **Verified Execution** — at the product/UX layer, then build the architecture that serves that UX rather than the other way round.

> Before an AI agent does the work, DSG proves that what it is about to do matches the plan you approved. After the work is done, DSG holds evidence that it did that and nothing else.

Five layers (Plan Lock → Verify → Execute → Observe → Prove), five nav destinations, one command bar, one receipt.

Files changed:

**Spec**
- `docs/product/DSG_ONE_VERIFIED_EXECUTION.md` — the locked product/UX layer: five layers, five destinations, receipt anatomy, execution boundary, claim boundary, and what is explicitly out of scope.

**Core (`lib/dsg-one/run/`)**
- `types.ts` — run/step model, phases, transition results. Includes explicit type guards because the repo compiles with `strict: false`, which disables discriminated-union narrowing.
- `state-machine.ts` — pure, deterministic transitions. No clock, no network: every timestamp arrives on the event, so a run replays from its event log to the same state.
- `plan-lock.ts` — deterministic intent → checkable plan. Returns no plan for an unrecognised intent rather than guessing.
- `verify-step.ts` — plan step → deterministic gate constraint context.
- `orchestrator.ts` — advance a locked run to the next dispatch or to settled.
- `receipt.ts` — run receipt plus per-field replay comparison.
- `repository.ts` — org-scoped persistence.

**API** — DSG orchestrates, the client executor performs the work
- `POST`/`GET` `/api/dsg/v1/runs`
- `POST` `/api/dsg/v1/runs/[runId]/approve`
- `GET` `/api/dsg/v1/runs/[runId]`
- `POST` `/api/dsg/v1/runs/[runId]/steps/[stepId]/observe`
- `GET` `/api/dsg/v1/runs/[runId]/receipt`

**Migration**
- `supabase/migrations/20260816120000_dsg_one_verified_execution_runs.sql` — `dsg_one_runs` and `dsg_one_run_steps`, with an approve check constraint, plan/approval immutability triggers, a terminal-status guard, and org-scoped read RLS. Writes are service-role only.

**UI (`app/one/`)**
- `layout.tsx` + `_components/OneNav.tsx` — Run | Activity | Proofs | Policies | Integrations
- `page.tsx` — the single command bar
- `runs/[runId]/` — Plan Lock card, then live progress, then the verdict
- `activity/`, `proofs/`, `proofs/[runId]/`, `policies/`, `integrations/`

**Tests**
- `tests/unit/dsg-one/run-state-machine.test.ts` (29)
- `tests/unit/dsg-one/run-receipt.test.ts` (11)

Verification:

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 228 files, 3114 passed
- [x] `npm run build` — succeeded; `/one`, `/one/activity`, `/one/proofs`, `/one/proofs/[runId]`, `/one/runs/[runId]`, `/one/policies`, `/one/integrations` and all five `/api/dsg/v1/runs` routes compiled
- [x] Migration applied to `dsg-control-plane-dev` (`zeyguilldygozufpgxms`) — the project `dsg-platform-deploy.yml` and `generate-types.yml` both target. Both tables exist with RLS enabled, one policy and one trigger each.
- [x] Invariants verified against the live database (see table below) inside a transaction that was rolled back; both tables are empty afterwards.
- [x] Supabase advisors — 114 project-wide findings, **none** referencing `dsg_one`. The new trigger functions set `search_path` and are `SECURITY INVOKER`, so they appear in neither the `function_search_path_mutable` nor the `security_definer_function_executable` lists.
- [x] `lib/database.types.ts` regenerated — a pure 149-line addition (`dsg_one_runs`, `dsg_one_run_steps`, plus the pre-existing `integration_test` table that had never been captured). All `as never` casts removed from `repository.ts`.
- [ ] Live endpoint checks against a deployed URL — **Not run.** The routes need an authenticated org-scoped caller, and preview deployments sit behind Vercel Deployment Protection (see the CI notes below).

Applying the migration surfaced two defects that no local test could have caught, because both only fail against a real Postgres schema. Both are fixed in `1a6a805`:

1. **RLS type mismatch.** `public.users.org_id` is `uuid`, but these tables use `text` org ids to match `requireDsgAuth` (which resolves an org id as a string) and the other DSG tables (`dsg_gate_usage`, `incidents`). The policy subquery compared `text` to `uuid` and would have raised `operator does not exist: text = uuid` on **every** authenticated read. Fixed with an explicit `u.org_id::text`.
2. **`gate_verdict` CHECK was missing `'REVIEW'`.** `verifyStep` stores the gate's raw `DeterministicProofStatus`, which includes `REVIEW`, so `saveRun` would have been rejected by the constraint whenever the gate returned it.

Enforced invariants, each with the test that holds it and its live-database result:

| Invariant | Test | Live DB |
|---|---|---|
| Nothing dispatches before approval | `refuses to dispatch a step before the plan is approved` | leaving DRAFT unfrozen REFUSED |
| `planHash` frozen at approval, immutable after | `freezes the planHash and sets an expiry`, `refuses to approve twice` | `plan_hash` immutable ENFORCED |
| Plan body immutable after approval | — | `plan` immutable ENFORCED |
| Approver cannot be reassigned | — | approver immutable ENFORCED |
| `UNSUPPORTED` is never `PASS` | `never turns UNSUPPORTED into a pass` (all four risk levels) | unknown verdict REFUSED |
| Observation must carry the frozen `planHash` | `blocks an observation carrying a different planHash` | — |
| Success with no evidence is not a pass | `sends a success with no evidence to review rather than passing it` | — |
| A run ends in exactly one verdict | `reaches VERIFIED only when every step passed`, `refuses to move a terminal run` | terminal run frozen ENFORCED |
| Replay catches a widened plan | `detects a plan widened after the receipt was issued` | — |

Known limits:

- **`plan-lock.ts` is a deterministic template compiler, not an LLM planner.** Four intent shapes are supported (deploy release, preview deploy, open PR, apply migration). Anything else returns `plan_not_compilable` with the supported list. This is stated in the spec, not hidden.
- **DSG does not execute.** `/observe` judges what a client executor reports. The receipt proves conformance of the report, not that DSG touched the customer's systems. `boundary.executedByDsg` is `false` on every receipt.
- **The gate is the DSG-native deterministic adapter.** No external Z3 solver is invoked; `boundary.externalZ3SolverInvoked` is `false`. Optimization/Ising are absent from this path entirely — they may select candidates elsewhere but never decide correctness.
- **`connectedSystems` is executor-declared and unverified.** It feeds the gate's permission and deploy-target constraints so an unreachable target fails closed. It is not a security boundary; `planHash` conformance on each observation is.
- **The migration is applied to the dev project only.** If any other environment uses a different Supabase project, it needs the migration before `/one` will work there.
- **Live Verification polls at 2s** rather than streaming. Fine at current step counts; would want SSE if runs get long.
- **`/one` is additive.** `/dashboard` and its 31 links are untouched.
- **No new production readiness claim.** Nothing here has been exercised end-to-end against a deployed URL.

Three CI checks are red and none is caused by this diff — full diagnoses in the thread:

- `dsg-gate` — probes a fixed live origin behind Vercel Deployment Protection; runs on `push: main` too.
- `verify-development-boundary` — blocks on `.github/workflows/bootstrap-new-vercel-production.yml`, which is on `origin/main` and untouched here.
- `Deploy Preview` — the Vercel **build succeeded**; the post-deploy `/api/health` probe got 8× HTTP 401 because `scripts/verify-health-url.mjs` sends no `x-vercel-protection-bypass` header.

This PR changes **zero** files under `.github/` or `scripts/`.

User-visible benefit:

A user types one sentence, sees exactly what the agent will do *and what it will not do*, presses **Approve & Run** once, watches plain progress (`Deploying → Testing → Checking production → Verified`) instead of logs, and ends with a receipt that replays to the same verdict or names the field that drifted. When something fails they get a sentence they can act on — "BLOCKED — deployment succeeded but health check failed" — rather than a status code.

Next step:

1. Exercise the five routes end-to-end against a deployed URL with an authenticated org-scoped caller.
2. Add integration tests for the routes against a seeded org.
3. Teach one executor surface (Unify `agent-service/src/dsgGate.ts` or the Trinity MCP server) to call `/observe`, and run one real end-to-end deploy.
4. Separately from this PR: add `x-vercel-protection-bypass` to `scripts/verify-health-url.mjs` so post-deploy health checks stop failing closed on protected previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3RLVDrpbidcF5nhrwczAU