### PR TITLE
feat(ising): add deterministic QUBO/Ising policy optimisation engine

### DIFF
--- a/.github/workflows/pibench-control-plane-agentbeats.yml
+++ b/.github/workflows/pibench-control-plane-agentbeats.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
     paths:
       - 'benchmarks/pibench_control_plane/**'
+      - 'lib/ising/qubo/**'
+      - 'lib/gateway/audit.ts'
       - '.github/workflows/pibench-control-plane-agentbeats.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'claude/pi-bench-score-increase-k1z3pt'
     paths:
       - 'benchmarks/pibench_control_plane/**'
+      - 'lib/ising/qubo/**'
+      - 'lib/gateway/audit.ts'
       - '.github/workflows/pibench-control-plane-agentbeats.yml'
   workflow_dispatch:
 
@@ -30,6 +36,11 @@ jobs:
           cache: pip
           cache-dependency-path: benchmarks/pibench_control_plane/requirements.txt
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Install benchmark dependencies
         run: python -m pip install -r benchmarks/pibench_control_plane/requirements.txt
 
@@ -44,10 +55,49 @@ jobs:
       - name: Compile check
         run: python -m compileall -q benchmarks/pibench_control_plane
 
+      - name: Bundle PR1180 native QUBO bridge
+        run: |
+          npx --yes esbuild@0.25.12 \
+            benchmarks/pibench_control_plane/qubo_bridge.ts \
+            --bundle \
+            --platform=node \
+            --format=esm \
+            --target=node18 \
+            --outfile=benchmark-evidence/qubo-bridge-ci.mjs
+
+      - name: PR1180 native QUBO smoke
+        run: |
+          cat > benchmark-evidence/native-signals.json <<'JSON'
+          {
+            "explicit_deny": false,
+            "requires_escalation": false,
+            "authorization_verified": true,
+            "mandatory_preconditions_satisfied": true,
+            "privacy_release_allowed": true,
+            "operational_action_requested": true,
+            "confidence": 1.0
+          }
+          JSON
+          node benchmark-evidence/qubo-bridge-ci.mjs \
+            < benchmark-evidence/native-signals.json \
+            > benchmark-evidence/pr1180-native-qubo.json
+          python - <<'PY'
+          import json
+          data = json.load(open('benchmark-evidence/pr1180-native-qubo.json'))
+          assert data['schema'] == 'dsg-pr1180-qubo-advisory/v1'
+          assert data['engine'] == 'dsg-qubo-anneal/1.0.0'
+          assert data['seed'] == 42
+          assert data['candidate'] == 'ALLOW'
+          assert data['feasible'] is True
+          assert data['provenance_hash']
+          assert data['matrix']['decision_count'] == 3
+          PY
+
       - name: Formal authority smoke
         run: |
-          PYTHONPATH=benchmarks/pibench_control_plane python - <<'PY' \
-            | tee benchmark-evidence/formal-authority.json
+          DSG_QUBO_BRIDGE="$PWD/benchmark-evidence/qubo-bridge-ci.mjs" \
+          PYTHONPATH=benchmarks/pibench_control_plane \
+          python - <<'PY' | tee benchmark-evidence/formal-authority.json
           import json
           from formal_gate import PolicySignals, solve_policy
 
@@ -61,6 +111,9 @@ jobs:
           assert out["deny"]["decision"] == "DENY"
           assert out["escalate"]["decision"] == "ESCALATE"
           assert all(item["z3"]["status"] == "SAT" for item in out.values())
+          assert all(item["qubo"]["engine"] == "dsg-qubo-anneal/1.0.0" for item in out.values())
+          assert all(item["qubo"]["feasible"] is True for item in out.values())
+          assert all(item["advisory_matches_authority"] is True for item in out.values())
           print(json.dumps(out, sort_keys=True))
           PY
 
@@ -71,6 +124,23 @@ jobs:
             -t dsg-control-plane-pibench:${GITHUB_SHA} .
           docker image inspect dsg-control-plane-pibench:${GITHUB_SHA} \
             --format '{{json .}}' > benchmark-evidence/docker-image.json
+
+      - name: Container PR1180 QUBO smoke
+        run: |
+          docker run --rm -i \
+            --entrypoint node \
+            dsg-control-plane-pibench:${GITHUB_SHA} \
+            /app/qubo-bridge.mjs \
+            < benchmark-evidence/native-signals.json \
+            > benchmark-evidence/container-pr1180-native-qubo.json
+          python - <<'PY'
+          import json
+          data = json.load(open('benchmark-evidence/container-pr1180-native-qubo.json'))
+          assert data['engine'] == 'dsg-qubo-anneal/1.0.0'
+          assert data['candidate'] == 'ALLOW'
+          assert data['feasible'] is True
+          assert data['provenance_hash']
+          PY
 
       - name: A2A card and bootstrap smoke
         run: |
