### PR TITLE
feat: candidate provenance verification + Azure rollback adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -290,3 +290,34 @@ NVIDIA_API_KEY=
 NVIDIA_LLM_VERIFIER_URL=
 # Override model id (default: nvidia/ising-calibration-1-35b-a3b)
 NVIDIA_LLM_VERIFIER_MODEL=
+
+# ============ Agentic self-evolution promotion (governed candidate pipeline) ============
+# HMAC secret POST /api/dsg/agentic-org/promotion/evaluate uses to verify the
+# x-dsg-signature header on incoming candidate-promotion requests. Same value
+# must be configured as the GitHub Actions secret of the same name on the
+# candidate source repo (e.g. dsg-agi-simulation)'s governed-self-evolution.yml.
+DSG_PROMOTION_EVALUATION_SECRET=
+# HMAC secret POST /api/dsg/agentic-org/post-deploy uses to verify inbound
+# monitoring post-deploy feedback (candidate/baseline commit + canary result).
+DSG_POST_DEPLOY_FEEDBACK_SECRET=
+# HMAC secret used both to sign the outbound rollback request (rollback-executor.ts)
+# and to verify it on the receiving rollback adapter route (e.g.
+# /api/dsg/agentic-org/rollback-adapters/azure) -- same value on both sides.
+DSG_PRODUCTION_ROLLBACK_SECRET=
+# GitHub token used to independently verify candidate provenance (approved
+# plan hash + commit lineage/diff scope) against the real repository state.
+# Read-only access to the repos in ALLOWED_REPOSITORIES is sufficient.
+DSG_GITHUB_AUTOMATION_TOKEN=
+
+# ============ Azure rollback adapter (POST /api/dsg/agentic-org/rollback-adapters/azure) ============
+# Service Principal with Website Contributor (or narrower slot-swap) RBAC on
+# the target App Service(s). Used only to execute a governed rollback
+# (deployment-slot swap), never for routine deploys.
+AZURE_TENANT_ID=
+AZURE_CLIENT_ID=
+AZURE_CLIENT_SECRET=
+AZURE_SUBSCRIPTION_ID=
+AZURE_RESOURCE_GROUP=
+# JSON map of governed target repository -> Azure App Service name, e.g.
+# {"tdealer01-crypto/dsg-agi-simulation":"dsg-agi-simulation-app"}
+DSG_AZURE_APP_SERVICE_MAP=

--- a/app/api/dsg/agentic-org/promotion/evaluate/route.ts
+++ b/app/api/dsg/agentic-org/promotion/evaluate/route.ts
@@ -7,6 +7,7 @@ import {
   type CinemaEnvelopeBindingProof,
   type CinemaRawEvidenceProof,
 } from '@/lib/agent-governance/agentic-org/promotion-packet';
+import { verifyCandidateProvenance } from '@/lib/agent-governance/agentic-org/candidate-lineage';
 
 export const dynamic = 'force-dynamic';
 
@@ -94,6 +95,29 @@ export async function POST(request: NextRequest) {
 
   const receipt = result.receipt;
   const envelope = result.rawBinding.envelope;
+
+  // Everything above checks internal consistency of what the caller sent.
+  // This is the independent check: it asks GitHub directly whether the
+  // approved plan, and the candidate commit's lineage/diff scope, actually
+  // match what the envelope claims. See candidate-lineage.ts for why this
+  // exists and what it does and does not verify.
+  const lineageFailures = await verifyCandidateProvenance(
+    envelope.targetRepository,
+    envelope.baselineCommit,
+    envelope.candidateCommit,
+    envelope.allowedPaths,
+    envelope.approvedPlanHash,
+  );
+  if (lineageFailures.length > 0) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'PROMOTION_PROVENANCE_NOT_VERIFIED',
+      gate: result.gate,
+      lineageFailures,
+      receipt: null,
+    }, { status: 409 });
+  }
+
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });

