### PR TITLE
fix(deploy): align Control Plane OIDC subject with GitHub assertion

### DIFF
--- a/.github/workflows/promoted-production-deploy-v2.yml
+++ b/.github/workflows/promoted-production-deploy-v2.yml
@@ -69,7 +69,7 @@ jobs:
           CONFIG_SUBJECT="$(jq -er '.federatedSubject' "$IDENTITY_FILE")"
           CONFIG_AUDIENCE="$(jq -er '.audience' "$IDENTITY_FILE")"
 
-          EXPECTED_SUBJECT='repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod'
+          EXPECTED_SUBJECT='repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod'
           test "$CONFIG_SUBJECT" = "$EXPECTED_SUBJECT" || { echo '::error::Azure OIDC federated subject mismatch'; exit 1; }
           test "$CONFIG_AUDIENCE" = 'api://AzureADTokenExchange' || { echo '::error::Azure OIDC audience mismatch'; exit 1; }
 

--- a/config/azure-github-oidc-identity.json
+++ b/config/azure-github-oidc-identity.json
@@ -6,10 +6,11 @@
   "resourceGroup": "rg-t.dealer01-0468",
   "azureIdentityName": "dsg-cinema-proof-agent-github-deployer",
   "federatedCredentialName": "github-control-plane-prod",
-  "federatedSubject": "repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod",
+  "federatedSubject": "repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod",
   "audience": "api://AzureADTokenExchange",
   "evidence": {
     "cinemaProductionOidcRunId": 32927629103,
-    "controlPlaneFederationBootstrapRunId": 33423069421
+    "controlPlaneFederationBootstrapRunId": 33430316124,
+    "failedControlPlanePromotionRunId": 33429266801
   }
 }

--- a/tests/unit/azure-github-oidc-identity.test.ts
+++ b/tests/unit/azure-github-oidc-identity.test.ts
@@ -22,8 +22,7 @@ describe('Azure GitHub OIDC identity contract', () => {
       tenantId: 'cbc618d5-9aa3-46b5-ae64-d07794603a7a',
       subscriptionId: 'dcf13c0d-0d9f-4f81-aa89-c6b50aaef839',
       resourceGroup: 'rg-t.dealer01-0468',
-      federatedSubject:
-        'repo:tdealer01-crypto@260597462/tdealer01-crypto-dsg-control-plane@1186640068:environment:prod',
+      federatedSubject: 'repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod',
       audience: 'api://AzureADTokenExchange',
     });
   });
@@ -32,6 +31,7 @@ describe('Azure GitHub OIDC identity contract', () => {
     expect(workflow).toContain("IDENTITY_FILE='config/azure-github-oidc-identity.json'");
     expect(workflow).toContain('AZURE_CLIENT_ID_CANDIDATE');
     expect(workflow).toContain('CONFIG_CLIENT_ID');
+    expect(workflow).toContain("EXPECTED_SUBJECT='repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod'");
     expect(broker).toContain("import azureGitHubOidcIdentity from '@/config/azure-github-oidc-identity.json'");
     expect(broker).toContain('DSG_AZURE_GITHUB_OIDC_CLIENT_ID');
     expect(broker).not.toContain('process.env.AZURE_CLIENT_ID?.trim()');


### PR DESCRIPTION
## Root cause evidence
Production promotion run `33429266801` on exact main SHA `4984183deded51731524e48f0518de5fec7c9e61` passed identity resolution and fail-closed deployment preflight, then failed at `azure/login@v2` with `AADSTS700213`.

GitHub's actual federated token assertion was:

`repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod`

The Control Plane source-of-truth still expected the earlier non-standard subject containing numeric IDs.

## Azure-side remediation already verified
Cinema bootstrap run `33430316124` successfully updated `github-control-plane-prod` to the exact subject above and passed issuer/subject/audience readback. No client secret was created and no RBAC role was broadened.

## Change
- correct `config/azure-github-oidc-identity.json` to the actual GitHub assertion
- record the successful Azure federation bootstrap run and failed promotion run as evidence
- align `promoted-production-deploy-v2.yml` subject validation to the actual assertion
- align the unit contract test to the same source-of-truth

## Gates retained
No deployment gate is relaxed. Exact-main-SHA validation, protected production bindings, Azure target/slot verification, immutable ACR digest build, staging provenance/health, staging proof E2E, slot swap, production provenance, production proof E2E/live DB verification, and rollback behavior remain unchanged.

## Truth boundary
PR CI proves source consistency only. After CI is green, merge will use a `[prod-e2e]` commit title to invoke the existing governed production deployment. Production is not considered updated until exact SHA/digest, staging E2E, production E2E, and live broker evidence pass.