### PR TITLE
docs: refresh Control Plane README to current production truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,217 @@
 # DSG Control Plane
 
-Deterministic governance control plane for AI-agent execution. The repository is the source of truth for implementation, policy gates, tests, deployment configuration, runtime evidence, and audit artifacts.
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/tdealer01-crypto-dsg-governance-plugins-dsg-governance)](https://www.claudepluginhub.com/plugins/tdealer01-crypto-dsg-governance-plugins-dsg-governance?ref=badge)
 
-## Production
+**Deterministic governance, verified execution, and replayable proof for AI agents.**
 
-**Authoritative production platform: Azure App Service**
+DSG Control Plane is the governance layer between an approved human plan and an AI agent's external actions. It evaluates whether an action is inside the approved scope, applies deterministic constraints, records evidence, verifies the resulting state, and preserves an audit/replay trail.
 
-- Production URL: `https://dsg-control-plane.azurewebsites.net`
-- Deployment target: [`config/production-deployment-target.json`](config/production-deployment-target.json)
-- Azure deployment evidence: [`qa-logs/azure-production/`](qa-logs/azure-production/)
-- Runtime environment guidance: [`docs/ops/azure-runtime-env-sync.md`](docs/ops/azure-runtime-env-sync.md)
+DSG is not intended to block authorized work merely because governance exists. The contract is:
 
-A deployment is not treated as production-ready from configuration alone. The Azure target, post-deploy health/readiness checks, and committed evidence must agree.
+> **Allow plan-authorized execution when its constraints and permissions are satisfied. Block unsupported claims and actions outside the approved plan.**
 
-## What DSG does
+---
 
-DSG evaluates agent actions against an approved plan and policy before execution. The intended runtime contract is:
+## Current status — 2026-08-31
 
-`approved plan -> preflight -> alignment/constraints -> execution -> evidence -> verification -> audit/replay`
+| Surface | Current repository truth |
+| --- | --- |
+| Production authority | **Azure App Service** |
+| Production URL | `https://dsg-control-plane.azurewebsites.net` |
+| Production binding | `BOUND_FAIL_CLOSED_LIVE_VERIFICATION_REQUIRED` |
+| Deployment model | Azure App Service Linux custom container + Azure Container Registry + staging slot |
+| Latest committed Azure deployment proof | **PASS** on 2026-08-28 for Git SHA `011cf0b60f85adf273908aa71b929549a18d9c07`; `/api/health` = 200 and `/api/readiness` = 200 |
+| Current `main` live deployment claim | **UNVERIFIED by committed deployment proof** until a newer governed production workflow proves the current source SHA/image digest live |
+| Vercel | **Retired as a DSG production target** |
+| Render | **Retired as a DSG production target** |
+| Claude plugin marketplace | Present in `.claude-plugin/marketplace.json`; currently contains 7 plugin entries |
 
-The governance layer must not block an action merely because governance exists. It must verify that the requested action is inside the approved plan, preserve evidence, and deny unsupported claims or actions outside the approved scope.
+The latest historical Azure proof is real evidence for the deployment it captured. It is **not** proof that a later `main` commit is already running in production.
+
+Repository authority for production targeting is:
+
+- [`config/production-deployment-target.json`](config/production-deployment-target.json)
+- [`.github/workflows/promoted-production-deploy.yml`](.github/workflows/promoted-production-deploy.yml)
+- [`qa-logs/azure-production/`](qa-logs/azure-production/)
+
+Retired provider checks can still appear in GitHub commit statuses if an external integration continues posting them. They are not the DSG production authority.
+
+---
+
+## Why DSG exists
+
+An AI agent reporting "done" is not sufficient for a governed production system.
+
+The useful questions are:
+
+- What plan did the user approve?
+- Was this exact action inside that plan?
+- Did the required permission and policy gates pass?
+- What was actually executed?
+- What evidence was produced?
+- Did the resulting system state match the claim?
+- Can the decision and execution be audited or replayed later?
+
+DSG is designed around those questions.
+
+---
+
+## Governed execution flow
+
+```text
+user-approved goal
+        ↓
+approved plan / plan hash
+        ↓
+preflight + alignment + constraints + permission
+        ↓
+ALLOW / REVIEW / BLOCK
+        ↓
+controlled execution
+        ↓
+evidence capture
+        ↓
+result verification
+        ↓
+audit + replay
+        ↓
+governed deployment / promotion when applicable
+```
+
+A command exit code, generated text, configuration file, or deployment request is not enough by itself to establish success. DSG verifies the resulting state and keeps the claim inside the available evidence boundary.
+
+---
+
+## Core capabilities in this repository
+
+### 1. Plan-bound authorization
+
+Agent actions are expected to remain bound to a user-approved goal and plan. Pre-execution logic verifies alignment rather than allowing an agent to widen its own scope.
+
+The current agentic-organization path also contains a separate candidate-realization authorization boundary before Builder intake. That authorization does not replace Builder approval, execution evidence, Cinema verification, or production promotion gates.
+
+### 2. Deterministic gates and constraints
+
+The repository contains deterministic verification paths, policy gates, exact-result checks, and solver-backed components including `z3-solver`.
+
+A solver dependency or static code path is not treated as proof that a particular solver-backed production path passed. Solver claims require execution evidence for that path.
+
+### 3. Evidence-first execution
+
+The repository keeps automated tests, deployment evidence, runtime evidence, database migrations, and audit artifacts as first-class project surfaces.
+
+Useful locations:
+
+- `tests/` — unit, integration, failure, migration, load, and E2E verification
+- `qa-logs/` — captured QA and deployment evidence
+- `supabase/migrations/` — source-controlled database history
+- `lib/` and `app/` — runtime and API implementation
+- `.github/workflows/` — CI/CD and governed promotion workflows
+- `docs/` — architecture, runbooks, status, and operating guidance
+
+### 4. Governed Azure production deployment
+
+The production deployment contract is bound to Azure App Service.
+
+The configured promotion path is designed to:
+
+1. require the governed promotion context,
+2. bind deployment to the exact source commit,
+3. build and resolve the container image digest,
+4. deploy through a staging slot,
+5. verify runtime and health surfaces,
+6. verify proof persistence and lookup behavior,
+7. check replay/idempotency and nonce-conflict behavior,
+8. verify anonymous database isolation,
+9. swap staging to production only after the required gates pass,
+10. recheck the exact SHA/digest and health after swap,
+11. attempt a reverse slot swap when post-swap verification fails.
+
+The production target is intentionally fail-closed: configuration alone never means "deployment passed."
+
+### 5. MCP and agent tooling
+
+The repository includes MCP servers/workspaces and agent-facing governance tooling for controlled execution, verification, context discovery, RCA, and related workflows.
+
+### 6. Claude Code plugin marketplace
+
+The root marketplace manifest currently declares these entries:
+
+- `proofgate-review`
+- `dsg-verify`
+- `evidence-guard`
+- `pr-body-helper`
+- `dsg-governance`
+- `compliance-ising-z3`
+- `dsg-verified-execution`
+
+Add the marketplace from Claude Code:
+
+```text
+/plugin marketplace add tdealer01-crypto/tdealer01-crypto-dsg-control-plane
+```
+
+Then install a plugin, for example:
+
+```text
+/plugin install dsg-governance@dsg-plugins
+```
+
+See [`plugins/`](plugins/) and [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) for the current source of truth.
+
+---
 
 ## Operator path
 
-1. Confirm the user-approved goal and plan.
-2. Run the applicable preflight/gate before external mutation.
-3. Execute only actions covered by the approved plan and available permissions.
-4. Record runtime evidence and test/deployment results.
-5. Verify the resulting state rather than inferring success from a command exit alone.
-6. Expose the result to the user as `PASS`, `REVIEW`, `BLOCK`, `FAILED`, or another repository-defined state with the next corrective action.
+For a governed task, the intended operator experience is:
+
+1. **Lock the goal** — identify the user-approved outcome.
+2. **Bind the plan** — use the approved plan/hash and exact action scope.
+3. **Run preflight** — evaluate alignment, constraints, permissions, and policy before mutation.
+4. **Execute only authorized actions** — no silent widening of scope.
+5. **Capture evidence** — test output, API result, DB state, deployment state, screenshots, or other applicable proof.
+6. **Verify the actual result** — do not infer success from the attempted action alone.
+7. **Return a work-state verdict** — for example `PASS`, `REVIEW`, `BLOCK`, or `FAILED`.
+8. **Tell the operator what to fix next** when the result is not `PASS`.
+
+The user should not need to inspect raw logs merely to learn whether the requested job succeeded.
+
+---
+
+## Production verification
+
+### Latest committed Azure proof
+
+The repository currently contains a committed deployment proof captured at `20260828T015648Z`:
+
+- result: `PASS`
+- health HTTP: `200`
+- readiness HTTP: `200`
+- deployed Git SHA: `011cf0b60f85adf273908aa71b929549a18d9c07`
+- service: `dsg-control-plane`
+- database check: passed in the captured health response
+- distributed rate limiter configuration check: passed in the captured health response
+
+Evidence:
+
+- [`qa-logs/azure-production/20260828T015648Z/DEPLOYMENT_PROOF.md`](qa-logs/azure-production/20260828T015648Z/DEPLOYMENT_PROOF.md)
+- [`qa-logs/azure-production/20260828T015648Z/SHA256SUMS.txt`](qa-logs/azure-production/20260828T015648Z/SHA256SUMS.txt)
+
+### What this does not prove
+
+It does **not** prove that every later commit on `main` is already deployed.
+
+A current production claim must match the running service's exact source SHA/container digest and current health/evidence. If those do not match, the correct state remains `UNVERIFIED`, `REVIEW`, `BLOCK`, or `FAILED` according to the applicable gate.
+
+---
 
 ## Local development
 
-Requirements:
+### Requirements
 
 - Node.js `>=24`
 - npm
-- Required runtime secrets/services for the feature being exercised
+- runtime services/secrets required by the feature being exercised
 
 ```bash
 git clone https://github.com/tdealer01-crypto/tdealer01-crypto-dsg-control-plane.git
@@ -47,38 +222,58 @@ npm test
 npm run build
 ```
 
-Do not treat a local build as production evidence. Production status is established by Azure deployment and post-deploy verification evidence.
+Additional verification commands available in `package.json` include live-DB tests, Playwright E2E tests, deterministic verification, policy verification, security-header verification, production-manifest verification, load tests, and evidence-chain tooling.
 
-## Verification and evidence
+A successful local build is useful development evidence. It is **not** production deployment evidence.
 
-Useful repository surfaces include:
+---
 
-- `tests/` — automated verification
-- `qa-logs/` — captured QA/deployment evidence
-- `.github/workflows/` — CI/CD automation
-- `lib/` and `app/` — implementation
-- `docs/` — operating and architecture documentation
-- `config/production-deployment-target.json` — production deployment authority
+## Secrets and runtime configuration
 
-For any capability claim, prefer current code plus executable evidence over historical planning documents or screenshots.
+Do not commit live secrets.
+
+Runtime configuration must use the current production secret-management path for Azure and the applicable external services. Example environment files document required names only; they do not prove that a secret exists or is correct in production.
+
+Relevant repository guidance includes:
+
+- [`docs/ops/azure-runtime-env-sync.md`](docs/ops/azure-runtime-env-sync.md)
+- `.env.example`
+- `scripts/secrets-manager.sh`
+
+---
+
+## Truth boundary
+
+The repository must not claim any of the following without current supporting evidence:
+
+- production deployment success,
+- current runtime health,
+- full live E2E completion,
+- solver proof,
+- compliance or certification,
+- database migration completion,
+- external mutation success,
+- replay correctness.
+
+When code, configuration, GitHub status checks, runtime state, and documentation disagree, verify the running authoritative Azure target and update the evidence so the surfaces converge.
+
+**No evidence = no PASS claim.**
+
+---
 
 ## Decision discipline
 
-Every material decision should preserve enough context to answer:
+Every material execution should leave enough evidence to answer:
 
-- What did the user approve?
-- What action was attempted?
-- Which policy/constraint was evaluated?
-- What evidence was produced?
-- What actually passed or failed?
-- What should the operator do next?
+```text
+What did the user approve?
+What action was attempted?
+Which constraint or policy was evaluated?
+What permission was used?
+What evidence was produced?
+What state actually changed?
+What passed or failed?
+What should happen next?
+```
 
-Unverified data is not a successful result. Missing evidence must remain `UNVERIFIED`, `REVIEW`, or `BLOCK` according to the applicable risk policy.
-
-## Secrets
-
-Do not commit live secrets. Runtime secrets should use the production secret-management path documented for Azure. Example environment files are documentation only and are not evidence that a secret exists in production.
-
-## Production truth boundary
-
-The repository must not claim production success, compliance, solver proof, deployment completion, or runtime health without current supporting evidence. If code, configuration, runtime state, and documentation disagree, verify the running Azure service and update the repository so they converge.
+That is the operating boundary of DSG Control Plane: **approved intent -> governed execution -> verifiable result -> replayable proof**.


### PR DESCRIPTION
## Goal
Rewrite the root README so public documentation matches the repository's current deployment authority, evidence boundary, and plugin surface as of 2026-08-31.

## Files changed
- `README.md`

## What changed
- added the ClaudePluginHub badge supplied for `dsg-governance`
- made Azure App Service the explicit authoritative production target
- marked Vercel and Render as retired DSG production targets
- surfaced `BOUND_FAIL_CLOSED_LIVE_VERIFICATION_REQUIRED`
- documented the latest committed Azure proof accurately: PASS on 2026-08-28 for SHA `011cf0b60f85adf273908aa71b929549a18d9c07`, health/readiness 200
- explicitly prevents that historical proof from being misrepresented as proof that the latest `main` is live
- documented the governed execution contract, operator path, evidence boundary, Azure promotion/rollback model, MCP/tooling, secrets guidance, and current 7-entry Claude plugin marketplace
- clarified that retired external provider checks may still appear in GitHub statuses but do not define production authority

## Verification
- inspected current `main` before the change: `c039197931da8ecf46fb9029b0d86cf86ce9b8f7`
- verified `config/production-deployment-target.json` identifies `AZURE_APP_SERVICE`, Vercel/Render retired, and live verification required
- verified committed Azure deployment evidence at `qa-logs/azure-production/20260828T015648Z/DEPLOYMENT_PROOF.md`
- verified `.claude-plugin/marketplace.json` currently declares 7 plugin entries
- verified `package.json` requires Node >=24 and exposes the verification commands referenced in the README
- branch comparison: 1 commit ahead, 0 behind; only `README.md` changed
- runtime tests/build: Not run; documentation-only change

## Known limits
- The latest committed Azure deployment proof is historical evidence for SHA `011cf0...`; it does not establish that the newest `main` SHA is live.
- Live Azure probing was not independently completed in this change, so the README intentionally keeps the current-main live state UNVERIFIED by committed deployment proof.

## User-visible benefit
A visitor can now see immediately where production actually runs, what has real deployment proof, what remains unverified, how DSG governs agent execution, where evidence is stored, and how to install the governance plugin without reading internal logs or outdated provider documentation.

## Next step
Merge after repository checks accept the documentation change. A subsequent governed Azure deployment should publish new SHA/digest-matched evidence for the then-current `main`.