### PR TITLE
fix(ci): reuse Azure OIDC variables in runner bootstrap

### DIFF
--- a/.github/workflows/bootstrap-agi-pr-validation-runner.yml
+++ b/.github/workflows/bootstrap-agi-pr-validation-runner.yml
@@ -73,6 +73,9 @@ jobs:
       TARGET_REPO: tdealer01-crypto/dsg-agi-simulation
       TARGET_BRANCH: ${{ inputs.target_branch || 'fix/runtime-baseline-capability-evolution' }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'rg-t.dealer01-0468' }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID || vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID || vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID || vars.AZURE_SUBSCRIPTION_ID }}
       RUNNER_VM_NAME: dsg-pr41-validator
       RUNNER_VM_SIZE: ${{ inputs.vm_size || 'Standard_B2s' }}
       RUNNER_LABELS: azure,dsg-pr-validation,pr41
@@ -82,10 +85,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate required bootstrap credentials
         shell: bash
-        env:
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
           set -euo pipefail
           test -n "${AZURE_CLIENT_ID:-}" || { echo '::error::AZURE_CLIENT_ID_REQUIRED'; exit 1; }
@@ -95,9 +94,9 @@ jobs:
       - name: Login to Azure with existing governed OIDC binding
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
       - name: Provision and prove GitHub runner registration
         id: runner
         shell: bash


### PR DESCRIPTION
## Why
The post-merge bootstrap run for #1185 failed before Azure login because `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, and `DSG_GITHUB_AUTOMATION_TOKEN` were empty.

## Change
Reuse the same `secret || variable` Azure OIDC resolution pattern already used by the existing Azure environment-sync workflow. Keep `DSG_GITHUB_AUTOMATION_TOKEN` secret-only.

## Safety
- no credential values are added to source
- no test or governance gate is reduced
- PR-validation runner trust boundary is unchanged
- workflow remains fail-closed when any required credential is absent

After merge, the path-limited main push will re-run the bootstrap and show whether the existing Azure variables resolve. Do not treat the runner as available until GitHub reports it online.