### PR TITLE
fix(db): quarantine duplicate legacy migration versions

### DIFF
--- a/scripts/prepare-supabase-canonical-migrations.mjs
+++ b/scripts/prepare-supabase-canonical-migrations.mjs
@@ -63,7 +63,8 @@ export async function prepareCanonicalMigrations({ ledger, migrationsDir, quaran
     .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
     .map((entry) => entry.name)
     .sort();
-  const localByVersion = new Map();
+  const canonicalFound = new Set();
+  const pendingByVersion = new Map();
   const keptCanonicalNames = [];
   const pendingNames = [];
   const quarantinedNames = [];
@@ -75,14 +76,15 @@ export async function prepareCanonicalMigrations({ ledger, migrationsDir, quaran
       continue;
     }
     const [, version, migrationName] = match;
-    assert(!localByVersion.has(version), `duplicate local migration version ${version}: ${localByVersion.get(version)}, ${name}`, 'DUPLICATE_LOCAL_VERSION');
-    localByVersion.set(version, name);
-
     if (canonicalByVersion.has(version)) {
       const canonicalName = canonicalByVersion.get(version);
       assert(migrationName === canonicalName, `canonical name mismatch for ${version}: expected ${canonicalName}, found ${migrationName}`, 'CANONICAL_NAME_MISMATCH', { canonicalName, name, version });
+      assert(!canonicalFound.has(version), `duplicate canonical migration version ${version}`, 'DUPLICATE_CANONICAL_VERSION', { name, version });
+      canonicalFound.add(version);
       keptCanonicalNames.push(name);
     } else if (version.localeCompare(canonical.remoteHead) > 0) {
+      assert(!pendingByVersion.has(version), `duplicate pending migration version ${version}: ${pendingByVersion.get(version)}, ${name}`, 'DUPLICATE_PENDING_VERSION', { name, version });
+      pendingByVersion.set(version, name);
       pendingNames.push(name);
     } else {
       quarantinedNames.push(name);
@@ -90,7 +92,7 @@ export async function prepareCanonicalMigrations({ ledger, migrationsDir, quaran
   }
 
   const missing = canonical.migrations
-    .filter(({ version }) => !localByVersion.has(version))
+    .filter(({ version }) => !canonicalFound.has(version))
     .map(({ version, name }) => `${version}_${name}.sql`);
   assert(missing.length === 0, `Local source is missing ${missing.length} canonical remote migrations: ${missing.join(', ')}`, 'MISSING_CANONICAL_MIGRATIONS', { missing });
 

--- a/tests/unit/scripts/prepare-supabase-canonical-migrations.test.ts
+++ b/tests/unit/scripts/prepare-supabase-canonical-migrations.test.ts
@@ -29,6 +29,7 @@ describe('canonical Supabase migration preparation', () => {
       writeFile(join(migrationsDir, '20260817081058_canonical_one.sql'), 'select 1;'),
       writeFile(join(migrationsDir, '20260823124642_canonical_two.sql'), 'select 2;'),
       writeFile(join(migrationsDir, '20260701000000_legacy.sql'), 'select 3;'),
+      writeFile(join(migrationsDir, '20260701000000_legacy_duplicate.sql'), 'select 3;'),
       writeFile(join(migrationsDir, '20260825083000_pending.sql'), 'select 4;'),
       writeFile(join(migrationsDir, 'invalid_name.sql'), 'select 5;'),
     ]);
@@ -39,8 +40,12 @@ describe('canonical Supabase migration preparation', () => {
       '20260823124642_canonical_two.sql',
       '20260825083000_pending.sql',
     ]);
-    expect(await readdir(quarantineDir)).toEqual(['20260701000000_legacy.sql', 'invalid_name.sql']);
-    expect(evidence).toMatchObject({ canonicalCount: 2, pendingCount: 1, quarantinedCount: 2, ready: true });
+    expect(await readdir(quarantineDir)).toEqual([
+      '20260701000000_legacy.sql',
+      '20260701000000_legacy_duplicate.sql',
+      'invalid_name.sql',
+    ]);
+    expect(evidence).toMatchObject({ canonicalCount: 2, pendingCount: 1, quarantinedCount: 3, ready: true });
   });
 
   it('fails closed when canonical source is missing', async () => {


### PR DESCRIPTION
The canonical-ledger preflight correctly blocked before DB mutation because two local-only legacy files share version `20260702000000`. Duplicate versions remain fatal for canonical or pending migrations; duplicates that are both older, non-canonical history are now quarantined together in runner temp storage. Synthetic regression coverage included.