### PR TITLE
feat(encoding): add read-only proof authority lookup

### DIFF
--- a/app/api/dsg/v1/encoding/proofs/[proofId]/route.ts
+++ b/app/api/dsg/v1/encoding/proofs/[proofId]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateProofHash } from '@/lib/dsg/deterministic/encoding-proof-engine';
+import { getPersistedEncodingProof } from '@/lib/dsg/deterministic/encoding-proof-store';
+import {
+  requireDsgAuth,
+  dsgAuthError,
+} from '@/lib/dsg/auth/require-dsg-auth';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+const PROOF_ID = /^epf_[0-9a-f]{32}$/;
+
+/**
+ * Read-only authority lookup for a previously persisted encoding proof.
+ *
+ * Solver services use this endpoint to verify that a caller-supplied proof id
+ * actually exists in the authenticated Control Plane organization and that the
+ * persisted proof still passes its canonical proof-hash integrity check. This
+ * endpoint never creates a proof and never records billable gate usage.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ proofId: string }> },
+) {
+  const caller = await requireDsgAuth(request);
+  if (!caller.ok) {
+    return dsgAuthError(caller as typeof caller & { ok: false });
+  }
+
+  const { proofId } = await params;
+  if (!PROOF_ID.test(proofId)) {
+    return NextResponse.json(
+      { ok: false, status: 'BLOCK', error: 'invalid_encoding_proof_id' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const proof = await getPersistedEncodingProof({
+      organizationId: caller.orgId,
+      proofId,
+    });
+
+    if (!proof) {
+      return NextResponse.json(
+        { ok: false, status: 'BLOCK', error: 'encoding_proof_not_found' },
+        { status: 404 },
+      );
+    }
+
+    if (!validateProofHash(proof)) {
+      return NextResponse.json(
+        { ok: false, status: 'BLOCK', error: 'stored_proof_integrity_failure' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      status: proof.status,
+      proofId: proof.proofId,
+      proof,
+    });
+  } catch (error) {
+    const message = String(error);
+    if (message.includes('encoding_proof_store:')) {
+      return NextResponse.json(
+        { ok: false, status: 'BLOCK', error: 'proof_store_unavailable' },
+        { status: 503 },
+      );
+    }
+    return handleApiError('api/dsg/v1/encoding/proofs/[proofId]', error);
+  }
+}

--- a/lib/dsg/deterministic/encoding-proof-store.ts
+++ b/lib/dsg/deterministic/encoding-proof-store.ts
@@ -131,6 +131,43 @@ export async function persistEncodingProof(input: {
   throw storeError('insert', error);
 }
 
+/**
+ * Read one proof by its public proof id, scoped to the authenticated
+ * organization. The duplicated relational columns are cross-checked against
+ * the persisted JSON proof so a corrupted/inconsistent row never becomes an
+ * authority response.
+ */
+export async function getPersistedEncodingProof(input: {
+  organizationId: string;
+  proofId: string;
+}): Promise<EncodingProof | null> {
+  const db = admin();
+  const { data, error } = await db
+    .from('dsg_encoding_proofs')
+    .select('problem_id,encoding_type,encoding_hash,proof_id,proof_hash,proof')
+    .eq('organization_id', input.organizationId)
+    .eq('proof_id', input.proofId)
+    .maybeSingle();
+
+  if (error) throw storeError('lookup_proof_id', error);
+  if (!data) return null;
+
+  const proof = data.proof as EncodingProof;
+  const rowMatchesProof =
+    String(data.proof_id) === input.proofId &&
+    proof?.proofId === String(data.proof_id) &&
+    proof?.proofHash === String(data.proof_hash) &&
+    proof?.encodingHash === String(data.encoding_hash) &&
+    proof?.subject?.problemId === String(data.problem_id) &&
+    proof?.subject?.encodingType === String(data.encoding_type);
+
+  if (!rowMatchesProof) {
+    throw new Error('encoding_proof_store:lookup_integrity:row_proof_mismatch');
+  }
+
+  return proof;
+}
+
 export async function getEncodingProofChainHead(
   organizationId: string,
 ): Promise<Pick<StoredRow, 'proof_hash' | 'sequence'> | null> {

--- a/tests/unit/encoding-proof-authority-lookup.test.ts
+++ b/tests/unit/encoding-proof-authority-lookup.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import type { EncodingProof } from '@/lib/dsg/deterministic/encoding-proof-types';
+import { GET } from '@/app/api/dsg/v1/encoding/proofs/[proofId]/route';
+import { requireDsgAuth } from '@/lib/dsg/auth/require-dsg-auth';
+import { getPersistedEncodingProof } from '@/lib/dsg/deterministic/encoding-proof-store';
+import { validateProofHash } from '@/lib/dsg/deterministic/encoding-proof-engine';
+
+vi.mock('@/lib/dsg/auth/require-dsg-auth', () => ({
+  requireDsgAuth: vi.fn(),
+  dsgAuthError: vi.fn(() => NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })),
+}));
+
+vi.mock('@/lib/dsg/deterministic/encoding-proof-store', () => ({
+  getPersistedEncodingProof: vi.fn(),
+}));
+
+vi.mock('@/lib/dsg/deterministic/encoding-proof-engine', () => ({
+  validateProofHash: vi.fn(),
+}));
+
+const PROOF_ID = `epf_${'a'.repeat(32)}`;
+
+function request(): NextRequest {
+  return new NextRequest(`https://control-plane.test/api/dsg/v1/encoding/proofs/${PROOF_ID}`);
+}
+
+function proof(): EncodingProof {
+  return {
+    proofId: PROOF_ID,
+    proofHash: 'b'.repeat(64),
+    encodingHash: 'c'.repeat(64),
+    subject: {
+      problemId: 'problem-1',
+      encodingType: 'qubo-v1',
+      requestHash: 'd'.repeat(64),
+      nonceHash: 'e'.repeat(64),
+      idempotencyKeyHash: 'f'.repeat(64),
+    },
+    checks: {
+      linear_terms_valid: true,
+      quadratic_terms_valid: true,
+      dimension_within_bounds: true,
+      coefficient_magnitude_bounded: true,
+      no_nan_or_infinity: true,
+      no_duplicate_edges: true,
+      variable_naming_consistent: true,
+      encoding_type_matches: true,
+    },
+    status: 'PASS',
+    constraintSetHash: '1'.repeat(64),
+    previousProofHash: '0'.repeat(64),
+    timestamp: '2026-08-29T00:00:00.000Z',
+    policyVersion: '1.0',
+    metadata: {
+      dimensionCount: 2,
+      linearTermsCount: 1,
+      quadraticTermsCount: 0,
+      maxCoefficientValue: '1',
+    },
+    evidenceBoundary: {
+      statement: 'structural encoding proof only',
+      externalVerifierInvoked: false,
+      certificationClaim: false,
+    },
+  };
+}
+
+describe('GET encoding proof authority lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDsgAuth).mockResolvedValue({
+      ok: true,
+      orgId: 'org-1',
+      actorType: 'api_key',
+      apiKeyId: 'key-1',
+    });
+    vi.mocked(getPersistedEncodingProof).mockResolvedValue(proof());
+    vi.mocked(validateProofHash).mockReturnValue(true);
+  });
+
+  it('rejects malformed proof ids before querying the store', async () => {
+    const response = await GET(request(), {
+      params: Promise.resolve({ proofId: 'epf_not-a-valid-id' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(getPersistedEncodingProof).not.toHaveBeenCalled();
+  });
+
+  it('looks up the proof inside the authenticated organization and returns the persisted proof', async () => {
+    const response = await GET(request(), {
+      params: Promise.resolve({ proofId: PROOF_ID }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getPersistedEncodingProof).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      proofId: PROOF_ID,
+    });
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe('PASS');
+    expect(body.proofId).toBe(PROOF_ID);
+  });
+
+  it('fails closed when the proof does not exist in that organization', async () => {
+    vi.mocked(getPersistedEncodingProof).mockResolvedValue(null);
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ proofId: PROOF_ID }),
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe('encoding_proof_not_found');
+  });
+
+  it('fails closed when the persisted proof hash is invalid', async () => {
+    vi.mocked(validateProofHash).mockReturnValue(false);
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ proofId: PROOF_ID }),
+    });
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).error).toBe('stored_proof_integrity_failure');
+  });
+
+  it('does not expose database errors', async () => {
+    vi.mocked(getPersistedEncodingProof).mockRejectedValue(
+      new Error('encoding_proof_store:lookup_proof_id:database detail'),
+    );
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ proofId: PROOF_ID }),
+    });
+
+    expect(response.status).toBe(503);
+    expect((await response.json()).error).toBe('proof_store_unavailable');
+  });
+});


