### PR TITLE
fix(env): document safe Azure/Supabase bindings and apply receipts migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,29 @@
 # ============ App URLs ============
+# Local defaults used by `cp .env.example .env.local`.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 APP_URL=http://localhost:3000
+
+# Azure production values belong in the container image build/App Settings,
+# not in this local-development template:
+# NEXT_PUBLIC_APP_URL=https://dsg-control-plane.azurewebsites.net
+# APP_URL=https://dsg-control-plane.azurewebsites.net
+# DSG_ALLOWED_ORIGINS=https://dsg-control-plane.azurewebsites.net
 
 # Comma-separated cross-origin allowlist for API access
 DSG_ALLOWED_ORIGINS=
 
 # ============ Supabase ============
+# Keep credentials blank in this committed template. Verified Azure production
+# project: dsg-control-plane-dev (zeyguilldygozufpgxms)
+# URL: https://zeyguilldygozufpgxms.supabase.co
+# Configure the browser-safe key at image-build time. Until every direct
+# consumer is migrated, NEXT_PUBLIC_SUPABASE_ANON_KEY remains the required
+# compatibility variable even when its value is a modern publishable key.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Optional modern alias for consumers that support it.
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+# Private server credential: Azure App Settings / GitHub Secrets only.
 SUPABASE_SERVICE_ROLE_KEY=
 
 # ============ Neon PostgreSQL (Production/Staging) ============
@@ -23,8 +38,10 @@ NEON_API_KEY=
 NEON_PROJECT_ID=
 
 # ============ DSG Core ============
-# Optional: route all /api/* calls from UI to a real remote Control Plane API origin
-# Example: https://dsg-control-plane-production.vercel.app
+# Optional: route all /api/* calls from a separately hosted UI to a remote API.
+# Leave both blank when this Azure App Service serves its own UI and API;
+# setting either value to the same origin would create a self-proxy loop.
+# Split-host example: https://dsg-control-plane.azurewebsites.net
 DSG_REMOTE_API_URL=
 NEXT_PUBLIC_DSG_REMOTE_API_URL=
 
@@ -292,6 +309,9 @@ NVIDIA_LLM_VERIFIER_URL=
 NVIDIA_LLM_VERIFIER_MODEL=
 
 # ============ Agentic self-evolution promotion (governed candidate pipeline) ============
+# Candidate-repository GitHub Actions variable (not consumed by this app):
+# DSG_PROMOTION_EVALUATION_URL=https://dsg-control-plane.azurewebsites.net/api/dsg/agentic-org/promotion/evaluate
+#
 # HMAC secret POST /api/dsg/agentic-org/promotion/evaluate uses to verify the
 # x-dsg-signature header on incoming candidate-promotion requests. Same value
 # must be configured as the GitHub Actions secret of the same name on the
@@ -317,7 +337,11 @@ AZURE_TENANT_ID=
 AZURE_CLIENT_ID=
 AZURE_CLIENT_SECRET=
 AZURE_SUBSCRIPTION_ID=
-AZURE_RESOURCE_GROUP=
-# JSON map of governed target repository -> Azure App Service name, e.g.
-# {"tdealer01-crypto/dsg-agi-simulation":"dsg-agi-simulation-app"}
+# Verified non-secret binding from qa-logs/azure-production/20260828T015648Z.
+AZURE_RESOURCE_GROUP=rg-t.dealer01-0468
+# JSON map of governed candidate repository -> Azure App Service name.
+# No eligible target is bound yet: the existing dsg-control-plane App Service
+# is the authority service, not a dsg-agi-simulation deployment target.
+# Keep blank so rollback fails closed until a real candidate App Service with
+# staging/production slots exists.
 DSG_AZURE_APP_SERVICE_MAP=

--- a/.env.example
+++ b/.env.example
@@ -337,8 +337,10 @@ AZURE_TENANT_ID=
 AZURE_CLIENT_ID=
 AZURE_CLIENT_SECRET=
 AZURE_SUBSCRIPTION_ID=
-# Verified non-secret binding from qa-logs/azure-production/20260828T015648Z.
-AZURE_RESOURCE_GROUP=rg-t.dealer01-0468
+# Verified production Azure App Setting from qa-logs/azure-production/20260828T015648Z:
+# AZURE_RESOURCE_GROUP=rg-t.dealer01-0468
+# Keep the local template blank to prevent accidental cross-environment rollback.
+AZURE_RESOURCE_GROUP=
 # JSON map of governed candidate repository -> Azure App Service name.
 # No eligible target is bound yet: the existing dsg-control-plane App Service
 # is the authority service, not a dsg-agi-simulation deployment target.

--- a/supabase/migrations/20260825083000_agentic_post_deploy_feedback.sql
+++ b/supabase/migrations/20260825083000_agentic_post_deploy_feedback.sql
@@ -1,6 +1,8 @@
 -- Durable, service-role-only promotion/post-deploy evidence and baseline state.
 -- Simulation and Monitoring never become authority. Canonical ALLOW receipts,
 -- baseline commits and rollback execution are Control Plane responsibilities.
+-- This migration must be applied before enabling the promotion evaluation route;
+-- otherwise a verified ALLOW cannot be persisted and must fail closed.
 
 create table if not exists public.agentic_promotion_receipts (
   promotion_id text primary key,


### PR DESCRIPTION
## Summary

- keeps `.env.example` safe for local `cp .env.example .env.local` usage
- documents the verified Azure Control Plane origin, Supabase project, promotion endpoint, and Azure resource group without committing credentials
- keeps `DSG_AZURE_APP_SERVICE_MAP` blank so rollback fails closed until a real governed candidate App Service with staging/production slots exists
- touches the canonical `20260825083000_agentic_post_deploy_feedback.sql` migration so the existing main-branch migration workflow applies it with its repository version

## Changed files

- `.env.example`
- `supabase/migrations/20260825083000_agentic_post_deploy_feedback.sql`

## Truth boundary

- No secret or API key value is committed.
- `.env.example` is documentation only; Azure App Settings/GitHub Secrets still need the real private values.
- Existing direct consumers still require `NEXT_PUBLIC_SUPABASE_ANON_KEY` as a compatibility variable. It may contain the browser-safe project publishable key.
- The production database did not contain `agentic_promotion_receipts` before this PR. Merge is not complete until the Supabase Migrations workflow succeeds and the four tables/RPC are verified live.
- Forward Azure candidate deployment is still absent; this PR does not make the full E2E pipeline production-ready.

## Verification plan

1. Require all PR checks to pass, including Gitleaks.
2. Merge to `main`.
3. Require `Supabase Migrations` to complete successfully.
4. Verify tables, RLS, grants, and `dsg_commit_evolution_baseline` against the linked Supabase project.
