### PR TITLE
feat(env): sync governed runtime settings to Azure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# ENV CATALOG ONLY — this is not a list of 119 production requirements.
+# Azure runtime values are allowlisted by config/azure-runtime-env.contract.json
+# and synchronized from the GitHub prod/staging Environment. See:
+# docs/ops/azure-runtime-env-sync.md
+#
 # ============ App URLs ============
 # Local defaults used by `cp .env.example .env.local`.
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/.github/workflows/sync-azure-app-settings.yml
+++ b/.github/workflows/sync-azure-app-settings.yml
@@ -1,0 +1,271 @@
+name: Sync Azure Runtime Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub Environment containing the canonical values
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
+        default: prod
+      profile:
+        description: Smallest runtime contract to enforce
+        required: true
+        type: choice
+        options:
+          - core
+          - governed
+          - rollback
+        default: governed
+      slot:
+        description: Azure App Service slot to configure
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: production
+      apply:
+        description: Apply after fail-closed preflight (false renders names-only evidence)
+        required: true
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      profile:
+        required: true
+        type: string
+      slot:
+        required: true
+        type: string
+      apply:
+        required: true
+        type: boolean
+    secrets:
+      AZURE_CLIENT_ID:
+        required: false
+      AZURE_TENANT_ID:
+        required: false
+      AZURE_SUBSCRIPTION_ID:
+        required: false
+      AZURE_CLIENT_SECRET:
+        required: false
+      APP_URL:
+        required: false
+      NEXT_PUBLIC_APP_URL:
+        required: false
+      DSG_ALLOWED_ORIGINS:
+        required: false
+      NEXT_PUBLIC_SUPABASE_URL:
+        required: false
+      NEXT_PUBLIC_SUPABASE_ANON_KEY:
+        required: false
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
+        required: false
+      SUPABASE_SERVICE_ROLE_KEY:
+        required: false
+      NEXTAUTH_SECRET:
+        required: false
+      DSG_CORE_MODE:
+        required: false
+      READINESS_STRICT:
+        required: false
+      UPSTASH_REDIS_REST_URL:
+        required: false
+      UPSTASH_REDIS_REST_TOKEN:
+        required: false
+      DSG_PROMOTION_EVALUATION_SECRET:
+        required: false
+      DSG_POST_DEPLOY_FEEDBACK_SECRET:
+        required: false
+      DSG_PRODUCTION_ROLLBACK_SECRET:
+        required: false
+      DSG_GITHUB_AUTOMATION_TOKEN:
+        required: false
+      DSG_AZURE_APP_SERVICE_MAP:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-runtime-env-${{ inputs.environment }}-${{ inputs.slot }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: ${{ inputs.apply && 'Apply' || 'Preflight' }} ${{ inputs.profile }} ENV
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 15
+    env:
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'rg-t.dealer01-0468' }}
+      AZURE_WEBAPP_NAME: ${{ vars.AZURE_WEBAPP_NAME || 'dsg-control-plane' }}
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@v4
+
+      - name: Render fail-closed App Settings contract
+        id: render
+        shell: bash
+        env:
+          PROFILE: ${{ inputs.profile }}
+          DSG_ENV_APP_URL: ${{ secrets.APP_URL || vars.APP_URL }}
+          DSG_ENV_NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL || vars.NEXT_PUBLIC_APP_URL }}
+          DSG_ENV_DSG_ALLOWED_ORIGINS: ${{ secrets.DSG_ALLOWED_ORIGINS || vars.DSG_ALLOWED_ORIGINS }}
+          DSG_ENV_NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || vars.NEXT_PUBLIC_SUPABASE_URL }}
+          DSG_ENV_NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          DSG_ENV_NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          DSG_ENV_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          DSG_ENV_NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          DSG_ENV_DSG_CORE_MODE: ${{ secrets.DSG_CORE_MODE || vars.DSG_CORE_MODE }}
+          DSG_ENV_READINESS_STRICT: ${{ secrets.READINESS_STRICT || vars.READINESS_STRICT }}
+          DSG_ENV_UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL || vars.UPSTASH_REDIS_REST_URL }}
+          DSG_ENV_UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          DSG_ENV_DSG_PROMOTION_EVALUATION_SECRET: ${{ secrets.DSG_PROMOTION_EVALUATION_SECRET }}
+          DSG_ENV_DSG_POST_DEPLOY_FEEDBACK_SECRET: ${{ secrets.DSG_POST_DEPLOY_FEEDBACK_SECRET }}
+          DSG_ENV_DSG_PRODUCTION_ROLLBACK_SECRET: ${{ secrets.DSG_PRODUCTION_ROLLBACK_SECRET }}
+          DSG_ENV_DSG_GITHUB_AUTOMATION_TOKEN: ${{ secrets.DSG_GITHUB_AUTOMATION_TOKEN }}
+          DSG_ENV_AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID || vars.AZURE_TENANT_ID }}
+          DSG_ENV_AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID || vars.AZURE_CLIENT_ID }}
+          DSG_ENV_AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          DSG_ENV_AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID || vars.AZURE_SUBSCRIPTION_ID }}
+          DSG_ENV_AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'rg-t.dealer01-0468' }}
+          DSG_ENV_DSG_AZURE_APP_SERVICE_MAP: ${{ secrets.DSG_AZURE_APP_SERVICE_MAP || vars.DSG_AZURE_APP_SERVICE_MAP }}
+        run: |
+          set -euo pipefail
+          settings_file="$RUNNER_TEMP/dsg-azure-appsettings.json"
+          evidence_file="$RUNNER_TEMP/dsg-azure-env-evidence.json"
+          node scripts/render-azure-app-settings.mjs \
+            --contract config/azure-runtime-env.contract.json \
+            --profile "$PROFILE" \
+            --settings-out "$settings_file" \
+            --evidence-out "$evidence_file"
+          echo "settings_file=$settings_file" >> "$GITHUB_OUTPUT"
+          echo "evidence_file=$evidence_file" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Azure OIDC binding
+        if: inputs.apply
+        shell: bash
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          test -n "${AZURE_CLIENT_ID:-}" || { echo '::error::Missing AZURE_CLIENT_ID'; exit 1; }
+          test -n "${AZURE_TENANT_ID:-}" || { echo '::error::Missing AZURE_TENANT_ID'; exit 1; }
+          test -n "${AZURE_SUBSCRIPTION_ID:-}" || { echo '::error::Missing AZURE_SUBSCRIPTION_ID'; exit 1; }
+
+      - name: Login to Azure with GitHub OIDC
+        if: inputs.apply
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Apply App Settings without printing values
+        if: inputs.apply
+        shell: bash
+        env:
+          SETTINGS_FILE: ${{ steps.render.outputs.settings_file }}
+          SLOT: ${{ inputs.slot }}
+        run: |
+          set -euo pipefail
+          slot_args=()
+          if [[ "$SLOT" == 'staging' ]]; then
+            slot_args=(--slot staging)
+          fi
+          az webapp config appsettings set \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_WEBAPP_NAME" \
+            "${slot_args[@]}" \
+            --settings @"$SETTINGS_FILE" \
+            --only-show-errors \
+            --output none
+
+      - name: Verify applied values without printing them
+        if: inputs.apply
+        id: verify
+        shell: bash
+        env:
+          SETTINGS_FILE: ${{ steps.render.outputs.settings_file }}
+          SLOT: ${{ inputs.slot }}
+        run: |
+          set -euo pipefail
+          slot_args=()
+          if [[ "$SLOT" == 'staging' ]]; then
+            slot_args=(--slot staging)
+          fi
+          umask 077
+          actual_file="$RUNNER_TEMP/dsg-azure-appsettings-actual.json"
+          verification_file="$RUNNER_TEMP/dsg-azure-env-verification.json"
+          echo "verification_file=$verification_file" >> "$GITHUB_OUTPUT"
+          az webapp config appsettings list \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_WEBAPP_NAME" \
+            "${slot_args[@]}" \
+            --only-show-errors \
+            --output json > "$actual_file"
+          SETTINGS_FILE="$SETTINGS_FILE" ACTUAL_FILE="$actual_file" VERIFICATION_FILE="$verification_file" \
+            AZURE_WEBAPP_NAME="$AZURE_WEBAPP_NAME" SLOT="$SLOT" node --input-type=module <<'NODE'
+          import { readFile, writeFile } from 'node:fs/promises';
+          const expectedRecords = JSON.parse(await readFile(process.env.SETTINGS_FILE, 'utf8'));
+          const actualRecords = JSON.parse(await readFile(process.env.ACTUAL_FILE, 'utf8'));
+          const actualByName = new Map(actualRecords.map(({ name, value }) => [name, String(value)]));
+          const expectedNames = expectedRecords.map(({ name }) => name).sort();
+          const missing = expectedNames.filter((name) => !actualByName.has(name));
+          const mismatched = expectedRecords
+            .filter(({ name, value }) => actualByName.has(name) && actualByName.get(name) !== String(value))
+            .map(({ name }) => name)
+            .sort();
+          const evidence = {
+            schemaVersion: 'dsg.azure-runtime-env-verification.v1',
+            appService: process.env.AZURE_WEBAPP_NAME,
+            slot: process.env.SLOT,
+            expectedNames,
+            missingNames: missing,
+            mismatchedNames: mismatched,
+            verified: missing.length === 0 && mismatched.length === 0,
+            truthBoundary: 'Value parity at Azure configuration readback does not prove application readiness or build-time NEXT_PUBLIC bundle parity.',
+          };
+          await writeFile(process.env.VERIFICATION_FILE, `${JSON.stringify(evidence, null, 2)}\n`);
+          if (!evidence.verified) {
+            console.error(`Azure App Setting verification failed. Missing: ${missing.join(', ') || '(none)'}; mismatched: ${mismatched.join(', ') || '(none)'}`);
+            process.exit(1);
+          }
+          console.log(`Verified ${expectedNames.length} Azure App Setting values; values were not printed.`);
+          NODE
+
+      - name: Delete runner-local settings file
+        if: always()
+        shell: bash
+        env:
+          SETTINGS_FILE: ${{ steps.render.outputs.settings_file }}
+        run: |
+          if [[ -n "${SETTINGS_FILE:-}" && -f "$SETTINGS_FILE" ]]; then
+            shred -u "$SETTINGS_FILE" 2>/dev/null || rm -f "$SETTINGS_FILE"
+          fi
+          actual_file="$RUNNER_TEMP/dsg-azure-appsettings-actual.json"
+          if [[ -f "$actual_file" ]]; then
+            shred -u "$actual_file" 2>/dev/null || rm -f "$actual_file"
+          fi
+
+      - name: Upload names-only evidence
+        if: always() && steps.render.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: azure-runtime-env-${{ inputs.environment }}-${{ inputs.profile }}-${{ github.run_id }}
+          path: |
+            ${{ steps.render.outputs.evidence_file }}
+            ${{ steps.verify.outputs.verification_file }}
+          if-no-files-found: warn
+          retention-days: 30

