### PR TITLE
fix(ci): restore Daily Health Check startup

### DIFF
--- a/.github/workflows/monitoring-daily-health-check.yml
+++ b/.github/workflows/monitoring-daily-health-check.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: health-report
           path: health-report.json


### PR DESCRIPTION
## Evidence

Latest scheduled run failed before any monitoring step because GitHub rejects deprecated `actions/upload-artifact@v3`.

## Change

Upgrade only the report upload action to `actions/upload-artifact@v4`.

## Truth boundary

This restores workflow startup. Production monitoring health must still be proven by the workflow run after merge.