### PR TITLE
feat(dsg): add exact pool selector v10 with regression proofs

### DIFF
--- a/lib/dsg/pool-exact/decimal.ts
+++ b/lib/dsg/pool-exact/decimal.ts
@@ -1,0 +1,85 @@
+export type ParsedDecimal = {
+  sign: number;
+  intPart: string;
+  fracPart: string;
+  exp: bigint;
+  digits: string;
+  expNet: bigint;
+};
+
+export function isValidDecimalFormat(s: string): boolean {
+  return /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(s.trim());
+}
+
+export function parseDecimalRaw(s: string): ParsedDecimal {
+  const trimmed = s.trim();
+  if (!isValidDecimalFormat(trimmed)) {
+    throw new Error(`INVALID_DECIMAL_FORMAT: ${s}`);
+  }
+
+  let sign = 1;
+  let rest = trimmed;
+  if (rest.startsWith('-')) {
+    sign = -1;
+    rest = rest.slice(1);
+  } else if (rest.startsWith('+')) {
+    rest = rest.slice(1);
+  }
+
+  const expMatch = rest.match(/^(.*?)[eE]([+-]?\d+)$/);
+  let exp = BigInt(0);
+  let mantissa = rest;
+  if (expMatch) {
+    mantissa = expMatch[1]!;
+    exp = BigInt(expMatch[2]!);
+  }
+
+  const dotIdx = mantissa.indexOf('.');
+  let intPart = '';
+  let fracPart = '';
+  if (dotIdx === -1) {
+    intPart = mantissa;
+  } else {
+    intPart = mantissa.slice(0, dotIdx);
+    fracPart = mantissa.slice(dotIdx + 1);
+  }
+
+  intPart = intPart.replace(/^0+/, '') || '0';
+  const digits = (intPart + fracPart).replace(/^0+/, '') || '0';
+  const expNet = exp - BigInt(fracPart.length);
+  return { sign, intPart, fracPart, exp, digits, expNet };
+}
+
+export function compareCompositeRaw(aRaw: string, bRaw: string): number {
+  const a = parseDecimalRaw(aRaw);
+  const b = parseDecimalRaw(bRaw);
+
+  const aIsZero = a.digits === '0';
+  const bIsZero = b.digits === '0';
+
+  if (aIsZero && bIsZero) return 0;
+  if (aIsZero) return b.sign === 1 ? -1 : 1;
+  if (bIsZero) return a.sign === 1 ? 1 : -1;
+
+  if (a.sign !== b.sign) return a.sign - b.sign;
+
+  const aTopExp = a.expNet + BigInt(a.digits.length);
+  const bTopExp = b.expNet + BigInt(b.digits.length);
+
+  let cmp = 0;
+  if (aTopExp !== bTopExp) {
+    cmp = aTopExp > bTopExp ? 1 : -1;
+  } else {
+    const len = Math.max(a.digits.length, b.digits.length);
+    for (let i = 0; i < len; i++) {
+      const ad = i < a.digits.length ? a.digits.charCodeAt(i) : 48;
+      const bd = i < b.digits.length ? b.digits.charCodeAt(i) : 48;
+      if (ad !== bd) {
+        cmp = ad > bd ? 1 : -1;
+        break;
+      }
+    }
+  }
+
+  return a.sign === 1 ? cmp : -cmp;
+}

