### PR TITLE
fix(deploy): require live preflight before Azure mutation

### DIFF
--- a/app/api/dsg/agentic-org/deployment/record/route.ts
+++ b/app/api/dsg/agentic-org/deployment/record/route.ts
@@ -5,6 +5,8 @@ import productionTargetJson from '@/config/production-deployment-target.json';
 import type { ProductionTargetSnapshot } from '@/lib/agent-governance/agentic-org/post-deploy-control';
 import {
   bindDeploymentToPromotion,
+  DEPLOYMENT_PREFLIGHT_MESSAGE,
+  evaluateDeploymentPreflightTarget,
   isDeploymentRecordRequest,
 } from '@/lib/agent-governance/agentic-org/deployment-record';
 
@@ -22,6 +24,74 @@ function verifySignature(rawBody: string, header: string | null, secret: string)
   const supplied = header.replace(/^sha256=/i, '').trim();
   const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
   return safeEqualHex(supplied, expected);
+}
+
+/**
+ * Read-only deployment preflight.
+ *
+ * The deployment workflow must call this before authenticating to the cloud or
+ * mutating a deployment slot. It proves the live Control Plane has the shared
+ * HMAC secret, Supabase service binding, a bound production provider and
+ * rollback target, and access to the promotion/deployment record stores.
+ */
+export async function GET(request: NextRequest) {
+  const secret = process.env.DSG_PROMOTION_EVALUATION_SECRET;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!secret || !supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'DEPLOYMENT_PREFLIGHT_NOT_CONFIGURED',
+      missing: [
+        ...(!secret ? ['DSG_PROMOTION_EVALUATION_SECRET'] : []),
+        ...(!supabaseUrl ? ['NEXT_PUBLIC_SUPABASE_URL'] : []),
+        ...(!serviceRoleKey ? ['SUPABASE_SERVICE_ROLE_KEY'] : []),
+      ],
+    }, { status: 503 });
+  }
+
+  if (!verifySignature(DEPLOYMENT_PREFLIGHT_MESSAGE, request.headers.get('x-dsg-signature'), secret)) {
+    return NextResponse.json({ status: 'BLOCK', reason: 'DEPLOYMENT_PREFLIGHT_SIGNATURE_INVALID' }, { status: 401 });
+  }
+
+  const target = productionTargetJson as ProductionTargetSnapshot;
+  const targetFailures = evaluateDeploymentPreflightTarget(target);
+  if (targetFailures.length > 0) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: targetFailures[0],
+      failures: targetFailures,
+      provider: target.provider,
+      deploymentSlot: target.rollbackTarget,
+    }, { status: 409 });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const [receiptProbe, deploymentProbe] = await Promise.all([
+    supabase.from('agentic_promotion_receipts').select('promotion_id').limit(1),
+    supabase.from('agentic_deployment_records').select('deployment_id').limit(1),
+  ]);
+  if (receiptProbe.error || deploymentProbe.error) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'DEPLOYMENT_PREFLIGHT_STORE_UNAVAILABLE',
+      stores: {
+        promotionReceipts: receiptProbe.error ? 'BLOCKED' : 'READY',
+        deploymentRecords: deploymentProbe.error ? 'BLOCKED' : 'READY',
+      },
+    }, { status: 503 });
+  }
+
+  return NextResponse.json({
+    status: 'PASS',
+    reason: 'DEPLOYMENT_PREFLIGHT_READY',
+    provider: target.provider,
+    deploymentSlot: target.rollbackTarget,
+    productionDeployEnabled: true,
+  });
 }
 
 /**
@@ -69,8 +139,9 @@ export async function POST(request: NextRequest) {
   }
 
   const target = productionTargetJson as ProductionTargetSnapshot;
-  if (target.provider === 'UNBOUND' || target.productionDeployEnabled !== true) {
-    return NextResponse.json({ status: 'BLOCK', reason: 'PRODUCTION_TARGET_UNBOUND' }, { status: 409 });
+  const targetFailures = evaluateDeploymentPreflightTarget(target);
+  if (targetFailures.length > 0) {
+    return NextResponse.json({ status: 'BLOCK', reason: targetFailures[0], failures: targetFailures }, { status: 409 });
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey, {

--- a/lib/agent-governance/agentic-org/deployment-record.ts
+++ b/lib/agent-governance/agentic-org/deployment-record.ts
@@ -15,6 +15,7 @@
 import type { PromotionReceipt } from './post-deploy-control';
 
 export const DEPLOYMENT_RECORD_SCHEMA_VERSION = 'dsg-deployment-record-v1' as const;
+export const DEPLOYMENT_PREFLIGHT_MESSAGE = 'dsg-deployment-preflight-v1' as const;
 
 const COMMIT = /^[0-9a-f]{40}$/i;
 const SHA256 = /^[0-9a-f]{64}$/i;
@@ -46,6 +47,29 @@ export type DeploymentRecordFailureCode =
   | 'DEPLOYMENT_RECORD_PAYLOAD_INVALID'
   | 'DEPLOYMENT_PROVIDER_MISMATCH'
   | 'DEPLOYMENT_PROMOTION_BINDING_MISMATCH';
+
+export type DeploymentPreflightFailureCode =
+  | 'PRODUCTION_TARGET_UNBOUND'
+  | 'DEPLOYMENT_ROLLBACK_TARGET_MISSING';
+
+export interface DeploymentPreflightTarget {
+  provider: string;
+  productionDeployEnabled: boolean;
+  rollbackTarget: string | null;
+}
+
+export function evaluateDeploymentPreflightTarget(
+  target: DeploymentPreflightTarget,
+): DeploymentPreflightFailureCode[] {
+  const failures: DeploymentPreflightFailureCode[] = [];
+  if (target.provider === 'UNBOUND' || target.productionDeployEnabled !== true) {
+    failures.push('PRODUCTION_TARGET_UNBOUND');
+  }
+  if (typeof target.rollbackTarget !== 'string' || target.rollbackTarget.trim().length === 0) {
+    failures.push('DEPLOYMENT_ROLLBACK_TARGET_MISSING');
+  }
+  return failures;
+}
 
 export function isDeploymentRecordRequest(value: unknown): value is DeploymentRecordRequest {
   if (!value || typeof value !== 'object') return false;

--- a/tests/unit/agentic-org-deployment-record.test.ts
+++ b/tests/unit/agentic-org-deployment-record.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   bindDeploymentToPromotion,
   deploymentRecordMatchesReceipt,
+  DEPLOYMENT_PREFLIGHT_MESSAGE,
   DEPLOYMENT_RECORD_SCHEMA_VERSION,
+  evaluateDeploymentPreflightTarget,
   isDeploymentRecordRequest,
   type DeploymentRecordRequest,
   type PersistedDeploymentRecordRow,
@@ -45,6 +47,38 @@ function receiptRow(overrides: Partial<PersistedPromotionReceiptRow> = {}): Pers
     ...overrides,
   };
 }
+
+describe('deployment preflight target', () => {
+  it('uses a stable HMAC message shared with the deployment workflow', () => {
+    expect(DEPLOYMENT_PREFLIGHT_MESSAGE).toBe('dsg-deployment-preflight-v1');
+  });
+
+  it('passes only for an enabled bound provider with a rollback slot', () => {
+    expect(evaluateDeploymentPreflightTarget({
+      provider: 'AZURE',
+      productionDeployEnabled: true,
+      rollbackTarget: 'staging',
+    })).toEqual([]);
+  });
+
+  it('blocks the canonical UNBOUND target before cloud mutation', () => {
+    const failures = evaluateDeploymentPreflightTarget({
+      provider: 'UNBOUND',
+      productionDeployEnabled: false,
+      rollbackTarget: null,
+    });
+    expect(failures).toContain('PRODUCTION_TARGET_UNBOUND');
+    expect(failures).toContain('DEPLOYMENT_ROLLBACK_TARGET_MISSING');
+  });
+
+  it('blocks a nominally enabled target with no rollback slot', () => {
+    expect(evaluateDeploymentPreflightTarget({
+      provider: 'AZURE',
+      productionDeployEnabled: true,
+      rollbackTarget: '',
+    })).toContain('DEPLOYMENT_ROLLBACK_TARGET_MISSING');
+  });
+});
 
 describe('isDeploymentRecordRequest', () => {
   it('accepts a well-formed request', () => {


### PR DESCRIPTION
## Goal

Close a deployment ordering gap exposed while reviewing dsg-agi-simulation #28. The simulation workflow can swap an Azure slot before it calls the deployment-record endpoint. If the Control Plane target is still `UNBOUND`, the later record call correctly blocks — but the production mutation would already have happened.

## Changes

- add an authenticated, read-only `GET /api/dsg/agentic-org/deployment/record` preflight;
- HMAC-authenticate a fixed `dsg-deployment-preflight-v1` message with `DSG_PROMOTION_EVALUATION_SECRET`;
- require Control Plane Supabase bindings;
- require a bound/enabled production provider and non-empty rollback target;
- probe both `agentic_promotion_receipts` and `agentic_deployment_records` through the service-role client without writing rows;
- return the live provider and rollback/deployment slot only on PASS;
- reuse the same target preflight contract in POST so record and preflight cannot disagree about target readiness;
- add unit coverage proving the canonical `UNBOUND` target fails closed and that an enabled provider without a rollback slot also blocks.

## Truth boundary

This PR does not bind the production target and does not deploy anything. With the current canonical target (`provider=UNBOUND`, `productionDeployEnabled=false`, `rollbackTarget=null`), the new preflight deliberately returns BLOCK. The paired simulation workflow must call this preflight before `azure/login`/slot mutation.

## Merge gate

Do not merge until current-head CI/typecheck/tests/build are green. After merge, patch simulation #28 to require `PASS`, provider `AZURE`, and `deploymentSlot === AZURE_DEPLOYMENT_SLOT` before any Azure action.