### PR TITLE
fix(db): make orders summary security invoker

### DIFF
--- a/supabase/migrations/20260828123000_harden_orders_summary_security_invoker.sql
+++ b/supabase/migrations/20260828123000_harden_orders_summary_security_invoker.sql
@@ -1,0 +1,7 @@
+-- Harden the legacy public.orders_summary view so callers execute it with
+-- their own database permissions and underlying public.orders RLS policies.
+-- This addresses Supabase Database Advisor security_definer_view without
+-- changing the existing orders policies or grants in the same migration.
+
+alter view public.orders_summary
+  set (security_invoker = true);


### PR DESCRIPTION
## Finding
Supabase Security Advisor currently reports `public.orders_summary` as an ERROR-level security-definer view.

Live verification before this PR:
- view owner: `postgres`
- view options: none (`security_invoker` not enabled)
- underlying relation: `public.orders`
- `public.orders` has RLS enabled
- the view is not found in the current GitHub source tree, so this is legacy/live-schema drift
- the live table currently contains 1 row; latest observed write was 2026-07-15

## Change
Adds a forward-only migration:

```sql
alter view public.orders_summary
  set (security_invoker = true);
```

Supabase's current Views/RLS documentation recommends `security_invoker=true` so views created by privileged roles enforce the caller's permissions and underlying RLS policies.

## Scope boundary
This PR intentionally does **not** rewrite the existing `orders` RLS policies or grants. Those policies appear broader than least-privilege and require separate usage analysis before changing authorization semantics.

## Verification after merge
- confirm migration version `20260828123000` is present in remote ledger
- confirm `orders_summary.reloptions` includes `security_invoker=true`
- re-run Supabase Security Advisor and confirm the ERROR is removed
