### PR TITLE
fix(ci): broker AGI runner bootstrap through Control Plane OIDC

### DIFF
--- a/.github/workflows/bootstrap-agi-pr-validation-runner.yml
+++ b/.github/workflows/bootstrap-agi-pr-validation-runner.yml
@@ -56,19 +56,20 @@ jobs:
           script='scripts/bootstrap-agi-pr-validation-runner.sh'
           workflow='.github/workflows/bootstrap-agi-pr-validation-runner.yml'
           broker='app/api/dsg/ops/runner-bootstrap/broker/route.ts'
+          token_name='DSG_GITHUB_AUTOMATION_TOKEN'
           grep -Fq 'dsgTrustBoundary=pr-validation-no-managed-identity' "$script"
           grep -Fq -- '--nsg-rule NONE' "$script"
           grep -Fq 'RUNNER_REGISTRATION_TOKEN' "$script"
           grep -Fq 'dsg-agi-runner-bootstrap' "$workflow"
           grep -Fq 'ACTIONS_ID_TOKEN_REQUEST_URL' "$workflow"
           grep -Fq 'verifyGitHubActionsOidcToken' "$broker"
-          grep -Fq 'DSG_GITHUB_AUTOMATION_TOKEN' "$broker"
+          grep -Fq "$token_name" "$broker"
           grep -Fq 'createRegistrationTokenForRepo' "$broker"
-          if grep -Fq 'DSG_GITHUB_AUTOMATION_TOKEN' "$script"; then
+          if grep -Fq "$token_name" "$script"; then
             echo '::error::Long-lived GitHub automation token must not enter the runner bootstrap script.' >&2
             exit 1
           fi
-          if grep -Fq 'DSG_GITHUB_AUTOMATION_TOKEN' "$workflow"; then
+          if grep -Eq "secrets\\.${token_name}|^[[:space:]]*${token_name}:[[:space:]]" "$workflow"; then
             echo '::error::Long-lived GitHub automation token must not be injected into the public workflow.' >&2
             exit 1
           fi

--- a/.github/workflows/bootstrap-agi-pr-validation-runner.yml
+++ b/.github/workflows/bootstrap-agi-pr-validation-runner.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - '.github/workflows/bootstrap-agi-pr-validation-runner.yml'
       - 'scripts/bootstrap-agi-pr-validation-runner.sh'
+      - 'app/api/dsg/ops/runner-bootstrap/broker/route.ts'
+      - 'lib/security/github-actions-oidc.ts'
   push:
     branches: [main]
     paths:
       - '.github/workflows/bootstrap-agi-pr-validation-runner.yml'
       - 'scripts/bootstrap-agi-pr-validation-runner.sh'
+      - 'app/api/dsg/ops/runner-bootstrap/broker/route.ts'
+      - 'lib/security/github-actions-oidc.ts'
   workflow_dispatch:
     inputs:
       target_branch:
@@ -45,20 +49,34 @@ jobs:
       - uses: actions/checkout@v4
       - name: Syntax-check bootstrap script
         run: bash -n scripts/bootstrap-agi-pr-validation-runner.sh
-      - name: Enforce PR-validation trust boundary
+      - name: Enforce OIDC broker and PR-validation trust boundary
         shell: bash
         run: |
           set -euo pipefail
