### PR TITLE
fix(ci): remove Supabase DB password dependency

### DIFF
--- a/.github/workflows/dsg-platform-deploy.yml
+++ b/.github/workflows/dsg-platform-deploy.yml
@@ -233,7 +233,6 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_ID || 'zeyguilldygozufpgxms' }}
     steps:
       - name: Checkout requested source
@@ -247,28 +246,27 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${SUPABASE_ACCESS_TOKEN:-}" || { echo 'SUPABASE_ACCESS_TOKEN is not configured' >&2; exit 3; }
-          test -n "${SUPABASE_DB_PASSWORD:-}" || { echo 'SUPABASE_DB_PASSWORD is not configured' >&2; exit 3; }
           test -n "${SUPABASE_PROJECT_REF:-}" || { echo 'SUPABASE_PROJECT_REF is not configured' >&2; exit 3; }
           test -f supabase/config.toml || { echo 'supabase/config.toml is missing' >&2; exit 3; }
 
       - name: Install pinned Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.84.2
+          version: 2.116.0
 
-      - name: Link project
+      - name: Link project without a database password
         shell: bash
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
       - name: Preflight pending migrations
         if: ${{ inputs.supabase_mode == 'migrations' || inputs.supabase_mode == 'all' }}
         shell: bash
-        run: supabase db push --dry-run | tee supabase-migration-dry-run.txt
+        run: supabase db push --linked --dry-run --yes | tee supabase-migration-dry-run.txt
 
       - name: Apply migrations
         if: ${{ inputs.supabase_mode == 'migrations' || inputs.supabase_mode == 'all' }}
         shell: bash
-        run: supabase db push | tee supabase-migration-push.txt
+        run: supabase db push --linked --yes | tee supabase-migration-push.txt
 
       - name: Deploy Edge Functions
         if: ${{ inputs.supabase_mode == 'functions' || inputs.supabase_mode == 'all' }}
@@ -279,7 +277,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          supabase migration list > supabase-migration-list.txt 2>&1 || true
+          supabase migration list --linked > supabase-migration-list.txt 2>&1 || true
           supabase functions list --project-ref "$SUPABASE_PROJECT_REF" > supabase-functions-list.txt 2>&1 || true
 
       - name: Capture evidence

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -3,7 +3,6 @@ name: Production Readiness Check
 # - VERCEL_TOKEN
 # - VERCEL_TOKEN_NEW (only when .github/vercel-routing.json selects new)
 # - SUPABASE_ACCESS_TOKEN
-# - SUPABASE_DB_PASSWORD
 # - SUPABASE_PROJECT_REF (optional override; project ID fallback is configured)
 #
 # Runtime readiness is verified through /api/finance-governance/readiness
@@ -44,7 +43,6 @@ jobs:
         id: check
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_ID || 'zeyguilldygozufpgxms' }}
         run: |
           if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
@@ -55,9 +53,9 @@ jobs:
             echo "⚠ Vercel management secrets missing — offline env-var-check will be skipped"
           fi
 
-          if [ -n "${SUPABASE_ACCESS_TOKEN:-}" ] && [ -n "${SUPABASE_DB_PASSWORD:-}" ] && [ -n "${SUPABASE_PROJECT_REF:-}" ]; then
+          if [ -n "${SUPABASE_ACCESS_TOKEN:-}" ] && [ -n "${SUPABASE_PROJECT_REF:-}" ]; then
             echo "has_supabase=true" >> $GITHUB_OUTPUT
-            echo "✓ Supabase migration secrets available"
+            echo "✓ Supabase passwordless migration access available"
           else
             echo "has_supabase=false" >> $GITHUB_OUTPUT
             echo "⚠ Supabase migration secrets missing — db-migration-check will be skipped"
@@ -192,32 +190,45 @@ jobs:
     if: needs.preflight-secrets-check.outputs.has_supabase == 'true'
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_ID || 'zeyguilldygozufpgxms' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v2
+        with:
+          version: 2.116.0
 
-      - name: Link to Supabase project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+      - name: Link to Supabase project without a database password
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
       - name: Check pending migrations
         id: migration_check
         run: |
-          OUTPUT=$(supabase db push --dry-run 2>&1 || true)
+          set +e
+          OUTPUT=$(supabase db push --linked --dry-run --yes 2>&1)
+          EXIT_CODE=$?
+          set -e
           echo "$OUTPUT" | tee /tmp/migration_output.txt