--- a/app/api/dsg/agentic-org/rollback-adapters/azure/route.ts
+++ b/app/api/dsg/agentic-org/rollback-adapters/azure/route.ts
@@ -1,0 +1,164 @@
+import crypto from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { handleApiError } from '@/lib/security/api-error';
+import {
+  executeAzureRollback,
+  AzureRollbackError,
+  type AzureRollbackConfig,
+} from '@/lib/agent-governance/agentic-org/azure-rollback-adapter';
+
+export const dynamic = 'force-dynamic';
+
+const SHA256 = /^[0-9a-f]{64}$/i;
+
+interface GovernedRollbackRequest {
+  schemaVersion: 'dsg-governed-rollback-v1';
+  promotionId: string;
+  deploymentId: string;
+  targetRepository: string;
+  candidateCommit: string;
+  adapter: string;
+  rollbackTarget: string;
+  controlEvidenceHash: string;
+}
+
+function isGovernedRollbackRequest(value: unknown): value is GovernedRollbackRequest {
+  if (!value || typeof value !== 'object') return false;
+  const body = value as Record<string, unknown>;
+  return (
+    body.schemaVersion === 'dsg-governed-rollback-v1' &&
+    typeof body.promotionId === 'string' && body.promotionId.trim().length > 0 &&
+    typeof body.deploymentId === 'string' && body.deploymentId.trim().length > 0 &&
+    typeof body.targetRepository === 'string' &&
+    typeof body.candidateCommit === 'string' &&
+    typeof body.adapter === 'string' &&
+    typeof body.rollbackTarget === 'string' && body.rollbackTarget.trim().length > 0 &&
+    typeof body.controlEvidenceHash === 'string' && SHA256.test(body.controlEvidenceHash)
+  );
+}
+
+function safeEqualHex(left: string, right: string): boolean {
+  if (!/^[0-9a-f]+$/i.test(left) || !/^[0-9a-f]+$/i.test(right)) return false;
+  const a = Buffer.from(left, 'hex');
+  const b = Buffer.from(right, 'hex');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function verifySignature(rawBody: string, header: string | null, secret: string): boolean {
+  if (!header) return false;
+  const supplied = header.replace(/^sha256=/i, '').trim();
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  return safeEqualHex(supplied, expected);
+}
+
+function loadAzureConfig(): AzureRollbackConfig | { missing: string[] } {
+  const tenantId = process.env.AZURE_TENANT_ID?.trim();
+  const clientId = process.env.AZURE_CLIENT_ID?.trim();
+  const clientSecret = process.env.AZURE_CLIENT_SECRET?.trim();
+  const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID?.trim();
+  const resourceGroup = process.env.AZURE_RESOURCE_GROUP?.trim();
+  const appServiceMapRaw = process.env.DSG_AZURE_APP_SERVICE_MAP?.trim();
+
+  const missing = [
+    ...(!tenantId ? ['AZURE_TENANT_ID'] : []),
+    ...(!clientId ? ['AZURE_CLIENT_ID'] : []),
+    ...(!clientSecret ? ['AZURE_CLIENT_SECRET'] : []),
+    ...(!subscriptionId ? ['AZURE_SUBSCRIPTION_ID'] : []),
+    ...(!resourceGroup ? ['AZURE_RESOURCE_GROUP'] : []),
+    ...(!appServiceMapRaw ? ['DSG_AZURE_APP_SERVICE_MAP'] : []),
+  ];
+  if (missing.length > 0) return { missing };
+
+  let appServiceByRepository: Record<string, string>;
+  try {
+    appServiceByRepository = JSON.parse(appServiceMapRaw!);
+  } catch {
+    return { missing: ['DSG_AZURE_APP_SERVICE_MAP (invalid JSON)'] };
+  }
+
+  return {
+    tenantId: tenantId!,
+    clientId: clientId!,
+    clientSecret: clientSecret!,
+    subscriptionId: subscriptionId!,
+    resourceGroup: resourceGroup!,
+    appServiceByRepository,
+  };
+}
+
+/**
+ * Receives the signed GovernedRollbackRequest that
+ * lib/agent-governance/agentic-org/rollback-executor.ts sends from the
+ * post-deploy control route, and performs a real Azure App Service
+ * deployment-slot swap. See azure-rollback-adapter.ts for why this is the
+ * chosen rollback mechanism and what remains unverified against live Azure.
+ */
+export async function POST(request: NextRequest) {
+  const rollbackSecret = process.env.DSG_PRODUCTION_ROLLBACK_SECRET;
+  if (!rollbackSecret) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'AZURE_ROLLBACK_ADAPTER_NOT_CONFIGURED',
+      missing: ['DSG_PRODUCTION_ROLLBACK_SECRET'],
+    }, { status: 503 });
+  }
+
+  const rawBody = await request.text();
+  if (!verifySignature(rawBody, request.headers.get('x-dsg-signature'), rollbackSecret)) {
+    return NextResponse.json({ status: 'BLOCK', reason: 'AZURE_ROLLBACK_SIGNATURE_INVALID' }, { status: 401 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ status: 'BLOCK', reason: 'AZURE_ROLLBACK_PAYLOAD_INVALID_JSON' }, { status: 400 });
+  }
+  if (!isGovernedRollbackRequest(parsed)) {
+    return NextResponse.json({ status: 'BLOCK', reason: 'AZURE_ROLLBACK_PAYLOAD_INVALID' }, { status: 400 });
+  }
+  if (parsed.adapter.toUpperCase() !== 'AZURE') {
+    return NextResponse.json({ status: 'BLOCK', reason: 'AZURE_ROLLBACK_ADAPTER_MISMATCH' }, { status: 400 });
+  }
+
+  const config = loadAzureConfig();
+  if ('missing' in config) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'AZURE_ROLLBACK_ADAPTER_NOT_CONFIGURED',
+      missing: config.missing,
+    }, { status: 503 });
+  }
+
+  try {
+    const result = await executeAzureRollback(fetch, config, {
+      targetRepository: parsed.targetRepository,
+      promotionId: parsed.promotionId,
+      deploymentId: parsed.deploymentId,
+      rollbackTarget: parsed.rollbackTarget,
+      healthProbePath: '/api/agent/status',
+    });
+
+    return NextResponse.json({
+      schemaVersion: 'dsg-governed-rollback-evidence-v1',
+      status: result.status,
+      promotionId: parsed.promotionId,
+      deploymentId: parsed.deploymentId,
+      rollbackTarget: parsed.rollbackTarget,
+      healthPassed: result.healthPassed,
+      evidenceHash: result.evidenceHash,
+    });
+  } catch (error) {
+    if (error instanceof AzureRollbackError) {
+      return NextResponse.json({
+        status: 'BLOCK',
+        reason: error.code,
+        message: error.message,
+      }, { status: 502 });
+    }
+    return handleApiError('api/dsg/agentic-org/rollback-adapters/azure', error, {
+      status: 502,
+      details: { promotionId: parsed.promotionId, deploymentId: parsed.deploymentId },
+    });
+  }
+}