-          file='scripts/bootstrap-agi-pr-validation-runner.sh'
-          grep -Fq 'dsgTrustBoundary=pr-validation-no-managed-identity' "$file"
-          grep -Fq -- '--nsg-rule NONE' "$file"
-          grep -Fq '/actions/runners/registration-token' "$file"
-          grep -Fq 'RUNNER_ALLOCATION_NOT_ONLINE' "$file"
-          if grep -Eq 'az vm identity assign|--assign-identity' "$file"; then
+          script='scripts/bootstrap-agi-pr-validation-runner.sh'
+          workflow='.github/workflows/bootstrap-agi-pr-validation-runner.yml'
+          broker='app/api/dsg/ops/runner-bootstrap/broker/route.ts'
+          grep -Fq 'dsgTrustBoundary=pr-validation-no-managed-identity' "$script"
+          grep -Fq -- '--nsg-rule NONE' "$script"
+          grep -Fq 'RUNNER_REGISTRATION_TOKEN' "$script"
+          grep -Fq 'dsg-agi-runner-bootstrap' "$workflow"
+          grep -Fq 'ACTIONS_ID_TOKEN_REQUEST_URL' "$workflow"
+          grep -Fq 'verifyGitHubActionsOidcToken' "$broker"
+          grep -Fq 'DSG_GITHUB_AUTOMATION_TOKEN' "$broker"
+          grep -Fq 'createRegistrationTokenForRepo' "$broker"
+          if grep -Fq 'DSG_GITHUB_AUTOMATION_TOKEN' "$script"; then
+            echo '::error::Long-lived GitHub automation token must not enter the runner bootstrap script.' >&2
+            exit 1
+          fi
+          if grep -Fq 'DSG_GITHUB_AUTOMATION_TOKEN' "$workflow"; then
+            echo '::error::Long-lived GitHub automation token must not be injected into the public workflow.' >&2
+            exit 1
+          fi
+          if grep -Eq 'az vm identity assign|--assign-identity' "$script"; then
             echo '::error::PR validation runner must not receive an Azure managed identity.' >&2
             exit 1
           fi
-          if grep -Eq -- '--nsg-rule (SSH|RDP)|--open-port' "$file"; then
+          if grep -Eq -- '--nsg-rule (SSH|RDP)|--open-port' "$script"; then
             echo '::error::PR validation runner must not expose inbound administration ports.' >&2
             exit 1
           fi
@@ -68,46 +86,137 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: prod
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       TARGET_REPO: tdealer01-crypto/dsg-agi-simulation
       TARGET_BRANCH: ${{ inputs.target_branch || 'fix/runtime-baseline-capability-evolution' }}
-      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'rg-t.dealer01-0468' }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID || vars.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID || vars.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID || vars.AZURE_SUBSCRIPTION_ID }}
       RUNNER_VM_NAME: dsg-pr41-validator
       RUNNER_VM_SIZE: ${{ inputs.vm_size || 'Standard_B2s' }}
       RUNNER_LABELS: azure,dsg-pr-validation,pr41
       RUNNER_TTL_MINUTES: ${{ inputs.ttl_minutes || 120 }}
