### PR TITLE
fix(governance): fail closed on unproven Z3 outcomes

### DIFF
--- a/skills/z3-formal-solver-verification/SKILL.md
+++ b/skills/z3-formal-solver-verification/SKILL.md
@@ -26,8 +26,8 @@ This skill coordinates a **hybrid verification pipeline** combining Ising optimi
            ↓
 ┌──────────────────────────────────────┐
 │ 1. Ising Solver                      │
-│    Find safe values satisfying       │
-│    policy + requirement              │
+│    Generate candidate assignments   │
+│    for policy + requirement         │
 └──────────┬───────────────────────────┘
            │
            ↓
@@ -48,10 +48,24 @@ This skill coordinates a **hybrid verification pipeline** combining Ising optimi
            ↓
 ┌──────────────────────────────────────┐
 │ 4. Action Layer                      │
-│    Execute gate decision             │
+│    Execute only proven decisions     │
 │    Generate CCVS evidence            │
 └──────────────────────────────────────┘
 ```
+
+## Authority Semantics
+
+Ising/QUBO is an advisory candidate generator and optimizer only. It may rank or propose assignments for Z3 to verify, but it is never the final execution authority and must never override an unproven solver outcome.
+
+Final gate semantics are fail-closed:
+
+* **SAT:** ALLOW only when the governing policy and required execution conditions are proven satisfied.
+* **UNSAT:** BLOCK and return violation evidence.
+* **UNKNOWN:** BLOCK or WAITING_VERIFICATION. Do not execute.
+* **TIMEOUT:** BLOCK or WAITING_VERIFICATION. Do not execute.
+* **ERROR:** BLOCK. Do not execute.
+
+No proof means no execution authorization.
 
 ## When to Use This Skill
 
@@ -68,7 +82,7 @@ Task: Generate formal proof that this policy is satisfiable with example values.
 
 **Skill handles:**
 
-1. Ising finds safe assignment: {risk\_score: 35, user\_role: "admin"}
+1. Ising proposes candidate assignment: {risk_score: 35, user_role: "admin"}
 2. Agent validates assignment against policy rules
 3. Z3 proves policy is SAT with model as evidence
 4. Output: Proof hash, model (satisfying assignment), CCVS L1 evidence
@@ -86,8 +100,8 @@ Task: Generate proof that proves same input → same output (deterministic).
 
 **Skill handles:**
 
-1. Ising solves gate constraints deterministically
-2. Agent processes in parallel
+1. Ising generates deterministic candidate assignments
+2. Agent processes candidates in parallel
 3. Z3 generates proof hash + replay evidence
 4. Output: Proof hash (deterministic), replay test data, CCVS L3 evidence
 
@@ -104,8 +118,8 @@ Task: Prove policy is UNSAT and show why.
 
 **Skill handles:**
 
-1. Ising detects infeasibility
-2. Agent attempts processing (fails safely)
+1. Ising may detect infeasibility or fail to produce a viable candidate
+2. Agent prepares candidate/evidence context
 3. Z3 generates UNSAT proof with minimal core
 4. Output: UNSAT proof, violated constraints, counterexample, evidence
 
@@ -171,42 +185,47 @@ Provide policy constraints in SMT-LIB or JSON format.
 
 ### Step 2: Ising Optimization
 
-Ising solver finds safe value assignments that:
+Ising solver generates candidate assignments that:
 
-* Satisfy all constraints
-* Minimize violations
-* Maximize policy compliance
+* Search promising regions of the constraint space
+* Minimize candidate violations
+* Rank candidate policy compliance
+
+These outputs are advisory and must be verified by Z3 before they can authorize execution.
 
 ### Step 3: Agent Parallel Processing
 
 Agent processes candidate assignments:
 
-* Validates each assignment
+* Validates each candidate representation
 * Builds evidence chains
-* Prepares for Z3 verification
+* Prepares candidates for Z3 verification
 
 ### Step 4: Z3 Formal Verification
 
-Z3 performs formal proof:
+Z3 performs formal verification:
 
 * Proves satisfiability (SAT/UNSAT/UNKNOWN)
 * Generates model (satisfying assignment) or counterexample (unsatisfiable core)
 * Computes proof hash for replay verification
+* Remains the final solver authority for execution gating
 
 ### Step 5: Action Execution
 
 Based on Z3 result:
 
-* **SAT:** Execute action with proof attached
-* **UNSAT:** Block action, return violation evidence
-* **UNKNOWN:** Use Ising advisory (safe fallback)
+* **SAT:** Execute only when all governing policy and execution preconditions are proven satisfied, with proof attached
+* **UNSAT:** BLOCK action and return violation evidence
+* **UNKNOWN:** BLOCK or WAITING_VERIFICATION; Ising output remains advisory only
+* **TIMEOUT:** BLOCK or WAITING_VERIFICATION; never authorize from an Ising candidate
+* **ERROR:** BLOCK and return solver failure evidence
 
 ### Step 6: Evidence Generation
 
 Produce CCVS-compatible evidence:
 
 * L1: Z3 proof object
-* L2: Proof + agent processing trace
+* L2: Ising candidate + agent processing + Z3 trace
 * L3: Replay determinism verification
 * L4: Formal property proof
 * L5: Provenance + signature chain (optional)
@@ -226,7 +245,7 @@ POST /api/dsg/v1/gates/evaluate
 
 ```
 L1 (Unit): Z3 proof object
