### PR TITLE
fix(db): stage only canonical Supabase migration history

### DIFF
--- a/.github/workflows/dsg-platform-deploy.yml
+++ b/.github/workflows/dsg-platform-deploy.yml
@@ -258,6 +258,16 @@ jobs:
         shell: bash
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
+      - name: Stage canonical migration ledger
+        if: ${{ inputs.supabase_mode == 'migrations' || inputs.supabase_mode == 'all' }}
+        shell: bash
+        run: |
+          node scripts/prepare-supabase-canonical-migrations.mjs \
+            --ledger supabase/canonical-migration-ledger.json \
+            --migrations-dir supabase/migrations \
+            --quarantine-dir "$RUNNER_TEMP/dsg-supabase-legacy-local-only" \
+            --evidence-out supabase-ledger-preparation.json
+
       - name: Preflight pending migrations
         if: ${{ inputs.supabase_mode == 'migrations' || inputs.supabase_mode == 'all' }}
         shell: bash
@@ -292,6 +302,7 @@ jobs:
           import hashlib, json, os, subprocess
           from pathlib import Path
           files = [
+              'supabase-ledger-preparation.json',
               'supabase-migration-dry-run.txt',
               'supabase-migration-push.txt',
               'supabase-functions-deploy.txt',
@@ -323,6 +334,7 @@ jobs:
           name: dsg-deployment-evidence-supabase-${{ inputs.environment }}-${{ inputs.idempotency_key }}
           path: |
             deployment-evidence.json
+            supabase-ledger-preparation.json
             supabase-*.txt
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/production-readiness.yml
+++ b/.github/workflows/production-readiness.yml
@@ -203,6 +203,14 @@ jobs:
       - name: Link to Supabase project without a database password
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
+      - name: Stage canonical migration ledger
+        run: |
+          node scripts/prepare-supabase-canonical-migrations.mjs \
+            --ledger supabase/canonical-migration-ledger.json \
+            --migrations-dir supabase/migrations \
+            --quarantine-dir "$RUNNER_TEMP/dsg-supabase-legacy-local-only" \
+            --evidence-out "$RUNNER_TEMP/dsg-supabase-ledger-preparation.json"
+
       - name: Check pending migrations
         id: migration_check
         run: |

--- a/.github/workflows/supabase-migrate.yml
+++ b/.github/workflows/supabase-migrate.yml
@@ -35,7 +35,25 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
+      - name: Stage canonical migration ledger
+        id: canonical_ledger
+        run: |
+          node scripts/prepare-supabase-canonical-migrations.mjs \
+            --ledger supabase/canonical-migration-ledger.json \
+            --migrations-dir supabase/migrations \
+            --quarantine-dir "$RUNNER_TEMP/dsg-supabase-legacy-local-only" \
+            --evidence-out "$RUNNER_TEMP/dsg-supabase-ledger-preparation.json"
+
       - name: Push migrations with temporary login role
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: supabase db push --linked --yes
+
+      - name: Upload canonical-ledger evidence
+        if: always() && steps.canonical_ledger.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: supabase-canonical-ledger-${{ github.run_id }}
+          path: ${{ runner.temp }}/dsg-supabase-ledger-preparation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -89,6 +89,15 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
 
+      - name: Stage canonical migration ledger
+        id: canonical_ledger
+        run: |
+          node scripts/prepare-supabase-canonical-migrations.mjs \
+            --ledger supabase/canonical-migration-ledger.json \
+            --migrations-dir supabase/migrations \
+            --quarantine-dir "$RUNNER_TEMP/dsg-supabase-legacy-local-only" \
+            --evidence-out "$RUNNER_TEMP/dsg-supabase-ledger-preparation.json"
+
       - name: Run database migrations with temporary login role
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -98,3 +107,12 @@ jobs:
         if: failure()
         run: |
           echo "::error::Database migration failed. Check logs and recovery steps in docs/RUNBOOK_DEPLOY.md"
+
+      - name: Upload canonical-ledger evidence
+        if: always() && steps.canonical_ledger.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: supabase-canonical-ledger-${{ github.run_id }}
+          path: ${{ runner.temp }}/dsg-supabase-ledger-preparation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/ops/supabase-passwordless-migrations.md
+++ b/docs/ops/supabase-passwordless-migrations.md
@@ -8,7 +8,12 @@ Hosted Supabase migrations use the CLI's temporary login role. GitHub Actions no
 - `SUPABASE_PROJECT_REF` or `SUPABASE_PROJECT_ID`: optional project selector. The canonical control-plane project ref is the checked-in fallback.
 - Supabase CLI `2.116.0`: pinned because this release restores the `postgres` role correctly in passwordless migration sessions.
 
-The workflows intentionally never pass `--include-all`. Normal `db push` therefore applies migrations newer than the remote migration head and does not replay older local-only history.
+The workflows intentionally never pass `--include-all`. Before `db push`,
+`scripts/prepare-supabase-canonical-migrations.mjs` verifies the checked-in
+remote ledger snapshot, keeps its exact files plus migrations newer than the
+remote head, and quarantines legacy local-only files in runner temporary
+storage. Normal `db push` therefore applies only new canonical migrations and
+does not replay divergent historical files.
 
 ## Workflows
 
@@ -44,3 +49,10 @@ Instead, recover `version`, `name`, and `statements` from
 timestamped files. The seven files from `20260817081058` through
 `20260823124642` were restored this way on 2026-08-28. This lets `db push`
 compare the ledger honestly and preserves full replay for a fresh database.
+
+`supabase/canonical-migration-ledger.json` records the canonical version/name
+pairs observed from the linked project. Preparation fails if a canonical file
+is missing, duplicated, or renamed. Files older than the recorded remote head
+that are not in that ledger are preserved in git but excluded only inside the
+ephemeral hosted runner. The names-only preparation evidence is uploaded with
+the migration run.

--- a/scripts/prepare-supabase-canonical-migrations.mjs
+++ b/scripts/prepare-supabase-canonical-migrations.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { chmod, copyFile, mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SCHEMA = 'dsg.supabase-canonical-ledger.v1';
+const VERSIONED_FILE = /^(\d{10}|\d{14})_(.+)\.sql$/;
+
+export class CanonicalMigrationError extends Error {
+  constructor(message, code, details = {}) {
+    super(message);
+    this.name = 'CanonicalMigrationError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function assert(condition, message, code = 'INVALID_LEDGER', details = {}) {
+  if (!condition) throw new CanonicalMigrationError(message, code, details);
+}
+
+export function validateCanonicalLedger(input) {
+  assert(input?.schemaVersion === SCHEMA, `Unsupported ledger schema: ${input?.schemaVersion ?? '(missing)'}`);
+  assert(typeof input?.projectRef === 'string' && input.projectRef.length > 0, 'projectRef is required');
+  assert(/^\d{10}$|^\d{14}$/.test(input?.remoteHead ?? ''), 'remoteHead must be a 10- or 14-digit version');
+  assert(Array.isArray(input?.migrations) && input.migrations.length > 0, 'migrations must be a non-empty array');
+
+  const seen = new Set();
+  let previous = '';
+  for (const migration of input.migrations) {
+    assert(/^\d{10}$|^\d{14}$/.test(migration?.version ?? ''), 'migration version is invalid');
+    assert(typeof migration?.name === 'string' && migration.name.length > 0, `${migration.version} name is missing`);
+    assert(!seen.has(migration.version), `duplicate canonical version: ${migration.version}`);
+    assert(previous === '' || previous.localeCompare(migration.version) < 0, 'canonical versions must be strictly sorted');
+    seen.add(migration.version);
+    previous = migration.version;
+  }
+  assert(previous === input.remoteHead, `remoteHead ${input.remoteHead} does not match final version ${previous}`);
+  return input;
+}
+
+async function moveFile(source, target) {
+  await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+  try {
+    await rename(source, target);
+  } catch (error) {
+    if (error?.code !== 'EXDEV') throw error;
+    await copyFile(source, target);
+    await unlink(source);
+  }
+}
+
+export async function prepareCanonicalMigrations({ ledger, migrationsDir, quarantineDir }) {
+  const canonical = validateCanonicalLedger(ledger);
+  const migrationRoot = resolve(migrationsDir);
+  const quarantineRoot = resolve(quarantineDir);
+  assert(quarantineRoot !== migrationRoot, 'quarantine directory must differ from migrations directory', 'INVALID_TARGET');
+  assert(quarantineRoot !== '/', 'quarantine directory cannot be filesystem root', 'INVALID_TARGET');
+
+  const canonicalByVersion = new Map(canonical.migrations.map((item) => [item.version, item.name]));
+  const entries = (await readdir(migrationRoot, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => entry.name)
+    .sort();
+  const localByVersion = new Map();
+  const keptCanonicalNames = [];
+  const pendingNames = [];
+  const quarantinedNames = [];
+
+  for (const name of entries) {
+    const match = VERSIONED_FILE.exec(name);
+    if (!match) {
+      quarantinedNames.push(name);
+      continue;
+    }
+    const [, version, migrationName] = match;
+    assert(!localByVersion.has(version), `duplicate local migration version ${version}: ${localByVersion.get(version)}, ${name}`, 'DUPLICATE_LOCAL_VERSION');
+    localByVersion.set(version, name);
+
+    if (canonicalByVersion.has(version)) {
+      const canonicalName = canonicalByVersion.get(version);
+      assert(migrationName === canonicalName, `canonical name mismatch for ${version}: expected ${canonicalName}, found ${migrationName}`, 'CANONICAL_NAME_MISMATCH', { canonicalName, name, version });
+      keptCanonicalNames.push(name);
+    } else if (version.localeCompare(canonical.remoteHead) > 0) {
+      pendingNames.push(name);
+    } else {
+      quarantinedNames.push(name);
+    }
+  }
+
+  const missing = canonical.migrations
+    .filter(({ version }) => !localByVersion.has(version))
+    .map(({ version, name }) => `${version}_${name}.sql`);
+  assert(missing.length === 0, `Local source is missing ${missing.length} canonical remote migrations: ${missing.join(', ')}`, 'MISSING_CANONICAL_MIGRATIONS', { missing });
+
+  await mkdir(quarantineRoot, { recursive: true, mode: 0o700 });
+  for (const name of quarantinedNames) {
+    await moveFile(join(migrationRoot, name), join(quarantineRoot, basename(name)));
+  }
+
+  return {
+    schemaVersion: 'dsg.supabase-canonical-ledger-preparation.v1',
+    projectRef: canonical.projectRef,
+    remoteHead: canonical.remoteHead,
+    canonicalCount: keptCanonicalNames.length,
+    pendingCount: pendingNames.length,
+    quarantinedCount: quarantinedNames.length,
+    keptCanonicalNames,
+    pendingNames,
+    quarantinedNames,
+    ready: true,
+    truthBoundary: 'This evidence proves only the runner migration set. Database mutation and live schema verification require separate evidence.',
+  };
+}
+
+function parseArguments(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) throw new CanonicalMigrationError('Arguments must be --name value pairs', 'INVALID_ARGUMENTS');
+    args.set(key.slice(2), value);
+  }
+  for (const required of ['ledger', 'migrations-dir', 'quarantine-dir', 'evidence-out']) {
+    if (!args.get(required)) throw new CanonicalMigrationError(`Missing --${required}`, 'INVALID_ARGUMENTS');
+  }
+  return args;
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const args = parseArguments(argv);
+  const ledger = JSON.parse(await readFile(args.get('ledger'), 'utf8'));
+  const evidence = await prepareCanonicalMigrations({
+    ledger,
+    migrationsDir: args.get('migrations-dir'),
+    quarantineDir: args.get('quarantine-dir'),
+  });
+  const evidencePath = args.get('evidence-out');
+  await mkdir(dirname(resolve(evidencePath)), { recursive: true });
+  await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, { encoding: 'utf8', mode: 0o644 });
+  await chmod(evidencePath, 0o644);
+  console.log(`Prepared canonical Supabase ledger: ${evidence.canonicalCount} canonical, ${evidence.pendingCount} pending, ${evidence.quarantinedCount} legacy local-only files quarantined.`);
+  console.log(`Pending names: ${evidence.pendingNames.join(', ') || '(none)'}`);
+  return evidence;
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isDirectRun) {
+  runCli().catch((error) => {
+    console.error(`::error::Canonical Supabase migration preparation failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    process.exitCode = 1;
+  });
+}

--- a/supabase/canonical-migration-ledger.json
+++ b/supabase/canonical-migration-ledger.json
@@ -1,0 +1,466 @@
+{
+  "schemaVersion": "dsg.supabase-canonical-ledger.v1",
+  "projectRef": "zeyguilldygozufpgxms",
+  "capturedAt": "2026-08-28T11:27:00Z",
+  "remoteHead": "20260823124642",
+  "policy": "keep-canonical-and-newer-quarantine-local-before-head",
+  "migrations": [
+    {
+      "version": "1784914864",
+      "name": "test_integration"
+    },
+    {
+      "version": "20260430102302",
+      "name": "finance_governance_control_layer_tables"
+    },
+    {
+      "version": "20260430145030",
+      "name": "gateway_managed_connectors"
+    },
+    {
+      "version": "20260430202349",
+      "name": "gateway_monitor_events"
+    },
+    {
+      "version": "20260502174934",
+      "name": "create_dsg_runtime_core_step_2"
+    },
+    {
+      "version": "20260502175026",
+      "name": "harden_dsg_runtime_functions_step_2"
+    },
+    {
+      "version": "20260502181720",
+      "name": "add_dsg_runtime_policies_and_rpc"
+    },
+    {
+      "version": "20260502183649",
+      "name": "add_dsg_plan_audit_completion_rpc"
+    },
+    {
+      "version": "20260502184542",
+      "name": "add_dsg_deployment_production_flow_rpc"
+    },
+    {
+      "version": "20260504035550",
+      "name": "create_dsg_governed_memory_layer"
+    },
+    {
+      "version": "20260504074722",
+      "name": "create_dsg_app_builder_runtime_tables"
+    },
+    {
+      "version": "20260504074941",
+      "name": "expose_dsg_app_builder_tables_in_api_schema"
+    },
+    {
+      "version": "20260504075201",
+      "name": "replace_api_app_builder_views_with_tables"
+    },
+    {
+      "version": "20260504090942",
+      "name": "create_dsg_one_memory_api_tables_retry"
+    },
+    {
+      "version": "20260504143801",
+      "name": "create_api_generated_app_items"
+    },
+    {
+      "version": "20260505190322",
+      "name": "create_dsg_crud_proof_tasks_20260506"
+    },
+    {
+      "version": "20260505201507",
+      "name": "create_api_dsg_record_production_flow_proof"
+    },
+    {
+      "version": "20260509061545",
+      "name": "create_dsg_agent_command_gate_v2"
+    },
+    {
+      "version": "20260512122854",
+      "name": "create_agent_gate_settings"
+    },
+    {
+      "version": "20260512165406",
+      "name": "add_runtime_spine_missing_tables_uuid_compatible"
+    },
+    {
+      "version": "20260512171007",
+      "name": "drop_legacy_runtime_commit_execution_contract"
+    },
+    {
+      "version": "20260512171043",
+      "name": "create_minimal_runtime_commit_execution_contract"
+    },
+    {
+      "version": "20260512171454",
+      "name": "fix_runtime_commit_execution_qualified_sequences"
+    },
+    {
+      "version": "20260512171820",
+      "name": "fix_runtime_commit_execution_return_output_vars"
+    },
+    {
+      "version": "20260512172033",
+      "name": "fix_runtime_commit_execution_pgcrypto_schema"
+    },
+    {
+      "version": "20260512172250",
+      "name": "add_policies_status_for_auto_setup"
+    },
+    {
+      "version": "20260512175603",
+      "name": "create_runtime_policies_table"
+    },
+    {
+      "version": "20260512180047",
+      "name": "create_runtime_policy_governance_events_table"
+    },
+    {
+      "version": "20260512182657",
+      "name": "seed_default_runtime_policy_if_missing"
+    },
+    {
+      "version": "20260516051839",
+      "name": "add_api_keys_webhooks_notifications"
+    },
+    {
+      "version": "20260516051853",
+      "name": "dsg_one_tables"
+    },
+    {
+      "version": "20260516051911",
+      "name": "dsg_templates"
+    },
+    {
+      "version": "20260518172627",
+      "name": "marketing_content"
+    },
+    {
+      "version": "20260518173030",
+      "name": "marketing_agent_runs"
+    },
+    {
+      "version": "20260518180715",
+      "name": "github_app_installations"
+    },
+    {
+      "version": "20260519054417",
+      "name": "fix_security_advisors_safe_defaults"
+    },
+    {
+      "version": "20260526034235",
+      "name": "dsg_template_marketplace"
+    },
+    {
+      "version": "20260526034248",
+      "name": "dsg_template_sales_rpc"
+    },
+    {
+      "version": "20260526034300",
+      "name": "template_sales_unique_buyer"
+    },
+    {
+      "version": "20260526125644",
+      "name": "dsg_mcp_billing_tables"
+    },
+    {
+      "version": "20260526125700",
+      "name": "dsg_mcp_billing_policies"
+    },
+    {
+      "version": "20260526125723",
+      "name": "dsg_mcp_billing_rpcs"
+    },
+    {
+      "version": "20260526142954",
+      "name": "dsg_template_entitlement"
+    },
+    {
+      "version": "20260526143111",
+      "name": "fix_can_use_template_ambiguity"
+    },
+    {
+      "version": "20260609153009",
+      "name": "create_dsg_access_invites_v2"
+    },
+    {
+      "version": "20260609153206",
+      "name": "create_dsg_provision_user_access_v2"
+    },
+    {
+      "version": "20260615062651",
+      "name": "fix_api_key_usage_summary_security_invoker"
+    },
+    {
+      "version": "20260702122530",
+      "name": "marketplace_stripe_schema"
+    },
+    {
+      "version": "20260703014019",
+      "name": "grant_org_membership_helpers_to_authenticated"
+    },
+    {
+      "version": "20260703023351",
+      "name": "add_monitoring_tables"
+    },
+    {
+      "version": "20260703025555",
+      "name": "add_monitoring_alerts_webhooks"
+    },
+    {
+      "version": "20260703025714",
+      "name": "grant_org_helpers_execute_to_anon"
+    },
+    {
+      "version": "20260703071335",
+      "name": "github_marketplace_events"
+    },
+    {
+      "version": "20260703083006",
+      "name": "marketplace_account_links"
+    },
+    {
+      "version": "20260704163930",
+      "name": "fix_payment_summary_monitoring_metrics_security_invoker"
+    },
+    {
+      "version": "20260704165250",
+      "name": "trinity_end_to_end_workflow"
+    },
+    {
+      "version": "20260704190930",
+      "name": "github_marketplace_oauth_link_columns"
+    },
+    {
+      "version": "20260709035923",
+      "name": "add_dsg_determinism_ledger"
+    },
+    {
+      "version": "20260710071019",
+      "name": "audit_batch_trail"
+    },
+    {
+      "version": "20260710071830",
+      "name": "revenue_events_phase2"
+    },
+    {
+      "version": "20260710111912",
+      "name": "20260628_agent_profiles_tables"
+    },
+    {
+      "version": "20260710112851",
+      "name": "20260603001000_breach_signal_evaluations"
+    },
+    {
+      "version": "20260710112906",
+      "name": "20260605_dsg_ui_memory"
+    },
+    {
+      "version": "20260710113859",
+      "name": "add_expires_at_to_guest_access_grants"
+    },
+    {
+      "version": "20260710130207",
+      "name": "add_guest_access_grants_expires_at"
+    },
+    {
+      "version": "20260713054100",
+      "name": "ai_firstify_core_schema"
+    },
+    {
+      "version": "20260713054110",
+      "name": "ai_firstify_audit_logs"
+    },
+    {
+      "version": "20260713080443",
+      "name": "ai_firstify_simplify_rls"
+    },
+    {
+      "version": "20260718115700",
+      "name": "20260718_superteam_agent_tables"
+    },
+    {
+      "version": "20260725030349",
+      "name": "20260725120000_system_inventory_schema"
+    },
+    {
+      "version": "20260731083805",
+      "name": "repair_system_inventory_seed_and_grants"
+    },
+    {
+      "version": "20260804084739",
+      "name": "agent_workspace_control_plane"
+    },
+    {
+      "version": "20260804085957",
+      "name": "agent_workspace_autonomy_v2"
+    },
+    {
+      "version": "20260804090121",
+      "name": "agent_workspace_authorization_alias_fix"
+    },
+    {
+      "version": "20260804090358",
+      "name": "agent_workspace_promotion_scopes"
+    },
+    {
+      "version": "20260804091421",
+      "name": "agent_workspace_plan_hash_trigger"
+    },
+    {
+      "version": "20260804091946",
+      "name": "agent_workspace_org_scoped_leases"
+    },
+    {
+      "version": "20260804092326",
+      "name": "agent_workspace_promotion_evidence_gate"
+    },
+    {
+      "version": "20260804093140",
+      "name": "agent_workspace_commit_bound_promotion"
+    },
+    {
+      "version": "20260804093707",
+      "name": "agent_workspace_dev_scope_boundaries"
+    },
+    {
+      "version": "20260804094212",
+      "name": "agent_workspace_permanent_production_lock"
+    },
+    {
+      "version": "20260804094654",
+      "name": "agent_workspace_promotion_state_machine"
+    },
+    {
+      "version": "20260804095110",
+      "name": "agent_workspace_ci_approval_provenance"
+    },
+    {
+      "version": "20260804100306",
+      "name": "agent_workspace_remove_unenforced_main_merge_scope"
+    },
+    {
+      "version": "20260806064005",
+      "name": "dsg_gate_revenue_hardening"
+    },
+    {
+      "version": "20260806064216",
+      "name": "dsg_gate_function_grants"
+    },
+    {
+      "version": "20260806065317",
+      "name": "dsg_gate_atomic_usage_position"
+    },
+    {
+      "version": "20260806065800",
+      "name": "revenue_event_idempotency"
+    },
+    {
+      "version": "20260806065903",
+      "name": "revenue_event_stripe_idempotency_backfill"
+    },
+    {
+      "version": "20260806065956",
+      "name": "revenue_event_idempotency_conflict_target"
+    },
+    {
+      "version": "20260808020115",
+      "name": "create_dsg_launchpad_launches"
+    },
+    {
+      "version": "20260808133441",
+      "name": "billing_activation_proofs"
+    },
+    {
+      "version": "20260808134158",
+      "name": "billing_activation_proofs_hardening"
+    },
+    {
+      "version": "20260808134235",
+      "name": "billing_activation_proofs_privilege_lockdown"
+    },
+    {
+      "version": "20260810052204",
+      "name": "secure_mcp_actor_context"
+    },
+    {
+      "version": "20260810052612",
+      "name": "secure_mcp_actor_context_uuid_fix"
+    },
+    {
+      "version": "20260810055902",
+      "name": "mcp_oauth_tokens"
+    },
+    {
+      "version": "20260810055931",
+      "name": "secure_mcp_oauth_context"
+    },
+    {
+      "version": "20260812163842",
+      "name": "dsg_gate_encoding_usage_route"
+    },
+    {
+      "version": "20260812203538",
+      "name": "create_leads_and_alerts_revenue_autopilot"
+    },
+    {
+      "version": "20260812203550",
+      "name": "leads_growth_columns_revenue_autopilot"
+    },
+    {
+      "version": "20260812203603",
+      "name": "outreach_approvals_revenue_autopilot"
+    },
+    {
+      "version": "20260812203613",
+      "name": "lead_enhancements_revenue_autopilot"
+    },
+    {
+      "version": "20260812204340",
+      "name": "revenue_autopilot_runtime"
+    },
+    {
+      "version": "20260814190648",
+      "name": "dashboard_live_data_contracts"
+    },
+    {
+      "version": "20260814191709",
+      "name": "dashboard_live_data_contract_grants"
+    },
+    {
+      "version": "20260816080453",
+      "name": "dsg_one_verified_execution_runs"
+    },
+    {
+      "version": "20260817081058",
+      "name": "trinity_revenue_tables"
+    },
+    {
+      "version": "20260818115153",
+      "name": "create_dsg_audit_ledger"
+    },
+    {
+      "version": "20260818123357",
+      "name": "create_dsg_audit_ledger_api_schema"
+    },
+    {
+      "version": "20260818123435",
+      "name": "grant_dsg_audit_ledger_service_role"
+    },
+    {
+      "version": "20260818124307",
+      "name": "add_dsg_audit_proof_hash"
+    },
+    {
+      "version": "20260823121921",
+      "name": "extend_dsg_guarded_evidence"
+    },
+    {
+      "version": "20260823124642",
+      "name": "guarded_evidence_text_payloads_and_observations"
+    }
+  ]
+}
+

--- a/tests/unit/scripts/prepare-supabase-canonical-migrations.test.ts
+++ b/tests/unit/scripts/prepare-supabase-canonical-migrations.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  prepareCanonicalMigrations,
+  validateCanonicalLedger,
+} from '../../../scripts/prepare-supabase-canonical-migrations.mjs';
+
+const LEDGER = {
+  schemaVersion: 'dsg.supabase-canonical-ledger.v1',
+  projectRef: 'test-project',
+  capturedAt: '2026-08-28T00:00:00Z',
+  remoteHead: '20260823124642',
+  policy: 'keep-canonical-and-newer-quarantine-local-before-head',
+  migrations: [
+    { version: '20260817081058', name: 'canonical_one' },
+    { version: '20260823124642', name: 'canonical_two' },
+  ],
+};
+
+describe('canonical Supabase migration preparation', () => {
+  it('keeps canonical and newer files while quarantining legacy local-only files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsg-migrations-'));
+    const migrationsDir = join(root, 'migrations');
+    const quarantineDir = join(root, 'quarantine');
+    await mkdir(migrationsDir);
+    await Promise.all([
+      writeFile(join(migrationsDir, '20260817081058_canonical_one.sql'), 'select 1;'),
+      writeFile(join(migrationsDir, '20260823124642_canonical_two.sql'), 'select 2;'),
+      writeFile(join(migrationsDir, '20260701000000_legacy.sql'), 'select 3;'),
+      writeFile(join(migrationsDir, '20260825083000_pending.sql'), 'select 4;'),
+      writeFile(join(migrationsDir, 'invalid_name.sql'), 'select 5;'),
+    ]);
+
+    const evidence = await prepareCanonicalMigrations({ ledger: LEDGER, migrationsDir, quarantineDir });
+    expect(await readdir(migrationsDir)).toEqual([
+      '20260817081058_canonical_one.sql',
+      '20260823124642_canonical_two.sql',
+      '20260825083000_pending.sql',
+    ]);
+    expect(await readdir(quarantineDir)).toEqual(['20260701000000_legacy.sql', 'invalid_name.sql']);
+    expect(evidence).toMatchObject({ canonicalCount: 2, pendingCount: 1, quarantinedCount: 2, ready: true });
+  });
+
+  it('fails closed when canonical source is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsg-migrations-'));
+    const migrationsDir = join(root, 'migrations');
+    await mkdir(migrationsDir);
+    await writeFile(join(migrationsDir, '20260817081058_canonical_one.sql'), 'select 1;');
+    await expect(prepareCanonicalMigrations({ ledger: LEDGER, migrationsDir, quarantineDir: join(root, 'q') }))
+      .rejects.toThrow('missing 1 canonical remote migrations');
+  });
+
+  it('rejects a canonical name mismatch instead of trusting a timestamp alone', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsg-migrations-'));
+    const migrationsDir = join(root, 'migrations');
+    await mkdir(migrationsDir);
+    await Promise.all([
+      writeFile(join(migrationsDir, '20260817081058_wrong.sql'), 'select 1;'),
+      writeFile(join(migrationsDir, '20260823124642_canonical_two.sql'), 'select 2;'),
+    ]);
+    await expect(prepareCanonicalMigrations({ ledger: LEDGER, migrationsDir, quarantineDir: join(root, 'q') }))
+      .rejects.toThrow('canonical name mismatch');
+  });
+
+  it('validates the checked-in ledger snapshot', async () => {
+    const ledger = JSON.parse(await readFile('supabase/canonical-migration-ledger.json', 'utf8'));
+    expect(() => validateCanonicalLedger(ledger)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Root cause confirmed by two passwordless runs
After the seven remote-only migrations were restored, `db push` correctly advanced to the next mismatch: 178 historical local-only/invalid files precede the remote head. Applying them with `--include-all` would replay divergent DDL against production.

## Fix
- checks in the 114-version canonical remote version/name ledger
- fail-closed script requires every canonical file and exact name
- keeps canonical files and versions newer than the remote head
- quarantines legacy local-only/invalid files only in runner temp storage
- uploads names-only preparation evidence
- wires the preparation into automatic/manual/deployment/readiness migration paths

## Verification
- synthetic canonical/pending/legacy preparation test passed
- remote repository directory compared against the ledger: 114/114 present, zero name mismatches, zero duplicate versions
- all modified workflows parse as YAML and every embedded shell block passes `bash -n`

## Truth boundary
No `--include-all`, no remote history rewrite, and no file deletion from git. PASS requires the post-merge passwordless run to apply `20260825083000` and live schema/RLS/grant verification.