### PR TITLE
feat(agentic-org): authorize candidate realization before Builder execution

### DIFF
--- a/app/api/dsg/agentic-org/realization/authorize/route.ts
+++ b/app/api/dsg/agentic-org/realization/authorize/route.ts
@@ -1,0 +1,79 @@
+import crypto from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { Octokit } from '@octokit/rest';
+import {
+  authorizeCandidateRealization,
+  signRealizationAuthorizationReceipt,
+  type GitHubPlanClient,
+} from '@/lib/agent-governance/agentic-org/realization-authorization';
+
+export const dynamic = 'force-dynamic';
+
+function safeEqualHex(left: string, right: string): boolean {
+  if (!/^[0-9a-f]+$/i.test(left) || !/^[0-9a-f]+$/i.test(right)) return false;
+  const a = Buffer.from(left, 'hex');
+  const b = Buffer.from(right, 'hex');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function verifySignature(rawBody: string, header: string | null, secret: string): boolean {
+  if (!header) return false;
+  const supplied = header.replace(/^sha256=/i, '').trim();
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  return safeEqualHex(supplied, expected);
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.DSG_REALIZATION_AUTHORIZATION_SECRET?.trim()
+    || process.env.DSG_PROMOTION_EVALUATION_SECRET?.trim();
+  const githubToken = process.env.DSG_GITHUB_AUTOMATION_TOKEN?.trim()
+    || process.env.GITHUB_TOKEN?.trim();
+
+  if (!secret || !githubToken) {
+    return NextResponse.json({
+      status: 'BLOCK',
+      reason: 'REALIZATION_AUTHORIZATION_NOT_CONFIGURED',
+      missing: [
+        ...(!secret ? ['DSG_REALIZATION_AUTHORIZATION_SECRET_OR_DSG_PROMOTION_EVALUATION_SECRET'] : []),
+        ...(!githubToken ? ['DSG_GITHUB_AUTOMATION_TOKEN_OR_GITHUB_TOKEN'] : []),
+      ],
+    }, { status: 503 });
+  }
+
+  const rawBody = await request.text();
+  if (!verifySignature(rawBody, request.headers.get('x-dsg-signature'), secret)) {
+    return NextResponse.json({ status: 'BLOCK', reason: 'REALIZATION_AUTHORIZATION_SIGNATURE_INVALID' }, { status: 401 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ status: 'BLOCK', reason: 'REALIZATION_AUTHORIZATION_INVALID_JSON' }, { status: 400 });
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !('spec' in parsed)) {
+    return NextResponse.json({ status: 'BLOCK', reason: 'REALIZATION_AUTHORIZATION_PAYLOAD_INVALID' }, { status: 400 });
+  }
+
+  const octokit = new Octokit({ auth: githubToken });
+  const client: GitHubPlanClient = {
+    getContent: (input) => octokit.rest.repos.getContent(input) as unknown as Promise<{ data: unknown }>,
+  };
+
+  try {
+    const receipt = await authorizeCandidateRealization(
+      client,
+      (parsed as { spec: unknown }).spec,
+    );
+    const receiptSignature = signRealizationAuthorizationReceipt(receipt, secret);
+    return NextResponse.json({
+      status: 'PASS',
+      reason: 'REALIZATION_AUTHORIZED',
+      receipt,
+      receiptSignature,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'REALIZATION_AUTHORIZATION_FAILED';
+    return NextResponse.json({ status: 'BLOCK', reason }, { status: 409 });
+  }
+}

--- a/app/api/dsg/agentic-org/realization/authorize/route.ts
+++ b/app/api/dsg/agentic-org/realization/authorize/route.ts
@@ -58,6 +58,9 @@ export async function POST(request: NextRequest) {
   const octokit = new Octokit({ auth: githubToken });
   const client: GitHubPlanClient = {
     getContent: (input) => octokit.rest.repos.getContent(input) as unknown as Promise<{ data: unknown }>,
+    compareCommits: (input) => octokit.rest.repos.compareCommitsWithBasehead(input) as unknown as Promise<{
+      data: { status: string; files?: Array<{ filename: string }> };
+    }>,
   };
 
   try {

--- a/lib/agent-governance/agentic-org/realization-authorization.ts
+++ b/lib/agent-governance/agentic-org/realization-authorization.ts
@@ -71,6 +71,9 @@ export interface RealizationAuthorizationReceipt {
 
 export interface GitHubPlanClient {
   getContent(input: { owner: string; repo: string; path: string; ref: string }): Promise<{ data: unknown }>;
+  compareCommits(input: { owner: string; repo: string; basehead: string }): Promise<{
+    data: { status: string; files?: Array<{ filename: string }> };
+  }>;
 }
 
 const APPROVED_PLAN_PATH_BY_REPOSITORY: Record<string, string> = {
@@ -180,7 +183,7 @@ async function loadApprovedPlan(client: GitHubPlanClient, spec: CandidateRealiza
 
   let response: { data: unknown };
   try {
-    response = await client.getContent({ ...repository, path, ref: spec.candidateCommit });
+    response = await client.getContent({ ...repository, path, ref: spec.baselineCommit });
   } catch {
     throw new Error('REALIZATION_APPROVED_PLAN_FETCH_FAILED');
   }
@@ -205,6 +208,30 @@ async function loadApprovedPlan(client: GitHubPlanClient, spec: CandidateRealiza
   return plan;
 }
 
+async function verifyCandidateLineage(client: GitHubPlanClient, spec: CandidateRealizationSpecV1, plan: ApprovedImprovementPlanV1): Promise<void> {
+  const repository = splitRepository(spec.targetRepository);
+  if (!repository) throw new Error('REALIZATION_TARGET_REPOSITORY_INVALID');
+
+  let comparison: { data: { status: string; files?: Array<{ filename: string }> } };
+  try {
+    comparison = await client.compareCommits({
+      ...repository,
+      basehead: `${spec.baselineCommit}...${spec.candidateCommit}`,
+    });
+  } catch {
+    throw new Error('REALIZATION_CANDIDATE_COMPARE_FAILED');
+  }
+  if (comparison.data.status !== 'ahead') throw new Error(`REALIZATION_BASELINE_NOT_ANCESTOR:${comparison.data.status}`);
+  const files = comparison.data.files ?? [];
+  if (files.length === 0) throw new Error('REALIZATION_CANDIDATE_DIFF_EMPTY');
+  const invalid = files.map((file) => file.filename).filter((filename) => {
+    const inPlan = plan.allowedPaths.some((scope) => pathInsideScope(filename, scope));
+    const inSpec = spec.allowedPaths.some((scope) => pathInsideScope(filename, scope));
+    return !inPlan || !inSpec;
+  });
+  if (invalid.length > 0) throw new Error(`REALIZATION_CANDIDATE_DIFF_OUTSIDE_SCOPE:${invalid.join(',')}`);
+}
+
 export async function authorizeCandidateRealization(
   client: GitHubPlanClient,
   value: unknown,
@@ -214,6 +241,7 @@ export async function authorizeCandidateRealization(
   const plan = await loadApprovedPlan(client, spec);
   const widened = spec.allowedPaths.filter((requested) => !plan.allowedPaths.some((approved) => requestedScopeInsideApprovedScope(requested, approved)));
   if (widened.length > 0) throw new Error(`REALIZATION_SCOPE_WIDENING_BLOCKED:${widened.join(',')}`);
+  await verifyCandidateLineage(client, spec, plan);
 
   const payload = {
     schemaVersion: REALIZATION_AUTHORIZATION_SCHEMA_VERSION,

--- a/lib/agent-governance/agentic-org/realization-authorization.ts
+++ b/lib/agent-governance/agentic-org/realization-authorization.ts
@@ -1,0 +1,247 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+export const CANDIDATE_REALIZATION_SCHEMA_VERSION = 'dsg-candidate-realization-v1' as const;
+export const REALIZATION_AUTHORIZATION_SCHEMA_VERSION = 'dsg-realization-authorization-v1' as const;
+
+export interface CandidateRealizationSpecV1 {
+  schemaVersion: typeof CANDIDATE_REALIZATION_SCHEMA_VERSION;
+  candidateId: string;
+  candidateKind: 'CONFIG_CANDIDATE' | 'CODE_CANDIDATE';
+  goalId: string;
+  targetRepository: string;
+  baselineCommit: string;
+  candidateCommit: string;
+  approvedPlanHash: string;
+  simulationHash: string;
+  allowedPaths: string[];
+  realization: {
+    action: 'CONFIG_PROMOTION' | 'GENERATE_CODE_PATCH';
+    capabilityId: string;
+    capabilityDescription: string;
+    acceptanceCriteria: string[];
+  };
+  objectiveContract: {
+    metricName: string;
+    direction: 'HIGHER_IS_BETTER' | 'LOWER_IS_BETTER';
+    baselineValue: number;
+    candidateValue: number;
+  };
+  valueContract: {
+    metricName: string;
+    direction: 'HIGHER_IS_BETTER' | 'LOWER_IS_BETTER';
+    baselineValue: number;
+    targetValue: number;
+    measurementSource: string;
+    guardrails: string[];
+  } | null;
+  requiredEvidence: string[];
+  candidateAuthority: 'SIMULATION_ONLY';
+  promotionAuthority: 'DSG_CONTROL_PLANE';
+  selfPromotionAllowed: false;
+  directProductionWriteAllowed: false;
+  specSha256: string;
+}
+
+interface ApprovedImprovementPlanV1 {
+  schemaVersion: 'dsg-approved-improvement-plan-v1';
+  goalId: string;
+  approvalStatus: string;
+  authority: 'DSG_CONTROL_PLANE';
+  targetRepository: string;
+  allowedPaths: string[];
+}
+
+export interface RealizationAuthorizationReceipt {
+  schemaVersion: typeof REALIZATION_AUTHORIZATION_SCHEMA_VERSION;
+  status: 'ALLOW';
+  candidateId: string;
+  goalId: string;
+  targetRepository: string;
+  baselineCommit: string;
+  originCandidateCommit: string;
+  approvedPlanHash: string;
+  specSha256: string;
+  allowedPaths: string[];
+  allowedOperations: Array<'READ' | 'WRITE' | 'TEST' | 'BUILD' | 'OPEN_PR'>;
+  authority: 'DSG_CONTROL_PLANE';
+  directProductionWriteAllowed: false;
+  issuedAt: string;
+  receiptSha256: string;
+}
+
+export interface GitHubPlanClient {
+  getContent(input: { owner: string; repo: string; path: string; ref: string }): Promise<{ data: unknown }>;
+}
+
+const APPROVED_PLAN_PATH_BY_REPOSITORY: Record<string, string> = {
+  'tdealer01-crypto/dsg-agi-simulation': 'contracts/agentic-improvement/self-evolution-plan.json',
+};
+
+const ALLOWED_REPOSITORIES = new Set([
+  'tdealer01-crypto/tdealer01-crypto-dsg-control-plane',
+  'tdealer01-crypto/dsg-one-v1',
+  'tdealer01-crypto/dsg-agi-simulation',
+  'tdealer01-crypto/DSG-Cinema-Proof-Agent',
+  'tdealer01-crypto/dsg-unified-data-monitoring',
+]);
+
+function sha256(value: Buffer | string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function splitRepository(repository: string): { owner: string; repo: string } | null {
+  const [owner, repo, extra] = repository.split('/');
+  return owner && repo && !extra ? { owner, repo } : null;
+}
+
+function validSha(value: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(value);
+}
+
+function canonicalPath(value: string): boolean {
+  if (!value || value.startsWith('/') || value.endsWith('/') || value.includes('\\') || value.includes('\0')) return false;
+  return value.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
+function pathInsideScope(path: string, scope: string): boolean {
+  if (!canonicalPath(path)) return false;
+  if (scope.endsWith('/**')) {
+    const root = scope.slice(0, -3);
+    return canonicalPath(root) && path.startsWith(`${root}/`);
+  }
+  return canonicalPath(scope) && path === scope;
+}
+
+function requestedScopeInsideApprovedScope(requested: string, approved: string): boolean {
+  const requestedRoot = requested.endsWith('/**') ? requested.slice(0, -3) : requested;
+  if (!canonicalPath(requestedRoot)) return false;
+  if (requested.endsWith('/**')) {
+    if (approved.endsWith('/**')) {
+      const approvedRoot = approved.slice(0, -3);
+      return canonicalPath(approvedRoot) && (requestedRoot === approvedRoot || requestedRoot.startsWith(`${approvedRoot}/`));
+    }
+    return false;
+  }
+  return pathInsideScope(requested, approved);
+}
+
+function orderedSpecPayload(spec: CandidateRealizationSpecV1) {
+  return {
+    schemaVersion: spec.schemaVersion,
+    candidateId: spec.candidateId,
+    candidateKind: spec.candidateKind,
+    goalId: spec.goalId,
+    targetRepository: spec.targetRepository,
+    baselineCommit: spec.baselineCommit,
+    candidateCommit: spec.candidateCommit,
+    approvedPlanHash: spec.approvedPlanHash,
+    simulationHash: spec.simulationHash,
+    allowedPaths: spec.allowedPaths,
+    objectiveContract: spec.objectiveContract,
+    candidateAuthority: spec.candidateAuthority,
+    promotionAuthority: spec.promotionAuthority,
+    selfPromotionAllowed: spec.selfPromotionAllowed,
+    directProductionWriteAllowed: spec.directProductionWriteAllowed,
+    realization: spec.realization,
+    valueContract: spec.valueContract,
+    requiredEvidence: spec.requiredEvidence,
+  };
+}
+
+export function verifyCandidateRealizationSpecV1(value: unknown): CandidateRealizationSpecV1 {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('REALIZATION_SPEC_INVALID');
+  const spec = value as CandidateRealizationSpecV1;
+  if (spec.schemaVersion !== CANDIDATE_REALIZATION_SCHEMA_VERSION) throw new Error('REALIZATION_SPEC_SCHEMA_INVALID');
+  if (spec.candidateKind !== 'CODE_CANDIDATE') throw new Error('REALIZATION_BUILDER_REQUIRES_CODE_CANDIDATE');
+  if (spec.realization?.action !== 'GENERATE_CODE_PATCH') throw new Error('REALIZATION_ACTION_INVALID');
+  if (spec.candidateAuthority !== 'SIMULATION_ONLY') throw new Error('REALIZATION_SPEC_AUTHORITY_INVALID');
+  if (spec.promotionAuthority !== 'DSG_CONTROL_PLANE') throw new Error('REALIZATION_SPEC_PROMOTION_AUTHORITY_INVALID');
+  if (spec.selfPromotionAllowed !== false || spec.directProductionWriteAllowed !== false) throw new Error('REALIZATION_SPEC_UNSAFE_AUTHORITY');
+  if (!ALLOWED_REPOSITORIES.has(spec.targetRepository)) throw new Error('REALIZATION_TARGET_REPOSITORY_NOT_ALLOWED');
+  if (!splitRepository(spec.targetRepository)) throw new Error('REALIZATION_TARGET_REPOSITORY_INVALID');
+  if (!validSha(spec.baselineCommit) || !validSha(spec.candidateCommit)) throw new Error('REALIZATION_COMMIT_SHA_INVALID');
+  if (!/^[0-9a-f]{64}$/i.test(spec.approvedPlanHash) || !/^[0-9a-f]{64}$/i.test(spec.specSha256)) throw new Error('REALIZATION_DIGEST_INVALID');
+  if (!Array.isArray(spec.allowedPaths) || spec.allowedPaths.length === 0 || spec.allowedPaths.some((path) => {
+    const root = path.endsWith('/**') ? path.slice(0, -3) : path;
+    return !canonicalPath(root);
+  })) throw new Error('REALIZATION_PATH_SCOPE_INVALID');
+  if (!spec.valueContract) throw new Error('REALIZATION_VALUE_CONTRACT_REQUIRED');
+  if (!Array.isArray(spec.realization.acceptanceCriteria) || spec.realization.acceptanceCriteria.length === 0) throw new Error('REALIZATION_ACCEPTANCE_CRITERIA_REQUIRED');
+  const actual = sha256(JSON.stringify(orderedSpecPayload(spec)));
+  if (actual !== spec.specSha256) throw new Error('REALIZATION_SPEC_HASH_MISMATCH');
+  return spec;
+}
+
+async function loadApprovedPlan(client: GitHubPlanClient, spec: CandidateRealizationSpecV1): Promise<ApprovedImprovementPlanV1> {
+  const repository = splitRepository(spec.targetRepository);
+  if (!repository) throw new Error('REALIZATION_TARGET_REPOSITORY_INVALID');
+  const path = APPROVED_PLAN_PATH_BY_REPOSITORY[spec.targetRepository];
+  if (!path) throw new Error('REALIZATION_APPROVED_PLAN_PATH_UNKNOWN');
+
+  let response: { data: unknown };
+  try {
+    response = await client.getContent({ ...repository, path, ref: spec.candidateCommit });
+  } catch {
+    throw new Error('REALIZATION_APPROVED_PLAN_FETCH_FAILED');
+  }
+  const data = response.data as { content?: string; encoding?: string };
+  if (typeof data.content !== 'string' || data.encoding !== 'base64') throw new Error('REALIZATION_APPROVED_PLAN_CONTENT_INVALID');
+  const bytes = Buffer.from(data.content, 'base64');
+  if (sha256(bytes) !== spec.approvedPlanHash) throw new Error('REALIZATION_APPROVED_PLAN_HASH_MISMATCH');
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw new Error('REALIZATION_APPROVED_PLAN_CONTENT_INVALID');
+  }
+  const plan = parsed as ApprovedImprovementPlanV1;
+  if (plan.schemaVersion !== 'dsg-approved-improvement-plan-v1') throw new Error('REALIZATION_APPROVED_PLAN_SCHEMA_INVALID');
+  if (plan.authority !== 'DSG_CONTROL_PLANE') throw new Error('REALIZATION_APPROVED_PLAN_AUTHORITY_INVALID');
+  if (typeof plan.approvalStatus !== 'string' || !plan.approvalStatus.startsWith('APPROVED_')) throw new Error('REALIZATION_APPROVED_PLAN_NOT_APPROVED');
+  if (plan.targetRepository !== spec.targetRepository) throw new Error('REALIZATION_APPROVED_PLAN_TARGET_MISMATCH');
+  if (plan.goalId !== spec.goalId) throw new Error('REALIZATION_APPROVED_PLAN_GOAL_MISMATCH');
+  if (!Array.isArray(plan.allowedPaths) || plan.allowedPaths.length === 0) throw new Error('REALIZATION_APPROVED_PLAN_SCOPE_MISSING');
+  return plan;
+}
+
+export async function authorizeCandidateRealization(
+  client: GitHubPlanClient,
+  value: unknown,
+  issuedAt = new Date().toISOString(),
+): Promise<RealizationAuthorizationReceipt> {
+  const spec = verifyCandidateRealizationSpecV1(value);
+  const plan = await loadApprovedPlan(client, spec);
+  const widened = spec.allowedPaths.filter((requested) => !plan.allowedPaths.some((approved) => requestedScopeInsideApprovedScope(requested, approved)));
+  if (widened.length > 0) throw new Error(`REALIZATION_SCOPE_WIDENING_BLOCKED:${widened.join(',')}`);
+
+  const payload = {
+    schemaVersion: REALIZATION_AUTHORIZATION_SCHEMA_VERSION,
+    status: 'ALLOW' as const,
+    candidateId: spec.candidateId,
+    goalId: spec.goalId,
+    targetRepository: spec.targetRepository,
+    baselineCommit: spec.baselineCommit,
+    originCandidateCommit: spec.candidateCommit,
+    approvedPlanHash: spec.approvedPlanHash,
+    specSha256: spec.specSha256,
+    allowedPaths: [...spec.allowedPaths],
+    allowedOperations: ['READ', 'WRITE', 'TEST', 'BUILD', 'OPEN_PR'] as RealizationAuthorizationReceipt['allowedOperations'],
+    authority: 'DSG_CONTROL_PLANE' as const,
+    directProductionWriteAllowed: false as const,
+    issuedAt,
+  };
+  return { ...payload, receiptSha256: sha256(JSON.stringify(payload)) };
+}
+
+export function signRealizationAuthorizationReceipt(receipt: RealizationAuthorizationReceipt, secret: string): string {
+  return createHmac('sha256', secret).update(JSON.stringify(receipt)).digest('hex');
+}
+
+export function verifyRealizationAuthorizationSignature(receipt: RealizationAuthorizationReceipt, signature: string, secret: string): boolean {
+  if (!/^[0-9a-f]{64}$/i.test(signature)) return false;
+  const expected = signRealizationAuthorizationReceipt(receipt, secret);
+  const left = Buffer.from(signature, 'hex');
+  const right = Buffer.from(expected, 'hex');
+  return left.length === right.length && timingSafeEqual(left, right);
+}

--- a/tests/unit/agent-governance/realization-authorization.test.ts
+++ b/tests/unit/agent-governance/realization-authorization.test.ts
@@ -63,16 +63,19 @@ function buildSpec(planBytes: Buffer): CandidateRealizationSpecV1 {
   return { ...payload, specSha256: sha256(JSON.stringify(payload)) };
 }
 
-function clientFor(planBytes: Buffer): GitHubPlanClient {
+function clientFor(planBytes: Buffer, files = ['src/checkpoint.ts']): GitHubPlanClient {
   return {
     getContent: async () => ({
       data: { content: planBytes.toString('base64'), encoding: 'base64' },
+    }),
+    compareCommits: async () => ({
+      data: { status: 'ahead', files: files.map((filename) => ({ filename })) },
     }),
   };
 }
 
 describe('candidate realization authorization', () => {
-  it('authorizes only a code candidate bound to the approved GitHub plan', async () => {
+  it('authorizes only a code candidate bound to the approved GitHub plan and commit lineage', async () => {
     const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
     const receipt = await authorizeCandidateRealization(clientFor(planBytes), buildSpec(planBytes), '2026-08-31T00:00:00.000Z');
     expect(receipt.status).toBe('ALLOW');
@@ -95,6 +98,19 @@ describe('candidate realization authorization', () => {
     const { specSha256: _old, ...rest } = spec;
     spec.specSha256 = sha256(JSON.stringify(rest));
     await expect(authorizeCandidateRealization(clientFor(planBytes), spec)).rejects.toThrow('REALIZATION_SCOPE_WIDENING_BLOCKED');
+  });
+
+  it('blocks a GitHub diff outside the candidate scope', async () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const spec = buildSpec(planBytes);
+    await expect(authorizeCandidateRealization(clientFor(planBytes, ['tests/outside.ts']), spec)).rejects.toThrow('REALIZATION_CANDIDATE_DIFF_OUTSIDE_SCOPE');
+  });
+
+  it('blocks a non-descendant origin candidate', async () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const client = clientFor(planBytes);
+    client.compareCommits = async () => ({ data: { status: 'diverged', files: [{ filename: 'src/checkpoint.ts' }] } });
+    await expect(authorizeCandidateRealization(client, buildSpec(planBytes))).rejects.toThrow('REALIZATION_BASELINE_NOT_ANCESTOR');
   });
 
   it('blocks traversal in requested scope', () => {

--- a/tests/unit/agent-governance/realization-authorization.test.ts
+++ b/tests/unit/agent-governance/realization-authorization.test.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  authorizeCandidateRealization,
+  verifyCandidateRealizationSpecV1,
+  type CandidateRealizationSpecV1,
+  type GitHubPlanClient,
+} from '../../../lib/agent-governance/agentic-org/realization-authorization';
+
+function sha256(value: string | Buffer) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function approvedPlan() {
+  return {
+    schemaVersion: 'dsg-approved-improvement-plan-v1',
+    goalId: 'goal-code-1',
+    approvalStatus: 'APPROVED_BY_USER_2026-08-31',
+    authority: 'DSG_CONTROL_PLANE',
+    targetRepository: 'tdealer01-crypto/dsg-agi-simulation',
+    allowedPaths: ['src/**', 'tests/**'],
+  };
+}
+
+function buildSpec(planBytes: Buffer): CandidateRealizationSpecV1 {
+  const payload = {
+    schemaVersion: 'dsg-candidate-realization-v1' as const,
+    candidateId: 'candidate-code-1',
+    candidateKind: 'CODE_CANDIDATE' as const,
+    goalId: 'goal-code-1',
+    targetRepository: 'tdealer01-crypto/dsg-agi-simulation',
+    baselineCommit: 'a'.repeat(40),
+    candidateCommit: 'b'.repeat(40),
+    approvedPlanHash: sha256(planBytes),
+    simulationHash: 'c'.repeat(64),
+    allowedPaths: ['src/**'],
+    objectiveContract: {
+      metricName: 'fitness_composite',
+      direction: 'HIGHER_IS_BETTER' as const,
+      baselineValue: 0.7,
+      candidateValue: 0.8,
+    },
+    candidateAuthority: 'SIMULATION_ONLY' as const,
+    promotionAuthority: 'DSG_CONTROL_PLANE' as const,
+    selfPromotionAllowed: false as const,
+    directProductionWriteAllowed: false as const,
+    realization: {
+      action: 'GENERATE_CODE_PATCH' as const,
+      capabilityId: 'capability-1',
+      capabilityDescription: 'Improve deterministic checkpoint recovery.',
+      acceptanceCriteria: ['checkpoint recovery test passes'],
+    },
+    valueContract: {
+      metricName: 'recovery_success_rate',
+      direction: 'HIGHER_IS_BETTER' as const,
+      baselineValue: 0.8,
+      targetValue: 0.9,
+      measurementSource: 'canary replay test',
+      guardrails: ['no regression in verification'],
+    },
+    requiredEvidence: ['CODE_PATCH', 'TEST_OUTPUT', 'BUILD_OUTPUT'],
+  };
+  return { ...payload, specSha256: sha256(JSON.stringify(payload)) };
+}
+
+function clientFor(planBytes: Buffer): GitHubPlanClient {
+  return {
+    getContent: async () => ({
+      data: { content: planBytes.toString('base64'), encoding: 'base64' },
+    }),
+  };
+}
+
+describe('candidate realization authorization', () => {
+  it('authorizes only a code candidate bound to the approved GitHub plan', async () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const receipt = await authorizeCandidateRealization(clientFor(planBytes), buildSpec(planBytes), '2026-08-31T00:00:00.000Z');
+    expect(receipt.status).toBe('ALLOW');
+    expect(receipt.authority).toBe('DSG_CONTROL_PLANE');
+    expect(receipt.originCandidateCommit).toBe('b'.repeat(40));
+    expect(receipt.directProductionWriteAllowed).toBe(false);
+  });
+
+  it('blocks a modified realization spec digest', () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const spec = buildSpec(planBytes);
+    spec.realization.capabilityDescription = 'tampered';
+    expect(() => verifyCandidateRealizationSpecV1(spec)).toThrow('REALIZATION_SPEC_HASH_MISMATCH');
+  });
+
+  it('blocks scope widening beyond the approved plan', async () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const spec = buildSpec(planBytes);
+    spec.allowedPaths = ['app/**'];
+    const { specSha256: _old, ...rest } = spec;
+    spec.specSha256 = sha256(JSON.stringify(rest));
+    await expect(authorizeCandidateRealization(clientFor(planBytes), spec)).rejects.toThrow('REALIZATION_SCOPE_WIDENING_BLOCKED');
+  });
+
+  it('blocks traversal in requested scope', () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const spec = buildSpec(planBytes);
+    spec.allowedPaths = ['src/../app/**'];
+    expect(() => verifyCandidateRealizationSpecV1(spec)).toThrow('REALIZATION_PATH_SCOPE_INVALID');
+  });
+
+  it('does not route configuration candidates into the Builder', () => {
+    const planBytes = Buffer.from(`${JSON.stringify(approvedPlan(), null, 2)}\n`);
+    const spec = buildSpec(planBytes);
+    spec.candidateKind = 'CONFIG_CANDIDATE';
+    expect(() => verifyCandidateRealizationSpecV1(spec)).toThrow('REALIZATION_BUILDER_REQUIRES_CODE_CANDIDATE');
+  });
+});


### PR DESCRIPTION
## Purpose
Add an independent pre-execution authorization boundary between simulation candidates and the DSG ONE Builder.

## What changes
- Adds `dsg-candidate-realization-v1` validation with deterministic digest verification.
- Independently fetches the approved improvement plan from GitHub at the origin candidate commit.
- Verifies plan hash, Control Plane authority, approval status, goal/target binding, and prevents path-scope widening.
- Only CODE_CANDIDATE / GENERATE_CODE_PATCH can enter this Builder authorization route; config candidates remain on the existing promotion path.
- Returns a signed `dsg-realization-authorization-v1` receipt with `directProductionWriteAllowed=false`.
- Adds fail-closed unit coverage for tamper, traversal and scope widening.

## Truth boundary
This authorizes Builder intake only. It does not approve the DSG ONE App Builder plan, execute code, deploy, or promote to production. App Builder approval and post-build Cinema/Control Plane evidence gates remain required.