-L2 (Integration): Ising + Agent + Z3 trace
+L2 (Integration): Ising candidate + Agent + Z3 trace
 L3 (Replay): Determinism verification
 L4 (Mutation/Proof): Formal property invariants
 L5 (Provenance): Build artifacts + signatures
@@ -243,12 +262,12 @@ DSG Brain: Credential Lease
 
 ## Key Features
 
-* ✅ **Ising Optimization:** Fast assignment finding for large constraint sets
+* ✅ **Ising Optimization:** Fast candidate generation and ranking for large constraint sets
 * ✅ **Parallel Processing:** Agent processes candidates while Z3 works
 * ✅ **Deterministic Proofs:** Same input → same proof hash (replay-safe)
 * ✅ **Counterexample Generation:** UNSAT produces minimal violated core
 * ✅ **CCVS Evidence:** L1-L5 evidence generation for compliance
-* ✅ **Hybrid Fallback:** Z3 timeout → Ising advisory (graceful degradation)
+* ✅ **Fail-Closed Solver Authority:** UNKNOWN, timeout, or error never fall back to heuristic authorization
 * ✅ **Audit Trail:** All proofs timestamped and hashable for verification
 
 ## Examples
@@ -317,25 +336,34 @@ Evidence: CCVS L3 (replay verification)
 
 If Z3 solver times out (typically >30s):
 
-* Fall back to Ising advisory
-* Mark result as "UNKNOWN" with Ising recommendation
-* Return fallback evidence for gate decision
+* Return `WAITING_VERIFICATION` or `BLOCK` according to the calling gate contract
+* Record solver timeout evidence and do not execute the protected action
+* Ising may still provide candidate or diagnostic output for a later retry, but that output is not authorization
+
+### Z3 UNKNOWN or Solver Error
+
+If Z3 returns UNKNOWN or the verifier errors:
+
+* Fail closed
+* Return `WAITING_VERIFICATION` for a retryable UNKNOWN condition, or `BLOCK` for a hard solver failure
+* Never convert advisory Ising output into ALLOW
 
 ### Infeasible Constraint Set
 
-If Ising cannot find assignment:
+If Ising cannot find a candidate assignment:
 
-* Return UNSAT immediately
-* Generate minimal violated constraint core
-* Suggest constraint relaxation
+* Treat it as advisory evidence of infeasibility, not a formal UNSAT proof
+* Ask Z3 to verify the constraint set when the verifier is available
+* If Z3 proves UNSAT, return BLOCK with the violated constraint core
+* If Z3 is unavailable or inconclusive, fail closed
 
 ### Large Solution Space
 
 If constraint space is very large:
 
-* Use sampling to find representative assignment
-* Verify sample with Z3
-* Return sample + proof
+* Use sampling or Ising optimization to find representative candidates
+* Verify every execution-authorizing candidate with Z3
+* Return only Z3-verified results as gate authority
 
 ## See Also
 


### PR DESCRIPTION
Aligns `z3-formal-solver-verification` with DSG fail-closed governance semantics.

Changes:
- make Ising/QUBO advisory candidate generation/optimization only
- keep Z3 as final execution authority
- `SAT` may authorize only when all governing conditions are proven
- `UNSAT` blocks
- `UNKNOWN` / timeout / solver error block or return `WAITING_VERIFICATION`
- remove heuristic fallback as execution authorization
- clarify infeasibility and large-search-space handling

This change prevents an unproven solver state from being converted into an execution permit.