### PR TITLE
fix(deploy): add the preflight GET the deploy job calls before touching Azure

### DIFF
--- a/app/api/dsg/agentic-org/deployment/record/route.ts
+++ b/app/api/dsg/agentic-org/deployment/record/route.ts
@@ -10,6 +10,9 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+/** Signed in place of a request body, since the preflight is a GET. Must match the deploy job. */
+const DEPLOYMENT_PREFLIGHT_MESSAGE = 'dsg-deployment-preflight-v1';
+
 function safeEqualHex(left: string, right: string): boolean {
   if (!/^[0-9a-f]+$/i.test(left) || !/^[0-9a-f]+$/i.test(right)) return false;
   const a = Buffer.from(left, 'hex');
@@ -22,6 +25,72 @@ function verifySignature(rawBody: string, header: string | null, secret: string)
   const supplied = header.replace(/^sha256=/i, '').trim();
   const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
   return safeEqualHex(supplied, expected);
+}
+
+/**
+ * Deployment preflight for the governed candidate deploy job.
+ *
+ * The deploy job in dsg-agi-simulation mutates real Azure infrastructure: it
+ * builds an image, publishes it to a slot, and swaps that slot into
+ * production. Without this, the first time the Control Plane could refuse the
+ * deployment was POST below -- after the swap had already happened. The job
+ * now calls this first and only touches Azure when it answers PASS.
+ *
+ * It deliberately reports the bound slot so the caller can compare it against
+ * its own AZURE_DEPLOYMENT_SLOT. A slot mismatch means the rollback adapter
+ * would later swap a different slot than the one deployed to, which is the one
+ * way a "successful" rollback can silently restore the wrong build.
+ *
+ * Authenticated with the same secret as POST, over the fixed string
+ * DEPLOYMENT_PREFLIGHT_MESSAGE -- there is no body to sign on a GET. This
+ * returns only configuration the caller is about to act on; no promotion,
+ * deployment, or database state is read or disclosed.
+ */
+export async function GET(request: NextRequest) {
+  const secret = process.env.DSG_PROMOTION_EVALUATION_SECRET;
+  if (!secret) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'DEPLOYMENT_RECORD_NOT_CONFIGURED',
+      missing: ['DSG_PROMOTION_EVALUATION_SECRET'],
+    }, { status: 503 });
+  }
+
+  if (!verifySignature(DEPLOYMENT_PREFLIGHT_MESSAGE, request.headers.get('x-dsg-signature'), secret)) {
+    return NextResponse.json({ status: 'BLOCK', reason: 'DEPLOYMENT_PREFLIGHT_SIGNATURE_INVALID' }, { status: 401 });
+  }
+
+  const target = productionTargetJson as ProductionTargetSnapshot;
+  if (target.provider === 'UNBOUND' || target.productionDeployEnabled !== true) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'PRODUCTION_TARGET_UNBOUND',
+      provider: target.provider,
+      productionDeployEnabled: target.productionDeployEnabled === true,
+      deploymentSlot: target.rollbackTarget ?? null,
+    }, { status: 409 });
+  }
+
+  // A bound target with no rollback slot would let a deploy proceed with no
+  // way back, so it is refused here rather than at rollback time.
+  if (typeof target.rollbackTarget !== 'string' || target.rollbackTarget.length === 0) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'PRODUCTION_TARGET_ROLLBACK_SLOT_MISSING',
+      provider: target.provider,
+      productionDeployEnabled: true,
+      deploymentSlot: null,
+    }, { status: 409 });
+  }
+
+  return NextResponse.json({
+    status: 'PASS',
+    reason: 'DEPLOYMENT_PREFLIGHT_OK',
+    provider: target.provider,
+    productionDeployEnabled: true,
+    deploymentSlot: target.rollbackTarget,
+    healthProbe: target.healthProbe ?? null,
+  });
 }
 
 /**

--- a/tests/unit/agentic-org-deployment-preflight.test.ts
+++ b/tests/unit/agentic-org-deployment-preflight.test.ts
@@ -1,0 +1,121 @@
+import crypto from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The preflight contract the deploy job in dsg-agi-simulation relies on. It
+// signs exactly this string (there is no body on a GET) and then reads
+// status / provider / productionDeployEnabled / deploymentSlot off the
+// response. These tests pin that contract: a drift here strands the deploy job
+// with an error it can only hit against real Azure, never in CI.
+const PREFLIGHT_MESSAGE = 'dsg-deployment-preflight-v1';
+const SECRET = 'test-preflight-secret';
+
+function signedRequest(message = PREFLIGHT_MESSAGE, secret = SECRET) {
+  const signature = crypto.createHmac('sha256', secret).update(message).digest('hex');
+  return new Request('https://control-plane.test/api/dsg/agentic-org/deployment/record', {
+    method: 'GET',
+    headers: { 'x-dsg-signature': `sha256=${signature}` },
+  });
+}
+
+async function loadRoute(target: Record<string, unknown>) {
+  vi.resetModules();
+  vi.doMock('@/config/production-deployment-target.json', () => ({ default: target }));
+  return import('../../app/api/dsg/agentic-org/deployment/record/route');
+}
+
+const BOUND_TARGET = {
+  schemaVersion: 'dsg.production-target.v1',
+  provider: 'AZURE',
+  status: 'BOUND',
+  productionDeployEnabled: true,
+  rollbackTarget: 'staging',
+  healthProbe: '/api/agent/status',
+};
+
+const UNBOUND_TARGET = {
+  schemaVersion: 'dsg.production-target.v1',
+  provider: 'UNBOUND',
+  status: 'BLOCKED_UNTIL_BOUND',
+  productionDeployEnabled: false,
+  rollbackTarget: null,
+  healthProbe: null,
+};
+
+describe('deployment preflight (GET)', () => {
+  beforeEach(() => {
+    process.env.DSG_PROMOTION_EVALUATION_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.DSG_PROMOTION_EVALUATION_SECRET;
+    vi.resetModules();
+    vi.doUnmock('@/config/production-deployment-target.json');
+  });
+
+  it('returns the fields the deploy job reads when the target is bound', async () => {
+    const { GET } = await loadRoute(BOUND_TARGET);
+    const response = await GET(signedRequest() as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    // Exactly the four assertions the deploy job makes before touching Azure.
+    expect(body.status).toBe('PASS');
+    expect(body.provider).toBe('AZURE');
+    expect(body.productionDeployEnabled).toBe(true);
+    expect(body.deploymentSlot).toBe('staging');
+  });
+
+  it('blocks while the production target is unbound', async () => {
+    const { GET } = await loadRoute(UNBOUND_TARGET);
+    const response = await GET(signedRequest() as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.status).toBe('BLOCK');
+    expect(body.reason).toBe('PRODUCTION_TARGET_UNBOUND');
+  });
+
+  it('blocks a bound target that has no rollback slot, rather than deploying with no way back', async () => {
+    const { GET } = await loadRoute({ ...BOUND_TARGET, rollbackTarget: '' });
+    const response = await GET(signedRequest() as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.reason).toBe('PRODUCTION_TARGET_ROLLBACK_SLOT_MISSING');
+    expect(body.deploymentSlot).toBeNull();
+  });
+
+  it('rejects a signature made with the wrong secret', async () => {
+    const { GET } = await loadRoute(BOUND_TARGET);
+    const response = await GET(signedRequest(PREFLIGHT_MESSAGE, 'wrong-secret') as never);
+
+    expect(response.status).toBe(401);
+    expect((await response.json()).reason).toBe('DEPLOYMENT_PREFLIGHT_SIGNATURE_INVALID');
+  });
+
+  it('rejects a signature over a different message', async () => {
+    const { GET } = await loadRoute(BOUND_TARGET);
+    const response = await GET(signedRequest('dsg-deployment-preflight-v2') as never);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects an unsigned request', async () => {
+    const { GET } = await loadRoute(BOUND_TARGET);
+    const request = new Request('https://control-plane.test/api/dsg/agentic-org/deployment/record', { method: 'GET' });
+    const response = await GET(request as never);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('fails closed when the signing secret is not configured', async () => {
+    delete process.env.DSG_PROMOTION_EVALUATION_SECRET;
+    const { GET } = await loadRoute(BOUND_TARGET);
+    const response = await GET(signedRequest() as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.reason).toBe('DEPLOYMENT_RECORD_NOT_CONFIGURED');
+    expect(body.missing).toContain('DSG_PROMOTION_EVALUATION_SECRET');
+  });
+});


### PR DESCRIPTION
## Closed — superseded by merged #1169

This PR was created from a stale view of the deployment-record route. Current `main` already exports the required authenticated GET preflight via merged PR #1169.

The canonical implementation on `main` is stronger than this branch:
- HMAC-authenticates `dsg-deployment-preflight-v1`;
- requires `DSG_PROMOTION_EVALUATION_SECRET`, `NEXT_PUBLIC_SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY`;
- fail-closes on an unbound/invalid production target through the shared `evaluateDeploymentPreflightTarget` contract;
- probes both `agentic_promotion_receipts` and `agentic_deployment_records` read-only before returning PASS;
- returns provider, deployment slot, and `productionDeployEnabled=true` only after those checks pass.

The paired simulation deployment path was subsequently merged through dsg-agi-simulation PR #29 with fresh CI success and the preflight step before `azure/login`.

Merging this PR would duplicate the handler and regress the stronger store-readiness check, so it is intentionally closed without merge.