--- a/lib/dsg/pool-exact/index.ts
+++ b/lib/dsg/pool-exact/index.ts
@@ -1,0 +1,502 @@
+import { createHash } from 'crypto';
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from 'fs';
+import { resolve, sep } from 'path';
+import { init } from 'z3-solver';
+import { compareCompositeRaw, isValidDecimalFormat, parseDecimalRaw } from './decimal';
+import { extractCompositeRawTopLevel } from './jsonl';
+
+type Candidate = {
+  id: string;
+  composite: number;
+  composite_raw: string;
+  [k: string]: any;
+};
+
+type ParsedEntry = {
+  value: any;
+  audit: {
+    line: number;
+    raw: string;
+    rawHash: string;
+    compositeRaw: string;
+  };
+};
+
+function compareId(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export const mcpTool = {
+  name: 'dsg_pool_exact_select',
+  description: 'Exact top-k 24->12 - Real exact via raw lexeme BigInt comparator',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      poolPath: { type: 'string', default: '.dsg/pool.jsonl' },
+      k: { type: 'integer', minimum: 1, maximum: 12, default: 12 },
+      minComposite: { type: 'string', default: '0', description: 'exact decimal string' },
+      useZ3: { type: 'boolean', default: false },
+    },
+    additionalProperties: false,
+  },
+  handler: async ({
+    poolPath = '.dsg/pool.jsonl',
+    k = 12,
+    minComposite = '0',
+    useZ3 = false,
+  }: any) => {
+    if (typeof poolPath !== 'string' || poolPath.length === 0) {
+      return { success: false, status: 'BLOCKED', reason: 'INVALID_POOL_PATH_TYPE' };
+    }
+    if (typeof useZ3 !== 'boolean') {
+      return { success: false, status: 'BLOCKED', reason: 'INVALID_USEZ3_TYPE' };
+    }
+    if (!Number.isInteger(k) || k < 1 || k > 12) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_K',
+        expected: 'integer 1..12',
+        received: k,
+      };
+    }
+    if (typeof minComposite !== 'string') {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_MIN_COMPOSITE_TYPE',
+        expected: 'string decimal',
+        received: typeof minComposite,
+      };
+    }
+    if (!isValidDecimalFormat(minComposite)) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_MIN_COMPOSITE_FORMAT',
+        received: minComposite,
+      };
+    }
+
+    let minCompositeRaw: string;
+    try {
+      parseDecimalRaw(minComposite);
+      minCompositeRaw = minComposite;
+    } catch (e: any) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_MIN_COMPOSITE_FORMAT',
+        received: minComposite,
+        error: e.message,
+      };
+    }
+
+    const dsgLexical = resolve('.dsg');
+
+    let canonicalRoot: string;
+    try {
+      canonicalRoot = realpathSync(dsgLexical);
+    } catch {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'DSG_ROOT_NOT_FOUND',
+        root: dsgLexical,
+      };
+    }
+
+    try {
+      const stat = lstatSync(dsgLexical);
+      if (stat.isSymbolicLink()) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'DSG_ROOT_SYMLINK_ESCAPE',
+          root: dsgLexical,
+          canonicalRoot,
+        };
+      }
+    } catch {}
+
+    const resolvedPool = resolve(poolPath);
+    if (resolvedPool !== dsgLexical && !resolvedPool.startsWith(dsgLexical + sep)) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'POOL_PATH_OUTSIDE_DSG_ROOT',
+        root: dsgLexical,
+        received: poolPath,
+      };
+    }
+
+    if (!existsSync(resolvedPool)) {
+      return { success: false, status: 'BLOCKED', reason: `pool not found: ${resolvedPool}` };
+    }
+
+    let canonicalPool: string;
+    try {
+      canonicalPool = realpathSync(resolvedPool);
+    } catch {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'POOL_REALPATH_RESOLVE_FAILED',
+        resolved: resolvedPool,
+      };
+    }
+
+    if (canonicalPool !== canonicalRoot && !canonicalPool.startsWith(canonicalRoot + sep)) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'POOL_REALPATH_OUTSIDE_DSG_ROOT',
+        canonicalRoot,
+        canonicalPool,
+      };
+    }
+
+    let fileStat: any;
+    try {
+      fileStat = statSync(canonicalPool);
+      if (!fileStat.isFile()) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'POOL_NOT_REGULAR_FILE',
+          path: canonicalPool,
+        };
+      }
+      if (fileStat.size > 1024 * 1024) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'POOL_FILE_TOO_LARGE',
+          maxBytes: 1024 * 1024,
+          actual: fileStat.size,
+        };
+      }
+    } catch {
+      return { success: false, status: 'BLOCKED', reason: 'POOL_STAT_FAILED' };
+    }
+
+    let fileContent: string;
+    try {
+      fileContent = readFileSync(canonicalPool, 'utf-8');
+    } catch (e: any) {
+      return { success: false, status: 'BLOCKED', reason: 'POOL_READ_FAILED', error: e.message };
+    }
+
+    const allLines = fileContent.split(/\r?\n/);
+    let prevHash = '0'.repeat(64);
+    const hashChain: { line: number; hash: string; rawHash: string }[] = [];
+    const parsed: ParsedEntry[] = [];
+    let nonBlankCount = 0;
+
+    for (let i = 0; i < allLines.length; i++) {
+      const raw = allLines[i]!;
+      const rawHash = createHash('sha256').update(raw).digest('hex');
+      const chainHash = createHash('sha256').update(prevHash + rawHash).digest('hex');
+      hashChain.push({ line: i + 1, hash: chainHash, rawHash });
+      prevHash = chainHash;
+
+      if (raw.trim().length === 0) continue;
+
+      nonBlankCount++;
+      if (nonBlankCount > 240) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'RAW_POOL_LIMIT_EXCEEDED',
+          maxRaw: 240,
+          actual: nonBlankCount,
+          line: i + 1,
+          hashChainHead: prevHash,
+        };
+      }
+
+      let value: any;
+      try {
+        value = JSON.parse(raw);
+      } catch {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'INVALID_POOL_JSONL',
+          line: i + 1,
+          hashChainHead: prevHash,
+        };
+      }
+
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'INVALID_CANDIDATE_OBJECT',
+          line: i + 1,
+        };
+      }
+
+      const compositeRaw = extractCompositeRawTopLevel(raw);
+      if (!compositeRaw) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'INVALID_CANDIDATE_COMPOSITE_MISSING_RAW',
+          line: i + 1,
+        };
+      }
+
+      if (!isValidDecimalFormat(compositeRaw)) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'INVALID_CANDIDATE_COMPOSITE_FORMAT',
+          line: i + 1,
+          composite_raw: compositeRaw,
+        };
+      }
+
+      parsed.push({
+        value,
+        audit: { line: i + 1, raw: raw.slice(0, 200), rawHash, compositeRaw },
+      });
+    }
+
+    const byId = new Map<string, Candidate & { __audit: ParsedEntry['audit'] }>();
+    for (const entry of parsed) {
+      const v = entry.value;
+      const audit = entry.audit;
+      if (!v.id || typeof v.id !== 'string') {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'INVALID_CANDIDATE_MISSING_ID',
+          line: audit.line,
+        };
+      }
+      if (typeof v.composite !== 'number' || !Number.isFinite(v.composite)) {
+        return {
+          success: false,
+          status: 'BLOCKED',
+          reason: 'INVALID_CANDIDATE_COMPOSITE',
+          line: audit.line,
+          id: v.id,
+        };
+      }
+      byId.set(v.id, { ...v, composite_raw: audit.compositeRaw, __audit: audit });
+    }
+
+    if (byId.size > 24) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'POOL_LIMIT_EXCEEDED',
+        maxPool: 24,
+        actual: byId.size,
+        rawCount: parsed.length,
+        hashChainHead: prevHash,
+      };
+    }
+
+    let candidates: (Candidate & { __audit: ParsedEntry['audit'] })[];
+    try {
+      candidates = Array.from(byId.values()).filter(
+        (c) => compareCompositeRaw(c.composite_raw, minCompositeRaw) >= 0,
+      );
+    } catch (e: any) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_EXACT_DECIMAL',
+        error: e.message,
+        hashChainHead: prevHash,
+      };
+    }
+
+    if (useZ3 && candidates.length < k) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INSUFFICIENT_CANDIDATES_FOR_EXACT_K',
+        required: k,
+        actual: candidates.length,
+      };
+    }
+
+    if (candidates.length <= k) {
+      return {
+        success: true,
+        mode: 'no-optimization-needed',
+        total: candidates.length,
+        selectedCount: candidates.length,
+        hashChainHead: prevHash,
+        selected: candidates.map((c) => ({
+          id: c.id,
+          composite: c.composite,
+          composite_raw: c.composite_raw,
+          sourceLine: c.__audit.line,
+          sourceRawHash: c.__audit.rawHash,
+        })),
+      };
+    }
+
+    let expectedSorted: (Candidate & { __audit: ParsedEntry['audit'] })[];
+    try {
+      expectedSorted = [...candidates].sort((a, b) => {
+        const cmp = compareCompositeRaw(b.composite_raw, a.composite_raw);
+        if (cmp !== 0) return cmp;
+        return compareId(a.id, b.id);
+      });
+    } catch (e: any) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_EXACT_DECIMAL',
+        error: e.message,
+        hashChainHead: prevHash,
+      };
+    }
+
+    const expected = expectedSorted.slice(0, k);
+    const expectedIds = expected.map((c) => c.id);
+
+    if (!useZ3) {
+      return {
+        success: true,
+        mode: 'exact-sort',
+        solver: 'none - sorting by exact raw decimal BigInt comparator is optimal',
+        total: candidates.length,
+        k,
+        selectedCount: expected.length,
+        totalCompositeRaw: expected.map((c) => c.composite_raw),
+        hashChainHead: prevHash,
+        hashChainCommitsBlanks: true,
+        selected: expected.map((c) => ({
+          id: c.id,
+          composite: c.composite,
+          composite_raw: c.composite_raw,
+          sourceLine: c.__audit.line,
+          sourceRawHash: c.__audit.rawHash,
+        })),
+      };
+    }
+
+    const { Context } = await init();
+    const z3 = Context('main');
+    const opt = new z3.Optimize();
+    const xs = candidates.map((_, i) => z3.Bool.const(`x${i}`));
+
+    let countExpr = z3.Int.val(0);
+    for (const x of xs) {
+      countExpr = countExpr.add(z3.If(x, z3.Int.val(1), z3.Int.val(0)));
+    }
+    opt.add(countExpr.eq(k));
+
+    let realObj = z3.Real.val(0);
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i]!;
+      const x = xs[i]!;
+      const realVal = z3.Real.val(c.composite_raw);
+      realObj = realObj.add(z3.If(x, realVal, z3.Real.val(0)) as any);
+    }
+    opt.maximize(realObj as any);
+
+    const sortedById = [...candidates]
+      .map((c, idx) => ({ c, idx, id: c.id }))
+      .sort((a, b) => compareId(a.id, b.id));
+    const idRank = new Map<string, number>();
+    sortedById.forEach((item, rank) => idRank.set(item.id, rank));
+
+    let secondary = z3.Int.val(0);
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i]!;
+      const x = xs[i]!;
+      const rank = idRank.get(c.id)!;
+      const power = candidates.length - 1 - rank;
+      const binaryWeight = Math.pow(2, power);
+      secondary = secondary.add(z3.If(x, z3.Int.val(binaryWeight), z3.Int.val(0)));
+    }
+    opt.maximize(secondary);
+
+    const result = await opt.check();
+    if (result !== 'sat') {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: `SOLVER_${result.toUpperCase()}`,
+        solverResult: result,
+      };
+    }
+
+    const model = opt.model();
+    const z3Selected: (Candidate & { __audit: ParsedEntry['audit'] })[] = [];
+    xs.forEach((x, i) => {
+      const v = model.eval(x);
+      if (v.toString() === 'true') z3Selected.push(candidates[i]!);
+    });
+
+    if (z3Selected.length !== k) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'SOLVER_POSTCONDITION_FAILED',
+        expected: k,
+        actual: z3Selected.length,
+      };
+    }
+
+    try {
+      z3Selected.sort((a, b) => {
+        const cmp = compareCompositeRaw(b.composite_raw, a.composite_raw);
+        if (cmp !== 0) return cmp;
+        return compareId(a.id, b.id);
+      });
+    } catch (e: any) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'INVALID_EXACT_DECIMAL',
+        error: e.message,
+      };
+    }
+
+    const actualIds = z3Selected.map((c) => c.id);
+    if (
+      expectedIds.length !== actualIds.length ||
+      expectedIds.some((id, idx) => id !== actualIds[idx])
+    ) {
+      return {
+        success: false,
+        status: 'BLOCKED',
+        reason: 'Z3_DETERMINISTIC_RESULT_MISMATCH',
+        expected: expectedIds,
+        actual: actualIds,
+        hashChainHead: prevHash,
+      };
+    }
+
+    return {
+      success: true,
+      mode: 'verified-exact',
+      solver: 'z3 Real exact via raw lexeme verified',
+      total: candidates.length,
+      k,
+      selectedCount: z3Selected.length,
+      totalCompositeRaw: z3Selected.map((c) => c.composite_raw),
+      hashChainHead: prevHash,
+      hashChainLength: hashChain.length,
+      verification: 'Z3 Real exact matched deterministic raw comparator sort',
+      selected: z3Selected.map((c) => ({
+        id: c.id,
+        composite: c.composite,
+        composite_raw: c.composite_raw,
+        sourceLine: c.__audit.line,
+        sourceRawHash: c.__audit.rawHash,
+      })),
+    };
+  },
+};
+
+export { compareCompositeRaw, isValidDecimalFormat, parseDecimalRaw } from './decimal';
+export { extractCompositeRawTopLevel } from './jsonl';

