### PR TITLE
fix(supabase): align DSG ONE migration filename with the applied version

### DIFF
--- a/supabase/migrations/20260816080453_dsg_one_verified_execution_runs.sql
+++ b/supabase/migrations/20260816080453_dsg_one_verified_execution_runs.sql
@@ -15,6 +15,13 @@
 --
 -- This migration is additive and idempotent so it can be applied from the
 -- Supabase dashboard SQL editor during recovery.
+--
+-- The 20260816080453 version prefix is not arbitrary and must not be renamed:
+-- it is the version recorded in supabase_migrations.schema_migrations when this
+-- migration was applied to the project. `supabase db push` fails closed with
+-- "Remote migration versions not found in local migrations directory" if a
+-- remote version has no matching local file, so the filename has to keep
+-- tracking the applied version rather than the other way round.
 
 BEGIN;
 


### PR DESCRIPTION
Goal:

Unblock the `Supabase Migrations` workflow, which is failing on `main` after #1130 and would fail on every subsequent deploy until reconciled.

```
Connecting to remote database...
Remote migration versions not found in local migrations directory.

Make sure your local git repo is up-to-date. If the error persists, try repairing the migration history table:
supabase migration repair --status reverted 20260816080453
```

Cause: I applied the DSG ONE runs migration to the project through the Supabase API. That records its own version stamp — `20260816080453` — while the file committed in #1130 was named `20260816120000`. `supabase db push` verifies that every remote version has a matching local file and fails closed when one does not.

This is a defect I introduced in #1130, not a pre-existing condition.

Files changed:

- `supabase/migrations/20260816120000_dsg_one_verified_execution_runs.sql` → `20260816080453_dsg_one_verified_execution_runs.sql` — renamed to the version actually recorded. The SQL body is unchanged; the header gains a note explaining that the prefix tracks the applied version and must not be renamed back.

Why rename rather than repair the history:

The CLI suggests `migration repair --status reverted 20260816080453` followed by `db pull`. That rewrites the history table to claim the migration was reverted, which is false — the tables exist and are in use. Renaming the file makes local match remote while keeping the record accurate, needs no DB write, and requires no CLI credentials. The migration name in `schema_migrations` (`dsg_one_verified_execution_runs`) already matches, and `20260816080453` still orders after `20260815180000`, so ordering is preserved.

Verification:

- [x] Queried `supabase_migrations.schema_migrations` on `zeyguilldygozufpgxms` — the remote head is `20260816080453 dsg_one_verified_execution_runs`, and it was the only remote version with no local file. All older versions already line up:

  | | version |
  |---|---|
  | remote head | `20260816080453` |
  | local head (before this PR) | `20260816120000` |
  | next older, both sides | `20260814191709`, `20260814190648`, `20260812204340`, … |

- [x] `grep` for `20260816120000` across the repo — no remaining references in docs, workflows, TypeScript, or SQL.
- [ ] `supabase db push` — **Not run locally.** No Supabase CLI or `SUPABASE_DB_PASSWORD` in this session; the `Supabase Migrations` workflow on this PR is the real check.

Known limits:

- This fixes the filename/version mismatch only. It does not touch the migration's SQL, which is already applied and verified against the live dev database (all ten invariants held — see #1130).
- The other red checks on `main` (`DSG Secure Deploy Gate`, `E2E Production Health Check`, `Production Readiness Check`) are unrelated to this change and were diagnosed in #1130: they probe live origins sitting behind Vercel Deployment Protection.
- `main` also has no production Vercel deployment for `886fb2b` yet; that is a separate deployment-pipeline question, not a migration one.

User-visible benefit:

Deploys stop failing at the database step. Until this lands, `supabase db push` fails closed on every run regardless of what the change contains.

Next step:

1. Confirm the `Supabase Migrations` check goes green on this PR.
2. Then return to why `main` has not produced a production Vercel deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3RLVDrpbidcF5nhrwczAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3RLVDrpbidcF5nhrwczAU)_