### PR TITLE
fix(deploy): unify Control Plane Azure GitHub OIDC identity

### DIFF
--- a/.github/workflows/promoted-production-deploy-v2.yml
+++ b/.github/workflows/promoted-production-deploy-v2.yml
@@ -49,30 +49,50 @@ jobs:
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
 
-      - name: Resolve Azure identity after prod environment load
+      - name: Resolve proven Azure GitHub OIDC identity
         id: azure_identity
         shell: bash
         env:
           AZURE_CLIENT_ID_CANDIDATE: ${{ secrets.AZURE_CLIENT_ID || vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID_CANDIDATE: ${{ secrets.AZURE_TENANT_ID || vars.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID_CANDIDATE: ${{ secrets.AZURE_SUBSCRIPTION_ID || vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP_CANDIDATE: ${{ vars.AZURE_RESOURCE_GROUP }}
         run: |
           set -euo pipefail
-          missing=()
-          test -n "$AZURE_CLIENT_ID_CANDIDATE" || missing+=(AZURE_CLIENT_ID)
-          test -n "$AZURE_TENANT_ID_CANDIDATE" || missing+=(AZURE_TENANT_ID)
-          test -n "$AZURE_SUBSCRIPTION_ID_CANDIDATE" || missing+=(AZURE_SUBSCRIPTION_ID)
-          if (( ${#missing[@]} > 0 )); then
-            printf '::error::Missing Azure prod environment identity binding(s): %s\n' "${missing[*]}"
-            exit 1
-          fi
-          echo "::add-mask::$AZURE_CLIENT_ID_CANDIDATE"
-          echo "::add-mask::$AZURE_TENANT_ID_CANDIDATE"
-          echo "::add-mask::$AZURE_SUBSCRIPTION_ID_CANDIDATE"
-          echo "client_id=$AZURE_CLIENT_ID_CANDIDATE" >> "$GITHUB_OUTPUT"
-          echo "tenant_id=$AZURE_TENANT_ID_CANDIDATE" >> "$GITHUB_OUTPUT"
-          echo "subscription_id=$AZURE_SUBSCRIPTION_ID_CANDIDATE" >> "$GITHUB_OUTPUT"
-          echo 'Azure identity bindings resolved after prod environment load.'
+          IDENTITY_FILE='config/azure-github-oidc-identity.json'
+          test -s "$IDENTITY_FILE" || { echo '::error::Azure GitHub OIDC identity config missing'; exit 1; }
+
+          CONFIG_CLIENT_ID="$(jq -er '.clientId' "$IDENTITY_FILE")"
+          CONFIG_TENANT_ID="$(jq -er '.tenantId' "$IDENTITY_FILE")"
+          CONFIG_SUBSCRIPTION_ID="$(jq -er '.subscriptionId' "$IDENTITY_FILE")"
+          CONFIG_RESOURCE_GROUP="$(jq -er '.resourceGroup' "$IDENTITY_FILE")"
+          CONFIG_SUBJECT="$(jq -er '.federatedSubject' "$IDENTITY_FILE")"
+          CONFIG_AUDIENCE="$(jq -er '.audience' "$IDENTITY_FILE")"
+
+          EXPECTED_SUBJECT='repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod'
+          test "$CONFIG_SUBJECT" = "$EXPECTED_SUBJECT" || { echo '::error::Azure OIDC federated subject mismatch'; exit 1; }
+          test "$CONFIG_AUDIENCE" = 'api://AzureADTokenExchange' || { echo '::error::Azure OIDC audience mismatch'; exit 1; }
+
+          CLIENT_ID="${AZURE_CLIENT_ID_CANDIDATE:-$CONFIG_CLIENT_ID}"
+          TENANT_ID="${AZURE_TENANT_ID_CANDIDATE:-$CONFIG_TENANT_ID}"
+          SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID_CANDIDATE:-$CONFIG_SUBSCRIPTION_ID}"
+          RESOURCE_GROUP="${AZURE_RESOURCE_GROUP_CANDIDATE:-$CONFIG_RESOURCE_GROUP}"
+
+          UUID_RE='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          [[ "$CLIENT_ID" =~ $UUID_RE ]] || { echo '::error::Azure client ID is invalid'; exit 1; }
+          [[ "$TENANT_ID" =~ $UUID_RE ]] || { echo '::error::Azure tenant ID is invalid'; exit 1; }
+          [[ "$SUBSCRIPTION_ID" =~ $UUID_RE ]] || { echo '::error::Azure subscription ID is invalid'; exit 1; }
+          test -n "$RESOURCE_GROUP" || { echo '::error::Azure resource group is empty'; exit 1; }
+
+          echo "::add-mask::$CLIENT_ID"
+          echo "::add-mask::$TENANT_ID"
+          echo "::add-mask::$SUBSCRIPTION_ID"
+          echo "client_id=$CLIENT_ID" >> "$GITHUB_OUTPUT"
+          echo "tenant_id=$TENANT_ID" >> "$GITHUB_OUTPUT"
+          echo "subscription_id=$SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
+          echo "resource_group=$RESOURCE_GROUP" >> "$GITHUB_OUTPUT"
+          echo "AZURE_RESOURCE_GROUP=$RESOURCE_GROUP" >> "$GITHUB_ENV"
+          echo 'Azure GitHub OIDC identity resolved from protected override or execution-verified config.'
 
       - name: Fail-closed deployment preflight
         shell: bash

--- a/app/api/dsg/ops/runner-bootstrap/broker/route.ts
+++ b/app/api/dsg/ops/runner-bootstrap/broker/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Octokit } from '@octokit/rest';
+import azureGitHubOidcIdentity from '@/config/azure-github-oidc-identity.json';
 import { verifyGitHubActionsOidcToken } from '@/lib/security/github-actions-oidc';
 import { handleApiError } from '@/lib/security/api-error';
 
@@ -12,6 +13,7 @@ const CONTROL_WORKFLOW = '.github/workflows/bootstrap-agi-pr-validation-runner.y
 const TARGET_REPOSITORY = 'tdealer01-crypto/dsg-agi-simulation';
 const TARGET_BRANCH = 'fix/runtime-baseline-capability-evolution';
 const RUNNER_NAME = 'dsg-pr41-validator';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface BrokerRequest {
   action: 'issue' | 'status';
@@ -46,24 +48,27 @@ function loadBrokerConfig():
     }
   | { missing: string[] } {
   const githubToken = process.env.DSG_GITHUB_AUTOMATION_TOKEN?.trim();
-  const azureClientId = process.env.AZURE_CLIENT_ID?.trim();
-  const azureTenantId = process.env.AZURE_TENANT_ID?.trim();
-  const azureSubscriptionId = process.env.AZURE_SUBSCRIPTION_ID?.trim();
-  const azureResourceGroup = process.env.AZURE_RESOURCE_GROUP?.trim() || 'rg-t.dealer01-0468';
+  const azureClientId = process.env.DSG_AZURE_GITHUB_OIDC_CLIENT_ID?.trim() || azureGitHubOidcIdentity.clientId;
+  const azureTenantId = process.env.DSG_AZURE_GITHUB_OIDC_TENANT_ID?.trim() || azureGitHubOidcIdentity.tenantId;
+  const azureSubscriptionId =
+    process.env.DSG_AZURE_GITHUB_OIDC_SUBSCRIPTION_ID?.trim() || azureGitHubOidcIdentity.subscriptionId;
+  const azureResourceGroup =
+    process.env.DSG_AZURE_GITHUB_OIDC_RESOURCE_GROUP?.trim() || azureGitHubOidcIdentity.resourceGroup;
 
   const missing = [
     ...(!githubToken ? ['DSG_GITHUB_AUTOMATION_TOKEN'] : []),
-    ...(!azureClientId ? ['AZURE_CLIENT_ID'] : []),
-    ...(!azureTenantId ? ['AZURE_TENANT_ID'] : []),
-    ...(!azureSubscriptionId ? ['AZURE_SUBSCRIPTION_ID'] : []),
+    ...(!UUID_RE.test(azureClientId) ? ['DSG_AZURE_GITHUB_OIDC_CLIENT_ID'] : []),
+    ...(!UUID_RE.test(azureTenantId) ? ['DSG_AZURE_GITHUB_OIDC_TENANT_ID'] : []),
+    ...(!UUID_RE.test(azureSubscriptionId) ? ['DSG_AZURE_GITHUB_OIDC_SUBSCRIPTION_ID'] : []),
+    ...(!azureResourceGroup ? ['DSG_AZURE_GITHUB_OIDC_RESOURCE_GROUP'] : []),
   ];
   if (missing.length > 0) return { missing };
 
   return {
     githubToken: githubToken!,
-    azureClientId: azureClientId!,
-    azureTenantId: azureTenantId!,
-    azureSubscriptionId: azureSubscriptionId!,
+    azureClientId,
+    azureTenantId,
+    azureSubscriptionId,
     azureResourceGroup,
   };
 }
@@ -138,23 +143,26 @@ export async function POST(request: Request) {
     if (parsed.action === 'status') {
       const runners = await octokit.rest.actions.listSelfHostedRunnersForRepo({ owner, repo, per_page: 100 });
       const runner = runners.data.runners.find((candidate) => candidate.name === RUNNER_NAME);
-      return NextResponse.json({
-        schemaVersion: 'dsg.runner-bootstrap-broker.v1',
-        status: 'PASS',
-        action: 'status',
-        targetRepository: TARGET_REPOSITORY,
-        targetBranch: TARGET_BRANCH,
-        targetSha,
-        runner: runner
-          ? {
-              id: runner.id,
-              name: runner.name,
-              status: runner.status,
-              busy: runner.busy,
-              labels: runner.labels.map(({ name }) => name).sort(),
-            }
-          : null,
-      }, { status: 200, headers });
+      return NextResponse.json(
+        {
+          schemaVersion: 'dsg.runner-bootstrap-broker.v1',
+          status: 'PASS',
+          action: 'status',
+          targetRepository: TARGET_REPOSITORY,
+          targetBranch: TARGET_BRANCH,
+          targetSha,
+          runner: runner
+            ? {
+                id: runner.id,
+                name: runner.name,
+                status: runner.status,
+                busy: runner.busy,
+                labels: runner.labels.map(({ name }) => name).sort(),
+              }
+            : null,
+        },
+        { status: 200, headers },
+      );
     }
 
     const registration = await octokit.rest.actions.createRegistrationTokenForRepo({ owner, repo });
@@ -163,26 +171,30 @@ export async function POST(request: Request) {
       return NextResponse.json({ status: 'BLOCK', reason: 'RUNNER_BOOTSTRAP_REGISTRATION_TOKEN_INVALID' }, { status: 502, headers });
     }
 
-    return NextResponse.json({
-      schemaVersion: 'dsg.runner-bootstrap-broker.v1',
-      status: 'PASS',
-      action: 'issue',
-      targetRepository: TARGET_REPOSITORY,
-      targetBranch: TARGET_BRANCH,
-      targetSha,
-      azure: {
-        clientId: config.azureClientId,
-        tenantId: config.azureTenantId,
-        subscriptionId: config.azureSubscriptionId,
-        resourceGroup: config.azureResourceGroup,
+    return NextResponse.json(
+      {
+        schemaVersion: 'dsg.runner-bootstrap-broker.v1',
+        status: 'PASS',
+        action: 'issue',
+        targetRepository: TARGET_REPOSITORY,
+        targetBranch: TARGET_BRANCH,
+        targetSha,
+        azure: {
+          clientId: config.azureClientId,
+          tenantId: config.azureTenantId,
+          subscriptionId: config.azureSubscriptionId,
+          resourceGroup: config.azureResourceGroup,
+        },
+        runner: {
+          name: RUNNER_NAME,
+          registrationToken,
+          expiresAt: registration.data.expires_at,
+        },
+        truthBoundary:
+          'The long-lived GitHub automation token remains inside the Control Plane runtime. Azure values come from the execution-verified GitHub OIDC identity binding (or dedicated DSG_AZURE_GITHUB_OIDC_* overrides), and the response contains only non-secret Azure identifiers plus a short-lived runner registration token.',
       },
-      runner: {
-        name: RUNNER_NAME,
-        registrationToken,
-        expiresAt: registration.data.expires_at,
-      },
-      truthBoundary: 'Long-lived GitHub and Azure client-secret credentials remain inside the Control Plane runtime; this response contains only Azure identifiers and a short-lived repository runner registration token.',
-    }, { status: 200, headers });
+      { status: 200, headers },
+    );
   } catch (error) {
     return handleApiError(ROUTE, error, { status: 502, headers });
   }

--- a/config/azure-github-oidc-identity.json
+++ b/config/azure-github-oidc-identity.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "dsg.azure-github-oidc-identity.v1",
+  "clientId": "bd54ab6e-5f92-48c8-8f8d-0c114ef938da",
+  "tenantId": "cbc618d5-9aa3-46b5-ae64-d07794603a7a",
+  "subscriptionId": "dcf13c0d-0d9f-4f81-aa89-c6b50aaef839",
+  "resourceGroup": "rg-t.dealer01-0468",
+  "azureIdentityName": "dsg-cinema-proof-agent-github-deployer",
+  "federatedCredentialName": "github-control-plane-prod",
+  "federatedSubject": "repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod",
+  "audience": "api://AzureADTokenExchange",
+  "evidence": {
+    "cinemaProductionOidcRunId": 32927629103,
+    "controlPlaneFederationBootstrapRunId": 33423069421
+  }
+}

--- a/tests/unit/azure-github-oidc-identity.test.ts
+++ b/tests/unit/azure-github-oidc-identity.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const identity = JSON.parse(readFileSync('config/azure-github-oidc-identity.json', 'utf8')) as {
+  schemaVersion: string;
+  clientId: string;
+  tenantId: string;
+  subscriptionId: string;
+  resourceGroup: string;
+  federatedSubject: string;
+  audience: string;
+};
+
+const workflow = readFileSync('.github/workflows/promoted-production-deploy-v2.yml', 'utf8');
+const broker = readFileSync('app/api/dsg/ops/runner-bootstrap/broker/route.ts', 'utf8');
+
+describe('Azure GitHub OIDC identity contract', () => {
+  it('pins the execution-verified non-secret identity and exact prod subject', () => {
+    expect(identity).toMatchObject({
+      schemaVersion: 'dsg.azure-github-oidc-identity.v1',
+      clientId: 'bd54ab6e-5f92-48c8-8f8d-0c114ef938da',
+      tenantId: 'cbc618d5-9aa3-46b5-ae64-d07794603a7a',
+      subscriptionId: 'dcf13c0d-0d9f-4f81-aa89-c6b50aaef839',
+      resourceGroup: 'rg-t.dealer01-0468',
+      federatedSubject:
+        'repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod',
+      audience: 'api://AzureADTokenExchange',
+    });
+  });
+
+  it('keeps deploy and runner bootstrap on the same identity source', () => {
+    expect(workflow).toContain("IDENTITY_FILE='config/azure-github-oidc-identity.json'");
+    expect(workflow).toContain('AZURE_CLIENT_ID_CANDIDATE');
+    expect(workflow).toContain('CONFIG_CLIENT_ID');
+    expect(broker).toContain("import azureGitHubOidcIdentity from '@/config/azure-github-oidc-identity.json'");
+    expect(broker).toContain('DSG_AZURE_GITHUB_OIDC_CLIENT_ID');
+    expect(broker).not.toContain('process.env.AZURE_CLIENT_ID?.trim()');
+  });
+});


### PR DESCRIPTION
## Problem
The Control Plane broker is merged but live production still returns 404 because the production deployment path cannot resolve Azure OIDC IDs from the `prod` environment. Separately, the broker was reading generic runtime `AZURE_*` values that were not proven to be the GitHub federated identity.

## Verified evidence
- Cinema production run `32927629103` passed Azure OIDC login and production deployment using client `bd54ab6e-5f92-48c8-8f8d-0c114ef938da`, tenant `cbc618d5-9aa3-46b5-ae64-d07794603a7a`, subscription `dcf13c0d-0d9f-4f81-aa89-c6b50aaef839`.
- Cinema bootstrap run `33423069421` created/updated and read back the exact Control Plane `prod` federated credential successfully.
- The exact federated subject is `repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod` with audience `api://AzureADTokenExchange`.

## Change
- add `config/azure-github-oidc-identity.json` as the non-secret identity source of truth
- production deployment resolves Azure IDs from protected `prod` overrides when present, otherwise from the verified config
- deployment validates exact subject/audience before Azure login
- broker consumes the same verified config, with only dedicated `DSG_AZURE_GITHUB_OIDC_*` runtime overrides allowed
- generic runtime `AZURE_CLIENT_ID` is no longer treated as proof that the broker has a GitHub OIDC identity
- add a unit contract test to prevent deploy/broker identity drift

## Gates retained
The existing exact-main-SHA check, protected E2E/Supabase bindings, Azure target verification, immutable ACR digest build, staging provenance/health, staging proof E2E, slot swap, production provenance, production proof E2E, DB persistence/isolation checks and rollback behavior remain intact.

## Truth boundary
Merging this PR is not by itself proof that production was updated. The merge commit will be explicitly marked `[prod-e2e]` only after CI is green, which triggers the existing governed production deployment. We will then require exact production SHA/digest evidence and a non-404 broker response before retrying the AGI runner bootstrap.