--- a/lib/agent-governance/agentic-org/azure-rollback-adapter.ts
+++ b/lib/agent-governance/agentic-org/azure-rollback-adapter.ts
@@ -1,0 +1,182 @@
+// ============================================================================
+// Azure rollback adapter — App Service deployment-slot swap
+// ============================================================================
+//
+// This is the orchestration logic behind the Azure rollback adapter route
+// (app/api/dsg/agentic-org/rollback-adapters/azure/route.ts). The rollback
+// mechanism is an Azure App Service slot swap: production always serves the
+// "production" slot; a governed deploy publishes to "staging" first, so
+// rollback is "swap production back to what staging currently holds" --
+// which for a same-day rollback is the previous known-good build, since the
+// new candidate is what just got swapped in.
+//
+// Every network call goes through a dependency-injected fetcher so this can
+// be unit tested without live Azure credentials, matching the pattern in
+// candidate-lineage.ts and github-branch-bootstrap.ts. It has NOT been
+// exercised against a real Azure subscription from this sandbox -- there is
+// no Azure CLI/API access here. Treat the ARM call shapes as "written to the
+// documented API contract, unverified live" until someone with a real
+// subscription confirms a rollback end to end.
+
+import crypto from 'node:crypto';
+
+export interface AzureRollbackConfig {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+  subscriptionId: string;
+  resourceGroup: string;
+  /** Maps a governed target repository to the Azure App Service name that serves it. */
+  appServiceByRepository: Record<string, string>;
+}
+
+export interface AzureRollbackInput {
+  targetRepository: string;
+  promotionId: string;
+  deploymentId: string;
+  rollbackTarget: string; // slot name currently holding the pre-candidate build, e.g. "staging"
+  healthProbePath: string; // e.g. "/api/agent/status"
+}
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+const ARM_BASE = 'https://management.azure.com';
+const TOKEN_POLL_INTERVAL_MS = 2000;
+const TOKEN_POLL_MAX_ATTEMPTS = 30; // ~1 minute
+const HEALTH_CHECK_TIMEOUT_MS = 10_000;
+
+export class AzureRollbackError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+  }
+}
+
+export async function getAzureAccessToken(
+  fetcher: FetchLike,
+  config: Pick<AzureRollbackConfig, 'tenantId' | 'clientId' | 'clientSecret'>,
+): Promise<string> {
+  const response = await fetcher(`https://login.microsoftonline.com/${config.tenantId}/oauth2/v2.0/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      scope: 'https://management.azure.com/.default',
+    }).toString(),
+  });
+  if (!response.ok) {
+    throw new AzureRollbackError(`Azure token request failed with HTTP ${response.status}`, 'AZURE_TOKEN_REQUEST_FAILED');
+  }
+  const body = (await response.json()) as { access_token?: string };
+  if (typeof body.access_token !== 'string' || !body.access_token) {
+    throw new AzureRollbackError('Azure token response did not include access_token', 'AZURE_TOKEN_RESPONSE_INVALID');
+  }
+  return body.access_token;
+}
+
+async function pollUntilDone(fetcher: FetchLike, token: string, statusUrl: string): Promise<void> {
+  for (let attempt = 0; attempt < TOKEN_POLL_MAX_ATTEMPTS; attempt++) {
+    const response = await fetcher(statusUrl, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (response.status === 200) return;
+    if (response.status !== 202) {
+      throw new AzureRollbackError(`Azure slot-swap status check returned HTTP ${response.status}`, 'AZURE_SLOT_SWAP_STATUS_FAILED');
+    }
+    await new Promise((resolve) => setTimeout(resolve, TOKEN_POLL_INTERVAL_MS));
+  }
+  throw new AzureRollbackError('Azure slot-swap did not complete within the poll budget', 'AZURE_SLOT_SWAP_TIMEOUT');
+}
+
+export async function swapAppServiceSlots(
+  fetcher: FetchLike,
+  token: string,
+  config: Pick<AzureRollbackConfig, 'subscriptionId' | 'resourceGroup'>,
+  appServiceName: string,
+  sourceSlot: string,
+): Promise<void> {
+  const url = `${ARM_BASE}/subscriptions/${config.subscriptionId}/resourceGroups/${config.resourceGroup}` +
+    `/providers/Microsoft.Web/sites/${appServiceName}/slots/${sourceSlot}/slotsswap?api-version=2022-03-01`;
+
+  const response = await fetcher(url, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ targetSlot: 'production' }),
+  });
+
+  if (response.status === 200) return; // completed synchronously
+  if (response.status !== 202) {
+    throw new AzureRollbackError(`Azure slot-swap request returned HTTP ${response.status}`, 'AZURE_SLOT_SWAP_REQUEST_FAILED');
+  }
+
+  const statusUrl = response.headers.get('location') ?? response.headers.get('azure-asyncoperation');
+  if (!statusUrl) {
+    throw new AzureRollbackError('Azure slot-swap accepted but returned no polling URL', 'AZURE_SLOT_SWAP_STATUS_URL_MISSING');
+  }
+  await pollUntilDone(fetcher, token, statusUrl);
+}
+
+export async function checkHealth(fetcher: FetchLike, healthUrl: string): Promise<boolean> {
+  try {
+    const response = await fetcher(healthUrl, { signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS) });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface AzureRollbackResult {
+  status: 'ROLLED_BACK';
+  healthPassed: true;
+  evidenceHash: string;
+}
+
+/**
+ * Executes a real rollback: swap the App Service slot named by
+ * `rollbackTarget` into production, then require the health probe to pass.
+ * Throws AzureRollbackError on any failure -- the caller (the API route)
+ * must not report success unless this resolves.
+ */
+export async function executeAzureRollback(
+  fetcher: FetchLike,
+  config: AzureRollbackConfig,
+  input: AzureRollbackInput,
+): Promise<AzureRollbackResult> {
+  const appServiceName = config.appServiceByRepository[input.targetRepository];
+  if (!appServiceName) {
+    throw new AzureRollbackError(
+      `No Azure App Service is registered for ${input.targetRepository}`,
+      'AZURE_APP_SERVICE_NOT_REGISTERED',
+    );
+  }
+
+  const token = await getAzureAccessToken(fetcher, config);
+  await swapAppServiceSlots(fetcher, token, config, appServiceName, input.rollbackTarget);
+
+  // Default Azure App Service hostname. A custom domain would need its own
+  // mapping; not needed for any repository registered today.
+  const healthUrl = new URL(input.healthProbePath, `https://${appServiceName}.azurewebsites.net`).toString();
+  const healthPassed = await checkHealth(fetcher, healthUrl);
+  if (!healthPassed) {
+    throw new AzureRollbackError(
+      `Health probe ${healthUrl} did not return 2xx after the slot swap`,
+      'AZURE_ROLLBACK_HEALTH_CHECK_FAILED',
+    );
+  }
+
+  const evidenceMaterial = {
+    schemaVersion: 'dsg-azure-rollback-evidence-v1',
+    promotionId: input.promotionId,
+    deploymentId: input.deploymentId,
+    appServiceName,
+    rollbackTarget: input.rollbackTarget,
+    healthProbe: input.healthProbePath,
+  };
+  const evidenceHash = crypto.createHash('sha256').update(JSON.stringify(evidenceMaterial)).digest('hex');
+
+  return { status: 'ROLLED_BACK', healthPassed: true, evidenceHash };
+}

--- a/lib/agent-governance/agentic-org/candidate-lineage.ts
+++ b/lib/agent-governance/agentic-org/candidate-lineage.ts
@@ -1,0 +1,203 @@
+// ============================================================================
+// Candidate provenance — independent GitHub-backed lineage verification
+// ============================================================================
+//
+// Everything the promotion/evaluate route checked before this module existed
+// (approvedPlanHash, planAligned, constraintsPassed, baseline/candidate SHAs)
+// came straight from the envelope the caller sent. That proves internal
+// consistency of the payload, never that the payload describes something
+// that actually happened on GitHub. This module is the independent check:
+// it fetches the approved plan and the commit range directly from GitHub
+// with a server-side credential and recomputes the answer itself.
+//
+// Two things it verifies that nothing else in this codebase did before:
+//   1. the approved plan file at the candidate commit hashes to exactly what
+//      the envelope claims, is authored by DSG_CONTROL_PLANE, is approved,
+//      and targets this repository;
+//   2. the candidate commit is a strict descendant of the baseline commit
+//      (GitHub compare status "ahead"), and every changed file is inside the
+//      plan's allowedPaths.
+//
+// Absent/misconfigured credentials, network failures, and API errors all
+// fail closed (BLOCK), never open.
+
+import { createHash } from 'node:crypto';
+import { Octokit } from '@octokit/rest';
+import { ALLOWED_REPOSITORIES } from './github-branch-bootstrap';
+
+export type LineageFailureCode =
+  | 'REPOSITORY_NOT_ALLOWED'
+  | 'REPOSITORY_FORMAT_INVALID'
+  | 'GITHUB_CREDENTIAL_MISSING'
+  | 'APPROVED_PLAN_PATH_UNKNOWN'
+  | 'APPROVED_PLAN_FETCH_FAILED'
+  | 'APPROVED_PLAN_CONTENT_INVALID'
+  | 'APPROVED_PLAN_HASH_MISMATCH'
+  | 'APPROVED_PLAN_NOT_APPROVED'
+  | 'APPROVED_PLAN_AUTHORITY_INVALID'
+  | 'APPROVED_PLAN_TARGET_MISMATCH'
+  | 'CANDIDATE_COMPARE_FAILED'
+  | 'BASELINE_NOT_ANCESTOR'
+  | 'DIFF_EMPTY'
+  | 'DIFF_OUTSIDE_ALLOWED_PATHS';
+
+export interface LineageFailure {
+  code: LineageFailureCode;
+  message: string;
+}
+
+export interface GitHubLineageClient {
+  getContent(input: { owner: string; repo: string; path: string; ref: string }): Promise<{ data: unknown }>;
+  compareCommits(input: { owner: string; repo: string; basehead: string }): Promise<{
+    data: { status: string; ahead_by: number; behind_by: number; files?: Array<{ filename: string }> };
+  }>;
+}
+
+/**
+ * Where the approved plan document lives per repository. A repository absent
+ * from this map fails closed (APPROVED_PLAN_PATH_UNKNOWN) rather than
+ * guessing a conventional path.
+ */
+const APPROVED_PLAN_PATH_BY_REPOSITORY: Record<string, string> = {
+  'tdealer01-crypto/dsg-agi-simulation': 'contracts/agentic-improvement/self-evolution-plan.json',
+};
+
+function splitRepository(repository: string): { owner: string; repo: string } | null {
+  const [owner, repo, extra] = repository.split('/');
+  return owner && repo && !extra ? { owner, repo } : null;
+}
+
+export async function verifyApprovedPlan(
+  client: GitHubLineageClient,
+  repository: string,
+  ref: string,
+  expectedPlanHash: string,
+): Promise<LineageFailure[]> {
+  const repo = splitRepository(repository);
+  if (!repo) return [{ code: 'REPOSITORY_FORMAT_INVALID', message: 'targetRepository must be "owner/repo".' }];
+
+  const path = APPROVED_PLAN_PATH_BY_REPOSITORY[repository];
+  if (!path) {
+    return [{ code: 'APPROVED_PLAN_PATH_UNKNOWN', message: `No approved-plan path is registered for ${repository}.` }];
+  }
+
+  let response: { data: unknown };
+  try {
+    response = await client.getContent({ ...repo, path, ref });
+  } catch (error) {
+    return [{
+      code: 'APPROVED_PLAN_FETCH_FAILED',
+      message: `Could not fetch ${path}@${ref}: ${error instanceof Error ? error.message : String(error)}`,
+    }];
+  }
+
+  const data = response.data as { content?: string; encoding?: string };
+  if (typeof data.content !== 'string' || data.encoding !== 'base64') {
+    return [{ code: 'APPROVED_PLAN_CONTENT_INVALID', message: 'Approved plan response did not carry base64 file content.' }];
+  }
+
+  const raw = Buffer.from(data.content, 'base64');
+  const actualHash = createHash('sha256').update(raw).digest('hex');
+  if (actualHash !== expectedPlanHash) {
+    return [{
+      code: 'APPROVED_PLAN_HASH_MISMATCH',
+      message: `Approved plan at ${ref} hashes to ${actualHash}, envelope claims ${expectedPlanHash}.`,
+    }];
+  }
+
+  let plan: Record<string, unknown>;
+  try {
+    plan = JSON.parse(raw.toString('utf8'));
+  } catch {
+    return [{ code: 'APPROVED_PLAN_CONTENT_INVALID', message: 'Approved plan is not valid JSON.' }];
+  }
+
+  const failures: LineageFailure[] = [];
+  if (plan.authority !== 'DSG_CONTROL_PLANE') {
+    failures.push({ code: 'APPROVED_PLAN_AUTHORITY_INVALID', message: 'Approved plan authority is not DSG_CONTROL_PLANE.' });
+  }
+  if (typeof plan.approvalStatus !== 'string' || !plan.approvalStatus.startsWith('APPROVED_')) {
+    failures.push({ code: 'APPROVED_PLAN_NOT_APPROVED', message: 'Approved plan approvalStatus does not start with APPROVED_.' });
+  }
+  if (plan.targetRepository !== repository) {
+    failures.push({ code: 'APPROVED_PLAN_TARGET_MISMATCH', message: 'Approved plan targetRepository does not match the candidate repository.' });
+  }
+  return failures;
+}
+
+export async function verifyCandidateLineage(
+  client: GitHubLineageClient,
+  repository: string,
+  baselineCommit: string,
+  candidateCommit: string,
+  allowedPaths: string[],
+): Promise<LineageFailure[]> {
+  const repo = splitRepository(repository);
+  if (!repo) return [{ code: 'REPOSITORY_FORMAT_INVALID', message: 'targetRepository must be "owner/repo".' }];
+
+  let response: { data: { status: string; files?: Array<{ filename: string }> } };
+  try {
+    response = await client.compareCommits({ ...repo, basehead: `${baselineCommit}...${candidateCommit}` });
+  } catch (error) {
+    return [{
+      code: 'CANDIDATE_COMPARE_FAILED',
+      message: `Could not compare ${baselineCommit}...${candidateCommit}: ${error instanceof Error ? error.message : String(error)}`,
+    }];
+  }
+
+  const failures: LineageFailure[] = [];
+  if (response.data.status !== 'ahead') {
+    failures.push({
+      code: 'BASELINE_NOT_ANCESTOR',
+      message: `GitHub reports baseline...candidate as "${response.data.status}", expected "ahead" (baseline must be a strict ancestor of candidate).`,
+    });
+  }
+
+  const changedFiles = response.data.files ?? [];
+  if (changedFiles.length === 0) {
+    failures.push({ code: 'DIFF_EMPTY', message: 'Candidate commit contains no file changes versus baseline.' });
+  }
+
+  const allowed = new Set(allowedPaths);
+  const outOfScope = changedFiles.filter((file) => !allowed.has(file.filename));
+  if (outOfScope.length > 0) {
+    failures.push({
+      code: 'DIFF_OUTSIDE_ALLOWED_PATHS',
+      message: `Candidate changes files outside allowedPaths: ${outOfScope.map((file) => file.filename).join(', ')}.`,
+    });
+  }
+
+  return failures;
+}
+
+export async function verifyCandidateProvenance(
+  repository: string,
+  baselineCommit: string,
+  candidateCommit: string,
+  allowedPaths: string[],
+  approvedPlanHash: string,
+): Promise<LineageFailure[]> {
+  if (!ALLOWED_REPOSITORIES.has(repository)) {
+    return [{ code: 'REPOSITORY_NOT_ALLOWED', message: `${repository} is not in the governed-repository allowlist.` }];
+  }
+
+  const token = process.env.DSG_GITHUB_AUTOMATION_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
+  if (!token) {
+    return [{ code: 'GITHUB_CREDENTIAL_MISSING', message: 'Server-side GitHub automation credential is not configured.' }];
+  }
+
+  const octokit = new Octokit({ auth: token });
+  const client: GitHubLineageClient = {
+    getContent: (input) => octokit.rest.repos.getContent(input) as unknown as Promise<{ data: unknown }>,
+    compareCommits: (input) =>
+      octokit.rest.repos.compareCommitsWithBasehead(input) as unknown as Promise<{
+        data: { status: string; ahead_by: number; behind_by: number; files?: Array<{ filename: string }> };
+      }>,
+  };
+
+  const [planFailures, lineageFailures] = await Promise.all([
+    verifyApprovedPlan(client, repository, candidateCommit, approvedPlanHash),
+    verifyCandidateLineage(client, repository, baselineCommit, candidateCommit, allowedPaths),
+  ]);
+  return [...planFailures, ...lineageFailures];
+}

--- a/lib/agent-governance/agentic-org/github-branch-bootstrap.ts
+++ b/lib/agent-governance/agentic-org/github-branch-bootstrap.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest';
 
-const ALLOWED_REPOSITORIES = new Set([
+export const ALLOWED_REPOSITORIES = new Set([
   'tdealer01-crypto/tdealer01-crypto-dsg-control-plane',
   'tdealer01-crypto/dsg-one-v1',
   'tdealer01-crypto/dsg-agi-simulation',

--- a/lib/agent-governance/agentic-org/post-deploy-control.ts
+++ b/lib/agent-governance/agentic-org/post-deploy-control.ts
@@ -97,7 +97,7 @@ export interface PostDeployControlResult {
 
 const SHA256 = /^[0-9a-f]{64}$/i;
 const COMMIT = /^[0-9a-f]{40}$/i;
-const ALLOWED_ROLLBACK_ADAPTERS = new Set(['AWS', 'GCLOUD', 'DOCKER']);
+const ALLOWED_ROLLBACK_ADAPTERS = new Set(['AWS', 'GCLOUD', 'DOCKER', 'AZURE']);
 
 function stableHash(value: unknown): string {
   return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');

--- a/tests/unit/agentic-org-azure-rollback-adapter.test.ts
+++ b/tests/unit/agentic-org-azure-rollback-adapter.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AzureRollbackError,
+  executeAzureRollback,
+  getAzureAccessToken,
+  swapAppServiceSlots,
+  type AzureRollbackConfig,
+} from '../../lib/agent-governance/agentic-org/azure-rollback-adapter';
+
+const CONFIG: AzureRollbackConfig = {
+  tenantId: 'tenant-1',
+  clientId: 'client-1',
+  clientSecret: 'secret-1',
+  subscriptionId: 'sub-1',
+  resourceGroup: 'rg-1',
+  appServiceByRepository: {
+    'tdealer01-crypto/dsg-agi-simulation': 'dsg-agi-simulation-app',
+  },
+};
+
+const INPUT = {
+  targetRepository: 'tdealer01-crypto/dsg-agi-simulation',
+  promotionId: 'promotion-1',
+  deploymentId: 'deploy-1',
+  rollbackTarget: 'staging',
+  healthProbePath: '/api/agent/status',
+};
+
+function fetchSequence(handlers: Array<(url: string, init?: RequestInit) => Response>) {
+  let call = 0;
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const handler = handlers[call];
+    call += 1;
+    if (!handler) throw new Error(`unexpected fetch call ${call}: ${url}`);
+    return handler(url, init);
+  });
+}
+
+describe('getAzureAccessToken', () => {
+  it('posts client-credentials and returns the access token', async () => {
+    const fetcher = fetchSequence([
+      () => new Response(JSON.stringify({ access_token: 'token-abc' }), { status: 200 }),
+    ]);
+    const token = await getAzureAccessToken(fetcher, CONFIG);
+    expect(token).toBe('token-abc');
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('fails closed on a non-2xx token response', async () => {
+    const fetcher = fetchSequence([() => new Response('nope', { status: 401 })]);
+    await expect(getAzureAccessToken(fetcher, CONFIG)).rejects.toThrow(AzureRollbackError);
+  });
+
+  it('fails closed when the token response has no access_token', async () => {
+    const fetcher = fetchSequence([() => new Response(JSON.stringify({}), { status: 200 })]);
+    await expect(getAzureAccessToken(fetcher, CONFIG)).rejects.toThrow(AzureRollbackError);
+  });
+});
+
+describe('swapAppServiceSlots', () => {
+  it('completes immediately on a synchronous 200', async () => {
+    const fetcher = fetchSequence([() => new Response(null, { status: 200 })]);
+    await expect(swapAppServiceSlots(fetcher, 'token', CONFIG, 'app-1', 'staging')).resolves.toBeUndefined();
+  });
+
+  it('polls the returned location until the operation completes', async () => {
+    const fetcher = fetchSequence([
+      () => new Response(null, { status: 202, headers: { location: 'https://management.azure.com/poll' } }),
+      () => new Response(null, { status: 202 }),
+      () => new Response(null, { status: 200 }),
+    ]);
+    vi.useFakeTimers();
+    const promise = swapAppServiceSlots(fetcher, 'token', CONFIG, 'app-1', 'staging');
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(promise).resolves.toBeUndefined();
+    vi.useRealTimers();
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed when the swap request itself errors', async () => {
+    const fetcher = fetchSequence([() => new Response('bad', { status: 500 })]);
+    await expect(swapAppServiceSlots(fetcher, 'token', CONFIG, 'app-1', 'staging')).rejects.toThrow(AzureRollbackError);
+  });
+
+  it('fails closed when a 202 carries no polling URL', async () => {
+    const fetcher = fetchSequence([() => new Response(null, { status: 202 })]);
+    await expect(swapAppServiceSlots(fetcher, 'token', CONFIG, 'app-1', 'staging'))
+      .rejects.toMatchObject({ code: 'AZURE_SLOT_SWAP_STATUS_URL_MISSING' });
+  });
+});
+
+describe('executeAzureRollback', () => {
+  it('gets a token, swaps the slot, checks health, and returns evidence', async () => {
+    const fetcher = fetchSequence([
+      () => new Response(JSON.stringify({ access_token: 'token-abc' }), { status: 200 }),
+      () => new Response(null, { status: 200 }), // slot swap, synchronous
+      () => new Response(null, { status: 200 }), // health check
+    ]);
+    const result = await executeAzureRollback(fetcher, CONFIG, INPUT);
+    expect(result.status).toBe('ROLLED_BACK');
+    expect(result.healthPassed).toBe(true);
+    expect(result.evidenceHash).toMatch(/^[0-9a-f]{64}$/);
+
+    const healthCall = fetcher.mock.calls[2];
+    expect(healthCall[0]).toBe('https://dsg-agi-simulation-app.azurewebsites.net/api/agent/status');
+  });
+
+  it('fails closed for a repository with no registered App Service', async () => {
+    const fetcher = fetchSequence([]);
+    await expect(executeAzureRollback(fetcher, CONFIG, { ...INPUT, targetRepository: 'tdealer01-crypto/unregistered' }))
+      .rejects.toMatchObject({ code: 'AZURE_APP_SERVICE_NOT_REGISTERED' });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the post-swap health probe does not return ok', async () => {
+    const fetcher = fetchSequence([
+      () => new Response(JSON.stringify({ access_token: 'token-abc' }), { status: 200 }),
+      () => new Response(null, { status: 200 }),
+      () => new Response(null, { status: 503 }),
+    ]);
+    await expect(executeAzureRollback(fetcher, CONFIG, INPUT)).rejects.toMatchObject({ code: 'AZURE_ROLLBACK_HEALTH_CHECK_FAILED' });
+  });
+
+  it('fails closed when the health probe request throws', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'token-abc' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValueOnce(new Error('network unreachable'));
+    await expect(executeAzureRollback(fetcher as unknown as typeof fetch, CONFIG, INPUT)).rejects.toMatchObject({ code: 'AZURE_ROLLBACK_HEALTH_CHECK_FAILED' });
+  });
+});

--- a/tests/unit/agentic-org-candidate-lineage.test.ts
+++ b/tests/unit/agentic-org-candidate-lineage.test.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  verifyApprovedPlan,
+  verifyCandidateLineage,
+  type GitHubLineageClient,
+} from '../../lib/agent-governance/agentic-org/candidate-lineage';
+
+const REPO = 'tdealer01-crypto/dsg-agi-simulation';
+const BASELINE = 'a'.repeat(40);
+const CANDIDATE = 'b'.repeat(40);
+
+function approvedPlanBytes(overrides: Record<string, unknown> = {}): Buffer {
+  const plan = {
+    schemaVersion: 'dsg-approved-improvement-plan-v1',
+    goalId: 'dsg-agi-self-evolution',
+    approvalStatus: 'APPROVED_BY_USER_2026-08-25',
+    authority: 'DSG_CONTROL_PLANE',
+    targetRepository: REPO,
+    allowedPaths: ['data/simulation-input.json'],
+    ...overrides,
+  };
+  return Buffer.from(JSON.stringify(plan));
+}
+
+function contentClient(bytes: Buffer): GitHubLineageClient['getContent'] {
+  return vi.fn(async () => ({
+    data: { content: bytes.toString('base64'), encoding: 'base64' },
+  }));
+}
+
+describe('verifyApprovedPlan', () => {
+  it('passes when the fetched plan hashes to exactly what the envelope claims and is approved', async () => {
+    const bytes = approvedPlanBytes();
+    const hash = createHash('sha256').update(bytes).digest('hex');
+    const client = { getContent: contentClient(bytes), compareCommits: vi.fn() };
+
+    const failures = await verifyApprovedPlan(client, REPO, CANDIDATE, hash);
+    expect(failures).toEqual([]);
+  });
+
+  it('blocks on a hash mismatch instead of trusting the envelope-supplied hash', async () => {
+    const bytes = approvedPlanBytes();
+    const client = { getContent: contentClient(bytes), compareCommits: vi.fn() };
+
+    const failures = await verifyApprovedPlan(client, REPO, CANDIDATE, 'c'.repeat(64));
+    expect(failures.map((f) => f.code)).toEqual(['APPROVED_PLAN_HASH_MISMATCH']);
+  });
+
+  it('blocks a plan that is not approved, even if the hash matches', async () => {
+    const bytes = approvedPlanBytes({ approvalStatus: 'DRAFT' });
+    const hash = createHash('sha256').update(bytes).digest('hex');
+    const client = { getContent: contentClient(bytes), compareCommits: vi.fn() };
+
+    const failures = await verifyApprovedPlan(client, REPO, CANDIDATE, hash);
+    expect(failures.map((f) => f.code)).toContain('APPROVED_PLAN_NOT_APPROVED');
+  });
+
+  it('blocks a plan whose authority is not DSG_CONTROL_PLANE', async () => {
+    const bytes = approvedPlanBytes({ authority: 'SIMULATION_ONLY' });
+    const hash = createHash('sha256').update(bytes).digest('hex');
+    const client = { getContent: contentClient(bytes), compareCommits: vi.fn() };
+
+    const failures = await verifyApprovedPlan(client, REPO, CANDIDATE, hash);
+    expect(failures.map((f) => f.code)).toContain('APPROVED_PLAN_AUTHORITY_INVALID');
+  });
+
+  it('fails closed for a repository with no registered approved-plan path', async () => {
+    const client = { getContent: vi.fn(), compareCommits: vi.fn() };
+    const failures = await verifyApprovedPlan(client, 'tdealer01-crypto/dsg-one-v1', CANDIDATE, 'x'.repeat(64));
+    expect(failures.map((f) => f.code)).toEqual(['APPROVED_PLAN_PATH_UNKNOWN']);
+    expect(client.getContent).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when GitHub cannot be reached', async () => {
+    const client = { getContent: vi.fn(async () => { throw new Error('network'); }), compareCommits: vi.fn() };
+    const failures = await verifyApprovedPlan(client, REPO, CANDIDATE, 'x'.repeat(64));
+    expect(failures.map((f) => f.code)).toEqual(['APPROVED_PLAN_FETCH_FAILED']);
+  });
+});
+
+describe('verifyCandidateLineage', () => {
+  function compareClient(status: string, files: Array<{ filename: string }>): GitHubLineageClient['compareCommits'] {
+    return vi.fn(async () => ({ data: { status, ahead_by: 1, behind_by: 0, files } }));
+  }
+
+  it('passes when the candidate is strictly ahead and every changed file is in allowedPaths', async () => {
+    const client = { getContent: vi.fn(), compareCommits: compareClient('ahead', [{ filename: 'data/simulation-input.json' }]) };
+    const failures = await verifyCandidateLineage(client, REPO, BASELINE, CANDIDATE, ['data/simulation-input.json']);
+    expect(failures).toEqual([]);
+  });
+
+  it('blocks when baseline is not an ancestor of the candidate', async () => {
+    const client = { getContent: vi.fn(), compareCommits: compareClient('diverged', [{ filename: 'data/simulation-input.json' }]) };
+    const failures = await verifyCandidateLineage(client, REPO, BASELINE, CANDIDATE, ['data/simulation-input.json']);
+    expect(failures.map((f) => f.code)).toContain('BASELINE_NOT_ANCESTOR');
+  });
+
+  it('blocks a candidate that changes files outside allowedPaths', async () => {
+    const client = {
+      getContent: vi.fn(),
+      compareCommits: compareClient('ahead', [
+        { filename: 'data/simulation-input.json' },
+        { filename: 'contracts/agentic-improvement/self-evolution-plan.json' },
+      ]),
+    };
+    const failures = await verifyCandidateLineage(client, REPO, BASELINE, CANDIDATE, ['data/simulation-input.json']);
+    expect(failures.map((f) => f.code)).toContain('DIFF_OUTSIDE_ALLOWED_PATHS');
+  });
+
+  it('blocks a candidate with no actual file changes', async () => {
+    const client = { getContent: vi.fn(), compareCommits: compareClient('ahead', []) };
+    const failures = await verifyCandidateLineage(client, REPO, BASELINE, CANDIDATE, ['data/simulation-input.json']);
+    expect(failures.map((f) => f.code)).toContain('DIFF_EMPTY');
+  });
+
+  it('fails closed when the compare API call errors', async () => {
+    const client = { getContent: vi.fn(), compareCommits: vi.fn(async () => { throw new Error('502'); }) };
+    const failures = await verifyCandidateLineage(client, REPO, BASELINE, CANDIDATE, ['data/simulation-input.json']);
+    expect(failures.map((f) => f.code)).toEqual(['CANDIDATE_COMPARE_FAILED']);
+  });
+});


### PR DESCRIPTION
Two commits on the shared task branch for this repo (per this session's branch convention — one designated branch per repo, not one PR per concern). Both close pieces of the same gap-audit: the self-evolution candidate pipeline (evolution → Cinema attest → Control Plane promotion → deploy → monitor → rollback/next-baseline).

## Commit 1 — feat(promotion): verify candidate provenance independently against GitHub

`promotion/evaluate` previously checked only internal consistency of whatever the caller sent (approvedPlanHash, planAligned, constraintsPassed, Cinema proof binding) — never independently confirmed any of it against GitHub.

- `lib/agent-governance/agentic-org/candidate-lineage.ts` (new) — fetches the approved plan at the candidate commit and recomputes its SHA-256 server-side, checks authority/approval/target fields, then uses GitHub's compare API to require the candidate is strictly ahead of baseline and every changed file is inside `allowedPaths`. DI'd GitHub client; missing credentials/network errors/API failures fail closed.
- `app/api/dsg/agentic-org/promotion/evaluate/route.ts` — calls it after the existing structural/raw Cinema binding and gate checks pass; any lineage failure returns 409 BLOCK with nothing persisted.
- `lib/agent-governance/agentic-org/github-branch-bootstrap.ts` — exported `ALLOWED_REPOSITORIES` for reuse.
- `tests/unit/agentic-org-candidate-lineage.test.ts` — 11 cases.

Deliberate non-change (documented in the commit message): this does not route promotion receipts through `runtime_commit_execution` — that RPC's org/agent/quota shape doesn't fit a cross-repo code-promotion event. `agentic_promotion_receipts` is already its own append-only, RLS-locked, service-role-only ledger with an atomic CAS baseline-commit RPC; that's this domain's canonical audit path by decision, now independently verified rather than payload-trusted.

## Commit 2 — feat(rollback): real Azure App Service rollback adapter

The negative-path half of "bind Azure as the production deploy adapter" — a real, executable rollback target instead of the AWS/GCLOUD/DOCKER-only allowlist that had no Azure option at all.

- `lib/agent-governance/agentic-org/azure-rollback-adapter.ts` (new) — Azure AD client-credentials token, App Service deployment-slot swap (polls the ARM async-operation URL when accepted rather than completed synchronously), requires the health probe to return 2xx before returning `ROLLED_BACK` evidence.
- `app/api/dsg/agentic-org/rollback-adapters/azure/route.ts` (new) — receives the HMAC-signed `GovernedRollbackRequest` `rollback-executor.ts` already sends, verifies the signature, loads Azure Service Principal config + a repository→App-Service-name map from env, returns the `dsg-governed-rollback-evidence-v1` contract.
- `lib/agent-governance/agentic-org/post-deploy-control.ts` — added `'AZURE'` to `ALLOWED_ROLLBACK_ADAPTERS`.
- `tests/unit/agentic-org-azure-rollback-adapter.test.ts` — 11 cases (token fetch, sync/polled slot-swap, swap failure, missing polling URL, unregistered repo, health-check failure both non-2xx and thrown, end-to-end evidence shape).
- `.env.example` — documents `DSG_PROMOTION_EVALUATION_SECRET`, `DSG_POST_DEPLOY_FEEDBACK_SECRET`, `DSG_PRODUCTION_ROLLBACK_SECRET`, `DSG_GITHUB_AUTOMATION_TOKEN` (already read by existing routes but never declared here) plus the new `AZURE_*`/`DSG_AZURE_APP_SERVICE_MAP`. Names only.

**Deliberately not done, and why:** `config/production-deployment-target.json` stays `UNBOUND`; `promoted-production-deploy.yml`'s fail-closed sentinel is untouched. That workflow gates control-plane's *own* production deploys through a separate, larger system (`agent_workspace_promotions` + a GitHub environment approval gate — see `docs/RUNBOOK_DEPLOY.md`), not the self-evolution candidate pipeline this PR closes pieces of. Flipping `productionDeployEnabled` to `true` before a real forward-deploy path exists, and without live Azure credentials to verify any of this against, would be exactly the unverified production-ready claim this repo's `CLAUDE.md` prohibits. There is also still no forward-deploy trigger for a promoted candidate (build+push to the App Service staging slot after ALLOW) — only the rollback half existed as a concept in this codebase; scoping and building that is separate follow-up work.

Verification:
- [x] `npm run typecheck` — clean
- [x] `npm run test -- tests/unit/agentic-org-{candidate-lineage,azure-rollback-adapter,rollback-executor,post-deploy-control,promotion-packet,promotion-gate}.test.ts` — 46/46 passed
- [x] `npm run build` — clean; both new routes appear in the route list
- [ ] Not run: a live rollback against a real Azure subscription — this sandbox has no Azure CLI/API access. The ARM REST call shapes follow the documented API contract but are unverified live.

Known limits:

- `DSG_GITHUB_AUTOMATION_TOKEN`/`AZURE_*`/`DSG_AZURE_APP_SERVICE_MAP` must actually be configured in the deployed environment for either new capability to do anything but fail closed.
- `DSG_AZURE_APP_SERVICE_MAP` only needs an entry for `dsg-agi-simulation` today (the only repo currently proposing candidates).

User-visible benefit:

A forged or replayed promotion envelope can no longer reach ALLOW without a real, approved, in-scope GitHub commit range behind it. A monitoring-recommended rollback on Azure now has a real adapter to execute against instead of failing closed with `ROLLBACK_ADAPTER_NOT_ALLOWLISTED`.

Next step:

Configure the Azure Service Principal + `DSG_AZURE_APP_SERVICE_MAP`, then design and build the forward-deploy trigger (candidate ALLOW → build/push to staging slot) this rollback adapter is the other half of.