### PR TITLE
feat: Wave 2 raw-evidence promotion proof hardening

### DIFF
--- a/lib/agent-governance/agentic-org/promotion-packet.ts
+++ b/lib/agent-governance/agentic-org/promotion-packet.ts
@@ -34,7 +34,8 @@ export type CinemaBindingFailureCode =
   | 'CINEMA_PROOF_HAS_FAILURES'
   | 'CINEMA_CANDIDATE_COMMIT_MISMATCH'
   | 'CINEMA_RAW_EVIDENCE_NOT_VERIFIED'
-  | 'CINEMA_RAW_ARTIFACT_DIGESTS_INCOMPLETE';
+  | 'CINEMA_RAW_ARTIFACT_DIGESTS_INCOMPLETE'
+  | 'CINEMA_RAW_ARTIFACT_DIGEST_MISMATCH';
 
 export interface CinemaBindingFailure {
   code: CinemaBindingFailureCode;
@@ -139,13 +140,29 @@ export function bindCinemaRawEvidenceProof(
       message: 'Cinema did not verify the raw evidence bytes.',
     });
   }
-  const requiredDigests = ['metric', 'test_output', 'build_output'];
-  if (requiredDigests.some((kind) => !proof.artifactDigests[kind])) {
-    failures.push({
-      code: 'CINEMA_RAW_ARTIFACT_DIGESTS_INCOMPLETE',
-      message: 'Metric, test and build raw artifact digests are required.',
-    });
+
+  const requiredDigests = ['metric', 'test_output', 'build_output'] as const;
+  for (const kind of requiredDigests) {
+    const proofDigest = proof.artifactDigests[kind];
+    const envelopeEvidence = envelope.evidence.find((item) => item.kind === kind);
+    const envelopeDigest = envelopeEvidence?.sha256;
+
+    if (!proofDigest || !envelopeDigest) {
+      failures.push({
+        code: 'CINEMA_RAW_ARTIFACT_DIGESTS_INCOMPLETE',
+        message: `Raw ${kind} digest must exist in both the Cinema proof and canonical envelope evidence.`,
+      });
+      continue;
+    }
+
+    if (proofDigest !== envelopeDigest) {
+      failures.push({
+        code: 'CINEMA_RAW_ARTIFACT_DIGEST_MISMATCH',
+        message: `Cinema ${kind} digest does not match the canonical envelope evidence digest.`,
+      });
+    }
   }
+
   if (failures.length > 0) {
     return { ok: false, failures, verificationLevel: 'BLOCKED', rawEvidenceVerified: false };
   }

--- a/tests/unit/agentic-org-promotion-packet.test.ts
+++ b/tests/unit/agentic-org-promotion-packet.test.ts
@@ -125,6 +125,26 @@ describe('Cinema promotion packet binding', () => {
     }
   });
 
+  it('blocks raw proof when a Cinema digest differs from canonical envelope evidence', () => {
+    const result = evaluateRawPromotionPacket(
+      candidate(),
+      structuralProof(),
+      rawProof({
+        artifactDigests: {
+          metric: '9'.repeat(64),
+          test_output: '2'.repeat(64),
+          build_output: '3'.repeat(64),
+        },
+      }),
+    );
+    expect(result.rawEvidenceVerified).toBe(false);
+    expect(result.gate).toBeNull();
+    expect(result.rawBinding?.ok).toBe(false);
+    if (result.rawBinding && !result.rawBinding.ok) {
+      expect(result.rawBinding.failures.map((failure) => failure.code)).toContain('CINEMA_RAW_ARTIFACT_DIGEST_MISMATCH');
+    }
+  });
+
   it('blocks a response that claims raw verification while still carrying verifier failures', () => {
     const result = bindCinemaRawEvidenceProof(candidate(), rawProof({ failures: ['RAW_ARTIFACT_DIGEST_MISMATCH:metric'] }));
     expect(result.ok).toBe(false);


### PR DESCRIPTION
Rebased onto current `main` and narrowed to the proof-binding defect that is still missing there.

## What changed
- binds Cinema `artifactDigests` to the canonical envelope SHA-256 values for `metric`, `test_output`, and `build_output`;
- missing digest on either side fails closed;
- digest mismatch returns `CINEMA_RAW_ARTIFACT_DIGEST_MISMATCH` and stops before the promotion gate (`gate=null`);
- adds a negative tamper test proving a mismatched metric digest cannot reach promotion.

## Scope correction
The earlier branch-only workflow job that merely echoed a Wave 2 PASS message was intentionally removed during rebase. It did not constitute execution evidence and added no enforcement.

## Truth boundary
- contract/test hardening only;
- no live Cinema OIDC attestation claim;
- no merge/deploy authority;
- production deployment remains separately governed by the canonical deployment target and runtime gates.

## Merge gate
Do not merge until CI on the rebased head is green.