### PR DESCRIPTION
## Goal

Give solver services an authority-backed way to verify that a caller-supplied encoding proof really exists in the authenticated Control Plane organization before executing the solver.

The existing `/api/dsg/v1/encoding/prove` POST is not suitable for verification-by-replay because even an idempotent replay calls `recordGateEvaluation`, creating usage/evaluation side effects. This PR adds a separate read-only lookup.

## Changes

- `lib/dsg/deterministic/encoding-proof-store.ts`
  - adds org-scoped `getPersistedEncodingProof({ organizationId, proofId })`;
  - queries by both authenticated organization and proof id;
  - cross-checks relational columns (`proof_id`, `proof_hash`, `encoding_hash`, `problem_id`, `encoding_type`) against the stored proof JSON;
  - fails closed on row/proof inconsistency.
- `GET /api/dsg/v1/encoding/proofs/[proofId]`
  - uses canonical DSG API-key/session auth;
  - validates `epf_<32 hex>` id format;
  - returns 404 when no proof exists in that organization;
  - recomputes the canonical proof hash before returning the proof;
  - returns sanitized fail-closed errors on store failure;
  - does not issue a proof and does not record billable gate usage.
- `tests/unit/encoding-proof-authority-lookup.test.ts`
  - malformed proof id blocks before DB lookup;
  - lookup is bound to authenticated org;
  - not-found, corrupt-proof and store-error paths all fail closed.

## Why this is needed

dsg-one-v1 #118 and dsg-agi-simulation #5 currently propose passing only an `encodingProofId`. Presence of a string is not proof authority, and passing a caller-supplied proof object would still be forgeable because `proofHash` is an integrity hash, not a signature. Solver-side authenticated lookup closes that authority gap without introducing a second proof format.

## Truth boundary

This endpoint proves that a persisted Control Plane structural encoding proof exists and its stored canonical hash is intact. It does not prove semantic equivalence of the encoding to the user's natural-language problem, global optimality, certification, or external solver invocation.

## Merge gate

Do not merge until current-head CI/typecheck/tests/build/security gates are green. After merge, rebase/redesign simulation #5 and dsg-one-v1 #118 so the simulation service independently resolves the proof by id and verifies `status`, `encodingHash`, `subject.problemId`, and `subject.encodingType` before solving.