+
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo "status=fail" >> $GITHUB_OUTPUT
+            echo "✗ Supabase migration check failed with exit code $EXIT_CODE"
+            exit "$EXIT_CODE"
+          fi
 
           if echo "$OUTPUT" | grep -q "No pending migrations"; then
             echo "status=pass" >> $GITHUB_OUTPUT
             echo "✓ All migrations applied"
-          elif echo "$OUTPUT" | grep -q "pending"; then
-            echo "status=warn" >> $GITHUB_OUTPUT
-            echo "⚠ Pending migrations found"
+          elif echo "$OUTPUT" | grep -Eq "Would push migration|Applying migration"; then
+            echo "status=fail" >> $GITHUB_OUTPUT
+            echo "✗ Pending migrations found"
+            exit 1
           else
-            echo "status=pass" >> $GITHUB_OUTPUT
+            echo "status=fail" >> $GITHUB_OUTPUT
+            echo "✗ Unrecognized Supabase migration check output"
+            exit 1
           fi
 
       - name: Generate migration summary

--- a/.github/workflows/supabase-history-reconcile.yml
+++ b/.github/workflows/supabase-history-reconcile.yml
@@ -23,39 +23,30 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v2
         with:
-          node-version: '24'
+          version: 2.116.0
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
-
-      - name: Validate required Supabase secrets
+      - name: Validate required Supabase access
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           test -n "${SUPABASE_ACCESS_TOKEN:-}" || { echo "::error::Missing SUPABASE_ACCESS_TOKEN repository secret"; exit 1; }
-          test -n "${SUPABASE_DB_PASSWORD:-}" || { echo "::error::Missing SUPABASE_DB_PASSWORD repository secret"; exit 1; }
 
-      - name: Link Supabase project
+      - name: Link Supabase project without a database password
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
       - name: Fetch canonical remote migration files
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-          SUPABASE_YES: 'true'
-        run: supabase migration fetch --linked
+        run: supabase migration fetch --linked --yes
 
       - name: Verify migration parity
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           supabase migration list --linked | tee /tmp/migration-list.txt
           if grep -Eq '^\s*\|\s*[0-9]{14}\s*\|' /tmp/migration-list.txt; then

--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -19,30 +19,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v2
         with:
-          node-version: '24'
+          version: 2.116.0
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
-
-      - name: Validate Supabase secrets
+      - name: Validate Supabase access
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           test -n "${SUPABASE_ACCESS_TOKEN:-}" || { echo "::error::Missing SUPABASE_ACCESS_TOKEN repository secret"; exit 1; }
-          test -n "${SUPABASE_DB_PASSWORD:-}" || { echo "::error::Missing SUPABASE_DB_PASSWORD repository secret"; exit 1; }
 
-      - name: Link project
+      - name: Link project without a database password
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
-      - name: Push migrations
+      - name: Push migrations with temporary login role
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase db push --linked
+        run: supabase db push --linked --yes

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v2
+        with:
+          version: 2.116.0
 
       - name: Validate Supabase access token
         env:
@@ -71,33 +73,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v2
         with:
-          node-version: 24
+          version: 2.116.0
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
-
-      - name: Validate Supabase migration secrets
+      - name: Validate Supabase migration access
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           test -n "${SUPABASE_ACCESS_TOKEN:-}" || { echo "::error::Missing SUPABASE_ACCESS_TOKEN repository secret"; exit 1; }
-          test -n "${SUPABASE_DB_PASSWORD:-}" || { echo "::error::Missing SUPABASE_DB_PASSWORD repository secret"; exit 1; }
 
-      - name: Link project
+      - name: Link project without a database password
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
-      - name: Run database migrations
+      - name: Run database migrations with temporary login role
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-        run: supabase db push --linked
+        run: supabase db push --linked --yes
 
       - name: Notify on migration failure
         if: failure()