--- a/lib/dsg/pool-exact/index.ts
+++ b/lib/dsg/pool-exact/index.ts
@@ -387,13 +387,13 @@ export const mcpTool = {
     const opt = new z3.Optimize();
     const xs = candidates.map((_, i) => z3.Bool.const(`x${i}`));
 
-    let countExpr = z3.Int.val(0);
+    let countExpr: any = z3.Int.val(0);
     for (const x of xs) {
       countExpr = countExpr.add(z3.If(x, z3.Int.val(1), z3.Int.val(0)));
     }
     opt.add(countExpr.eq(k));
 
-    let realObj = z3.Real.val(0);
+    let realObj: any = z3.Real.val(0);
     for (let i = 0; i < candidates.length; i++) {
       const c = candidates[i]!;
       const x = xs[i]!;
@@ -408,7 +408,7 @@ export const mcpTool = {
     const idRank = new Map<string, number>();
     sortedById.forEach((item, rank) => idRank.set(item.id, rank));
 
-    let secondary = z3.Int.val(0);
+    let secondary: any = z3.Int.val(0);
     for (let i = 0; i < candidates.length; i++) {
       const c = candidates[i]!;
       const x = xs[i]!;

--- a/lib/dsg/pool-exact/jsonl.ts
+++ b/lib/dsg/pool-exact/jsonl.ts
@@ -1,0 +1,104 @@
+export function extractCompositeRawTopLevel(jsonLine: string): string | null {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let keyStart = -1;
+  let keyRaw = '';
+  let readingKey = false;
+  let lastCompositeRaw: string | null = null;
+
+  for (let i = 0; i < jsonLine.length; i++) {
+    const ch = jsonLine[i]!;
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      if (!inString) {
+        inString = true;
+        if (depth === 1) {
+          keyStart = i;
+          readingKey = true;
+        }
+      } else {
+        inString = false;
+        if (readingKey && depth === 1) {
+          const keyLexeme = jsonLine.slice(keyStart, i + 1);
+          try {
+            keyRaw = JSON.parse(keyLexeme);
+          } catch {
+            keyRaw = '';
+          }
+          readingKey = false;
+        }
+      }
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === '{' || ch === '[') {
+      depth++;
+      continue;
+    }
+
+    if (ch === '}' || ch === ']') {
+      depth--;
+      continue;
+    }
+
+    if (depth === 1 && ch === ':' && keyRaw === 'composite') {
+      let j = i + 1;
+      while (j < jsonLine.length && /\s/.test(jsonLine[j]!)) j++;
+      if (j >= jsonLine.length) break;
+
+      const start = j;
+      let end = j;
+
+      if (jsonLine[j] === '"') {
+        j++;
+        let innerEscape = false;
+        while (j < jsonLine.length) {
+          if (innerEscape) {
+            innerEscape = false;
+            j++;
+            continue;
+          }
+          if (jsonLine[j] === '\\') {
+            innerEscape = true;
+            j++;
+            continue;
+          }
+          if (jsonLine[j] === '"') {
+            end = j + 1;
+            break;
+          }
+          j++;
+        }
+        const quoted = jsonLine.slice(start, end);
+        try {
+          const inner = JSON.parse(quoted);
+          lastCompositeRaw = inner.toString();
+        } catch {
+          lastCompositeRaw = quoted.slice(1, -1);
+        }
+      } else {
+        while (j < jsonLine.length && !/[,\}\]]/.test(jsonLine[j]!)) j++;
+        end = j;
+        lastCompositeRaw = jsonLine.slice(start, end).trim();
+      }
+      keyRaw = '';
+    }
+
+    if (depth === 1 && ch === ',') keyRaw = '';
+  }
+
+  return lastCompositeRaw;
+}

--- a/tests/unit/dsg/pool-exact-v10.test.ts
+++ b/tests/unit/dsg/pool-exact-v10.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { mcpTool } from '../../../lib/dsg/pool-exact';
+
+const created: string[] = [];
+let seq = 0;
+
+function pool(lines: string[]): string {
+  const dir = path.join(process.cwd(), '.dsg');
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `pool-exact-v10-${process.pid}-${seq++}.jsonl`);
+  writeFileSync(file, lines.join('\n'), 'utf8');
+  created.push(file);
+  return path.relative(process.cwd(), file);
+}
+
+afterEach(() => {
+  for (const file of created.splice(0)) rmSync(file, { force: true });
+});
+
+describe('dsg_pool_exact_select v10 regressions', () => {
+  it('keeps positive 0.5 when minComposite is zero', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"positive","composite":0.5}',
+        '{"id":"negative","composite":-0.5}',
+      ]),
+      k: 1,
+      minComposite: '0',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(1);
+    expect(result.selected.map((x: any) => x.id)).toEqual(['positive']);
+    expect(result.selected[0].composite_raw).toBe('0.5');
+  });
+
+  it.each(['abc', '.'])('fails closed for invalid minComposite %s', async (minComposite) => {
+    const result = await mcpTool.handler({
+      poolPath: '.dsg/not-read-for-invalid-threshold.jsonl',
+      k: 1,
+      minComposite,
+      useZ3: false,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      status: 'BLOCKED',
+      reason: 'INVALID_MIN_COMPOSITE_FORMAT',
+    });
+  });
+
+  it('compares huge exponent gaps exactly without exponent-sized padding', async () => {
+    const nineTimesA = `9${'0'.repeat(10001)}e-20002`;
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"a","composite":1e-10001}',
+        `{"id":"b","composite":${nineTimesA}}`,
+      ]),
+      k: 1,
+      minComposite: '0',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('exact-sort');
+    expect(result.selected.map((x: any) => x.id)).toEqual(['b']);
+    expect(result.selected[0].composite_raw).toBe(nineTimesA);
+  });
+
+  it('binds escaped top-level composite keys using JSON key semantics and last-key-wins', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"a","composite":1,"\\u0063omposite":2}',
+        '{"id":"b","composite":1.5}',
+      ]),
+      k: 1,
+      minComposite: '0',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.selected.map((x: any) => x.id)).toEqual(['a']);
+    expect(result.selected[0].composite_raw).toBe('2');
+  });
+
+  it('preserves exact precision beyond IEEE-754 sorting precision', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"lo","composite":0.50003}',
+        '{"id":"hi","composite":0.50004}',
+      ]),
+      k: 1,
+      minComposite: '0',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.selected.map((x: any) => x.id)).toEqual(['hi']);
+  });
+
+  it('keeps exponent parsing exact beyond Number.MAX_SAFE_INTEGER', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"a","composite":1e-9007199254740993}',
+        '{"id":"b","composite":2e-9007199254740993}',
+      ]),
+      k: 1,
+      minComposite: '0',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.selected.map((x: any) => x.id)).toEqual(['b']);
+  });
+
+  it('normalizes signed zero and applies deterministic id tie-break', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"b","composite":-0}',
+        '{"id":"a","composite":0}',
+      ]),
+      k: 1,
+      minComposite: '-1',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.selected.map((x: any) => x.id)).toEqual(['a']);
+  });
+
+  it('treats equivalent decimal spellings as equal and ties by id', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"c","composite":10e-1}',
+        '{"id":"b","composite":1.0}',
+        '{"id":"a","composite":1}',
+      ]),
+      k: 2,
+      minComposite: '0',
+      useZ3: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.selected.map((x: any) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('executes the Z3 path and matches the deterministic exact top-k result', async () => {
+    const lines = Array.from({ length: 13 }, (_, i) => {
+      const score = (13 - i) / 100;
+      return JSON.stringify({ id: `id-${String(i).padStart(2, '0')}`, composite: score });
+    });
+    const result = await mcpTool.handler({
+      poolPath: pool(lines),
+      k: 12,
+      minComposite: '0',
+      useZ3: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('verified-exact');
+    expect(result.selectedCount).toBe(12);
+    expect(result.selected.map((x: any) => x.id)).not.toContain('id-12');
+    expect(result.verification).toContain('Z3 Real exact matched');
+  }, 30_000);
+
+  it('accepts scientific notation on the Z3 path without losing exactness', async () => {
+    const result = await mcpTool.handler({
+      poolPath: pool([
+        '{"id":"a","composite":5e-1}',
+        '{"id":"b","composite":0.49}',
+      ]),
+      k: 1,
+      minComposite: '0',
+      useZ3: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('verified-exact');
+    expect(result.selected.map((x: any) => x.id)).toEqual(['a']);
+  }, 30_000);
+});


### PR DESCRIPTION
## What changed
- add `lib/dsg/pool-exact` exact raw-decimal top-k selector based on the verified v10 candidate
- split exact decimal comparison and JSONL raw-lexeme extraction into focused modules
- preserve fail-closed validation, `.dsg` path containment, audit hash chain, 24->12 limits, deterministic id tie-break, and optional Z3 verification
- adapt BigInt initialization for this repository's `target: ES2017` (`BigInt(0)` instead of a BigInt literal)

## Regression proof added
- `0.5` vs `minComposite="0"`
- invalid `minComposite`: `abc` and `.` => BLOCKED
- huge exponent gap without exponent-sized padding
- escaped `\u0063omposite` duplicate-key binding / last-key-wins
- exact precision ordering
- exponent beyond `Number.MAX_SAFE_INTEGER`
- `-0` vs `0`
- equivalent decimal spellings with deterministic id tie-break
- real `useZ3:true` top-k execution
- scientific notation on the Z3 path

## Merge gate
Do not merge unless repository CI/typecheck/tests are green. The Z3 tests are intentionally included because that was the remaining unverified execution path.