### PR TITLE
fix(db): restore missing Supabase migration ledger source

### DIFF
--- a/docs/ops/supabase-passwordless-migrations.md
+++ b/docs/ops/supabase-passwordless-migrations.md
@@ -28,3 +28,19 @@ After a migration run:
 4. Do not treat a workflow success alone as application E2E proof.
 
 For a self-hosted database or a direct PostgreSQL connection, use a separate credentialed workflow. Do not add a hosted database password back to these workflows.
+
+## Shared migration ledger recovery
+
+The linked project is also used by governed DSG services outside this
+repository. A successful passwordless connection can therefore still stop with
+`Remote migration versions not found in local migrations directory` when an
+external service applied DDL but its exact ledger files were never committed
+here.
+
+Do not run `migration repair --status reverted` for migrations that are visibly
+present in the live schema. That rewrites history rather than restoring source.
+Instead, recover `version`, `name`, and `statements` from
+`supabase_migrations.schema_migrations`, review the DDL, and commit the exact
+timestamped files. The seven files from `20260817081058` through
+`20260823124642` were restored this way on 2026-08-28. This lets `db push`
+compare the ledger honestly and preserves full replay for a fresh database.

--- a/supabase/migrations/20260817081058_trinity_revenue_tables.sql
+++ b/supabase/migrations/20260817081058_trinity_revenue_tables.sql
@@ -1,0 +1,79 @@
+-- Restored verbatim in meaning from supabase_migrations.schema_migrations on
+-- 2026-08-28. Keep this version/name stable: it is already applied remotely.
+
+CREATE TABLE IF NOT EXISTS trinity_revenue_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id text NOT NULL,
+  period_start timestamptz NOT NULL,
+  period_end timestamptz NOT NULL,
+  source text NOT NULL DEFAULT 'trinity-agents',
+  total_amount_usd decimal(10, 4) NOT NULL,
+  agent_count integer NOT NULL,
+  healthy_agents integer,
+  fragmentation_risk decimal(5, 2),
+  context_sharing decimal(5, 2),
+  metrics_json jsonb,
+  status text NOT NULL DEFAULT 'pending_reconciliation',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT valid_amount CHECK (total_amount_usd >= 0),
+  CONSTRAINT valid_agent_count CHECK (agent_count >= 0),
+  CONSTRAINT valid_healthy_agents CHECK (healthy_agents IS NULL OR healthy_agents >= 0),
+  CONSTRAINT valid_period CHECK (period_end > period_start)
+);
+
+CREATE TABLE IF NOT EXISTS trinity_revenue_agents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  trinity_revenue_record_id uuid REFERENCES trinity_revenue_records(id) ON DELETE CASCADE,
+  agent_name text NOT NULL,
+  jobs_processed integer DEFAULT 0,
+  cpu_usage decimal(5, 2),
+  agent_cost_usd decimal(10, 4) NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT valid_cost CHECK (agent_cost_usd >= 0),
+  CONSTRAINT valid_jobs CHECK (jobs_processed >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS trinity_revenue_sync_state (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  last_successful_sync timestamptz,
+  last_sync_attempt timestamptz,
+  last_sync_period text,
+  last_sync_record_count integer,
+  last_sync_total_cost decimal(10, 4),
+  status text NOT NULL DEFAULT 'ready',
+  error_message text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_trinity_revenue_records_org_period
+  ON trinity_revenue_records(organization_id, period_start DESC, period_end DESC);
+CREATE INDEX IF NOT EXISTS idx_trinity_revenue_records_status
+  ON trinity_revenue_records(status);
+CREATE INDEX IF NOT EXISTS idx_trinity_revenue_records_created
+  ON trinity_revenue_records(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_trinity_revenue_agents_record
+  ON trinity_revenue_agents(trinity_revenue_record_id);
+CREATE INDEX IF NOT EXISTS idx_trinity_revenue_agents_agent
+  ON trinity_revenue_agents(agent_name);
+
+ALTER TABLE trinity_revenue_records ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trinity_revenue_agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trinity_revenue_sync_state ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS trinity_revenue_service_role ON trinity_revenue_records;
+CREATE POLICY trinity_revenue_service_role
+  ON trinity_revenue_records FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS trinity_revenue_agents_service_role ON trinity_revenue_agents;
+CREATE POLICY trinity_revenue_agents_service_role
+  ON trinity_revenue_agents FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS trinity_sync_state_service_role ON trinity_revenue_sync_state;
+CREATE POLICY trinity_sync_state_service_role
+  ON trinity_revenue_sync_state FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE trinity_revenue_records IS 'Trinity DSG Agent cost records from hourly revenue sync';
+COMMENT ON TABLE trinity_revenue_agents IS 'Per-agent cost breakdown within each revenue record';
+COMMENT ON TABLE trinity_revenue_sync_state IS 'State tracking for Trinity revenue sync operations';
+COMMENT ON COLUMN trinity_revenue_records.status IS 'Status: pending_reconciliation, reconciled, billed, archived';
+COMMENT ON COLUMN trinity_revenue_sync_state.status IS 'Status: ready, syncing, failed, degraded';

--- a/supabase/migrations/20260818115153_create_dsg_audit_ledger.sql
+++ b/supabase/migrations/20260818115153_create_dsg_audit_ledger.sql
@@ -1,0 +1,32 @@
+-- Restored from supabase_migrations.schema_migrations on 2026-08-28.
+
+CREATE TABLE IF NOT EXISTS public.dsg_audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_open_id text NOT NULL,
+  execution_id text NOT NULL,
+  attempt_number integer NOT NULL DEFAULT 0 CHECK (attempt_number >= 0),
+  event_type text NOT NULL,
+  agent_id text NOT NULL,
+  adapter_kind text NOT NULL,
+  action_kind text NOT NULL,
+  decision text NOT NULL,
+  status text NOT NULL,
+  policy_version text NOT NULL,
+  evidence_hash text,
+  previous_hash text,
+  current_hash text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(owner_open_id, current_hash)
+);
+
+CREATE INDEX IF NOT EXISTS dsg_audit_events_owner_time_idx
+  ON public.dsg_audit_events(owner_open_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS dsg_audit_events_execution_idx
+  ON public.dsg_audit_events(owner_open_id, execution_id, attempt_number);
+ALTER TABLE public.dsg_audit_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dsg_audit_events_owner_select
+  ON public.dsg_audit_events FOR SELECT USING (owner_open_id = auth.uid()::text);
+CREATE POLICY dsg_audit_events_owner_insert
+  ON public.dsg_audit_events FOR INSERT WITH CHECK (owner_open_id = auth.uid()::text);

--- a/supabase/migrations/20260818123357_create_dsg_audit_ledger_api_schema.sql
+++ b/supabase/migrations/20260818123357_create_dsg_audit_ledger_api_schema.sql
@@ -1,0 +1,32 @@
+-- Restored from supabase_migrations.schema_migrations on 2026-08-28.
+
+CREATE TABLE IF NOT EXISTS api.dsg_audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_open_id text NOT NULL,
+  execution_id text NOT NULL,
+  attempt_number integer NOT NULL DEFAULT 0 CHECK (attempt_number >= 0),
+  event_type text NOT NULL,
+  agent_id text NOT NULL,
+  adapter_kind text NOT NULL,
+  action_kind text NOT NULL,
+  decision text NOT NULL,
+  status text NOT NULL,
+  policy_version text NOT NULL,
+  evidence_hash text,
+  previous_hash text,
+  current_hash text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(owner_open_id, current_hash)
+);
+
+CREATE INDEX IF NOT EXISTS dsg_audit_events_owner_time_idx
+  ON api.dsg_audit_events(owner_open_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS dsg_audit_events_execution_idx
+  ON api.dsg_audit_events(owner_open_id, execution_id, attempt_number);
+ALTER TABLE api.dsg_audit_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dsg_audit_events_owner_select
+  ON api.dsg_audit_events FOR SELECT USING (owner_open_id = auth.uid()::text);
+CREATE POLICY dsg_audit_events_owner_insert
+  ON api.dsg_audit_events FOR INSERT WITH CHECK (owner_open_id = auth.uid()::text);

--- a/supabase/migrations/20260818123435_grant_dsg_audit_ledger_service_role.sql
+++ b/supabase/migrations/20260818123435_grant_dsg_audit_ledger_service_role.sql
@@ -1,0 +1,4 @@
+-- Restored from supabase_migrations.schema_migrations on 2026-08-28.
+
+GRANT USAGE ON SCHEMA api TO service_role;
+GRANT SELECT, INSERT ON TABLE api.dsg_audit_events TO service_role;

--- a/supabase/migrations/20260818124307_add_dsg_audit_proof_hash.sql
+++ b/supabase/migrations/20260818124307_add_dsg_audit_proof_hash.sql
@@ -1,0 +1,3 @@
+-- Restored from supabase_migrations.schema_migrations on 2026-08-28.
+
+ALTER TABLE api.dsg_audit_events ADD COLUMN IF NOT EXISTS proof_hash text;

--- a/supabase/migrations/20260823121921_extend_dsg_guarded_evidence.sql
+++ b/supabase/migrations/20260823121921_extend_dsg_guarded_evidence.sql
@@ -1,0 +1,37 @@
+-- Restored from supabase_migrations.schema_migrations on 2026-08-28.
+
+ALTER TABLE dsg_guarded_evidence
+    ADD COLUMN IF NOT EXISTS plan_id TEXT NOT NULL DEFAULT 'prototype',
+    ADD COLUMN IF NOT EXISTS plan_hash TEXT NOT NULL DEFAULT repeat('0', 64),
+    ADD COLUMN IF NOT EXISTS agent_identity TEXT NOT NULL DEFAULT 'prototype',
+    ADD COLUMN IF NOT EXISTS channel TEXT NOT NULL DEFAULT 'api',
+    ADD COLUMN IF NOT EXISTS step_id TEXT,
+    ADD COLUMN IF NOT EXISTS action TEXT NOT NULL DEFAULT 'prototype',
+    ADD COLUMN IF NOT EXISTS target TEXT NOT NULL DEFAULT 'prototype',
+    ADD COLUMN IF NOT EXISTS parameters JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS decision TEXT NOT NULL DEFAULT 'PROTOTYPE',
+    ADD COLUMN IF NOT EXISTS control_hash TEXT NOT NULL DEFAULT repeat('0', 64),
+    ADD COLUMN IF NOT EXISTS mutation_status TEXT NOT NULL DEFAULT 'succeeded',
+    ADD COLUMN IF NOT EXISTS outputs JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS evidence_hash TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS recorded_at TEXT NOT NULL DEFAULT '';
+
+UPDATE dsg_guarded_evidence
+   SET recorded_at = to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+ WHERE recorded_at = '';
+
+ALTER TABLE dsg_guarded_evidence
+    ALTER COLUMN plan_id DROP DEFAULT,
+    ALTER COLUMN plan_hash DROP DEFAULT,
+    ALTER COLUMN agent_identity DROP DEFAULT,
+    ALTER COLUMN channel DROP DEFAULT,
+    ALTER COLUMN action DROP DEFAULT,
+    ALTER COLUMN target DROP DEFAULT,
+    ALTER COLUMN decision DROP DEFAULT,
+    ALTER COLUMN control_hash DROP DEFAULT,
+    ALTER COLUMN mutation_status DROP DEFAULT,
+    ALTER COLUMN evidence_hash DROP DEFAULT,
+    ALTER COLUMN recorded_at DROP DEFAULT;
+
+CREATE INDEX IF NOT EXISTS dsg_guarded_evidence_tenant_created_idx
+    ON dsg_guarded_evidence (tenant_id, created_at DESC);

--- a/supabase/migrations/20260823124642_guarded_evidence_text_payloads_and_observations.sql
+++ b/supabase/migrations/20260823124642_guarded_evidence_text_payloads_and_observations.sql
@@ -1,0 +1,20 @@
+-- Restored from supabase_migrations.schema_migrations on 2026-08-28.
+
+ALTER TABLE dsg_guarded_evidence
+    ADD COLUMN IF NOT EXISTS output_sha256 TEXT,
+    ADD COLUMN IF NOT EXISTS started_at TEXT,
+    ADD COLUMN IF NOT EXISTS finished_at TEXT;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'dsg_guarded_evidence'
+           AND column_name IN ('parameters', 'outputs')
+           AND data_type = 'jsonb'
+    ) THEN
+        ALTER TABLE dsg_guarded_evidence
+            ALTER COLUMN parameters TYPE TEXT USING parameters::text,
+            ALTER COLUMN outputs TYPE TEXT USING outputs::text;
+    END IF;
+END $$;


### PR DESCRIPTION
## Root cause
`Supabase Migrations` reached the hosted database through the passwordless temporary login role, then failed because seven remote migration versions were absent from this repository.

## Fix
- restores versions `20260817081058` through `20260823124642` with their original names and DDL
- source was read from the live `supabase_migrations.schema_migrations.statements` ledger, not inferred from table presence
- documents why `migration repair --status reverted` is incorrect when the schema and history are real

## Expected next run
`supabase db push` should match the remote ledger and apply only the pending `20260825083000_agentic_post_deploy_feedback.sql` migration.

## Truth boundary
This PR restores version-controlled migration replay. PASS still requires the post-merge migration workflow plus live verification of tables, RPCs, RLS, and grants.