--- a/config/azure-runtime-env.contract.json
+++ b/config/azure-runtime-env.contract.json
@@ -1,0 +1,213 @@
+{
+  "schemaVersion": "dsg.azure-runtime-env.v1",
+  "target": "dsg-control-plane",
+  "description": "Allowlisted Azure App Service settings sourced from GitHub Actions. .env.example is documentation, not a production-required checklist.",
+  "profiles": {
+    "core": 0,
+    "governed": 1,
+    "rollback": 2
+  },
+  "neverSync": [
+    {
+      "name": "GITHUB_TOKEN",
+      "reason": "GitHub issues an ephemeral workflow token; it must never become a runtime App Setting."
+    },
+    {
+      "name": "SUPABASE_ACCESS_TOKEN",
+      "reason": "CI management credential used only by Supabase CLI workflows."
+    },
+    {
+      "name": "SUPABASE_DB_PASSWORD",
+      "reason": "CI migration credential; the application runtime does not need the database password."
+    },
+    {
+      "name": "SUPABASE_PROJECT_REF",
+      "reason": "CI migration metadata; the runtime uses the Supabase URL instead."
+    }
+  ],
+  "settings": [
+    {
+      "name": "APP_URL",
+      "source": "variable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true,
+      "default": "https://dsg-control-plane.azurewebsites.net"
+    },
+    {
+      "name": "NEXT_PUBLIC_APP_URL",
+      "source": "variable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "buildAndRuntime",
+      "slotSetting": true,
+      "default": "https://dsg-control-plane.azurewebsites.net"
+    },
+    {
+      "name": "DSG_ALLOWED_ORIGINS",
+      "source": "variable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true,
+      "default": "https://dsg-control-plane.azurewebsites.net"
+    },
+    {
+      "name": "NEXT_PUBLIC_SUPABASE_URL",
+      "source": "secretOrVariable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "buildAndRuntime",
+      "slotSetting": true,
+      "default": "https://zeyguilldygozufpgxms.supabase.co"
+    },
+    {
+      "name": "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      "source": "secretOrVariable",
+      "minimumProfile": "core",
+      "required": false,
+      "phase": "buildAndRuntime",
+      "slotSetting": true
+    },
+    {
+      "name": "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+      "source": "secretOrVariable",
+      "minimumProfile": "core",
+      "required": false,
+      "phase": "buildAndRuntime",
+      "slotSetting": true
+    },
+    {
+      "name": "SUPABASE_SERVICE_ROLE_KEY",
+      "source": "secret",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "NEXTAUTH_SECRET",
+      "source": "secret",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "DSG_CORE_MODE",
+      "source": "variable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true,
+      "default": "internal"
+    },
+    {
+      "name": "READINESS_STRICT",
+      "source": "variable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true,
+      "default": "true"
+    },
+    {
+      "name": "UPSTASH_REDIS_REST_URL",
+      "source": "secretOrVariable",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "UPSTASH_REDIS_REST_TOKEN",
+      "source": "secret",
+      "minimumProfile": "core",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "DSG_PROMOTION_EVALUATION_SECRET",
+      "source": "secret",
+      "minimumProfile": "governed",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "DSG_POST_DEPLOY_FEEDBACK_SECRET",
+      "source": "secret",
+      "minimumProfile": "governed",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "DSG_PRODUCTION_ROLLBACK_SECRET",
+      "source": "secret",
+      "minimumProfile": "governed",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "DSG_GITHUB_AUTOMATION_TOKEN",
+      "source": "secret",
+      "minimumProfile": "governed",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "AZURE_TENANT_ID",
+      "source": "secretOrVariable",
+      "minimumProfile": "rollback",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "AZURE_CLIENT_ID",
+      "source": "secretOrVariable",
+      "minimumProfile": "rollback",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "AZURE_CLIENT_SECRET",
+      "source": "secret",
+      "minimumProfile": "rollback",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "AZURE_SUBSCRIPTION_ID",
+      "source": "secretOrVariable",
+      "minimumProfile": "rollback",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    },
+    {
+      "name": "AZURE_RESOURCE_GROUP",
+      "source": "variable",
+      "minimumProfile": "rollback",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true,
+      "default": "rg-t.dealer01-0468"
+    },
+    {
+      "name": "DSG_AZURE_APP_SERVICE_MAP",
+      "source": "secretOrVariable",
+      "minimumProfile": "rollback",
+      "required": true,
+      "phase": "runtime",
+      "slotSetting": true
+    }
+  ]
+}

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -1,5 +1,11 @@
 # Secret Management Guide
 