@@ -170,7 +240,9 @@ jobs:
           if-no-files-found: error
 
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/claude/pi-bench-score-increase-k1z3pt')
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -191,7 +263,7 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and publish immutable AgentBeats image
+      - name: Build and publish AgentBeats image
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -200,8 +272,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/tdealer01-crypto/dsg-control-plane-pibench-agent:latest
             ghcr.io/tdealer01-crypto/dsg-control-plane-pibench-agent:${{ github.sha }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tdealer01-crypto/dsg-control-plane-pibench-agent:latest' || 'ghcr.io/tdealer01-crypto/dsg-control-plane-pibench-agent:pr1180' }}
           labels: |
             org.opencontainers.image.source=https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane
             org.opencontainers.image.revision=${{ github.sha }}
@@ -214,6 +286,7 @@ jobs:
           {
             "repository": "ghcr.io/tdealer01-crypto/dsg-control-plane-pibench-agent",
             "commit": "${GITHUB_SHA}",
+            "ref": "${GITHUB_REF}",
             "digest": "${{ steps.build.outputs.digest }}",
             "platform": "linux/amd64",
             "source": "https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane"

--- a/benchmarks/pibench_control_plane/Dockerfile
+++ b/benchmarks/pibench_control_plane/Dockerfile
@@ -1,14 +1,36 @@
+FROM node:24-bookworm-slim AS qubo-builder
+
+WORKDIR /src
+
+COPY benchmarks/pibench_control_plane/qubo_bridge.ts /src/benchmarks/pibench_control_plane/qubo_bridge.ts
+COPY lib/ising/qubo /src/lib/ising/qubo
+COPY lib/gateway/audit.ts /src/lib/gateway/audit.ts
+
+RUN npx --yes esbuild@0.25.12 \
+    /src/benchmarks/pibench_control_plane/qubo_bridge.ts \
+    --bundle \
+    --platform=node \
+    --format=esm \
+    --target=node18 \
+    --outfile=/out/qubo-bridge.mjs
+
 FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    DSG_QUBO_BRIDGE=/app/qubo-bridge.mjs
 
 WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY benchmarks/pibench_control_plane/requirements.txt /app/requirements.txt
 RUN python -m pip install --no-cache-dir -r /app/requirements.txt
 
+COPY --from=qubo-builder /out/qubo-bridge.mjs /app/qubo-bridge.mjs
 COPY benchmarks/pibench_control_plane/formal_gate.py /app/formal_gate.py
 COPY benchmarks/pibench_control_plane/execution_gate.py /app/execution_gate.py
 COPY benchmarks/pibench_control_plane/analyzer.py /app/analyzer.py

--- a/benchmarks/pibench_control_plane/amber-manifest-pr1180.json5
+++ b/benchmarks/pibench_control_plane/amber-manifest-pr1180.json5
@@ -1,0 +1,56 @@
+{
+  manifest_version: "0.1.0",
+
+  config_schema: {
+    type: "object",
+    properties: {
+      openai_api_key: { type: "string", secret: true },
+      openai_model: { type: "string", default: "gpt-5" },
+      policy_analyzer_model: { type: "string", default: "gpt-5" },
+      reasoning_effort: {
+        type: "string",
+        enum: ["low", "medium", "high"],
+        default: "medium",
+      },
+      policy_reasoning_effort: {
+        type: "string",
+        enum: ["low", "medium", "high"],
+        default: "low",
+      },
+    },
+    required: ["openai_api_key"],
+    additionalProperties: false,
+  },
+
+  slots: {},
+
+  program: {
+    image: "ghcr.io/tdealer01-crypto/dsg-control-plane-pibench-agent:pr1180",
+    entrypoint: [
+      "python",
+      "/app/server.py",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "9010"
+    ],
+    env: {
+      OPENAI_API_KEY: "${config.openai_api_key}",
+      OPENAI_MODEL: "${config.openai_model}",
+      POLICY_ANALYZER_MODEL: "${config.policy_analyzer_model}",
+      REASONING_EFFORT: "${config.reasoning_effort}",
+      POLICY_REASONING_EFFORT: "${config.policy_reasoning_effort}",
+    },
+    network: {
+      endpoints: [
+        { name: "a2a_endpoint", port: 9010 },
+      ],
+    },
+  },
+
+  provides: {
+    a2a: { kind: "a2a", endpoint: "a2a_endpoint" },
+  },
+
+  exports: { a2a: "a2a" },
+}

--- a/benchmarks/pibench_control_plane/formal_gate.py
+++ b/benchmarks/pibench_control_plane/formal_gate.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 from dataclasses import asdict, dataclass
 from decimal import Decimal, getcontext
 from typing import Any
@@ -9,6 +11,7 @@ from typing import Any
 getcontext().prec = 50
 
 DECISIONS = ("ALLOW", "DENY", "ESCALATE")
+_PR1180_SOLVER_VERSION = "dsg-qubo-anneal/1.0.0"
 
 
 def canonical_json(value: Any) -> str:
@@ -43,7 +46,7 @@ class PolicySignals:
 
 
 class Mulberry32:
-    """32-bit deterministic PRNG used only by the advisory QUBO search."""
+    """32-bit deterministic PRNG retained as a compatibility fallback for tests."""
 
     def __init__(self, seed: int = 42) -> None:
         self._state = seed & 0xFFFFFFFF
@@ -82,10 +85,7 @@ def _decision_biases(signals: PolicySignals) -> dict[str, int]:
 
 
 def build_qubo(signals: PolicySignals, one_hot_penalty: int = 12) -> list[list[int]]:
-    """Build a 3x3 upper-triangular QUBO over ALLOW/DENY/ESCALATE.
-
-    QUBO is advisory only. Z3 is the execution authority.
-    """
+    """Compatibility QUBO used only when the PR1180 native bridge is not configured."""
 
     biases = _decision_biases(signals)
     n = len(DECISIONS)
@@ -154,8 +154,6 @@ def deterministic_anneal(
         trajectory.append({**core, "hash": step_hash})
         previous_hash = step_hash
 
-    # Enforce a deterministic one-hot advisory candidate by selecting the
-    # minimum-energy one-hot state after the annealing trajectory.
     one_hot = []
     for idx in range(len(DECISIONS)):
         bits = [0] * len(DECISIONS)
@@ -164,6 +162,7 @@ def deterministic_anneal(
     _, selected_idx, selected_bits = min(one_hot, key=lambda item: (item[0], item[1]))
 
     return {
+        "engine": "python-compat-advisory/v1",
         "seed": seed,
         "steps": steps,
         "candidate": DECISIONS[selected_idx],
@@ -173,6 +172,54 @@ def deterministic_anneal(
         "trajectory_head": previous_hash,
         "trajectory_hash": sha256_json(trajectory),
     }
+
+
+def _native_qubo_bridge() -> str | None:
+    value = os.getenv("DSG_QUBO_BRIDGE", "").strip()
+    return value or None
+
+
+def _run_pr1180_qubo(signals: PolicySignals) -> tuple[list[list[Any]], dict[str, Any]]:
+    bridge = _native_qubo_bridge()
+    if bridge is None:
+        q = build_qubo(signals)
+        return q, deterministic_anneal(q)
+
+    node_binary = os.getenv("NODE_BINARY", "node").strip() or "node"
+    completed = subprocess.run(
+        [node_binary, bridge],
+        input=canonical_json(asdict(signals)),
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip()[:500] or f"exit={completed.returncode}"
+        raise RuntimeError(f"PR1180 QUBO bridge failed: {detail}")
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("PR1180 QUBO bridge returned invalid JSON") from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError("PR1180 QUBO bridge returned non-object payload")
+    if payload.get("engine") != _PR1180_SOLVER_VERSION:
+        raise RuntimeError("PR1180 QUBO bridge solver version mismatch")
+    if payload.get("seed") != 42:
+        raise RuntimeError("PR1180 QUBO bridge seed mismatch")
+    if payload.get("feasible") is not True:
+        raise RuntimeError("PR1180 QUBO bridge returned infeasible advisory candidate")
+    if payload.get("candidate") not in DECISIONS:
+        raise RuntimeError("PR1180 QUBO bridge returned invalid decision candidate")
+    matrix = payload.get("matrix")
+    if not isinstance(matrix, dict) or not isinstance(matrix.get("matrix"), list):
+        raise RuntimeError("PR1180 QUBO bridge omitted matrix evidence")
+    if not isinstance(payload.get("provenance_hash"), str) or not payload["provenance_hash"]:
+        raise RuntimeError("PR1180 QUBO bridge omitted provenance hash")
+
+    return matrix["matrix"], payload
 
 
 def z3_authority(signals: PolicySignals) -> dict[str, Any]:
@@ -249,13 +296,13 @@ def z3_authority(signals: PolicySignals) -> dict[str, Any]:
 
 
 def solve_policy(signals: PolicySignals) -> dict[str, Any]:
-    q = build_qubo(signals)
-    qubo = deterministic_anneal(q)
+    q, qubo = _run_pr1180_qubo(signals)
     z3 = z3_authority(signals)
     return {
         "signals_hash": sha256_json(asdict(signals)),
         "qubo_matrix": q,
         "qubo": qubo,
         "z3": z3,
+        "advisory_matches_authority": qubo.get("candidate") == z3.get("decision"),
         "decision": z3["decision"],
     }

--- a/benchmarks/pibench_control_plane/qubo_bridge.ts
+++ b/benchmarks/pibench_control_plane/qubo_bridge.ts
@@ -1,10 +1,6 @@
-import {
-  buildQuboMatrix,
-  solveQubo,
-  toIsingModel,
-  type FormalConstraint,
-  type PolicyControl,
-} from '../../lib/ising/qubo';
+import { solveQubo } from '../../lib/ising/qubo/annealer';
+import { buildQuboMatrix, toIsingModel } from '../../lib/ising/qubo/matrix';
+import type { FormalConstraint, PolicyControl } from '../../lib/ising/qubo/types';
 
 type Decision = 'ALLOW' | 'DENY' | 'ESCALATE';
 

--- a/benchmarks/pibench_control_plane/qubo_bridge.ts
+++ b/benchmarks/pibench_control_plane/qubo_bridge.ts
@@ -1,0 +1,176 @@
+import {
+  buildQuboMatrix,
+  solveQubo,
+  toIsingModel,
+  type FormalConstraint,
+  type PolicyControl,
+} from '../../lib/ising/qubo';
+
+type Decision = 'ALLOW' | 'DENY' | 'ESCALATE';
+
+type PolicySignals = {
+  explicit_deny: boolean;
+  requires_escalation: boolean;
+  authorization_verified: boolean;
+  mandatory_preconditions_satisfied: boolean;
+  privacy_release_allowed: boolean;
+  operational_action_requested: boolean;
+  confidence?: number;
+};
+
+const DECISIONS: readonly Decision[] = ['ALLOW', 'DENY', 'ESCALATE'];
+const ONE_HOT_PENALTY = 1000;
+
+function requireBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`${name} must be boolean`);
+  return value;
+}
+
+function parseSignals(raw: unknown): PolicySignals {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('signals must be an object');
+  }
+  const value = raw as Record<string, unknown>;
+  return {
+    explicit_deny: requireBoolean(value.explicit_deny, 'explicit_deny'),
+    requires_escalation: requireBoolean(value.requires_escalation, 'requires_escalation'),
+    authorization_verified: requireBoolean(value.authorization_verified, 'authorization_verified'),
+    mandatory_preconditions_satisfied: requireBoolean(
+      value.mandatory_preconditions_satisfied,
+      'mandatory_preconditions_satisfied',
+    ),
+    privacy_release_allowed: requireBoolean(value.privacy_release_allowed, 'privacy_release_allowed'),
+    operational_action_requested: requireBoolean(
+      value.operational_action_requested,
+      'operational_action_requested',
+    ),
+    confidence:
+      typeof value.confidence === 'number' && Number.isFinite(value.confidence)
+        ? Math.max(0, Math.min(1, value.confidence))
+        : 0,
+  };
+}
+
+function decisionBiases(signals: PolicySignals): Record<Decision, number> {
+  const denyTrigger =
+    signals.explicit_deny ||
+    (signals.operational_action_requested && !signals.privacy_release_allowed);
+  const escalateTrigger =
+    signals.requires_escalation ||
+    (signals.operational_action_requested &&
+      (!signals.authorization_verified || !signals.mandatory_preconditions_satisfied));
+  const allowTrigger = !denyTrigger && !escalateTrigger;
+
+  return {
+    ALLOW: allowTrigger ? -4 : 10,
+    DENY: denyTrigger ? -6 : 6,
+    ESCALATE: !denyTrigger && escalateTrigger ? -5 : 5,
+  };
+}
+
+function controlFor(decision: Decision, bias: number): PolicyControl {
+  // solveQubo minimizes cost - value - riskReduction. Split the signed bias
+  // across non-negative cost/value fields so the diagonal objective equals it.
+  return {
+    id: decision,
+    label: decision,
+    framework: 'PI-Bench formal decision advisory',
+    cost: bias > 0 ? bias : 0,
+    value: bias < 0 ? -bias : 0,
+    riskReduction: 0,
+  };
+}
+
+function solve(signals: PolicySignals) {
+  const biases = decisionBiases(signals);
+  const controls = DECISIONS.map((decision) => controlFor(decision, biases[decision]));
+  const constraints: FormalConstraint[] = [
+    {
+      kind: 'at_least',
+      id: 'decision-at-least-one',
+      controls: [...DECISIONS],
+      minimum: 1,
+      penalty: ONE_HOT_PENALTY,
+    },
+    {
+      kind: 'mutual_exclusion',
+      id: 'allow-xor-deny',
+      left: 'ALLOW',
+      right: 'DENY',
+      penalty: ONE_HOT_PENALTY,
+    },
+    {
+      kind: 'mutual_exclusion',
+      id: 'allow-xor-escalate',
+      left: 'ALLOW',
+      right: 'ESCALATE',
+      penalty: ONE_HOT_PENALTY,
+    },
+    {
+      kind: 'mutual_exclusion',
+      id: 'deny-xor-escalate',
+      left: 'DENY',
+      right: 'ESCALATE',
+      penalty: ONE_HOT_PENALTY,
+    },
+  ];
+
+  const problem = {
+    controls,
+    constraints,
+    defaultPenalty: ONE_HOT_PENALTY,
+  };
+  const matrix = buildQuboMatrix(problem);
+  const ising = toIsingModel(matrix);
+  const solution = solveQubo(problem, {
+    seed: 42,
+    maxIterations: 5000,
+    coolingRate: 0.995,
+    retainTrajectorySteps: 0,
+  });
+
+  if (!solution.feasible) throw new Error('PR1180 QUBO solver returned an infeasible decision set');
+  if (solution.selected.length !== 1 || !DECISIONS.includes(solution.selected[0] as Decision)) {
+    throw new Error(`PR1180 QUBO solver violated one-hot decision contract: ${solution.selected.join(',')}`);
+  }
+
+  return {
+    schema: 'dsg-pr1180-qubo-advisory/v1',
+    engine: solution.solverVersion,
+    seed: solution.seed,
+    candidate: solution.selected[0] as Decision,
+    feasible: solution.feasible,
+    energy: solution.energy,
+    iterations: solution.iterations,
+    final_temperature: solution.finalTemperature,
+    provenance_hash: solution.provenanceHash,
+    biases,
+    matrix: {
+      variables: matrix.variables,
+      decision_count: matrix.decisionCount,
+      matrix: matrix.matrix,
+      offset: matrix.offset,
+    },
+    ising: {
+      variables: ising.variables,
+      h: ising.h,
+      J: ising.J,
+      offset: ising.offset,
+    },
+    verdicts: solution.verdicts,
+  };
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += String(chunk);
+  if (!input.trim()) throw new Error('missing policy signals on stdin');
+  const signals = parseSignals(JSON.parse(input));
+  process.stdout.write(`${JSON.stringify(solve(signals))}\n`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`PR1180_QUBO_BRIDGE_ERROR: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/lib/ising/qubo/README.md
+++ b/lib/ising/qubo/README.md
@@ -1,0 +1,101 @@
+# Deterministic QUBO / Ising policy engine
+
+`lib/ising/solver.ts` searches boolean assignments against callback predicates.
+This module adds the algebraic layer it does not have: an explicit QUBO matrix,
+the exact QUBO ↔ Ising transform, formal constraint encodings, a reproducible
+annealing trajectory, and a SHA-256 provenance chain.
+
+## What each piece does
+
+| File | Responsibility |
+|---|---|
+| `matrix.ts` | Builds the upper-triangular QUBO `Q`, encodes constraints as penalties, converts to Ising `(h, J, offset)`, evaluates energy in either form |
+| `deterministic-rng.ts` | Mulberry32 PRNG — 32-bit integer ops only, so a seed reproduces the identical stream on any platform |
+| `annealer.ts` | Deterministic simulated annealing + single-flip descent polish + provenance chain |
+| `constraints.ts` | Exact verification of an assignment, independent of the penalty encoding |
+| `what-if.ts` | Counterfactual budget shifts → ΔC / ΔR / ΔV and rule divergence |
+| `catalog-adapter.ts` | Builds controls from the repository's own `REQUIREMENT_CATALOG` |
+
+## Objective and encodings
+
+The objective minimises `Σ (cost_i − value_i − riskReduction_i)·x_i`, which is
+equivalent to maximising net benefit. Constraints become penalty terms:
+
+| Constraint | Pseudo-boolean form | QUBO encoding |
+|---|---|---|
+| `implication` A→B | `x_A − x_A·x_B ≤ 0` | `Q_AA += P`, `Q_AB −= P` |
+| `equivalence` A↔B | `(x_A − x_B)² = 0` | `Q_AA += P`, `Q_BB += P`, `Q_AB −= 2P` |
+| `mutual_exclusion` | `x_A·x_B = 0` | `Q_AB += P` |
+| `at_least` | `Σ x_i ≥ k` | `P·(Σx_i − k − s)²` with binary slack `s` |
+| `budget_cap` | `Σ c_i·x_i ≤ B` | `P·(Σc_i x_i + s − B)²` with binary slack `s` |
+
+The two inequality constraints introduce slack variables so the inequality is
+encoded exactly rather than approximated. Slack is binary-encoded on a
+`slackGranularity` grid (default 1, i.e. integral costs); non-integral costs are
+rounded onto that grid, so set the granularity to match your units.
+
+## Determinism
+
+`solveQubo` draws every random decision from the seeded PRNG, starts from the
+all-unselected assignment, and scans variables in matrix order during the
+polish. Nothing depends on wall-clock time or map iteration order, so the same
+`(problem, seed)` reproduces the same selection, the same energy, the same
+trajectory, and the same `provenanceHash`. `replayProvenance` recomputes the
+head hash from retained steps and detects any alteration.
+
+Every step is chained whether or not it is retained, so `provenanceHash` covers
+the whole run while `retainTrajectorySteps` bounds memory. Replay therefore
+matches only when the full trajectory was retained.
+
+## Claim boundary
+
+- **Penalties bias, they do not prove.** A low-energy assignment can still
+  violate a constraint. `verifyConstraints` is the authority, `solution.feasible`
+  reports its verdict, and the annealer prefers a verified-feasible assignment
+  over a lower-energy infeasible one. Check `feasible` before acting on
+  `selected`.
+- **Simulated annealing is a heuristic.** The polish step guarantees a local
+  optimum under single flips, not a proven global optimum. This module does not
+  invoke Z3; the constraint encodings above are the pseudo-boolean forms an SMT
+  encoding would use, verified here by direct evaluation.
+- **Framework scope is whatever the repository actually carries.**
+  `controlsFromCatalog()` reads `REQUIREMENT_CATALOG`, which today covers
+  EU AI Act, ISO 42001, NIST AI RMF, SLSA, and one DSG-internal requirement.
+  There are no GDPR, PDPA, Thai criminal law, or FinTech rows in this
+  repository, so the adapter cannot emit controls for them — pass your own
+  `PolicyControl[]` if you need those frameworks.
+- **The catalog weighting is a modelling choice.** `DEFAULT_CATALOG_WEIGHTING`
+  derives value/risk/cost from `min_severity_level`, `evidence_type`, and
+  `mutation_required`. Those are engineering weights for the optimiser, not a
+  legal, actuarial, or certification judgement. Override them with your own.
+
+## Usage
+
+```ts
+import { controlsFromCatalog, runWhatIf, solveQubo } from '@/lib/ising/qubo';
+
+const controls = controlsFromCatalog();
+const problem = {
+  controls,
+  constraints: [
+    { kind: 'budget_cap', id: 'q3-budget', budget: 20 },
+    { kind: 'implication', id: 'audit-needs-oversight',
+      antecedent: 'EU-AI-ACT-ART12', consequent: 'EU-AI-ACT-ART14' },
+  ],
+} as const;
+
+const solution = solveQubo(problem, { seed: 42, retainTrajectorySteps: 100 });
+if (!solution.feasible) throw new Error('no feasible control set under this budget');
+
+const report = runWhatIf(problem, [
+  { id: 'cut', budgetDelta: -300 },
+  { id: 'raise', budgetDelta: 500 },
+], { seed: 42 });
+```
+
+## Verification
+
+```bash
+npx vitest run tests/unit/qubo-policy-engine.test.ts
+npm run typecheck
+```

--- a/lib/ising/qubo/annealer.ts
+++ b/lib/ising/qubo/annealer.ts
@@ -1,0 +1,257 @@
+import { hashGatewayValue } from '../../gateway/audit';
+import { assertConstraintsResolve, verifyConstraints } from './constraints';
+import { createRng } from './deterministic-rng';
+import { buildQuboMatrix, quboEnergy } from './matrix';
+import type {
+  AnnealConfig,
+  AnnealStep,
+  ConstraintVerdict,
+  PolicyControl,
+  QuboMatrix,
+  QuboProblem,
+  QuboSolution,
+} from './types';
+
+export const SOLVER_VERSION = 'dsg-qubo-anneal/1.0.0';
+export const PROVENANCE_CHAIN_ROOT = 'dsg-qubo-provenance/1.0.0';
+
+const DEFAULTS = {
+  seed: 42,
+  maxIterations: 5000,
+  coolingRate: 0.995,
+  retainTrajectorySteps: 0,
+} as const;
+
+/**
+ * Start hot enough for the problem's own energy scale.
+ *
+ * A fixed initial temperature makes the chain greedy from the first move on
+ * any problem whose weights are larger than it, which traps the search in
+ * whichever basin it happens to enter first. Scaling with the largest matrix
+ * entry keeps early moves genuinely exploratory regardless of the units the
+ * caller expresses value, risk, and cost in.
+ */
+function defaultInitialTemperature(qubo: QuboMatrix): number {
+  let largest = 0;
+  for (let i = 0; i < qubo.matrix.length; i += 1) {
+    for (let j = i; j < qubo.matrix.length; j += 1) {
+      const magnitude = Math.abs(qubo.matrix[i][j]);
+      if (magnitude > largest) largest = magnitude;
+    }
+  }
+  return Math.max(1, largest);
+}
+
+/** Coupling between two distinct variables, read from the upper triangle. */
+function coupling(matrix: number[][], a: number, b: number): number {
+  return a < b ? matrix[a][b] : matrix[b][a];
+}
+
+/**
+ * Energy contribution of variable `k` when it is set: its diagonal term plus
+ * every coupling to a currently-set variable. Flipping `k` changes the total
+ * energy by exactly `+/- localField`, so a step costs O(n) instead of O(n^2).
+ */
+function localField(qubo: QuboMatrix, bits: number[], k: number): number {
+  let field = qubo.matrix[k][k];
+  for (let i = 0; i < bits.length; i += 1) {
+    if (i !== k && bits[i] === 1) field += coupling(qubo.matrix, i, k);
+  }
+  return field;
+}
+
+function toAssignment(variables: string[], bits: number[]): Record<string, boolean> {
+  const assignment: Record<string, boolean> = {};
+  variables.forEach((name, i) => {
+    assignment[name] = bits[i] === 1;
+  });
+  return assignment;
+}
+
+/**
+ * Deterministic simulated annealing over an explicit QUBO matrix.
+ *
+ * Identical `seed` and problem produce an identical trajectory, identical
+ * energies, and an identical provenance hash: the PRNG is the only source of
+ * randomness and it is seeded, so nothing in the run depends on wall-clock
+ * time, iteration timing, or map ordering.
+ */
+export function solveQubo(problem: QuboProblem, config: AnnealConfig = {}): QuboSolution {
+  assertConstraintsResolve(problem.controls, problem.constraints);
+  const qubo = buildQuboMatrix(problem);
+
+  const seed = config.seed ?? DEFAULTS.seed;
+  const maxIterations = config.maxIterations ?? DEFAULTS.maxIterations;
+  const coolingRate = config.coolingRate ?? DEFAULTS.coolingRate;
+  const retain = config.retainTrajectorySteps ?? DEFAULTS.retainTrajectorySteps;
+  if (!(coolingRate > 0 && coolingRate < 1)) {
+    throw new Error('coolingRate must be strictly between 0 and 1');
+  }
+
+  const rng = createRng(seed);
+  const size = qubo.variables.length;
+  const bits = new Array<number>(size).fill(0);
+
+  let temperature = config.initialTemperature ?? defaultInitialTemperature(qubo);
+  let energy = qubo.offset;
+  let bestEnergy = energy;
+  let bestBits = [...bits];
+  let bestFeasibleEnergy = Number.POSITIVE_INFINITY;
+  let bestFeasibleBits: number[] | null = null;
+
+  const evaluateFeasible = (candidate: number[]): boolean =>
+    verifyConstraints(
+      problem.controls,
+      problem.constraints,
+      toAssignment(qubo.variables, candidate),
+    ).every((verdict) => verdict.satisfied);
+
+  if (evaluateFeasible(bits)) {
+    bestFeasibleEnergy = energy;
+    bestFeasibleBits = [...bits];
+  }
+
+  let previousHash: string | null = null;
+  let chainHash = hashGatewayValue({ root: PROVENANCE_CHAIN_ROOT, seed, variables: qubo.variables });
+  const trajectory: AnnealStep[] = [];
+
+  let iteration = 0;
+  for (; iteration < maxIterations && size > 0; iteration += 1) {
+    const k = rng.nextInt(size);
+    const field = localField(qubo, bits, k);
+    const flippedTo = bits[k] === 1 ? 0 : 1;
+    const deltaEnergy = (flippedTo - bits[k]) * field;
+
+    const accepted =
+      deltaEnergy <= 0 || (temperature > 0 && rng.next() < Math.exp(-deltaEnergy / temperature));
+    const energyBefore = energy;
+    if (accepted) {
+      bits[k] = flippedTo;
+      energy += deltaEnergy;
+      if (energy < bestEnergy) {
+        bestEnergy = energy;
+        bestBits = [...bits];
+      }
+      if (energy < bestFeasibleEnergy && evaluateFeasible(bits)) {
+        bestFeasibleEnergy = energy;
+        bestFeasibleBits = [...bits];
+      }
+    }
+
+    const step: Omit<AnnealStep, 'stepHash'> = {
+      sequence: iteration,
+      variable: qubo.variables[k],
+      flippedTo: flippedTo === 1,
+      accepted,
+      temperature,
+      energyBefore,
+      energyAfter: energy,
+      deltaEnergy,
+      previousHash,
+    };
+    // Every step is chained, whether or not it is retained, so the head hash
+    // covers the whole trajectory rather than only the retained window.
+    const stepHash = hashGatewayValue({ chain: chainHash, ...step });
+    chainHash = stepHash;
+    previousHash = stepHash;
+    if (trajectory.length < retain) trajectory.push({ ...step, stepHash });
+
+    temperature *= coolingRate;
+  }
+
+  const finalBits = polish(qubo, problem, bestFeasibleBits ?? bestBits, bestFeasibleBits !== null);
+  const assignment = toAssignment(qubo.variables, finalBits);
+  const verdicts: ConstraintVerdict[] = verifyConstraints(
+    problem.controls,
+    problem.constraints,
+    assignment,
+  );
+  const selected = problem.controls.filter((c) => assignment[c.id]).map((c) => c.id);
+
+  return {
+    selected,
+    assignment,
+    energy: quboEnergy(qubo, assignment),
+    totalValue: sumOver(problem.controls, assignment, (c) => c.value),
+    totalRiskReduction: sumOver(problem.controls, assignment, (c) => c.riskReduction),
+    totalCost: sumOver(problem.controls, assignment, (c) => c.cost),
+    verdicts,
+    feasible: verdicts.every((verdict) => verdict.satisfied),
+    iterations: iteration,
+    finalTemperature: temperature,
+    provenanceHash: chainHash,
+    trajectory,
+    seed,
+    solverVersion: SOLVER_VERSION,
+  };
+}
+
+/**
+ * Deterministic single-flip descent from the annealed state.
+ *
+ * Annealing ends wherever the cooling schedule left it, which is often one
+ * flip away from a strictly better assignment. Scanning variables in matrix
+ * order keeps the polish reproducible, and when the annealed state was
+ * feasible the descent refuses any flip that would break feasibility.
+ */
+function polish(
+  qubo: QuboMatrix,
+  problem: QuboProblem,
+  start: number[],
+  requireFeasible: boolean,
+): number[] {
+  const bits = [...start];
+  const isFeasible = (candidate: number[]): boolean =>
+    verifyConstraints(
+      problem.controls,
+      problem.constraints,
+      toAssignment(qubo.variables, candidate),
+    ).every((verdict) => verdict.satisfied);
+
+  let improved = true;
+  let guard = 0;
+  while (improved && guard < qubo.variables.length * 4) {
+    improved = false;
+    guard += 1;
+    for (let k = 0; k < bits.length; k += 1) {
+      const flippedTo = bits[k] === 1 ? 0 : 1;
+      const deltaEnergy = (flippedTo - bits[k]) * localField(qubo, bits, k);
+      if (deltaEnergy >= 0) continue;
+      const candidate = [...bits];
+      candidate[k] = flippedTo;
+      if (requireFeasible && !isFeasible(candidate)) continue;
+      bits[k] = flippedTo;
+      improved = true;
+    }
+  }
+  return bits;
+}
+
+function sumOver(
+  controls: PolicyControl[],
+  assignment: Record<string, boolean>,
+  pick: (control: PolicyControl) => number,
+): number {
+  const total = controls.reduce((sum, c) => (assignment[c.id] ? sum + pick(c) : sum), 0);
+  return Math.round(total * 1e6) / 1e6;
+}
+
+/**
+ * Re-derive a provenance chain from retained steps.
+ *
+ * Returns the recomputed head hash, which equals the run's `provenanceHash`
+ * only when every step was retained. A mismatch means the retained window is
+ * partial or the steps were altered.
+ */
+export function replayProvenance(
+  steps: AnnealStep[],
+  seed: number,
+  variables: string[],
+): string {
+  let chainHash = hashGatewayValue({ root: PROVENANCE_CHAIN_ROOT, seed, variables });
+  for (const step of steps) {
+    const { stepHash: _ignored, ...core } = step;
+    chainHash = hashGatewayValue({ chain: chainHash, ...core });
+  }
+  return chainHash;
+}

--- a/lib/ising/qubo/catalog-adapter.ts
+++ b/lib/ising/qubo/catalog-adapter.ts
@@ -1,0 +1,63 @@
+import { EVIDENCE_SEVERITY } from '../../ccvs/evidence-collector';
+import { REQUIREMENT_CATALOG, type RequirementControl } from '../../ccvs/compliance-matrix';
+import type { PolicyControl } from './types';
+
+/**
+ * How a CCVS requirement's existing fields become QUBO decision weights.
+ *
+ * These are engineering weights over fields that already exist in
+ * `REQUIREMENT_CATALOG` (`min_severity_level`, `evidence_type`,
+ * `mutation_required`). They are a modelling choice for the optimiser, not a
+ * legal, actuarial, or certification judgement, and callers are expected to
+ * override them with their own numbers.
+ */
+export interface CatalogWeighting {
+  /** Business value per unit of `min_severity_level`. */
+  valuePerSeverity: number;
+  /** Risk reduction per unit of `min_severity_level`. */
+  riskPerSeverity: number;
+  /** Cost per unit of the control's evidence-type severity. */
+  costPerEvidenceSeverity: number;
+  /** Extra cost when the requirement demands mutation testing. */
+  mutationCost: number;
+}
+
+export const DEFAULT_CATALOG_WEIGHTING: CatalogWeighting = {
+  valuePerSeverity: 2,
+  riskPerSeverity: 3,
+  costPerEvidenceSeverity: 1,
+  mutationCost: 2,
+};
+
+/**
+ * Build QUBO controls from the repository's own requirement catalog.
+ *
+ * Scope boundary: the catalog currently covers EU AI Act, ISO 42001,
+ * NIST AI RMF, SLSA, and one DSG-internal requirement. It contains no GDPR,
+ * PDPA, Thai criminal law, or FinTech rows, so this adapter cannot produce
+ * controls for those frameworks; supply them explicitly as `PolicyControl[]`
+ * if you need them.
+ */
+export function controlsFromCatalog(
+  weighting: Partial<CatalogWeighting> = {},
+  catalog: RequirementControl[] = REQUIREMENT_CATALOG,
+): PolicyControl[] {
+  const w: CatalogWeighting = { ...DEFAULT_CATALOG_WEIGHTING, ...weighting };
+  return catalog.map((requirement) => ({
+    id: requirement.requirement_id,
+    label: requirement.title,
+    framework: requirement.framework,
+    value: requirement.min_severity_level * w.valuePerSeverity,
+    riskReduction: requirement.min_severity_level * w.riskPerSeverity,
+    cost:
+      EVIDENCE_SEVERITY[requirement.evidence_type] * w.costPerEvidenceSeverity +
+      (requirement.mutation_required ? w.mutationCost : 0),
+  }));
+}
+
+/** Frameworks actually present in the catalog, for scope reporting. */
+export function catalogFrameworks(
+  catalog: RequirementControl[] = REQUIREMENT_CATALOG,
+): string[] {
+  return [...new Set(catalog.map((requirement) => requirement.framework))].sort();
+}

--- a/lib/ising/qubo/constraints.ts
+++ b/lib/ising/qubo/constraints.ts
@@ -1,0 +1,121 @@
+import type { ConstraintVerdict, FormalConstraint, PolicyControl } from './types';
+
+/**
+ * Exact constraint verification, independent of the annealer.
+ *
+ * The QUBO encoding expresses each constraint as a penalty, which biases the
+ * search but never proves anything: a penalised assignment is still a possible
+ * output. These predicates are the authority on whether an assignment actually
+ * satisfies the constraint set, so the engine can fail closed on a violation
+ * rather than reporting a low-energy but infeasible selection.
+ */
+export function verifyConstraints(
+  controls: PolicyControl[],
+  constraints: FormalConstraint[],
+  assignment: Record<string, boolean>,
+): ConstraintVerdict[] {
+  const selected = (id: string) => assignment[id] === true;
+  return constraints.map((constraint) => verifyOne(controls, constraint, selected));
+}
+
+function verifyOne(
+  controls: PolicyControl[],
+  constraint: FormalConstraint,
+  selected: (id: string) => boolean,
+): ConstraintVerdict {
+  switch (constraint.kind) {
+    case 'implication': {
+      const a = selected(constraint.antecedent);
+      const b = selected(constraint.consequent);
+      return {
+        constraintId: constraint.id,
+        kind: constraint.kind,
+        satisfied: !a || b,
+        formalExpression: `x_${constraint.antecedent} - x_${constraint.antecedent} * x_${constraint.consequent} <= 0`,
+        detail: `${constraint.antecedent}=${a ? 1 : 0}, ${constraint.consequent}=${b ? 1 : 0}`,
+      };
+    }
+    case 'equivalence': {
+      const l = selected(constraint.left);
+      const r = selected(constraint.right);
+      return {
+        constraintId: constraint.id,
+        kind: constraint.kind,
+        satisfied: l === r,
+        formalExpression: `(x_${constraint.left} - x_${constraint.right})^2 = 0`,
+        detail: `${constraint.left}=${l ? 1 : 0}, ${constraint.right}=${r ? 1 : 0}`,
+      };
+    }
+    case 'mutual_exclusion': {
+      const l = selected(constraint.left);
+      const r = selected(constraint.right);
+      return {
+        constraintId: constraint.id,
+        kind: constraint.kind,
+        satisfied: !(l && r),
+        formalExpression: `x_${constraint.left} * x_${constraint.right} = 0`,
+        detail: `${constraint.left}=${l ? 1 : 0}, ${constraint.right}=${r ? 1 : 0}`,
+      };
+    }
+    case 'at_least': {
+      const active = constraint.controls.filter(selected).length;
+      return {
+        constraintId: constraint.id,
+        kind: constraint.kind,
+        satisfied: active >= constraint.minimum,
+        formalExpression: `sum(x_i) >= ${constraint.minimum}`,
+        detail: `active=${active} of ${constraint.controls.length}`,
+      };
+    }
+    case 'budget_cap': {
+      const spend = controls.reduce((sum, c) => (selected(c.id) ? sum + c.cost : sum), 0);
+      return {
+        constraintId: constraint.id,
+        kind: constraint.kind,
+        satisfied: spend <= constraint.budget,
+        formalExpression: `sum(c_i * x_i) <= ${constraint.budget}`,
+        detail: `spend=${round(spend)} budget=${constraint.budget}`,
+      };
+    }
+    default: {
+      const exhaustive: never = constraint;
+      throw new Error(`Unsupported constraint: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+/** Ids of the controls a constraint refers to, for dependency reporting. */
+export function constraintScope(constraint: FormalConstraint): string[] {
+  switch (constraint.kind) {
+    case 'implication':
+      return [constraint.antecedent, constraint.consequent];
+    case 'equivalence':
+    case 'mutual_exclusion':
+      return [constraint.left, constraint.right];
+    case 'at_least':
+      return [...constraint.controls];
+    case 'budget_cap':
+      return [];
+    default:
+      return [];
+  }
+}
+
+/** Fail closed early: a constraint naming an unknown control is a defect. */
+export function assertConstraintsResolve(
+  controls: PolicyControl[],
+  constraints: FormalConstraint[],
+): void {
+  const known = new Set(controls.map((c) => c.id));
+  for (const constraint of constraints) {
+    for (const id of constraintScope(constraint)) {
+      if (!known.has(id)) {
+        throw new Error(`Constraint ${constraint.id} references unknown control ${id}`);
+      }
+    }
+  }
+}

--- a/lib/ising/qubo/deterministic-rng.ts
+++ b/lib/ising/qubo/deterministic-rng.ts
@@ -1,0 +1,46 @@
+/**
+ * Mulberry32 — a 32-bit seeded PRNG.
+ *
+ * Chosen because every operation is a 32-bit integer op, so a given seed
+ * reproduces the identical sequence on any platform and in any process. That
+ * bit-exact reproducibility is what lets an annealing run be replayed and its
+ * provenance chain re-derived.
+ */
+export class DeterministicRng {
+  private state: number;
+
+  constructor(readonly seed: number) {
+    if (!Number.isFinite(seed)) {
+      throw new Error('DeterministicRng requires a finite numeric seed');
+    }
+    // Force the seed into uint32 space so fractional or negative seeds still
+    // produce a well-defined, reproducible stream.
+    this.state = Math.trunc(seed) >>> 0;
+  }
+
+  /** Next float in [0, 1). */
+  next(): number {
+    this.state = (this.state + 0x6d2b79f5) >>> 0;
+    let t = this.state;
+    t = Math.imul(t ^ (t >>> 15), 1 | t);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  /** Next integer in [0, boundExclusive). */
+  nextInt(boundExclusive: number): number {
+    if (!Number.isInteger(boundExclusive) || boundExclusive <= 0) {
+      throw new Error('nextInt bound must be a positive integer');
+    }
+    return Math.floor(this.next() * boundExclusive) % boundExclusive;
+  }
+
+  /** Restart the stream from the original seed. */
+  reset(): void {
+    this.state = Math.trunc(this.seed) >>> 0;
+  }
+}
+
+export function createRng(seed: number): DeterministicRng {
+  return new DeterministicRng(seed);
+}

--- a/lib/ising/qubo/index.ts
+++ b/lib/ising/qubo/index.ts
@@ -1,0 +1,22 @@
+export * from './types';
+export { DeterministicRng, createRng } from './deterministic-rng';
+export {
+  DEFAULT_PENALTY,
+  DEFAULT_SLACK_GRANULARITY,
+  buildQuboMatrix,
+  isingEnergy,
+  quboEnergy,
+  slackWeights,
+  toBits,
+  toIsingModel,
+  toSpins,
+} from './matrix';
+export { assertConstraintsResolve, constraintScope, verifyConstraints } from './constraints';
+export { PROVENANCE_CHAIN_ROOT, SOLVER_VERSION, replayProvenance, solveQubo } from './annealer';
+export {
+  DEFAULT_CATALOG_WEIGHTING,
+  catalogFrameworks,
+  controlsFromCatalog,
+  type CatalogWeighting,
+} from './catalog-adapter';
+export { runWhatIf, type WhatIfOutcome, type WhatIfReport, type WhatIfScenario } from './what-if';

--- a/lib/ising/qubo/matrix.ts
+++ b/lib/ising/qubo/matrix.ts
@@ -1,0 +1,276 @@
+import type {
+  FormalConstraint,
+  IsingModel,
+  PolicyControl,
+  QuboMatrix,
+  QuboProblem,
+} from './types';
+
+export const DEFAULT_PENALTY = 100;
+export const DEFAULT_SLACK_GRANULARITY = 1;
+
+/**
+ * Binary weights that represent every integer in [0, maxValue] exactly once
+ * per achievable total: powers of two, with the final coefficient truncated so
+ * the encoding cannot overshoot `maxValue`.
+ */
+export function slackWeights(maxValue: number): number[] {
+  const bound = Math.floor(maxValue);
+  if (!Number.isFinite(bound) || bound <= 0) return [];
+  const weights: number[] = [];
+  let covered = 0;
+  let power = 1;
+  while (covered + power <= bound) {
+    weights.push(power);
+    covered += power;
+    power *= 2;
+  }
+  if (covered < bound) weights.push(bound - covered);
+  return weights;
+}
+
+interface PenaltyTerm {
+  /** Coefficient per variable index. */
+  coefficients: Map<number, number>;
+  /** Additive constant inside the squared expression. */
+  constant: number;
+  penalty: number;
+}
+
+class MatrixBuilder {
+  readonly variables: string[];
+  private readonly index = new Map<string, number>();
+  private readonly cells = new Map<string, number>();
+  offset = 0;
+
+  constructor(variables: string[]) {
+    this.variables = [...variables];
+    this.variables.forEach((name, i) => this.index.set(name, i));
+  }
+
+  indexOf(name: string): number {
+    const i = this.index.get(name);
+    if (i === undefined) throw new Error(`Unknown QUBO variable: ${name}`);
+    return i;
+  }
+
+  addVariable(name: string): number {
+    if (this.index.has(name)) throw new Error(`Duplicate QUBO variable: ${name}`);
+    const i = this.variables.length;
+    this.variables.push(name);
+    this.index.set(name, i);
+    return i;
+  }
+
+  add(i: number, j: number, weight: number): void {
+    if (weight === 0) return;
+    const [lo, hi] = i <= j ? [i, j] : [j, i];
+    const key = `${lo}:${hi}`;
+    this.cells.set(key, (this.cells.get(key) ?? 0) + weight);
+  }
+
+  build(decisionCount: number): QuboMatrix {
+    const size = this.variables.length;
+    const matrix: number[][] = Array.from({ length: size }, () => new Array<number>(size).fill(0));
+    for (const [key, weight] of this.cells) {
+      const [lo, hi] = key.split(':').map(Number);
+      matrix[lo][hi] = weight;
+    }
+    return { variables: this.variables, decisionCount, matrix, offset: this.offset };
+  }
+}
+
+/** Expand `penalty * (sum(coef_k * y_k) + constant)^2` into QUBO cells. */
+function applySquaredPenalty(builder: MatrixBuilder, term: PenaltyTerm): void {
+  const entries = [...term.coefficients.entries()];
+  const { constant, penalty } = term;
+  for (const [i, a] of entries) {
+    // y^2 = y for binary y, so the square of each coefficient folds into the
+    // diagonal together with the cross term against the constant.
+    builder.add(i, i, penalty * (a * a + 2 * constant * a));
+  }
+  for (let k = 0; k < entries.length; k += 1) {
+    for (let l = k + 1; l < entries.length; l += 1) {
+      builder.add(entries[k][0], entries[l][0], 2 * penalty * entries[k][1] * entries[l][1]);
+    }
+  }
+  builder.offset += penalty * constant * constant;
+}
+
+function addCoefficient(coefficients: Map<number, number>, index: number, value: number): void {
+  coefficients.set(index, (coefficients.get(index) ?? 0) + value);
+}
+
+/**
+ * Build the upper-triangular QUBO matrix for a policy-selection problem.
+ *
+ * The objective minimises `sum_i (cost_i - value_i - riskReduction_i) * x_i`,
+ * which is equivalent to maximising net benefit. Constraints are added as
+ * penalty terms; `at_least` and `budget_cap` introduce binary slack variables
+ * so the inequality is encoded exactly rather than approximated.
+ */
+export function buildQuboMatrix(problem: QuboProblem): QuboMatrix {
+  assertUniqueControls(problem.controls);
+  const defaultPenalty = problem.defaultPenalty ?? DEFAULT_PENALTY;
+  const granularity = problem.slackGranularity ?? DEFAULT_SLACK_GRANULARITY;
+  if (!(granularity > 0)) throw new Error('slackGranularity must be greater than 0');
+
+  const decisionCount = problem.controls.length;
+  const builder = new MatrixBuilder(problem.controls.map((c) => c.id));
+
+  for (const control of problem.controls) {
+    const i = builder.indexOf(control.id);
+    builder.add(i, i, control.cost - control.value - control.riskReduction);
+  }
+
+  for (const constraint of problem.constraints) {
+    const penalty = constraint.penalty ?? defaultPenalty;
+    if (penalty < 0) throw new Error(`Constraint ${constraint.id} has a negative penalty`);
+    encodeConstraint(builder, problem, constraint, penalty, granularity);
+  }
+
+  return builder.build(decisionCount);
+}
+
+function encodeConstraint(
+  builder: MatrixBuilder,
+  problem: QuboProblem,
+  constraint: FormalConstraint,
+  penalty: number,
+  granularity: number,
+): void {
+  switch (constraint.kind) {
+    case 'implication': {
+      // x_A - x_A x_B <= 0
+      const a = builder.indexOf(constraint.antecedent);
+      const b = builder.indexOf(constraint.consequent);
+      builder.add(a, a, penalty);
+      builder.add(a, b, -penalty);
+      return;
+    }
+    case 'equivalence': {
+      // (x_A - x_B)^2 = x_A + x_B - 2 x_A x_B
+      const l = builder.indexOf(constraint.left);
+      const r = builder.indexOf(constraint.right);
+      builder.add(l, l, penalty);
+      builder.add(r, r, penalty);
+      builder.add(l, r, -2 * penalty);
+      return;
+    }
+    case 'mutual_exclusion': {
+      // x_A x_B = 0
+      builder.add(builder.indexOf(constraint.left), builder.indexOf(constraint.right), penalty);
+      return;
+    }
+    case 'at_least': {
+      // sum(x_i) - k - s = 0, with s in [0, |controls| - k]
+      const minimum = Math.max(0, Math.floor(constraint.minimum));
+      if (minimum === 0) return;
+      const coefficients = new Map<number, number>();
+      for (const id of constraint.controls) addCoefficient(coefficients, builder.indexOf(id), 1);
+      const slackMax = constraint.controls.length - minimum;
+      for (const [bit, weight] of slackWeights(slackMax).entries()) {
+        const index = builder.addVariable(`slack:${constraint.id}:${bit}`);
+        addCoefficient(coefficients, index, -weight);
+      }
+      applySquaredPenalty(builder, { coefficients, constant: -minimum, penalty });
+      return;
+    }
+    case 'budget_cap': {
+      // sum(c_i x_i) + s - B = 0, with s in [0, B], on the granularity grid
+      const budget = Math.floor(constraint.budget / granularity);
+      const coefficients = new Map<number, number>();
+      for (const control of problem.controls) {
+        const scaled = Math.round(control.cost / granularity);
+        if (scaled !== 0) addCoefficient(coefficients, builder.indexOf(control.id), scaled);
+      }
+      for (const [bit, weight] of slackWeights(budget).entries()) {
+        const index = builder.addVariable(`slack:${constraint.id}:${bit}`);
+        addCoefficient(coefficients, index, weight);
+      }
+      applySquaredPenalty(builder, { coefficients, constant: -budget, penalty });
+      return;
+    }
+    default: {
+      const exhaustive: never = constraint;
+      throw new Error(`Unsupported constraint: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+function assertUniqueControls(controls: PolicyControl[]): void {
+  const seen = new Set<string>();
+  for (const control of controls) {
+    if (seen.has(control.id)) throw new Error(`Duplicate control id: ${control.id}`);
+    seen.add(control.id);
+  }
+}
+
+/** Energy of a 0/1 assignment: `sum_{i <= j} Q[i][j] x_i x_j + offset`. */
+export function quboEnergy(qubo: QuboMatrix, assignment: Record<string, boolean>): number {
+  const bits = qubo.variables.map((name) => (assignment[name] ? 1 : 0));
+  let energy = qubo.offset;
+  for (let i = 0; i < bits.length; i += 1) {
+    if (bits[i] === 0) continue;
+    for (let j = i; j < bits.length; j += 1) {
+      if (bits[j] === 1) energy += qubo.matrix[i][j];
+    }
+  }
+  return energy;
+}
+
+/**
+ * Exact QUBO -> Ising transform under `x_i = (1 + s_i) / 2`.
+ *
+ * Energies agree for every assignment, which is what makes the spin form a
+ * faithful rewrite rather than a re-parameterisation.
+ */
+export function toIsingModel(qubo: QuboMatrix): IsingModel {
+  const size = qubo.variables.length;
+  const h = new Array<number>(size).fill(0);
+  const J: number[][] = Array.from({ length: size }, () => new Array<number>(size).fill(0));
+  let offset = qubo.offset;
+
+  for (let i = 0; i < size; i += 1) {
+    const diagonal = qubo.matrix[i][i];
+    h[i] += diagonal / 2;
+    offset += diagonal / 2;
+    for (let j = i + 1; j < size; j += 1) {
+      const coupling = qubo.matrix[i][j];
+      if (coupling === 0) continue;
+      J[i][j] += coupling / 4;
+      h[i] += coupling / 4;
+      h[j] += coupling / 4;
+      offset += coupling / 4;
+    }
+  }
+
+  return { variables: qubo.variables, h, J, offset };
+}
+
+/** Energy of a spin assignment in `{-1, +1}`. */
+export function isingEnergy(model: IsingModel, spins: Record<string, -1 | 1>): number {
+  const values = model.variables.map((name) => spins[name] ?? -1);
+  let energy = model.offset;
+  for (let i = 0; i < values.length; i += 1) {
+    energy += model.h[i] * values[i];
+    for (let j = i + 1; j < values.length; j += 1) {
+      if (model.J[i][j] !== 0) energy += model.J[i][j] * values[i] * values[j];
+    }
+  }
+  return energy;
+}
+
+/** `x in {0,1}` -> `s in {-1,+1}`. */
+export function toSpins(assignment: Record<string, boolean>): Record<string, -1 | 1> {
+  const spins: Record<string, -1 | 1> = {};
+  for (const [name, value] of Object.entries(assignment)) spins[name] = value ? 1 : -1;
+  return spins;
+}
+
+/** `s in {-1,+1}` -> `x in {0,1}`. */
+export function toBits(spins: Record<string, -1 | 1>): Record<string, boolean> {
+  const assignment: Record<string, boolean> = {};
+  for (const [name, value] of Object.entries(spins)) assignment[name] = value === 1;
+  return assignment;
+}

--- a/lib/ising/qubo/types.ts
+++ b/lib/ising/qubo/types.ts
@@ -1,0 +1,132 @@
+/**
+ * Deterministic QUBO / Ising policy-optimization types.
+ *
+ * The existing `lib/ising/solver.ts` searches boolean assignments against
+ * callback predicates. This module adds the missing algebraic layer: an
+ * explicit upper-triangular QUBO matrix, the exact QUBO <-> Ising transform,
+ * formal constraint encodings, and a reproducible annealing trajectory.
+ */
+
+/** A selectable policy control with its decision weights. */
+export interface PolicyControl {
+  /** Stable identifier, e.g. a CCVS requirement_id. */
+  id: string;
+  /** Business value gained by selecting this control. */
+  value: number;
+  /** Risk reduction gained by selecting this control. */
+  riskReduction: number;
+  /** Cost incurred by selecting this control. */
+  cost: number;
+  /** Optional human-readable label carried through to results. */
+  label?: string;
+  /** Optional framework/source tag carried through to results. */
+  framework?: string;
+}
+
+export type FormalConstraint =
+  /** A -> B : selecting `antecedent` requires `consequent`. */
+  | { kind: 'implication'; id: string; antecedent: string; consequent: string; penalty?: number }
+  /** A <-> B : both selected or both unselected. */
+  | { kind: 'equivalence'; id: string; left: string; right: string; penalty?: number }
+  /** NOT (A AND B) : the two controls cannot both be selected. */
+  | { kind: 'mutual_exclusion'; id: string; left: string; right: string; penalty?: number }
+  /** sum(x_i) >= k over `controls`. */
+  | { kind: 'at_least'; id: string; controls: string[]; minimum: number; penalty?: number }
+  /** sum(cost_i * x_i) <= budget over all controls. */
+  | { kind: 'budget_cap'; id: string; budget: number; penalty?: number };
+
+export interface QuboProblem {
+  controls: PolicyControl[];
+  constraints: FormalConstraint[];
+  /** Penalty weight applied to constraints that do not set their own. */
+  defaultPenalty?: number;
+  /**
+   * Granularity used when binary-encoding slack for inequality constraints
+   * (`at_least`, `budget_cap`). Costs and budgets are divided by this value and
+   * rounded, so a granularity of 1 assumes integral costs. Default 1.
+   */
+  slackGranularity?: number;
+}
+
+/**
+ * Upper-triangular QUBO matrix over `variables`.
+ *
+ * Energy is `sum_{i <= j} Q[i][j] * x_i * x_j` with `x in {0, 1}`; because
+ * `x_i^2 = x_i`, the diagonal carries the linear terms.
+ */
+export interface QuboMatrix {
+  /** Variable names in matrix order: decision variables first, then slack. */
+  variables: string[];
+  /** Number of leading entries in `variables` that are real controls. */
+  decisionCount: number;
+  /** `matrix[i][j]` is defined for `j >= i`; lower entries are 0. */
+  matrix: number[][];
+  /** Constant energy offset contributed by constraint encodings. */
+  offset: number;
+}
+
+/** Ising form: `E(s) = offset + sum_i h_i s_i + sum_{i<j} J_ij s_i s_j`. */
+export interface IsingModel {
+  variables: string[];
+  /** Local fields, indexed like `variables`. */
+  h: number[];
+  /** Upper-triangular couplings; `J[i][j]` defined for `j > i`. */
+  J: number[][];
+  offset: number;
+}
+
+export interface ConstraintVerdict {
+  constraintId: string;
+  kind: FormalConstraint['kind'];
+  satisfied: boolean;
+  /** Formal statement that was checked, in the pseudo-boolean form used. */
+  formalExpression: string;
+  detail: string;
+}
+
+export interface AnnealStep {
+  sequence: number;
+  variable: string;
+  flippedTo: boolean;
+  accepted: boolean;
+  temperature: number;
+  energyBefore: number;
+  energyAfter: number;
+  deltaEnergy: number;
+  /** SHA-256 over this step bound to the previous step's hash. */
+  stepHash: string;
+  previousHash: string | null;
+}
+
+export interface AnnealConfig {
+  /** Seed for the Mulberry32 PRNG. Identical seeds reproduce identical runs. */
+  seed?: number;
+  maxIterations?: number;
+  initialTemperature?: number;
+  /** Multiplicative cooling factor per iteration, 0 < rate < 1. */
+  coolingRate?: number;
+  /** Retain at most this many trajectory steps in the result. Default 0. */
+  retainTrajectorySteps?: number;
+}
+
+export interface QuboSolution {
+  /** Selected control ids, in catalog order. */
+  selected: string[];
+  /** Assignment over every matrix variable, slack included. */
+  assignment: Record<string, boolean>;
+  /** QUBO energy of `assignment`, including constraint penalties. */
+  energy: number;
+  totalValue: number;
+  totalRiskReduction: number;
+  totalCost: number;
+  /** Exact verification of every constraint against `assignment`. */
+  verdicts: ConstraintVerdict[];
+  feasible: boolean;
+  iterations: number;
+  finalTemperature: number;
+  /** Head of the SHA-256 provenance chain over the annealing trajectory. */
+  provenanceHash: string;
+  trajectory: AnnealStep[];
+  seed: number;
+  solverVersion: string;
+}

--- a/lib/ising/qubo/what-if.ts
+++ b/lib/ising/qubo/what-if.ts
@@ -1,0 +1,84 @@
+import { solveQubo } from './annealer';
+import type { AnnealConfig, QuboProblem, QuboSolution } from './types';
+
+export interface WhatIfScenario {
+  id: string;
+  /** Shift applied to every `budget_cap` constraint, e.g. -300 or +500. */
+  budgetDelta: number;
+  description?: string;
+}
+
+export interface WhatIfOutcome {
+  scenarioId: string;
+  budgetDelta: number;
+  description?: string;
+  solution: QuboSolution;
+  /** Controls selected here but not in the baseline. */
+  added: string[];
+  /** Controls selected in the baseline but not here. */
+  removed: string[];
+  /** Count of controls whose selection differs from the baseline. */
+  ruleDivergence: number;
+  deltaCost: number;
+  deltaRiskReduction: number;
+  deltaValue: number;
+  feasibilityChanged: boolean;
+}
+
+export interface WhatIfReport {
+  baseline: QuboSolution;
+  outcomes: WhatIfOutcome[];
+}
+
+function shiftBudgets(problem: QuboProblem, delta: number): QuboProblem {
+  return {
+    ...problem,
+    constraints: problem.constraints.map((constraint) =>
+      constraint.kind === 'budget_cap'
+        ? { ...constraint, budget: Math.max(0, constraint.budget + delta) }
+        : constraint,
+    ),
+  };
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+/**
+ * Counterfactual variance analysis over budget shifts.
+ *
+ * Every scenario is solved with the same seed as the baseline, so a difference
+ * in the selected set is attributable to the budget shift rather than to a
+ * different random trajectory.
+ */
+export function runWhatIf(
+  problem: QuboProblem,
+  scenarios: WhatIfScenario[],
+  config: AnnealConfig = {},
+): WhatIfReport {
+  const baseline = solveQubo(problem, config);
+  const baselineSet = new Set(baseline.selected);
+
+  const outcomes = scenarios.map((scenario) => {
+    const solution = solveQubo(shiftBudgets(problem, scenario.budgetDelta), config);
+    const scenarioSet = new Set(solution.selected);
+    const added = solution.selected.filter((id) => !baselineSet.has(id));
+    const removed = baseline.selected.filter((id) => !scenarioSet.has(id));
+    return {
+      scenarioId: scenario.id,
+      budgetDelta: scenario.budgetDelta,
+      description: scenario.description,
+      solution,
+      added,
+      removed,
+      ruleDivergence: added.length + removed.length,
+      deltaCost: round(solution.totalCost - baseline.totalCost),
+      deltaRiskReduction: round(solution.totalRiskReduction - baseline.totalRiskReduction),
+      deltaValue: round(solution.totalValue - baseline.totalValue),
+      feasibilityChanged: solution.feasible !== baseline.feasible,
+    };
+  });
+
+  return { baseline, outcomes };
+}

--- a/tests/unit/qubo-policy-engine.test.ts
+++ b/tests/unit/qubo-policy-engine.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DeterministicRng,
+  buildQuboMatrix,
+  catalogFrameworks,
+  controlsFromCatalog,
+  isingEnergy,
+  quboEnergy,
+  replayProvenance,
+  runWhatIf,
+  slackWeights,
+  solveQubo,
+  toIsingModel,
+  toSpins,
+  verifyConstraints,
+} from '@/lib/ising/qubo';
+import type { FormalConstraint, PolicyControl, QuboProblem } from '@/lib/ising/qubo';
+
+const CONTROLS: PolicyControl[] = [
+  { id: 'A', value: 10, riskReduction: 5, cost: 3 },
+  { id: 'B', value: 4, riskReduction: 9, cost: 6 },
+  { id: 'C', value: 1, riskReduction: 1, cost: 8 },
+];
+
+function problem(constraints: FormalConstraint[] = []): QuboProblem {
+  return { controls: CONTROLS, constraints };
+}
+
+describe('DeterministicRng (Mulberry32)', () => {
+  it('reproduces the identical stream for the same seed', () => {
+    const first = Array.from({ length: 16 }, () => new DeterministicRng(42).next());
+    const rng = new DeterministicRng(42);
+    const stream = Array.from({ length: 16 }, () => rng.next());
+    expect(first[0]).toBe(stream[0]);
+    expect(stream).toEqual(Array.from({ length: 16 }, (_, i) => stream[i]));
+
+    const replay = new DeterministicRng(42);
+    expect(Array.from({ length: 16 }, () => replay.next())).toEqual(stream);
+  });
+
+  it('produces a different stream for a different seed', () => {
+    const a = Array.from({ length: 8 }, () => 0).map(() => new DeterministicRng(1).next());
+    const b = new DeterministicRng(2).next();
+    expect(a[0]).not.toBe(b);
+  });
+
+  it('emits values inside [0, 1) and bounded integers', () => {
+    const rng = new DeterministicRng(7);
+    for (let i = 0; i < 500; i += 1) {
+      const value = rng.next();
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+      expect(rng.nextInt(5)).toBeLessThan(5);
+    }
+  });
+
+  it('reset replays the same stream', () => {
+    const rng = new DeterministicRng(99);
+    const first = [rng.next(), rng.next(), rng.next()];
+    rng.reset();
+    expect([rng.next(), rng.next(), rng.next()]).toEqual(first);
+  });
+});
+
+describe('QUBO matrix', () => {
+  it('puts net benefit on the diagonal', () => {
+    const qubo = buildQuboMatrix(problem());
+    // cost - value - riskReduction
+    expect(qubo.matrix[0][0]).toBe(3 - 10 - 5);
+    expect(qubo.matrix[1][1]).toBe(6 - 4 - 9);
+    expect(qubo.matrix[2][2]).toBe(8 - 1 - 1);
+  });
+
+  it('stays upper-triangular', () => {
+    const qubo = buildQuboMatrix(
+      problem([{ kind: 'mutual_exclusion', id: 'mx', left: 'A', right: 'C' }]),
+    );
+    for (let i = 0; i < qubo.matrix.length; i += 1) {
+      for (let j = 0; j < i; j += 1) {
+        expect(qubo.matrix[i][j]).toBe(0);
+      }
+    }
+  });
+
+  it('rejects duplicate control ids', () => {
+    expect(() =>
+      buildQuboMatrix({ controls: [CONTROLS[0], CONTROLS[0]], constraints: [] }),
+    ).toThrow(/Duplicate control id/);
+  });
+
+  it('penalises an implication only when the antecedent is unsupported', () => {
+    const p = problem([
+      { kind: 'implication', id: 'imp', antecedent: 'A', consequent: 'B', penalty: 50 },
+    ]);
+    const qubo = buildQuboMatrix(p);
+    const violating = quboEnergy(qubo, { A: true, B: false, C: false });
+    const satisfying = quboEnergy(qubo, { A: true, B: true, C: false });
+    expect(violating - quboEnergy(buildQuboMatrix(problem()), { A: true, B: false, C: false })).toBe(50);
+    expect(satisfying).toBeLessThan(violating);
+  });
+
+  it('penalises a mutual exclusion only when both are selected', () => {
+    const qubo = buildQuboMatrix(
+      problem([{ kind: 'mutual_exclusion', id: 'mx', left: 'A', right: 'B', penalty: 40 }]),
+    );
+    const base = buildQuboMatrix(problem());
+    expect(quboEnergy(qubo, { A: true, B: true }) - quboEnergy(base, { A: true, B: true })).toBe(40);
+    expect(quboEnergy(qubo, { A: true, B: false })).toBe(quboEnergy(base, { A: true, B: false }));
+  });
+
+  it('penalises an equivalence only when the two differ', () => {
+    const qubo = buildQuboMatrix(
+      problem([{ kind: 'equivalence', id: 'eq', left: 'A', right: 'B', penalty: 30 }]),
+    );
+    const base = buildQuboMatrix(problem());
+    for (const [assignment, expected] of [
+      [{ A: true, B: true }, 0],
+      [{ A: false, B: false }, 0],
+      [{ A: true, B: false }, 30],
+      [{ A: false, B: true }, 30],
+    ] as const) {
+      expect(quboEnergy(qubo, assignment) - quboEnergy(base, assignment)).toBe(expected);
+    }
+  });
+});
+
+describe('slack encoding', () => {
+  it('covers every integer up to the bound without overshooting', () => {
+    for (const bound of [0, 1, 2, 3, 5, 8, 13]) {
+      const weights = slackWeights(bound);
+      expect(weights.reduce((a, b) => a + b, 0)).toBe(bound);
+      const reachable = new Set<number>([0]);
+      for (const weight of weights) {
+        for (const value of [...reachable]) reachable.add(value + weight);
+      }
+      for (let v = 0; v <= bound; v += 1) expect(reachable.has(v)).toBe(true);
+    }
+  });
+
+  it('leaves a within-budget selection unpenalised and penalises an over-budget one', () => {
+    const constraint: FormalConstraint = { kind: 'budget_cap', id: 'cap', budget: 9, penalty: 100 };
+    const qubo = buildQuboMatrix(problem([constraint]));
+    const base = buildQuboMatrix(problem());
+
+    // A + B costs 9, exactly the cap: some slack setting must reach zero penalty.
+    const slackVars = qubo.variables.filter((v) => v.startsWith('slack:'));
+    const withinBudget = { A: true, B: true, C: false } as Record<string, boolean>;
+    for (const v of slackVars) withinBudget[v] = false;
+    expect(quboEnergy(qubo, withinBudget) - quboEnergy(base, withinBudget)).toBe(0);
+
+    // A + B + C costs 17, over the cap, and no slack assignment can absorb it.
+    const overBudget = { A: true, B: true, C: true } as Record<string, boolean>;
+    for (const v of slackVars) overBudget[v] = false;
+    expect(quboEnergy(qubo, overBudget)).toBeGreaterThan(quboEnergy(base, overBudget));
+  });
+});
+
+describe('QUBO <-> Ising transform', () => {
+  it('preserves energy for every assignment', () => {
+    const qubo = buildQuboMatrix(
+      problem([
+        { kind: 'implication', id: 'imp', antecedent: 'A', consequent: 'B' },
+        { kind: 'mutual_exclusion', id: 'mx', left: 'B', right: 'C' },
+      ]),
+    );
+    const ising = toIsingModel(qubo);
+    const n = qubo.variables.length;
+
+    for (let mask = 0; mask < 1 << n; mask += 1) {
+      const assignment: Record<string, boolean> = {};
+      qubo.variables.forEach((name, i) => {
+        assignment[name] = Boolean(mask & (1 << i));
+      });
+      expect(isingEnergy(ising, toSpins(assignment))).toBeCloseTo(quboEnergy(qubo, assignment), 9);
+    }
+  });
+});
+
+describe('formal constraint verification', () => {
+  it('checks each constraint kind exactly', () => {
+    const constraints: FormalConstraint[] = [
+      { kind: 'implication', id: 'imp', antecedent: 'A', consequent: 'B' },
+      { kind: 'equivalence', id: 'eq', left: 'B', right: 'C' },
+      { kind: 'mutual_exclusion', id: 'mx', left: 'A', right: 'C' },
+      { kind: 'at_least', id: 'min', controls: ['A', 'B', 'C'], minimum: 2 },
+      { kind: 'budget_cap', id: 'cap', budget: 9 },
+    ];
+    const verdicts = verifyConstraints(CONTROLS, constraints, { A: true, B: true, C: false });
+    expect(verdicts.map((v) => [v.constraintId, v.satisfied])).toEqual([
+      ['imp', true],
+      ['eq', false],
+      ['mx', true],
+      ['min', true],
+      ['cap', true],
+    ]);
+    expect(verdicts[4].detail).toContain('spend=9');
+  });
+
+  it('rejects a constraint naming an unknown control', () => {
+    expect(() =>
+      solveQubo(problem([{ kind: 'implication', id: 'bad', antecedent: 'A', consequent: 'ZZZ' }])),
+    ).toThrow(/unknown control ZZZ/);
+  });
+});
+
+describe('deterministic annealing', () => {
+  it('is bit-for-bit reproducible across runs with the same seed', () => {
+    const p = problem([{ kind: 'budget_cap', id: 'cap', budget: 9 }]);
+    const first = solveQubo(p, { seed: 42, maxIterations: 400, retainTrajectorySteps: 400 });
+    const second = solveQubo(p, { seed: 42, maxIterations: 400, retainTrajectorySteps: 400 });
+
+    expect(second.selected).toEqual(first.selected);
+    expect(second.energy).toBe(first.energy);
+    expect(second.provenanceHash).toBe(first.provenanceHash);
+    expect(second.trajectory).toEqual(first.trajectory);
+  });
+
+  it('diverges for a different seed while staying self-consistent', () => {
+    const p = problem([{ kind: 'budget_cap', id: 'cap', budget: 9 }]);
+    const a = solveQubo(p, { seed: 42, maxIterations: 400 });
+    const b = solveQubo(p, { seed: 4242, maxIterations: 400 });
+    expect(b.provenanceHash).not.toBe(a.provenanceHash);
+    expect(b.feasible).toBe(true);
+    expect(a.feasible).toBe(true);
+  });
+
+  it('selects the net-positive controls and drops the net-negative one', () => {
+    const solution = solveQubo(problem(), { seed: 42, maxIterations: 2000 });
+    expect(solution.selected).toEqual(['A', 'B']);
+    expect(solution.totalCost).toBe(9);
+    expect(solution.feasible).toBe(true);
+  });
+
+  it('honours a budget cap that excludes the full selection', () => {
+    const solution = solveQubo(problem([{ kind: 'budget_cap', id: 'cap', budget: 5 }]), {
+      seed: 42,
+      maxIterations: 2000,
+    });
+    expect(solution.totalCost).toBeLessThanOrEqual(5);
+    expect(solution.feasible).toBe(true);
+    expect(solution.verdicts.find((v) => v.constraintId === 'cap')?.satisfied).toBe(true);
+  });
+
+  it('respects a mutual exclusion between the two best controls', () => {
+    const solution = solveQubo(
+      problem([{ kind: 'mutual_exclusion', id: 'mx', left: 'A', right: 'B' }]),
+      { seed: 42, maxIterations: 2000 },
+    );
+    expect(solution.selected).toEqual(['A']);
+    expect(solution.feasible).toBe(true);
+  });
+
+  it('drags in a required consequent through an implication', () => {
+    const solution = solveQubo(
+      problem([{ kind: 'implication', id: 'imp', antecedent: 'A', consequent: 'C' }]),
+      { seed: 42, maxIterations: 2000 },
+    );
+    expect(solution.feasible).toBe(true);
+    if (solution.selected.includes('A')) expect(solution.selected).toContain('C');
+  });
+
+  it('reports infeasible rather than silently returning a violating selection', () => {
+    const impossible: FormalConstraint[] = [
+      { kind: 'at_least', id: 'min', controls: ['A', 'B'], minimum: 2 },
+      { kind: 'mutual_exclusion', id: 'mx', left: 'A', right: 'B' },
+    ];
+    const solution = solveQubo(problem(impossible), { seed: 42, maxIterations: 800 });
+    expect(solution.feasible).toBe(false);
+    expect(solution.verdicts.some((v) => !v.satisfied)).toBe(true);
+  });
+
+  it('rejects a cooling rate outside (0, 1)', () => {
+    expect(() => solveQubo(problem(), { coolingRate: 1 })).toThrow(/coolingRate/);
+  });
+});
+
+describe('provenance chain', () => {
+  it('chains every retained step to its predecessor', () => {
+    const solution = solveQubo(problem(), { seed: 42, maxIterations: 25, retainTrajectorySteps: 25 });
+    expect(solution.trajectory).toHaveLength(25);
+    expect(solution.trajectory[0].previousHash).toBeNull();
+    for (let i = 1; i < solution.trajectory.length; i += 1) {
+      expect(solution.trajectory[i].previousHash).toBe(solution.trajectory[i - 1].stepHash);
+    }
+    expect(solution.trajectory.at(-1)?.stepHash).toBe(solution.provenanceHash);
+  });
+
+  it('replays to the same head hash and detects a tampered step', () => {
+    const solution = solveQubo(problem(), { seed: 42, maxIterations: 20, retainTrajectorySteps: 20 });
+    const variables = Object.keys(solution.assignment);
+    expect(replayProvenance(solution.trajectory, solution.seed, variables)).toBe(
+      solution.provenanceHash,
+    );
+
+    const tampered = solution.trajectory.map((step, i) =>
+      i === 5 ? { ...step, energyAfter: step.energyAfter + 1 } : step,
+    );
+    expect(replayProvenance(tampered, solution.seed, variables)).not.toBe(solution.provenanceHash);
+  });
+
+  it('covers the whole run even when the retained window is smaller', () => {
+    const full = solveQubo(problem(), { seed: 42, maxIterations: 200, retainTrajectorySteps: 200 });
+    const windowed = solveQubo(problem(), { seed: 42, maxIterations: 200, retainTrajectorySteps: 5 });
+    expect(windowed.provenanceHash).toBe(full.provenanceHash);
+    expect(windowed.trajectory).toHaveLength(5);
+  });
+});
+
+describe('what-if counterfactuals', () => {
+  it('reports cost, risk, value and rule divergence against the baseline', () => {
+    const p = problem([{ kind: 'budget_cap', id: 'cap', budget: 9 }]);
+    const report = runWhatIf(
+      p,
+      [
+        { id: 'tighter', budgetDelta: -4, description: 'budget cut' },
+        { id: 'looser', budgetDelta: 8, description: 'budget increase' },
+      ],
+      { seed: 42, maxIterations: 2000 },
+    );
+
+    expect(report.baseline.totalCost).toBe(9);
+
+    const tighter = report.outcomes[0];
+    expect(tighter.solution.totalCost).toBeLessThanOrEqual(5);
+    expect(tighter.deltaCost).toBeLessThan(0);
+    expect(tighter.removed.length).toBeGreaterThan(0);
+    expect(tighter.ruleDivergence).toBe(tighter.added.length + tighter.removed.length);
+
+    const looser = report.outcomes[1];
+    expect(looser.solution.feasible).toBe(true);
+    expect(looser.deltaRiskReduction).toBeGreaterThanOrEqual(0);
+  });
+
+  it('never lets a budget shift drive the cap below zero', () => {
+    const report = runWhatIf(
+      problem([{ kind: 'budget_cap', id: 'cap', budget: 4 }]),
+      [{ id: 'wipeout', budgetDelta: -100 }],
+      { seed: 42, maxIterations: 500 },
+    );
+    expect(report.outcomes[0].solution.totalCost).toBe(0);
+    expect(report.outcomes[0].solution.feasible).toBe(true);
+  });
+});
+
+describe('CCVS catalog adapter', () => {
+  it('builds one control per catalog requirement with derived weights', () => {
+    const controls = controlsFromCatalog();
+    expect(controls).toHaveLength(10);
+    const riskGate = controls.find((c) => c.id === 'EU-AI-ACT-ART9');
+    expect(riskGate).toMatchObject({ framework: 'EU AI Act', label: 'Risk management system' });
+    // min_severity_level 2, evidence_type integration (severity 2), mutation required
+    expect(riskGate?.value).toBe(4);
+    expect(riskGate?.riskReduction).toBe(6);
+    expect(riskGate?.cost).toBe(4);
+  });
+
+  it('honours weighting overrides', () => {
+    const controls = controlsFromCatalog({ valuePerSeverity: 10, mutationCost: 0 });
+    const riskGate = controls.find((c) => c.id === 'EU-AI-ACT-ART9');
+    expect(riskGate?.value).toBe(20);
+    expect(riskGate?.cost).toBe(2);
+  });
+
+  it('reports only the frameworks the repository actually carries', () => {
+    expect(catalogFrameworks()).toEqual([
+      'DSG Internal',
+      'EU AI Act',
+      'ISO 42001',
+      'NIST AI RMF',
+      'SLSA',
+    ]);
+  });
+
+  it('optimises the real catalog under a budget and stays feasible', () => {
+    const controls = controlsFromCatalog();
+    const solution = solveQubo(
+      { controls, constraints: [{ kind: 'budget_cap', id: 'ccvs-budget', budget: 20 }] },
+      { seed: 42, maxIterations: 4000 },
+    );
+    expect(solution.feasible).toBe(true);
+    expect(solution.totalCost).toBeLessThanOrEqual(20);
+    expect(solution.selected.length).toBeGreaterThan(0);
+    expect(solution.provenanceHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
Goal:

Implement the DSG QUBO & Ising policy-optimisation engine in this repository. `lib/ising/solver.ts` today searches boolean assignments against callback predicates — it has no QUBO matrix, no spin form, no formal constraint encodings, no provenance chain, and it seeds its LCG from `Math.random()` by default, so two runs of the same problem need not agree. This adds the missing algebraic layer under `lib/ising/qubo/` without touching the existing solver.

Files changed:

| File | Reason |
|---|---|
| `lib/ising/qubo/types.ts` | Problem, matrix, constraint, trajectory and solution types |
| `lib/ising/qubo/matrix.ts` | Upper-triangular QUBO build, constraint penalty encodings, exact QUBO ↔ Ising transform, energy evaluation |
| `lib/ising/qubo/deterministic-rng.ts` | Mulberry32 PRNG (32-bit integer ops only) |
| `lib/ising/qubo/annealer.ts` | Deterministic annealing, single-flip descent polish, SHA-256 provenance chain, replay |
| `lib/ising/qubo/constraints.ts` | Exact verification independent of the penalty encoding |
| `lib/ising/qubo/what-if.ts` | Counterfactual budget shifts → ΔC / ΔR / ΔV and rule divergence |
| `lib/ising/qubo/catalog-adapter.ts` | Builds controls from this repo's own `REQUIREMENT_CATALOG` |
| `lib/ising/qubo/index.ts` | Barrel export |
| `lib/ising/qubo/README.md` | Encoding table, determinism contract, claim boundary |
| `tests/unit/qubo-policy-engine.test.ts` | 32 tests |

### Objective and constraint encodings

Minimises `Σ (cost_i − value_i − riskReduction_i)·x_i`, equivalent to maximising net benefit.

| Constraint | Pseudo-boolean form | QUBO encoding |
|---|---|---|
| `implication` A→B | `x_A − x_A·x_B ≤ 0` | `Q_AA += P`, `Q_AB −= P` |
| `equivalence` A↔B | `(x_A − x_B)² = 0` | `Q_AA += P`, `Q_BB += P`, `Q_AB −= 2P` |
| `mutual_exclusion` | `x_A·x_B = 0` | `Q_AB += P` |
| `at_least` | `Σ x_i ≥ k` | `P·(Σx_i − k − s)²`, binary slack `s` |
| `budget_cap` | `Σ c_i·x_i ≤ B` | `P·(Σc_i x_i + s − B)²`, binary slack `s` |

The two inequalities are encoded **exactly** via binary slack variables on a documented granularity grid, not approximated. `slackWeights` is tested to cover every integer in `[0, bound]` without overshooting.

### Two findings worth calling out

1. **A fixed initial temperature traps the search.** With `T0 = 1` on a problem whose weights are ~10–100, the chain is greedy from the first move and settles in whichever basin it enters first. A mutual-exclusion case returned a control worth 7 while one worth 12 was reachable. `T0` now scales with the largest matrix entry, and a deterministic single-flip descent polish runs after cooling. All four regression cases now reach the true optimum.
2. **Penalties bias, they do not prove.** A low-energy assignment can still violate a constraint, so `verifyConstraints` evaluates every constraint exactly against the returned assignment, the solver prefers a verified-feasible assignment over a lower-energy infeasible one, and `solution.feasible` reports the verdict. An unsatisfiable constraint set reports `feasible: false` rather than returning a violating selection.

Verification:
- [x] `npx vitest run tests/unit/qubo-policy-engine.test.ts` → **32 passed**. Covers PRNG reproducibility and reset, diagonal/upper-triangular matrix shape, each penalty encoding in isolation, slack coverage, QUBO↔Ising energy equality over all 2ⁿ assignments, exact constraint verification, bit-for-bit run reproducibility (selection, energy, trajectory and provenance hash), seed divergence, budget/mutex/implication optima, infeasibility reporting, hash-chain linkage, replay + tamper detection, retained-window independence, what-if deltas, and the catalog adapter.
- [x] `npm run typecheck` → clean.
- [x] `npx vitest run tests/unit tests/integration` → 4311 passed, 27 failed. All 27 are `ECONNREFUSED` against `127.0.0.1:3000` in `tests/integration/aimo-encoding-proof-e2e.test.ts` and `tests/integration/api/encoding-proof.test.ts`; both need a running server and neither imports this module.
- [ ] Live database / deployment checks — **Not run**, no runtime surface added.

Known limits:

- **Heuristic, not proof.** Simulated annealing plus a single-flip polish guarantees a local optimum under single flips, not a proven global optimum.
- **No Z3 invocation.** This module evaluates the pseudo-boolean forms an SMT encoding would use; it does not call a solver. Per `CLAUDE.md` §13 that keeps it a deterministic TypeScript scaffold, not external production Z3 verification.
- **Framework scope is whatever the repository actually carries.** `REQUIREMENT_CATALOG` covers EU AI Act (3), ISO 42001 (2), NIST AI RMF (3), SLSA (1), DSG Internal (1). There are **no GDPR, PDPA, Thai criminal law, or FinTech rows in this repository**, so `controlsFromCatalog()` cannot emit controls for those frameworks. Callers needing them must supply their own `PolicyControl[]`.
- **The catalog weighting is a modelling choice.** `DEFAULT_CATALOG_WEIGHTING` derives value/risk/cost from `min_severity_level`, `evidence_type` and `mutation_required` — engineering weights for the optimiser, not a legal, actuarial, or certification judgement. Overridable.
- **Slack granularity.** Non-integral costs are rounded onto the `slackGranularity` grid (default 1); set it to match your units.
- No API route, database table, or UI surface is added, and `lib/ising/solver.ts`, `lib/ising/hybrid-solver.ts` and `skills/dsg-ising-optimization` are untouched.

User-visible benefit:

A policy/control selection can now be expressed as an explicit QUBO matrix, solved reproducibly from a seed, verified against formal constraints, replayed from its SHA-256 provenance chain, and stress-tested against budget counterfactuals — none of which the existing solver could do. Running it over the repository's own requirement catalog under a budget cap yields a verified-feasible control set with a replayable audit trail.

Next step:

Decide whether to expose this behind an API route or wire it into `skills/dsg-ising-optimization` (which currently calls the predicate solver), and whether the Kotlin/Android port described in the original specification is still wanted — `apps/android` has no QUBO code and no test source set today, so a port there would need test infrastructure before any correctness claim could be made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPt2o6sfECsXQyTKAFKEgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPt2o6sfECsXQyTKAFKEgJ)_