### PR TITLE
fix(ci): trigger canonical migration preflight changes

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'supabase/migrations/**'
+      - 'supabase/canonical-migration-ledger.json'
+      - 'scripts/prepare-supabase-canonical-migrations.mjs'
       - '.github/workflows/supabase-migrations.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
Adds the canonical ledger manifest and preparation script to the automatic Supabase migration workflow path filter. This ensures a fix to fail-closed staging cannot merge without running the hosted migration check.