+> [!IMPORTANT]
+> Azure App Service is the active production target. Use
+> [Azure Runtime Environment Sync](./ops/azure-runtime-env-sync.md) for the
+> current GitHub-to-Azure contract. The AWS/Vercel material below is retained
+> only as legacy reference and must not be used as production authority.
+
 Enterprise-grade secret management for DSG ONE control plane.
 
 ## Overview

--- a/docs/ops/azure-runtime-env-sync.md
+++ b/docs/ops/azure-runtime-env-sync.md
@@ -1,0 +1,69 @@
+# Azure Runtime Environment Sync
+
+The production application must not be configured by copying every entry from
+`.env.example`. That file documents all optional product surfaces and currently
+contains more than one hundred names. It is not a production-required checklist.
+
+The canonical source is the GitHub Actions Environment (`prod` or `staging`).
+`config/azure-runtime-env.contract.json` selects only the settings required by
+the active Azure control-plane surface:
+
+- `core`: application, Supabase runtime, authentication, readiness, and Redis.
+- `governed`: `core` plus promotion, post-deploy feedback, rollback signing,
+  and independent GitHub provenance verification.
+- `rollback`: `governed` plus the current Azure rollback adapter credentials
+  and repository-to-App-Service mapping.
+
+The `Sync Azure Runtime Environment` workflow performs a fail-closed render
+before any Azure mutation. A dry run is the default. When `apply=true`, it logs
+in through GitHub OIDC, writes a mode-0600 temporary JSON file, applies the
+allowlisted settings, reads the values back into a second mode-0600 temporary
+file, compares exact value parity without printing values, uploads names-only
+evidence, and deletes both temporary values files.
+
+## One-time Azure binding
+
+Configure a federated GitHub OIDC identity with the least Azure RBAC scope that
+can update the target App Service, then configure these GitHub Environment
+secrets:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+The workflow defaults to the verified target `dsg-control-plane` in resource
+group `rg-t.dealer01-0468`. Override those non-secret identifiers with GitHub
+Environment variables `AZURE_WEBAPP_NAME` and `AZURE_RESOURCE_GROUP` only when
+the governed target changes.
+
+The application rollback adapter still uses client-credentials authentication,
+so the `rollback` profile additionally requires `AZURE_CLIENT_SECRET` until that
+adapter is migrated to Managed Identity.
+
+## Supabase boundary
+
+`SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, and `SUPABASE_PROJECT_REF` are
+migration-only credentials and are explicitly denied from Azure runtime sync.
+The database password must be valid in GitHub for `supabase db push`; resetting
+that one stale value is separate from App Service configuration.
+
+`SUPABASE_SERVICE_ROLE_KEY` is runtime-only and remains server-side. Never expose
+it through a `NEXT_PUBLIC_` variable or a client bundle.
+
+## Build-time boundary
+
+Contract entries marked `buildAndRuntime` include `NEXT_PUBLIC_*` values. Azure
+App Settings make them available to the running container, but Next.js also
+inlines them during `next build`. A forward ACR deployment workflow must consume
+the same GitHub values before `az acr build`; changing App Settings alone does
+not rewrite an already-built JavaScript bundle.
+
+## Operating sequence
+
+1. Run `Sync Azure Runtime Environment` with `apply=false` and the smallest
+   required profile.
+2. Resolve any named missing settings in the selected GitHub Environment.
+3. Run again with `apply=true`.
+4. Treat names-only evidence of value parity as configuration evidence, not E2E evidence.
+   Readiness, exact image/SHA, promotion receipt, and monitoring acceptance are
+   verified separately.

--- a/scripts/render-azure-app-settings.mjs
+++ b/scripts/render-azure-app-settings.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CONTRACT_SCHEMA = 'dsg.azure-runtime-env.v1';
+const NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const SOURCE_TYPES = new Set(['secret', 'variable', 'secretOrVariable']);
+const PHASES = new Set(['runtime', 'buildAndRuntime']);
+
+export class AzureRuntimeEnvError extends Error {
+  constructor(message, code, details = {}) {
+    super(message);
+    this.name = 'AzureRuntimeEnvError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function assert(condition, message, code = 'INVALID_CONTRACT', details = {}) {
+  if (!condition) throw new AzureRuntimeEnvError(message, code, details);
+}
+
+export function validateContract(contract) {
+  assert(contract?.schemaVersion === CONTRACT_SCHEMA, `Unsupported contract schema: ${contract?.schemaVersion ?? '(missing)'}`);
+  assert(contract?.profiles && typeof contract.profiles === 'object', 'profiles must be an object');
+  assert(Array.isArray(contract?.settings), 'settings must be an array');
+  assert(Array.isArray(contract?.neverSync), 'neverSync must be an array');
+
+  const profileNames = Object.keys(contract.profiles);
+  const ranks = Object.values(contract.profiles);
+  assert(profileNames.length > 0, 'at least one profile is required');
+  assert(ranks.every((rank) => Number.isInteger(rank) && rank >= 0), 'profile ranks must be non-negative integers');
+  assert(new Set(ranks).size === ranks.length, 'profile ranks must be unique');
+
+  const denied = new Set();
+  for (const item of contract.neverSync) {
+    assert(NAME_PATTERN.test(item?.name ?? ''), 'neverSync contains an invalid name');
+    assert(!denied.has(item.name), `duplicate neverSync name: ${item.name}`);
+    denied.add(item.name);
+  }
+
+  const names = new Set();
+  for (const setting of contract.settings) {
+    assert(NAME_PATTERN.test(setting?.name ?? ''), 'setting contains an invalid name');
+    assert(!names.has(setting.name), `duplicate setting name: ${setting.name}`);
+    assert(!denied.has(setting.name), `${setting.name} is both allowlisted and denied`);
+    assert(SOURCE_TYPES.has(setting.source), `${setting.name} has an invalid source`);
+    assert(profileNames.includes(setting.minimumProfile), `${setting.name} has an invalid minimumProfile`);
+    assert(typeof setting.required === 'boolean', `${setting.name} required must be boolean`);
+    assert(PHASES.has(setting.phase), `${setting.name} has an invalid phase`);
+    assert(typeof setting.slotSetting === 'boolean', `${setting.name} slotSetting must be boolean`);
+    if (Object.hasOwn(setting, 'default')) {
+      assert(setting.source !== 'secret', `${setting.name} cannot give a secret a committed default`);
+      assert(typeof setting.default === 'string' && setting.default.length > 0, `${setting.name} default must be a non-empty string`);
+    }
+    names.add(setting.name);
+  }
+
+  return contract;
+}
+
+function configuredValue(environment, name) {
+  const value = environment[`DSG_ENV_${name}`];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function renderAzureAppSettings(contractInput, profile, environment = process.env) {
+  const contract = validateContract(contractInput);
+  const selectedRank = contract.profiles[profile];
+  assert(Number.isInteger(selectedRank), `Unknown profile: ${profile}`, 'UNKNOWN_PROFILE', { profile });
+
+  const selected = contract.settings.filter(
+    (setting) => contract.profiles[setting.minimumProfile] <= selectedRank,
+  );
+  const missing = [];
+  const settings = [];
+  const evidenceSettings = [];
+
+  for (const setting of selected) {
+    const configured = configuredValue(environment, setting.name);
+    const value = configured ?? setting.default;
+    if (value === undefined) {
+      if (setting.required) missing.push(setting.name);
+      continue;
+    }
+
+    settings.push({
+      name: setting.name,
+      value,
+      slotSetting: setting.slotSetting,
+    });
+    evidenceSettings.push({
+      name: setting.name,
+      phase: setting.phase,
+      required: setting.required,
+      sourceType: setting.source,
+      resolution: configured === undefined ? 'contract-default' : 'github-actions',
+      slotSetting: setting.slotSetting,
+    });
+  }
+
+  if (missing.length > 0) {
+    throw new AzureRuntimeEnvError(
+      `Missing required ${profile} settings: ${missing.join(', ')}`,
+      'MISSING_REQUIRED_SETTINGS',
+      { missing, profile },
+    );
+  }
+
+  return {
+    settings,
+    evidence: {
+      schemaVersion: 'dsg.azure-runtime-env-evidence.v1',
+      contractSchemaVersion: contract.schemaVersion,
+      target: contract.target,
+      profile,
+      settingCount: settings.length,
+      settings: evidenceSettings,
+      neverSyncedNames: contract.neverSync.map((item) => item.name).sort(),
+      truthBoundary: 'This evidence proves contract resolution only. Azure mutation and deployed application readiness require separate verification.',
+    },
+  };
+}
+
+async function writeJson(path, value, mode) {
+  await mkdir(dirname(resolve(path)), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode });
+  await chmod(path, mode);
+}
+
+function parseArguments(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new AzureRuntimeEnvError('Arguments must be supplied as --name value pairs', 'INVALID_ARGUMENTS');
+    }
+    values.set(key.slice(2), value);
+  }
+  for (const required of ['contract', 'profile', 'settings-out', 'evidence-out']) {
+    if (!values.get(required)) {
+      throw new AzureRuntimeEnvError(`Missing --${required}`, 'INVALID_ARGUMENTS');
+    }
+  }
+  return values;
+}
+
+export async function runCli(argv = process.argv.slice(2), environment = process.env) {
+  const args = parseArguments(argv);
+  const contract = JSON.parse(await readFile(args.get('contract'), 'utf8'));
+  const rendered = renderAzureAppSettings(contract, args.get('profile'), environment);
+
+  // The settings file contains secrets. Keep it runner-local, mode 0600, and
+  // never upload it as an artifact. The workflow deletes it in an always() step.
+  await writeJson(args.get('settings-out'), rendered.settings, 0o600);
+  await writeJson(args.get('evidence-out'), rendered.evidence, 0o644);
+
+  console.log(`Resolved ${rendered.settings.length} Azure App Settings for profile ${args.get('profile')}.`);
+  console.log(`Names: ${rendered.settings.map((setting) => setting.name).join(', ')}`);
+  return rendered.evidence;
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isDirectRun) {
+  runCli().catch((error) => {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(`::error::Azure runtime ENV render failed: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/unit/scripts/azure-app-settings.test.ts
+++ b/tests/unit/scripts/azure-app-settings.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  AzureRuntimeEnvError,
+  renderAzureAppSettings,
+  validateContract,
+} from '../../../scripts/render-azure-app-settings.mjs';
+
+const CONTRACT = {
+  schemaVersion: 'dsg.azure-runtime-env.v1',
+  target: 'test-app',
+  profiles: { core: 0, governed: 1, rollback: 2 },
+  neverSync: [{ name: 'SUPABASE_DB_PASSWORD', reason: 'CI only' }],
+  settings: [
+    {
+      name: 'APP_URL',
+      source: 'variable',
+      minimumProfile: 'core',
+      required: true,
+      phase: 'runtime',
+      slotSetting: true,
+      default: 'https://example.test',
+    },
+    {
+      name: 'CORE_SECRET',
+      source: 'secret',
+      minimumProfile: 'core',
+      required: true,
+      phase: 'runtime',
+      slotSetting: true,
+    },
+    {
+      name: 'GOVERNED_SECRET',
+      source: 'secret',
+      minimumProfile: 'governed',
+      required: true,
+      phase: 'runtime',
+      slotSetting: true,
+    },
+    {
+      name: 'OPTIONAL_PUBLIC',
+      source: 'secretOrVariable',
+      minimumProfile: 'core',
+      required: false,
+      phase: 'buildAndRuntime',
+      slotSetting: true,
+    },
+  ],
+};
+
+describe('Azure App Service runtime ENV contract', () => {
+  it('resolves a profile from configured values plus safe defaults', () => {
+    const rendered = renderAzureAppSettings(CONTRACT, 'core', {
+      DSG_ENV_CORE_SECRET: 'do-not-print-me',
+      DSG_ENV_OPTIONAL_PUBLIC: 'public-value',
+    });
+
+    expect(rendered.settings).toEqual([
+      { name: 'APP_URL', value: 'https://example.test', slotSetting: true },
+      { name: 'CORE_SECRET', value: 'do-not-print-me', slotSetting: true },
+      { name: 'OPTIONAL_PUBLIC', value: 'public-value', slotSetting: true },
+    ]);
+    expect(JSON.stringify(rendered.evidence)).not.toContain('do-not-print-me');
+    expect(JSON.stringify(rendered.evidence)).not.toContain('public-value');
+  });
+
+  it('fails closed and reports names when a required setting is absent', () => {
+    const render = () => renderAzureAppSettings(CONTRACT, 'governed', {
+      DSG_ENV_CORE_SECRET: 'present',
+    });
+    expect(render).toThrow('Missing required governed settings: GOVERNED_SECRET');
+    try {
+      render();
+    } catch (error) {
+      expect(error).toBeInstanceOf(AzureRuntimeEnvError);
+      expect(error).toMatchObject({
+        code: 'MISSING_REQUIRED_SETTINGS',
+        details: { missing: ['GOVERNED_SECRET'], profile: 'governed' },
+      });
+    }
+  });
+
+  it('does not include a higher profile in a lower profile render', () => {
+    const rendered = renderAzureAppSettings(CONTRACT, 'core', {
+      DSG_ENV_CORE_SECRET: 'present',
+      DSG_ENV_GOVERNED_SECRET: 'configured-but-out-of-scope',
+    });
+    expect(rendered.settings.map((setting) => setting.name)).not.toContain('GOVERNED_SECRET');
+  });
+
+  it('rejects a setting that is also on the never-sync list', () => {
+    const invalid = structuredClone(CONTRACT);
+    invalid.settings.push({
+      name: 'SUPABASE_DB_PASSWORD',
+      source: 'secret',
+      minimumProfile: 'core',
+      required: true,
+      phase: 'runtime',
+      slotSetting: true,
+    });
+    expect(() => validateContract(invalid)).toThrow('SUPABASE_DB_PASSWORD is both allowlisted and denied');
+  });
+
+  it('validates the checked-in production contract', () => {
+    const productionContract = JSON.parse(
+      readFileSync('config/azure-runtime-env.contract.json', 'utf8'),
+    );
+    expect(() => validateContract(productionContract)).not.toThrow();
+    expect(productionContract.neverSync.map(({ name }: { name: string }) => name)).toContain(
+      'SUPABASE_DB_PASSWORD',
+    );
+  });
+});