-      DSG_GITHUB_AUTOMATION_TOKEN: ${{ secrets.DSG_GITHUB_AUTOMATION_TOKEN }}
+      BROKER_URL: ${{ vars.DSG_RUNNER_BOOTSTRAP_BROKER_URL || 'https://dsg-control-plane.azurewebsites.net/api/dsg/ops/runner-bootstrap/broker' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Validate required bootstrap credentials
+
+      - name: Exchange GitHub OIDC for short-lived bootstrap material
+        id: broker
         shell: bash
         run: |
           set -euo pipefail
-          test -n "${AZURE_CLIENT_ID:-}" || { echo '::error::AZURE_CLIENT_ID_REQUIRED'; exit 1; }
-          test -n "${AZURE_TENANT_ID:-}" || { echo '::error::AZURE_TENANT_ID_REQUIRED'; exit 1; }
-          test -n "${AZURE_SUBSCRIPTION_ID:-}" || { echo '::error::AZURE_SUBSCRIPTION_ID_REQUIRED'; exit 1; }
-          test -n "${DSG_GITHUB_AUTOMATION_TOKEN:-}" || { echo '::error::DSG_GITHUB_AUTOMATION_TOKEN_REQUIRED'; exit 1; }
+          get_oidc_token() {
+            curl --fail --silent --show-error \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=dsg-agi-runner-bootstrap" | jq -er '.value'
+          }
+
+          oidc_token="$(get_oidc_token)"
+          echo "::add-mask::$oidc_token"
+          payload="$(jq -nc --arg repo "$TARGET_REPO" --arg branch "$TARGET_BRANCH" \
+            '{action:"issue",targetRepository:$repo,targetBranch:$branch}')"
+          response_file="$RUNNER_TEMP/dsg-runner-broker-issue.json"
+          http_status="$(curl --silent --show-error -o "$response_file" -w '%{http_code}' \
+            -X POST "$BROKER_URL" \
+            -H "Authorization: Bearer $oidc_token" \
+            -H 'Content-Type: application/json' \
+            --data "$payload")"
+          if [[ "$http_status" != 200 ]]; then
+            jq -c '{status,reason,missing,detail}' "$response_file" 2>/dev/null || true
+            echo "::error::RUNNER_BOOTSTRAP_BROKER_ISSUE_FAILED:http=$http_status" >&2
+            exit 1
+          fi
+          jq -e --arg repo "$TARGET_REPO" --arg branch "$TARGET_BRANCH" \
+            '.status == "PASS" and .action == "issue" and .targetRepository == $repo and .targetBranch == $branch' \
+            "$response_file" >/dev/null
+
+          azure_client_id="$(jq -er '.azure.clientId' "$response_file")"
+          azure_tenant_id="$(jq -er '.azure.tenantId' "$response_file")"
+          azure_subscription_id="$(jq -er '.azure.subscriptionId' "$response_file")"
+          azure_resource_group="$(jq -er '.azure.resourceGroup' "$response_file")"
+          registration_token="$(jq -er '.runner.registrationToken' "$response_file")"
+          target_sha="$(jq -er '.targetSha' "$response_file")"
+          expires_at="$(jq -er '.runner.expiresAt' "$response_file")"
+
+          [[ "$target_sha" =~ ^[0-9a-fA-F]{40}$ ]] || { echo '::error::BROKER_TARGET_SHA_INVALID'; exit 1; }
+          [[ ${#registration_token} -ge 20 ]] || { echo '::error::BROKER_REGISTRATION_TOKEN_INVALID'; exit 1; }
+          for value in "$azure_client_id" "$azure_tenant_id" "$azure_subscription_id" "$registration_token"; do
+            echo "::add-mask::$value"
+          done
+          {
+            echo "azure_client_id=$azure_client_id"
+            echo "azure_tenant_id=$azure_tenant_id"
+            echo "azure_subscription_id=$azure_subscription_id"
+            echo "azure_resource_group=$azure_resource_group"
+            echo "registration_token=$registration_token"
+            echo "target_sha=$target_sha"
+            echo "registration_expires_at=$expires_at"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$response_file"
+
       - name: Login to Azure with existing governed OIDC binding
         uses: azure/login@v2
         with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-      - name: Provision and prove GitHub runner registration
+          client-id: ${{ steps.broker.outputs.azure_client_id }}
+          tenant-id: ${{ steps.broker.outputs.azure_tenant_id }}
+          subscription-id: ${{ steps.broker.outputs.azure_subscription_id }}
+
+      - name: Provision dedicated VM with short-lived runner token
         id: runner
         shell: bash
+        env:
+          AZURE_RESOURCE_GROUP: ${{ steps.broker.outputs.azure_resource_group }}
+          RUNNER_REGISTRATION_TOKEN: ${{ steps.broker.outputs.registration_token }}
+          TARGET_SHA: ${{ steps.broker.outputs.target_sha }}
         run: bash scripts/bootstrap-agi-pr-validation-runner.sh
+
+      - name: Prove GitHub reports the runner online through the broker
+        id: online
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ steps.broker.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          get_oidc_token() {
+            curl --fail --silent --show-error \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=dsg-agi-runner-bootstrap" | jq -er '.value'
+          }
+
+          payload="$(jq -nc --arg repo "$TARGET_REPO" --arg branch "$TARGET_BRANCH" --arg runner "$RUNNER_VM_NAME" \
+            '{action:"status",targetRepository:$repo,targetBranch:$branch,runnerName:$runner}')"
+          deadline=$((SECONDS + 600))
+          while (( SECONDS < deadline )); do
+            oidc_token="$(get_oidc_token)"
+            echo "::add-mask::$oidc_token"
+            response_file="$RUNNER_TEMP/dsg-runner-broker-status.json"
+            http_status="$(curl --silent --show-error -o "$response_file" -w '%{http_code}' \
+              -X POST "$BROKER_URL" \
+              -H "Authorization: Bearer $oidc_token" \
+              -H 'Content-Type: application/json' \
+              --data "$payload")"
+            if [[ "$http_status" == 200 ]] && \
+               jq -e --arg sha "$EXPECTED_SHA" --arg runner "$RUNNER_VM_NAME" \
+                 '.status == "PASS" and .action == "status" and .targetSha == $sha and .runner.name == $runner and .runner.status == "online" and (.runner.labels | index("dsg-pr-validation")) != null and (.runner.labels | index("pr41")) != null' \
+                 "$response_file" >/dev/null 2>&1; then
+              runner_id="$(jq -er '.runner.id' "$response_file")"
+              echo "runner_id=$runner_id" >> "$GITHUB_OUTPUT"
+              echo "runner_name=$RUNNER_VM_NAME" >> "$GITHUB_OUTPUT"
+              rm -f "$response_file"
+              exit 0
+            fi
+            rm -f "$response_file"
+            sleep 10
+          done
+          echo "::error::RUNNER_ALLOCATION_NOT_ONLINE:name=${RUNNER_VM_NAME}" >&2
+          exit 1
+
       - name: Record allocation evidence
         shell: bash
         env:
-          RUNNER_ID: ${{ steps.runner.outputs.runner_id }}
-          RUNNER_NAME: ${{ steps.runner.outputs.runner_name }}
-          TARGET_SHA: ${{ steps.runner.outputs.target_sha }}
+          RUNNER_ID: ${{ steps.online.outputs.runner_id }}
+          RUNNER_NAME: ${{ steps.online.outputs.runner_name }}
+          TARGET_SHA: ${{ steps.broker.outputs.target_sha }}
           AUTO_SHUTDOWN_UTC: ${{ steps.runner.outputs.auto_shutdown_utc }}
+          REGISTRATION_EXPIRES_AT: ${{ steps.broker.outputs.registration_expires_at }}
         run: |
           {
             echo '## DSG AGI PR validation runner'
@@ -115,6 +224,8 @@ jobs:
             echo "- runner: ${RUNNER_NAME}"
             echo "- runner id: ${RUNNER_ID}"
             echo "- target SHA: ${TARGET_SHA}"
+            echo "- bootstrap auth: GitHub OIDC → Control Plane broker → short-lived runner token"
+            echo "- runner registration token expiry: ${REGISTRATION_EXPIRES_AT}"
             echo "- labels: self-hosted, Linux, X64, azure, dsg-pr-validation, pr41"
             echo "- Azure managed identity: prohibited"
             echo "- inbound admin ports: prohibited"

--- a/app/api/dsg/ops/runner-bootstrap/broker/route.ts
+++ b/app/api/dsg/ops/runner-bootstrap/broker/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from 'next/server';
+import { Octokit } from '@octokit/rest';
+import { verifyGitHubActionsOidcToken } from '@/lib/security/github-actions-oidc';
+import { handleApiError } from '@/lib/security/api-error';
+
+export const dynamic = 'force-dynamic';
+
+const ROUTE = 'api/dsg/ops/runner-bootstrap/broker';
+const OIDC_AUDIENCE = 'dsg-agi-runner-bootstrap';
+const CONTROL_REPOSITORY = 'tdealer01-crypto/tdealer01-crypto-dsg-control-plane';
+const CONTROL_WORKFLOW = '.github/workflows/bootstrap-agi-pr-validation-runner.yml';
+const TARGET_REPOSITORY = 'tdealer01-crypto/dsg-agi-simulation';
+const TARGET_BRANCH = 'fix/runtime-baseline-capability-evolution';
+const RUNNER_NAME = 'dsg-pr41-validator';
+
+interface BrokerRequest {
+  action: 'issue' | 'status';
+  targetRepository: string;
+  targetBranch: string;
+  runnerName?: string;
+}
+
+function bearerToken(request: Request): string {
+  const header = request.headers.get('authorization') ?? '';
+  return header.startsWith('Bearer ') ? header.slice(7).trim() : '';
+}
+
+function isBrokerRequest(value: unknown): value is BrokerRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const body = value as Record<string, unknown>;
+  return (
+    (body.action === 'issue' || body.action === 'status') &&
+    typeof body.targetRepository === 'string' &&
+    typeof body.targetBranch === 'string' &&
+    (body.runnerName === undefined || typeof body.runnerName === 'string')
+  );
+}
+
+function loadBrokerConfig():
+  | {
+      githubToken: string;
+      azureClientId: string;
+      azureTenantId: string;
+      azureSubscriptionId: string;
+      azureResourceGroup: string;
+    }
+  | { missing: string[] } {
+  const githubToken = process.env.DSG_GITHUB_AUTOMATION_TOKEN?.trim();
+  const azureClientId = process.env.AZURE_CLIENT_ID?.trim();
+  const azureTenantId = process.env.AZURE_TENANT_ID?.trim();
+  const azureSubscriptionId = process.env.AZURE_SUBSCRIPTION_ID?.trim();
+  const azureResourceGroup = process.env.AZURE_RESOURCE_GROUP?.trim() || 'rg-t.dealer01-0468';
+
+  const missing = [
+    ...(!githubToken ? ['DSG_GITHUB_AUTOMATION_TOKEN'] : []),
+    ...(!azureClientId ? ['AZURE_CLIENT_ID'] : []),
+    ...(!azureTenantId ? ['AZURE_TENANT_ID'] : []),
+    ...(!azureSubscriptionId ? ['AZURE_SUBSCRIPTION_ID'] : []),
+  ];
+  if (missing.length > 0) return { missing };
+
+  return {
+    githubToken: githubToken!,
+    azureClientId: azureClientId!,
+    azureTenantId: azureTenantId!,
+    azureSubscriptionId: azureSubscriptionId!,
+    azureResourceGroup,
+  };
+}
+
+async function authorize(request: Request): Promise<{ ok: true } | { ok: false; response: NextResponse }> {
+  const token = bearerToken(request);
+  if (!token || token.split('.').length !== 3) {
+    return {
+      ok: false,
+      response: NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_OIDC_REQUIRED' }, { status: 401 }),
+    };
+  }
+
+  const verified = await verifyGitHubActionsOidcToken(token, {
+    audience: OIDC_AUDIENCE,
+    repository: CONTROL_REPOSITORY,
+    ref: 'refs/heads/main',
+    workflowPath: CONTROL_WORKFLOW,
+    allowedEvents: ['push', 'workflow_dispatch'],
+  });
+  if (verified.ok === false) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_OIDC_INVALID', detail: verified.error },
+        { status: 401 },
+      ),
+    };
+  }
+
+  return { ok: true };
+}
+
+export async function POST(request: Request) {
+  const headers = { 'Cache-Control': 'no-store' };
+  try {
+    const auth = await authorize(request);
+    if (auth.ok === false) return auth.response;
+
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_INVALID_JSON' }, { status: 400, headers });
+    }
+    if (!isBrokerRequest(parsed)) {
+      return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_PAYLOAD_INVALID' }, { status: 400, headers });
+    }
+    if (parsed.targetRepository !== TARGET_REPOSITORY || parsed.targetBranch !== TARGET_BRANCH) {
+      return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_TARGET_NOT_ALLOWLISTED' }, { status: 403, headers });
+    }
+    if (parsed.runnerName !== undefined && parsed.runnerName !== RUNNER_NAME) {
+      return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_RUNNER_NOT_ALLOWLISTED' }, { status: 403, headers });
+    }
+
+    const config = loadBrokerConfig();
+    if ('missing' in config) {
+      return NextResponse.json(
+        { status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_RUNTIME_NOT_CONFIGURED', missing: config.missing },
+        { status: 503, headers },
+      );
+    }
+
+    const [owner, repo] = TARGET_REPOSITORY.split('/');
+    const octokit = new Octokit({ auth: config.githubToken });
+    const branch = await octokit.rest.repos.getBranch({ owner, repo, branch: TARGET_BRANCH });
+    const targetSha = branch.data.commit.sha;
+    if (!/^[0-9a-f]{40}$/i.test(targetSha)) {
+      return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_TARGET_SHA_INVALID' }, { status: 502, headers });
+    }
+
+    if (parsed.action === 'status') {
+      const runners = await octokit.rest.actions.listSelfHostedRunnersForRepo({ owner, repo, per_page: 100 });
+      const runner = runners.data.runners.find((candidate) => candidate.name === RUNNER_NAME);
+      return NextResponse.json({
+        schemaVersion: 'dsg.runner-bootstrap-broker.v1',
+        status: 'PASS',
+        action: 'status',
+        targetRepository: TARGET_REPOSITORY,
+        targetBranch: TARGET_BRANCH,
+        targetSha,
+        runner: runner
+          ? {
+              id: runner.id,
+              name: runner.name,
+              status: runner.status,
+              busy: runner.busy,
+              labels: runner.labels.map(({ name }) => name).sort(),
+            }
+          : null,
+      }, { status: 200, headers });
+    }
+
+    const registration = await octokit.rest.actions.createRegistrationTokenForRepo({ owner, repo });
+    const registrationToken = registration.data.token;
+    if (typeof registrationToken !== 'string' || registrationToken.length < 20) {
+      return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_REGISTRATION_TOKEN_INVALID' }, { status: 502, headers });
+    }
+
+    return NextResponse.json({
+      schemaVersion: 'dsg.runner-bootstrap-broker.v1',
+      status: 'PASS',
+      action: 'issue',
+      targetRepository: TARGET_REPOSITORY,
+      targetBranch: TARGET_BRANCH,
+      targetSha,
+      azure: {
+        clientId: config.azureClientId,
+        tenantId: config.azureTenantId,
+        subscriptionId: config.azureSubscriptionId,
+        resourceGroup: config.azureResourceGroup,
+      },
+      runner: {
+        name: RUNNER_NAME,
+        registrationToken,
+        expiresAt: registration.data.expires_at,
+      },
+      truthBoundary: 'Long-lived GitHub and Azure client-secret credentials remain inside the Control Plane runtime; this response contains only Azure identifiers and a short-lived repository runner registration token.',
+    }, { status: 200, headers });
+  } catch (error) {
+    return handleApiError(ROUTE, error, { status: 502, headers });
+  }
+}

--- a/scripts/bootstrap-agi-pr-validation-runner.sh
+++ b/scripts/bootstrap-agi-pr-validation-runner.sh
@@ -9,7 +9,8 @@ required() {
   fi
 }
 
-required DSG_GITHUB_AUTOMATION_TOKEN
+required RUNNER_REGISTRATION_TOKEN
+required TARGET_SHA
 required AZURE_RESOURCE_GROUP
 required TARGET_REPO
 required TARGET_BRANCH
@@ -28,36 +29,20 @@ if ! [[ "$TARGET_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$TARGET_BRANCH" == *'..
   echo '::error::TARGET_BRANCH_INVALID' >&2
   exit 1
 fi
+if ! [[ "$TARGET_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo '::error::TARGET_SHA_INVALID' >&2
+  exit 1
+fi
+if [[ ${#RUNNER_REGISTRATION_TOKEN} -lt 20 ]]; then
+  echo '::error::RUNNER_REGISTRATION_TOKEN_INVALID' >&2
+  exit 1
+fi
 if ! [[ "$RUNNER_VM_NAME" =~ ^[A-Za-z0-9-]{1,64}$ ]]; then
   echo '::error::RUNNER_VM_NAME_INVALID' >&2
   exit 1
 fi
 if ! [[ "$RUNNER_TTL_MINUTES" =~ ^[0-9]+$ ]] || (( RUNNER_TTL_MINUTES < 30 || RUNNER_TTL_MINUTES > 360 )); then
   echo '::error::RUNNER_TTL_MINUTES_INVALID' >&2
-  exit 1
-fi
-
-api() {
-  curl --fail --silent --show-error \
-    -H "Authorization: Bearer ${DSG_GITHUB_AUTOMATION_TOKEN}" \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2022-11-28' \
-    "$@"
-}
-
-echo "Resolving target branch ${TARGET_REPO}@${TARGET_BRANCH}..."
-ref_json="$(api "https://api.github.com/repos/${TARGET_REPO}/git/ref/heads/${TARGET_BRANCH}")"
-TARGET_SHA="$(jq -er '.object.sha' <<<"$ref_json")"
-if ! [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-  echo '::error::TARGET_SHA_INVALID' >&2
-  exit 1
-fi
-
-echo 'Requesting short-lived repository runner registration token...'
-registration_json="$(api -X POST "https://api.github.com/repos/${TARGET_REPO}/actions/runners/registration-token")"
-RUNNER_REGISTRATION_TOKEN="$(jq -er '.token' <<<"$registration_json")"
-if [[ ${#RUNNER_REGISTRATION_TOKEN} -lt 20 ]]; then
-  echo '::error::RUNNER_REGISTRATION_TOKEN_INVALID' >&2
   exit 1
 fi
 
@@ -174,7 +159,6 @@ az vm create \
   --only-show-errors \
   --output none
 
-# Explicitly prove that no managed identity was attached.
 identity_type="$(az vm show --resource-group "$AZURE_RESOURCE_GROUP" --name "$RUNNER_VM_NAME" --query 'identity.type' --output tsv 2>/dev/null || true)"
 if [[ -n "$identity_type" && "$identity_type" != 'None' ]]; then
   echo "::error::RUNNER_VM_MANAGED_IDENTITY_PRESENT:${identity_type}" >&2
@@ -189,29 +173,9 @@ az vm auto-shutdown \
   --only-show-errors \
   --output none
 
-echo "Waiting for GitHub to report runner ${RUNNER_VM_NAME} online..."
-deadline=$((SECONDS + 600))
-runner_id=''
-runner_status=''
-while (( SECONDS < deadline )); do
-  runners_json="$(api "https://api.github.com/repos/${TARGET_REPO}/actions/runners?per_page=100")"
-  runner_id="$(jq -r --arg name "$RUNNER_VM_NAME" '.runners[]? | select(.name == $name) | .id' <<<"$runners_json" | head -n1)"
-  runner_status="$(jq -r --arg name "$RUNNER_VM_NAME" '.runners[]? | select(.name == $name) | .status' <<<"$runners_json" | head -n1)"
-  if [[ -n "$runner_id" && "$runner_status" == 'online' ]]; then
-    break
-  fi
-  sleep 10
-done
-
-if [[ -z "$runner_id" || "$runner_status" != 'online' ]]; then
-  echo "::error::RUNNER_ALLOCATION_NOT_ONLINE:name=${RUNNER_VM_NAME},status=${runner_status:-missing}" >&2
-  exit 1
-fi
-
-echo "RUNNER_REGISTRATION_ONLINE name=${RUNNER_VM_NAME} id=${runner_id} targetSha=${TARGET_SHA} labels=${RUNNER_LABELS}"
+echo "RUNNER_VM_PROVISIONED name=${RUNNER_VM_NAME} targetSha=${TARGET_SHA} labels=${RUNNER_LABELS}"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
-    echo "runner_id=${runner_id}"
     echo "runner_name=${RUNNER_VM_NAME}"
     echo "target_sha=${TARGET_SHA}"
     echo "auto_shutdown_utc=${auto_shutdown}"


### PR DESCRIPTION
## Problem
The AGI runner bootstrap is blocked before Azure login because the GitHub `prod` environment does not currently expose `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, or `DSG_GITHUB_AUTOMATION_TOKEN`. The Control Plane already defines Azure Key Vault as the canonical runtime secret authority, so duplicating the long-lived GitHub automation token back into Actions would violate that boundary.

## Change
- add an OIDC-authenticated Control Plane runner-bootstrap broker
- validate exact GitHub repo/ref/workflow/event using the existing `github-actions-oidc` verifier
- keep `DSG_GITHUB_AUTOMATION_TOKEN` inside the Control Plane runtime
- issue only Azure non-secret identifiers plus a short-lived repository runner registration token
- move target SHA resolution and private-repo runner status lookup into the broker
- remove `DSG_GITHUB_AUTOMATION_TOKEN` from the public bootstrap workflow and VM bootstrap script
- keep the PR validation VM without managed identity or inbound admin ports and retain auto-shutdown

## Trust boundary
`GitHub Actions OIDC -> Control Plane runtime/Key Vault-backed env -> short-lived runner registration token -> Azure OIDC -> dedicated PR validation VM`.

The broker is allowlisted to `tdealer01-crypto/dsg-agi-simulation`, branch `fix/runtime-baseline-capability-evolution`, runner `dsg-pr41-validator`, and the exact bootstrap workflow on `main`.

## Truth boundary
Merging this PR does not by itself prove the broker is deployed live. After merge, the bootstrap push run must reach the live broker, Azure OIDC login must succeed, GitHub must report the runner `online`, and PR #41's harmless allocation proof must execute before any CI jobs are migrated to self-hosted.