### PR TITLE
fix(db): harden agentic baseline RPC search path

### DIFF
--- a/supabase/migrations/20260828120500_harden_agentic_baseline_search_path.sql
+++ b/supabase/migrations/20260828120500_harden_agentic_baseline_search_path.sql
@@ -1,0 +1,13 @@
+-- Harden the SECURITY DEFINER baseline commit RPC against search-path shadowing.
+-- Supabase Database Advisor 0011 recommends a fixed empty search_path for
+-- SECURITY DEFINER functions when relation references are schema-qualified.
+
+alter function public.dsg_commit_evolution_baseline(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text
+) set search_path = '';


### PR DESCRIPTION
## Why
Supabase Security Advisor reports `0011_function_search_path_mutable` for `public.dsg_commit_evolution_baseline`.

The RPC is `SECURITY DEFINER`, so its lookup path must be fixed. Supabase's current Database Functions guidance says `SECURITY DEFINER` functions must set `search_path`, and Advisor 0011 recommends an empty search path when object references are schema-qualified.

## Change
Adds a forward-only migration that sets:

```sql
ALTER FUNCTION public.dsg_commit_evolution_baseline(text,text,text,text,text,text,text)
SET search_path = '';
```

The already-applied `20260825083000_agentic_post_deploy_feedback` migration is not rewritten.

## Verified preconditions
- live function signature is exactly seven `text` arguments
- live function currently has `SECURITY DEFINER`
- table references in the function are schema-qualified as `public.agentic_evolution_baselines`
- anon/authenticated EXECUTE is denied; service_role EXECUTE is allowed

## Truth boundary
This PR changes database hardening only. It does not claim the follow-up migration has been applied to Supabase until the migration is actually executed and re-verified there.