### PR DESCRIPTION
## Outcome

Stop treating `.env.example` as a 119-variable production checklist. Introduce a small, allowlisted Azure runtime contract sourced from GitHub Actions Environments so a recreated App Service or slot can be configured again without manually re-entering every value.

## Changes

- add `core`, `governed`, and `rollback` runtime profiles
- add a fail-closed renderer that reports missing names without logging values
- add a manual/reusable GitHub OIDC workflow that:
  - defaults to dry-run
  - writes secret values only to runner-local mode-0600 files
  - applies allowlisted App Settings
  - reads values back and compares exact parity without printing them
  - uploads names-only evidence
  - deletes both temporary value files before artifact upload
- explicitly deny CI-only `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, and `SUPABASE_PROJECT_REF` from App Service sync
- document the Next.js build-time boundary for `NEXT_PUBLIC_*`
- mark the old AWS/Vercel secrets guide as legacy
- add unit coverage for profile selection, missing-value failure, evidence redaction, and denylist enforcement

## Verification performed

- Node 24 renderer smoke tests for `governed` and `rollback`
- missing-value failure confirmed non-zero without value disclosure
- JSON contract and workflow YAML parsed
- every allowlisted contract name has exactly one workflow mapping
- no denied migration credential has a runtime mapping

## Truth boundary

This closes repeated runtime ENV re-entry at the code/workflow layer. It does not create the Azure federated identity, rotate the stale Supabase database password, deploy an image, or prove application E2E readiness. `NEXT_PUBLIC_*` values must also be supplied to the future ACR build workflow because App Settings cannot rewrite an already-built Next.js bundle.