### PR TITLE
ci(deploy): explicit Control Plane production E2E trigger

### DIFF
--- a/.github/workflows/control-plane-live-e2e-trigger.yml
+++ b/.github/workflows/control-plane-live-e2e-trigger.yml
@@ -1,0 +1,19 @@
+name: Control Plane Live E2E Promotion Trigger
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  promote-production:
+    if: contains(github.event.head_commit.message, '[prod-e2e]')
+    uses: ./.github/workflows/promoted-production-deploy.yml
+    with:
+      operation: control-plane-live-e2e
+      commit_sha: ${{ github.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Scope
Control Plane only. No Simulation changes.

## Purpose
Wire an explicit, auditable caller for the already-merged reusable Azure App Service production workflow.

## Behavior
- runs only on pushes to `main`
- calls production promotion only when the merge commit message contains `[prod-e2e]`
- passes the exact `github.sha` as `commit_sha`
- inherits the existing protected secret/environment boundary
- does not auto-deploy ordinary merges

This PR itself does not claim live production success. The merge commit will carry `[prod-e2e]` only after PR CI is green so the resulting main SHA is the exact artifact verified by the governed Azure workflow.