--- a/docs/ops/supabase-passwordless-migrations.md
+++ b/docs/ops/supabase-passwordless-migrations.md
@@ -1,0 +1,30 @@
+# Supabase passwordless migrations
+
+Hosted Supabase migrations use the CLI's temporary login role. GitHub Actions no longer depends on `SUPABASE_DB_PASSWORD`, so rotating or moving a database does not require updating a copied password in every workflow.
+
+## Canonical inputs
+
+- `SUPABASE_ACCESS_TOKEN`: the only secret required by migration workflows. Use a fine-grained token with the minimum database migration permissions.
+- `SUPABASE_PROJECT_REF` or `SUPABASE_PROJECT_ID`: optional project selector. The canonical control-plane project ref is the checked-in fallback.
+- Supabase CLI `2.116.0`: pinned because this release restores the `postgres` role correctly in passwordless migration sessions.
+
+The workflows intentionally never pass `--include-all`. Normal `db push` therefore applies migrations newer than the remote migration head and does not replay older local-only history.
+
+## Workflows
+
+- `supabase-migrations.yml`: runs automatically when migrations or the workflow change.
+- `supabase-migrate.yml`: manual recovery entry point.
+- `supabase-history-reconcile.yml`: fetches canonical remote history into a review branch.
+- `dsg-platform-deploy.yml`: governed manual Supabase deployment surface.
+- `production-readiness.yml`: fail-closed dry-run; connection errors, unknown output, and pending migrations cannot be reported as PASS.
+
+## Verification
+
+After a migration run:
+
+1. Confirm the workflow used the pinned CLI and initialized a temporary login role.
+2. Confirm the exact migration version appears in remote migration history.
+3. Verify the expected tables, functions, RLS, and grants from the live database.
+4. Do not treat a workflow success alone as application E2E proof.
+
+For a self-hosted database or a direct PostgreSQL connection, use a separate credentialed workflow. Do not add a hosted database password back to these workflows.

--- a/scripts/supabase-init.sh
+++ b/scripts/supabase-init.sh
@@ -1,23 +1,22 @@
 #!/usr/bin/env bash
 # Link the canonical DSG Supabase project and apply repository migrations.
-# SUPABASE_DB_PASSWORD must be the raw database password; do not percent-encode it here.
+# Hosted Supabase uses a temporary CLI login role; no database password is required.
 
 set -euo pipefail
 
 : "${SUPABASE_ACCESS_TOKEN:?SUPABASE_ACCESS_TOKEN is required}"
-: "${SUPABASE_DB_PASSWORD:?SUPABASE_DB_PASSWORD is required}"
 
 SUPABASE_PROJECT_REF="${SUPABASE_PROJECT_REF:-${SUPABASE_PROJECT_ID:-zeyguilldygozufpgxms}}"
 
 command -v supabase >/dev/null 2>&1 || {
-  echo "supabase CLI is required. Install it before running this script." >&2
+  echo "supabase CLI 2.116.0 or newer is required. Install it before running this script." >&2
   exit 1
 }
 
 echo "Linking Supabase project: $SUPABASE_PROJECT_REF"
-supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
 echo "Applying canonical repository migrations..."
-supabase db push --linked
+supabase db push --linked --yes
 
 echo "Supabase initialization complete."


### PR DESCRIPTION
## Outcome

Removes `SUPABASE_DB_PASSWORD` from hosted Supabase migration, reconciliation, governed deploy, and readiness workflows.

## Changes

- pin Supabase CLI `2.116.0`, which includes the passwordless role-restore fix
- authenticate with the existing `SUPABASE_ACCESS_TOKEN` and temporary CLI login role
- keep `db push` fail-closed and intentionally omit `--include-all`
- make Production Readiness fail on connection errors, pending migrations, or unknown output instead of reporting a false PASS
- update the local initialization helper and add an operations note

## Safety evidence

- live remote migration head: `20260823124642`
- only repository migration newer than that head: `20260825083000_agentic_post_deploy_feedback.sql`
- all five changed workflow files parse as YAML
- no operational workflow in this change references `SUPABASE_DB_PASSWORD` or `--password`
- automatic `supabase-migrations.yml` run after merge will therefore apply at most the single new migration under normal `db push` ordering; older local-only files are not force-included

## Verification after merge

1. inspect the automatic Supabase Migrations run
2. confirm remote migration history contains `20260825083000`
3. query the four receipt/baseline tables and `dsg_commit_evolution_baseline`
4. verify RLS and service-role grants

This fixes credential drift; it is not by itself evidence that the full governed E2E chain passed.