### PR TITLE
ops: prove Azure deployer mutation authority

### DIFF
--- a/.github/workflows/inspect-control-plane-deployer-authority.yml
+++ b/.github/workflows/inspect-control-plane-deployer-authority.yml
@@ -1,0 +1,363 @@
+name: Inspect Control Plane Deployer Authority
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/inspect-control-plane-deployer-authority.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/inspect-control-plane-deployer-authority.yml'
+
+permissions:
+  contents: read
+  id-token: write
+  statuses: write
+
+concurrency:
+  group: inspect-control-plane-deployer-authority
+  cancel-in-progress: false
+
+jobs:
+  validate-contract:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate read-only authority inspection
+        shell: bash
+        run: |
+          set -euo pipefail
+          file='.github/workflows/inspect-control-plane-deployer-authority.yml'
+          inspect_block="$(awk '/^  inspect-authority:/{found=1} found{print}' "$file")"
+          grep -Fq 'Microsoft.Authorization/permissions' <<<"$inspect_block"
+          grep -Fq 'role assignment list' <<<"$inspect_block"
+          grep -Fq -- '--include-inherited' <<<"$inspect_block"
+          grep -Fq 'role definition' <<<"$inspect_block"
+          grep -Fq 'microsoft.managedidentity/userassignedidentities/write' <<<"$inspect_block"
+          grep -Fq 'microsoft.managedidentity/userassignedidentities/assign/action' <<<"$inspect_block"
+          grep -Fq 'microsoft.web/sites/write' <<<"$inspect_block"
+          grep -Fq 'microsoft.web/sites/config/write' <<<"$inspect_block"
+          grep -Fq 'microsoft.web/serverfarms/join/action' <<<"$inspect_block"
+          grep -Fq 'microsoft.authorization/roleassignments/write' <<<"$inspect_block"
+          grep -Fq 'microsoft.keyvault/vaults/accesspolicies/write' <<<"$inspect_block"
+          grep -Fq 'steps.authority.outcome' <<<"$inspect_block"
+          if grep -Eq 'az [^\n]*[[:space:]](create|update|set|delete|assign|add|remove)([[:space:]]|$)|AZURE_CLIENT_SECRET' <<<"$inspect_block"; then
+            echo '::error::Deployer authority inspection must remain Azure-read-only and secretless.' >&2
+            exit 1
+          fi
+
+  inspect-authority:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: prod
+    timeout-minutes: 10
+    env:
+      AZURE_RESOURCE_GROUP: rg-t.dealer01-0468
+      AZURE_WEBAPP_NAME: dsg-control-plane
+      AZURE_KEY_VAULT_NAME: dsg-kv-tdealer01-0468
+      AZURE_ACR_NAME: dsgcp50aaef839
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve proven Azure GitHub OIDC identity
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          file='config/azure-github-oidc-identity.json'
+          client_id="$(jq -er '.clientId' "$file")"
+          tenant_id="$(jq -er '.tenantId' "$file")"
+          subscription_id="$(jq -er '.subscriptionId' "$file")"
+          test "$(jq -er '.resourceGroup' "$file")" = "$AZURE_RESOURCE_GROUP"
+          test "$(jq -er '.federatedSubject' "$file")" = 'repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod'
+          echo "::add-mask::$client_id"
+          echo "::add-mask::$tenant_id"
+          echo "::add-mask::$subscription_id"
+          echo "client_id=$client_id" >> "$GITHUB_OUTPUT"
+          echo "tenant_id=$tenant_id" >> "$GITHUB_OUTPUT"
+          echo "subscription_id=$subscription_id" >> "$GITHUB_OUTPUT"
+
+      - name: Publish pending authority statuses
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for context in \
+            azure/oidc-uami-write \
+            azure/oidc-uami-assign \
+            azure/oidc-webapp-write \
+            azure/oidc-webapp-config-write \
+            azure/oidc-plan-join \
+            azure/oidc-rbac-write-kv \
+            azure/oidc-rbac-write-acr \
+            azure/oidc-kv-access-policy-write
+          do
+            gh api --method POST -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state='pending' -f context="$context" \
+              -f description='read-only Azure authority inspection in progress'
+          done
+
+      - name: Login to Azure with GitHub OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ steps.identity.outputs.client_id }}
+          tenant-id: ${{ steps.identity.outputs.tenant_id }}
+          subscription-id: ${{ steps.identity.outputs.subscription_id }}
+
+      - name: Inspect effective deployer authority
+        id: authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+
+          RG_ID="$(az group show -n "$AZURE_RESOURCE_GROUP" --query id -o tsv)"
+          VAULT_ID="$(az keyvault show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_KEY_VAULT_NAME" --query id -o tsv)"
+          ACR_ID="$(az acr show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_ACR_NAME" --query id -o tsv)"
+          PLAN_ID="$(az webapp show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_WEBAPP_NAME" --query serverFarmId -o tsv)"
+          test -n "$RG_ID" && test -n "$VAULT_ID" && test -n "$ACR_ID" && test -n "$PLAN_ID"
+
+          ARM_TOKEN="$(az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv)"
+          test -n "$ARM_TOKEN"
+          PRINCIPAL_ID="$(TOKEN="$ARM_TOKEN" python3 - <<'PY'
+          import base64, json, os
+          token = os.environ['TOKEN']
+          part = token.split('.')[1]
+          part += '=' * (-len(part) % 4)
+          payload = json.loads(base64.urlsafe_b64decode(part.encode()))
+          oid = payload.get('oid') or payload.get('sub')
+          if not oid:
+              raise SystemExit('OID claim not found in ARM token')
+          print(oid)
+          PY
+          )"
+          unset ARM_TOKEN
+          test -n "$PRINCIPAL_ID"
+          echo "::add-mask::$PRINCIPAL_ID"
+
+          az role assignment list \
+            --assignee-object-id "$PRINCIPAL_ID" \
+            --all \
+            --include-inherited \
+            --fill-principal-name false \
+            -o json > /tmp/assignments.json
+
+          : > /tmp/roledefs.jsonl
+          jq -r '.[].roleDefinitionId' /tmp/assignments.json | sort -u | while IFS= read -r role_definition_id; do
+            [[ -n "$role_definition_id" ]] || continue
+            role_guid="${role_definition_id##*/}"
+            az role definition list --name "$role_guid" -o json \
+              | jq -c --arg id "$role_definition_id" '.[0] | {id: $id, roleName: .roleName, permissions: .permissions}' \
+              >> /tmp/roledefs.jsonl
+          done
+
+          az rest --method GET --url "https://management.azure.com${RG_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/rg-permissions.json
+          az rest --method GET --url "https://management.azure.com${VAULT_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/vault-permissions.json
+          az rest --method GET --url "https://management.azure.com${ACR_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/acr-permissions.json
+          az rest --method GET --url "https://management.azure.com${PLAN_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/plan-permissions.json
+
+          export RG_ID VAULT_ID ACR_ID PLAN_ID
+          python3 - <<'PY' > /tmp/authority.json
+          import fnmatch
+          import json
+          import os
+
+          with open('/tmp/assignments.json', encoding='utf-8') as fh:
+              assignments = json.load(fh)
+          roledefs = {}
+          with open('/tmp/roledefs.jsonl', encoding='utf-8') as fh:
+              for line in fh:
+                  if line.strip():
+                      item = json.loads(line)
+                      roledefs[item['id'].lower()] = item
+
+          permission_docs = {}
+          for name in ('rg', 'vault', 'acr', 'plan'):
+              with open(f'/tmp/{name}-permissions.json', encoding='utf-8') as fh:
+                  permission_docs[name] = json.load(fh)
+
+          scopes = {
+              'rg': os.environ['RG_ID'].lower().rstrip('/'),
+              'vault': os.environ['VAULT_ID'].lower().rstrip('/'),
+              'acr': os.environ['ACR_ID'].lower().rstrip('/'),
+              'plan': os.environ['PLAN_ID'].lower().rstrip('/'),
+          }
+
+          targets = {
+              'uami_write': ('rg', 'microsoft.managedidentity/userassignedidentities/write'),
+              'uami_assign': ('rg', 'microsoft.managedidentity/userassignedidentities/assign/action'),
+              'webapp_write': ('rg', 'microsoft.web/sites/write'),
+              'webapp_config_write': ('rg', 'microsoft.web/sites/config/write'),
+              'plan_join': ('plan', 'microsoft.web/serverfarms/join/action'),
+              'rbac_write_kv': ('vault', 'microsoft.authorization/roleassignments/write'),
+              'rbac_write_acr': ('acr', 'microsoft.authorization/roleassignments/write'),
+              'kv_access_policy_write': ('vault', 'microsoft.keyvault/vaults/accesspolicies/write'),
+          }
+
+          def matches(pattern, target):
+              return fnmatch.fnmatchcase(target, (pattern or '').lower())
+
+          def block_grants(block, target):
+              allowed = block.get('actions') or []
+              denied = block.get('notActions') or []
+              return any(matches(x, target) for x in allowed) and not any(matches(x, target) for x in denied)
+
+          def scope_applies(assignment_scope, target_scope):
+              assignment_scope = (assignment_scope or '').lower().rstrip('/')
+              return bool(assignment_scope) and (target_scope == assignment_scope or target_scope.startswith(assignment_scope + '/'))
+
+          def caller_permissions_grant(doc, target):
+              for block in doc.get('value') or []:
+                  if block_grants(block, target):
+                      return True
+              return False
+
+          result = {}
+          for key, (scope_key, action) in targets.items():
+              target_scope = scopes[scope_key]
+              unconditioned = []
+              conditioned = []
+              for assignment in assignments:
+                  if not scope_applies(assignment.get('scope'), target_scope):
+                      continue
+                  role = roledefs.get((assignment.get('roleDefinitionId') or '').lower())
+                  if not role:
+                      continue
+                  if not any(block_grants(block, action) for block in (role.get('permissions') or [])):
+                      continue
+                  row = {
+                      'role': role.get('roleName') or assignment.get('roleDefinitionName') or 'unknown',
+                      'scope': assignment.get('scope') or '',
+                  }
+                  if assignment.get('condition'):
+                      conditioned.append(row)
+                  else:
+                      unconditioned.append(row)
+
+              permission_api = caller_permissions_grant(permission_docs[scope_key], action)
+              proven = permission_api and bool(unconditioned)
+              result[key] = {
+                  'action': action,
+                  'scope': target_scope,
+                  'permissionApi': permission_api,
+                  'unconditionedRoleGrant': bool(unconditioned),
+                  'conditionedRoleGrantOnly': (not unconditioned and bool(conditioned)),
+                  'proven': proven,
+                  'roles': sorted({x['role'] for x in unconditioned}),
+                  'roleScopes': sorted({f"{x['role']}@{x['scope']}" for x in unconditioned}),
+              }
+
+          print(json.dumps(result, sort_keys=True, separators=(',', ':')))
+          PY
+
+          for key in uami_write uami_assign webapp_write webapp_config_write plan_join rbac_write_kv rbac_write_acr kv_access_policy_write; do
+            value="$(jq -r --arg key "$key" '.[$key].proven' /tmp/authority.json)"
+            conditioned="$(jq -r --arg key "$key" '.[$key].conditionedRoleGrantOnly' /tmp/authority.json)"
+            roles="$(jq -r --arg key "$key" '.[$key].roles | join(",")' /tmp/authority.json)"
+            echo "${key}=$value" >> "$GITHUB_OUTPUT"
+            echo "${key}_conditioned=$conditioned" >> "$GITHUB_OUTPUT"
+            echo "${key}_roles=$roles" >> "$GITHUB_OUTPUT"
+          done
+
+          rm -f /tmp/assignments.json /tmp/roledefs.jsonl /tmp/rg-permissions.json /tmp/vault-permissions.json /tmp/acr-permissions.json /tmp/plan-permissions.json /tmp/authority.json
+
+      - name: Publish proven authority statuses
+        if: steps.authority.outcome == 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UAMI_WRITE: ${{ steps.authority.outputs.uami_write }}
+          UAMI_WRITE_ROLES: ${{ steps.authority.outputs.uami_write_roles }}
+          UAMI_ASSIGN: ${{ steps.authority.outputs.uami_assign }}
+          UAMI_ASSIGN_ROLES: ${{ steps.authority.outputs.uami_assign_roles }}
+          WEBAPP_WRITE: ${{ steps.authority.outputs.webapp_write }}
+          WEBAPP_WRITE_ROLES: ${{ steps.authority.outputs.webapp_write_roles }}
+          WEBAPP_CONFIG_WRITE: ${{ steps.authority.outputs.webapp_config_write }}
+          WEBAPP_CONFIG_WRITE_ROLES: ${{ steps.authority.outputs.webapp_config_write_roles }}
+          PLAN_JOIN: ${{ steps.authority.outputs.plan_join }}
+          PLAN_JOIN_ROLES: ${{ steps.authority.outputs.plan_join_roles }}
+          RBAC_WRITE_KV: ${{ steps.authority.outputs.rbac_write_kv }}
+          RBAC_WRITE_KV_CONDITIONED: ${{ steps.authority.outputs.rbac_write_kv_conditioned }}
+          RBAC_WRITE_KV_ROLES: ${{ steps.authority.outputs.rbac_write_kv_roles }}
+          RBAC_WRITE_ACR: ${{ steps.authority.outputs.rbac_write_acr }}
+          RBAC_WRITE_ACR_CONDITIONED: ${{ steps.authority.outputs.rbac_write_acr_conditioned }}
+          RBAC_WRITE_ACR_ROLES: ${{ steps.authority.outputs.rbac_write_acr_roles }}
+          KV_POLICY_WRITE: ${{ steps.authority.outputs.kv_access_policy_write }}
+          KV_POLICY_WRITE_ROLES: ${{ steps.authority.outputs.kv_access_policy_write_roles }}
+        run: |
+          set -euo pipefail
+
+          publish() {
+            local context="$1" value="$2" roles="$3" extra="${4:-}"
+            local state=failure
+            [[ "$value" == true ]] && state=success
+            local desc="proven=$value"
+            [[ -z "$roles" ]] || desc="$desc; roles=$roles"
+            [[ -z "$extra" ]] || desc="$desc; $extra"
+            desc="${desc:0:140}"
+            gh api --method POST -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state="$state" -f context="$context" -f description="$desc"
+          }
+
+          publish azure/oidc-uami-write "$UAMI_WRITE" "$UAMI_WRITE_ROLES"
+          publish azure/oidc-uami-assign "$UAMI_ASSIGN" "$UAMI_ASSIGN_ROLES"
+          publish azure/oidc-webapp-write "$WEBAPP_WRITE" "$WEBAPP_WRITE_ROLES"
+          publish azure/oidc-webapp-config-write "$WEBAPP_CONFIG_WRITE" "$WEBAPP_CONFIG_WRITE_ROLES"
+          publish azure/oidc-plan-join "$PLAN_JOIN" "$PLAN_JOIN_ROLES"
+          publish azure/oidc-rbac-write-kv "$RBAC_WRITE_KV" "$RBAC_WRITE_KV_ROLES" "conditionalOnly=$RBAC_WRITE_KV_CONDITIONED"
+          publish azure/oidc-rbac-write-acr "$RBAC_WRITE_ACR" "$RBAC_WRITE_ACR_ROLES" "conditionalOnly=$RBAC_WRITE_ACR_CONDITIONED"
+          publish azure/oidc-kv-access-policy-write "$KV_POLICY_WRITE" "$KV_POLICY_WRITE_ROLES"
+
+      - name: Publish inspection failure statuses
+        if: always() && steps.authority.outcome != 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for context in \
+            azure/oidc-uami-write \
+            azure/oidc-uami-assign \
+            azure/oidc-webapp-write \
+            azure/oidc-webapp-config-write \
+            azure/oidc-plan-join \
+            azure/oidc-rbac-write-kv \
+            azure/oidc-rbac-write-acr \
+            azure/oidc-kv-access-policy-write
+          do
+            gh api --method POST -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state='failure' -f context="$context" \
+              -f description='authority inspection failed before proof; no mutation performed'
+          done
+
+      - name: Record authority summary
+        if: steps.authority.outcome == 'success'
+        shell: bash
+        env:
+          UAMI_WRITE: ${{ steps.authority.outputs.uami_write }}
+          UAMI_ASSIGN: ${{ steps.authority.outputs.uami_assign }}
+          WEBAPP_WRITE: ${{ steps.authority.outputs.webapp_write }}
+          WEBAPP_CONFIG_WRITE: ${{ steps.authority.outputs.webapp_config_write }}
+          PLAN_JOIN: ${{ steps.authority.outputs.plan_join }}
+          RBAC_WRITE_KV: ${{ steps.authority.outputs.rbac_write_kv }}
+          RBAC_WRITE_ACR: ${{ steps.authority.outputs.rbac_write_acr }}
+          KV_POLICY_WRITE: ${{ steps.authority.outputs.kv_access_policy_write }}
+        run: |
+          {
+            echo '## GitHub OIDC deployer authority proof'
+            echo '- Azure mutation performed: no'
+            echo "- create UAMI: $UAMI_WRITE"
+            echo "- assign UAMI: $UAMI_ASSIGN"
+            echo "- create/update Web App: $WEBAPP_WRITE"
+            echo "- write Web App config: $WEBAPP_CONFIG_WRITE"
+            echo "- join existing App Service plan: $PLAN_JOIN"
+            echo "- create RBAC assignment at Key Vault: $RBAC_WRITE_KV"
+            echo "- create RBAC assignment at ACR: $RBAC_WRITE_ACR"
+            echo "- write Key Vault access policy: $KV_POLICY_WRITE"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/inspect-control-plane-deployer-authority.yml
+++ b/.github/workflows/inspect-control-plane-deployer-authority.yml
@@ -30,9 +30,13 @@ jobs:
           set -euo pipefail
           file='.github/workflows/inspect-control-plane-deployer-authority.yml'
           inspect_block="$(awk '/^  inspect-authority:/{found=1} found{print}' "$file")"
+          mutation_re='(^|[^[:alnum:]_])az[[:space:]][^[:cntrl:]]*[[:space:]](create|update|set|delete|assign|add|remove)([[:space:]]|$)'
+
           grep -Fq 'Microsoft.Authorization/permissions' <<<"$inspect_block"
-          grep -Fq 'role assignment list' <<<"$inspect_block"
+          grep -Fq 'nextLink' <<<"$inspect_block"
+          grep -Fq -- '--include-groups' <<<"$inspect_block"
           grep -Fq -- '--include-inherited' <<<"$inspect_block"
+          grep -Fq -- '--scope "$scope"' <<<"$inspect_block"
           grep -Fq 'role definition' <<<"$inspect_block"
           grep -Fq 'microsoft.managedidentity/userassignedidentities/write' <<<"$inspect_block"
           grep -Fq 'microsoft.managedidentity/userassignedidentities/assign/action' <<<"$inspect_block"
@@ -41,8 +45,23 @@ jobs:
           grep -Fq 'microsoft.web/serverfarms/join/action' <<<"$inspect_block"
           grep -Fq 'microsoft.authorization/roleassignments/write' <<<"$inspect_block"
           grep -Fq 'microsoft.keyvault/vaults/accesspolicies/write' <<<"$inspect_block"
-          grep -Fq 'steps.authority.outcome' <<<"$inspect_block"
-          if grep -Eq 'az [^\n]*[[:space:]](create|update|set|delete|assign|add|remove)([[:space:]]|$)|AZURE_CLIENT_SECRET' <<<"$inspect_block"; then
+          grep -Fq 'steps.publish.outcome' <<<"$inspect_block"
+
+          for sample in \
+            'az identity create -g rg -n uami' \
+            'az role assignment create --role Reader --scope /x' \
+            'x="$(az webapp config appsettings set -g rg -n app --settings A=B)"' \
+            'az resource update --ids /x'; do
+            if ! grep -Eq "$mutation_re" <<<"$sample"; then
+              echo "::error::Mutation guard missed prohibited sample: $sample" >&2
+              exit 1
+            fi
+          done
+          if grep -Eq "$mutation_re" <<< 'az role assignment list --scope /x'; then
+            echo '::error::Mutation guard rejected a read-only Azure command.' >&2
+            exit 1
+          fi
+          if grep -Eq "$mutation_re" <<<"$inspect_block" || grep -Fq 'AZURE_CLIENT_SECRET' <<<"$inspect_block"; then
             echo '::error::Deployer authority inspection must remain Azure-read-only and secretless.' >&2
             exit 1
           fi
@@ -79,12 +98,14 @@ jobs:
           echo "subscription_id=$subscription_id" >> "$GITHUB_OUTPUT"
 
       - name: Publish pending authority statuses
+        id: pending
         continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -u
+          failed=0
           for context in \
             azure/oidc-uami-write \
             azure/oidc-uami-assign \
@@ -93,13 +114,13 @@ jobs:
             azure/oidc-plan-join \
             azure/oidc-rbac-write-kv \
             azure/oidc-rbac-write-acr \
-            azure/oidc-kv-access-policy-write
-          do
+            azure/oidc-kv-access-policy-write; do
             gh api --method POST -H 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
               -f state='pending' -f context="$context" \
-              -f description='read-only Azure authority inspection in progress'
+              -f description='read-only Azure authority inspection in progress' || failed=1
           done
+          exit "$failed"
 
       - name: Login to Azure with GitHub OIDC
         uses: azure/login@v2
@@ -126,9 +147,9 @@ jobs:
           PRINCIPAL_ID="$(TOKEN="$ARM_TOKEN" python3 - <<'PY'
           import base64, json, os
           token = os.environ['TOKEN']
-          part = token.split('.')[1]
-          part += '=' * (-len(part) % 4)
-          payload = json.loads(base64.urlsafe_b64decode(part.encode()))
+          payload_part = token.split('.')[1]
+          payload_part += '=' * (-len(payload_part) % 4)
+          payload = json.loads(base64.urlsafe_b64decode(payload_part.encode()))
           oid = payload.get('oid') or payload.get('sub')
           if not oid:
               raise SystemExit('OID claim not found in ARM token')
@@ -139,15 +160,48 @@ jobs:
           test -n "$PRINCIPAL_ID"
           echo "::add-mask::$PRINCIPAL_ID"
 
-          az role assignment list \
-            --assignee-object-id "$PRINCIPAL_ID" \
-            --all \
-            --include-inherited \
-            --fill-principal-name false \
-            -o json > /tmp/assignments.json
+          fetch_permissions() {
+            local first_url="$1" out="$2" page='/tmp/permission-page.json' merged='/tmp/permission-merged.json'
+            printf '{"value":[]}\n' > "$out"
+            local url="$first_url" pages=0
+            while [[ -n "$url" ]]; do
+              pages=$((pages + 1))
+              [[ "$pages" -le 100 ]] || { echo '::error::Permission pagination exceeded 100 pages.' >&2; return 1; }
+              az rest --method GET --url "$url" > "$page"
+              jq -s '{value: ((.[0].value // []) + (.[1].value // []))}' "$out" "$page" > "$merged"
+              mv "$merged" "$out"
+              url="$(jq -r '.nextLink // empty' "$page")"
+            done
+          }
+
+          fetch_permissions "https://management.azure.com${RG_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" /tmp/rg-permissions.json
+          fetch_permissions "https://management.azure.com${VAULT_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" /tmp/vault-permissions.json
+          fetch_permissions "https://management.azure.com${ACR_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" /tmp/acr-permissions.json
+          fetch_permissions "https://management.azure.com${PLAN_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" /tmp/plan-permissions.json
+
+          role_context() {
+            local scope="$1" out="$2"
+            if az role assignment list \
+              --assignee "$PRINCIPAL_ID" \
+              --scope "$scope" \
+              --include-inherited \
+              --include-groups \
+              --fill-principal-name false \
+              --fill-role-definition-name false \
+              -o json > "$out"; then
+              return 0
+            fi
+            printf '[]\n' > "$out"
+            return 1
+          }
+
+          VAULT_ROLE_CONTEXT=true
+          ACR_ROLE_CONTEXT=true
+          role_context "$VAULT_ID" /tmp/vault-role-assignments.json || VAULT_ROLE_CONTEXT=false
+          role_context "$ACR_ID" /tmp/acr-role-assignments.json || ACR_ROLE_CONTEXT=false
 
           : > /tmp/roledefs.jsonl
-          jq -r '.[].roleDefinitionId' /tmp/assignments.json | sort -u | while IFS= read -r role_definition_id; do
+          jq -r '.[].roleDefinitionId' /tmp/vault-role-assignments.json /tmp/acr-role-assignments.json | sort -u | while IFS= read -r role_definition_id; do
             [[ -n "$role_definition_id" ]] || continue
             role_guid="${role_definition_id##*/}"
             az role definition list --name "$role_guid" -o json \
@@ -155,37 +209,30 @@ jobs:
               >> /tmp/roledefs.jsonl
           done
 
-          az rest --method GET --url "https://management.azure.com${RG_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/rg-permissions.json
-          az rest --method GET --url "https://management.azure.com${VAULT_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/vault-permissions.json
-          az rest --method GET --url "https://management.azure.com${ACR_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/acr-permissions.json
-          az rest --method GET --url "https://management.azure.com${PLAN_ID}/providers/Microsoft.Authorization/permissions?api-version=2022-04-01" > /tmp/plan-permissions.json
-
-          export RG_ID VAULT_ID ACR_ID PLAN_ID
+          export VAULT_ROLE_CONTEXT ACR_ROLE_CONTEXT
           python3 - <<'PY' > /tmp/authority.json
-          import fnmatch
-          import json
-          import os
+          import fnmatch, json, os
 
-          with open('/tmp/assignments.json', encoding='utf-8') as fh:
-              assignments = json.load(fh)
+          def load(path):
+              with open(path, encoding='utf-8') as fh:
+                  return json.load(fh)
+
+          docs = {
+              'rg': load('/tmp/rg-permissions.json'),
+              'vault': load('/tmp/vault-permissions.json'),
+              'acr': load('/tmp/acr-permissions.json'),
+              'plan': load('/tmp/plan-permissions.json'),
+          }
+          assignments = {
+              'vault': load('/tmp/vault-role-assignments.json'),
+              'acr': load('/tmp/acr-role-assignments.json'),
+          }
           roledefs = {}
           with open('/tmp/roledefs.jsonl', encoding='utf-8') as fh:
               for line in fh:
                   if line.strip():
                       item = json.loads(line)
                       roledefs[item['id'].lower()] = item
-
-          permission_docs = {}
-          for name in ('rg', 'vault', 'acr', 'plan'):
-              with open(f'/tmp/{name}-permissions.json', encoding='utf-8') as fh:
-                  permission_docs[name] = json.load(fh)
-
-          scopes = {
-              'rg': os.environ['RG_ID'].lower().rstrip('/'),
-              'vault': os.environ['VAULT_ID'].lower().rstrip('/'),
-              'acr': os.environ['ACR_ID'].lower().rstrip('/'),
-              'plan': os.environ['PLAN_ID'].lower().rstrip('/'),
-          }
 
           targets = {
               'uami_write': ('rg', 'microsoft.managedidentity/userassignedidentities/write'),
@@ -201,125 +248,114 @@ jobs:
           def matches(pattern, target):
               return fnmatch.fnmatchcase(target, (pattern or '').lower())
 
-          def block_grants(block, target):
-              allowed = block.get('actions') or []
-              denied = block.get('notActions') or []
+          def grants(block, target, allow='actions', deny='notActions'):
+              allowed = block.get(allow) or []
+              denied = block.get(deny) or []
               return any(matches(x, target) for x in allowed) and not any(matches(x, target) for x in denied)
 
-          def scope_applies(assignment_scope, target_scope):
-              assignment_scope = (assignment_scope or '').lower().rstrip('/')
-              return bool(assignment_scope) and (target_scope == assignment_scope or target_scope.startswith(assignment_scope + '/'))
+          def permission_api(scope_key, action):
+              return any(grants(block, action) for block in docs[scope_key].get('value') or [])
 
-          def caller_permissions_grant(doc, target):
-              for block in doc.get('value') or []:
-                  if block_grants(block, target):
-                      return True
-              return False
+          def unconditional_role_grants(scope_key, action):
+              rows = []
+              conditioned = []
+              for assignment in assignments[scope_key]:
+                  role = roledefs.get((assignment.get('roleDefinitionId') or '').lower())
+                  if not role or not any(grants(block, action) for block in role.get('permissions') or []):
+                      continue
+                  role_name = role.get('roleName') or assignment.get('roleDefinitionName') or 'unknown'
+                  row = {'role': role_name, 'scope': assignment.get('scope') or ''}
+                  (conditioned if assignment.get('condition') else rows).append(row)
+              return rows, conditioned
 
           result = {}
           for key, (scope_key, action) in targets.items():
-              target_scope = scopes[scope_key]
-              unconditioned = []
-              conditioned = []
-              for assignment in assignments:
-                  if not scope_applies(assignment.get('scope'), target_scope):
-                      continue
-                  role = roledefs.get((assignment.get('roleDefinitionId') or '').lower())
-                  if not role:
-                      continue
-                  if not any(block_grants(block, action) for block in (role.get('permissions') or [])):
-                      continue
-                  row = {
-                      'role': role.get('roleName') or assignment.get('roleDefinitionName') or 'unknown',
-                      'scope': assignment.get('scope') or '',
-                  }
-                  if assignment.get('condition'):
-                      conditioned.append(row)
-                  else:
-                      unconditioned.append(row)
-
-              permission_api = caller_permissions_grant(permission_docs[scope_key], action)
-              proven = permission_api and bool(unconditioned)
-              result[key] = {
+              api_effective = permission_api(scope_key, action)
+              entry = {
                   'action': action,
-                  'scope': target_scope,
-                  'permissionApi': permission_api,
-                  'unconditionedRoleGrant': bool(unconditioned),
-                  'conditionedRoleGrantOnly': (not unconditioned and bool(conditioned)),
-                  'proven': proven,
-                  'roles': sorted({x['role'] for x in unconditioned}),
-                  'roleScopes': sorted({f"{x['role']}@{x['scope']}" for x in unconditioned}),
+                  'permissionApi': api_effective,
+                  'proven': api_effective,
+                  'roleContextAvailable': True,
+                  'unconditionedRoleGrant': None,
+                  'conditionedRoleGrantOnly': False,
+                  'roles': [],
               }
+              if key in ('rbac_write_kv', 'rbac_write_acr'):
+                  context_available = os.environ['VAULT_ROLE_CONTEXT' if scope_key == 'vault' else 'ACR_ROLE_CONTEXT'].lower() == 'true'
+                  rows, conditioned = unconditional_role_grants(scope_key, action) if context_available else ([], [])
+                  entry['roleContextAvailable'] = context_available
+                  entry['unconditionedRoleGrant'] = bool(rows)
+                  entry['conditionedRoleGrantOnly'] = (not rows and bool(conditioned))
+                  entry['roles'] = sorted({row['role'] for row in rows})
+                  entry['proven'] = api_effective and context_available and bool(rows)
+              result[key] = entry
 
           print(json.dumps(result, sort_keys=True, separators=(',', ':')))
           PY
 
           for key in uami_write uami_assign webapp_write webapp_config_write plan_join rbac_write_kv rbac_write_acr kv_access_policy_write; do
-            value="$(jq -r --arg key "$key" '.[$key].proven' /tmp/authority.json)"
-            conditioned="$(jq -r --arg key "$key" '.[$key].conditionedRoleGrantOnly' /tmp/authority.json)"
-            roles="$(jq -r --arg key "$key" '.[$key].roles | join(",")' /tmp/authority.json)"
-            echo "${key}=$value" >> "$GITHUB_OUTPUT"
-            echo "${key}_conditioned=$conditioned" >> "$GITHUB_OUTPUT"
-            echo "${key}_roles=$roles" >> "$GITHUB_OUTPUT"
+            echo "${key}=$(jq -r --arg key "$key" '.[$key].proven' /tmp/authority.json)" >> "$GITHUB_OUTPUT"
+            echo "${key}_api=$(jq -r --arg key "$key" '.[$key].permissionApi' /tmp/authority.json)" >> "$GITHUB_OUTPUT"
+            echo "${key}_role_context=$(jq -r --arg key "$key" '.[$key].roleContextAvailable' /tmp/authority.json)" >> "$GITHUB_OUTPUT"
+            echo "${key}_conditioned=$(jq -r --arg key "$key" '.[$key].conditionedRoleGrantOnly' /tmp/authority.json)" >> "$GITHUB_OUTPUT"
+            echo "${key}_roles=$(jq -r --arg key "$key" '.[$key].roles | join(",")' /tmp/authority.json)" >> "$GITHUB_OUTPUT"
           done
 
-          rm -f /tmp/assignments.json /tmp/roledefs.jsonl /tmp/rg-permissions.json /tmp/vault-permissions.json /tmp/acr-permissions.json /tmp/plan-permissions.json /tmp/authority.json
+          rm -f /tmp/permission-page.json /tmp/permission-merged.json /tmp/rg-permissions.json /tmp/vault-permissions.json /tmp/acr-permissions.json /tmp/plan-permissions.json /tmp/vault-role-assignments.json /tmp/acr-role-assignments.json /tmp/roledefs.jsonl /tmp/authority.json
 
-      - name: Publish proven authority statuses
+      - name: Publish terminal authority statuses
+        id: publish
         if: steps.authority.outcome == 'success'
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           UAMI_WRITE: ${{ steps.authority.outputs.uami_write }}
-          UAMI_WRITE_ROLES: ${{ steps.authority.outputs.uami_write_roles }}
           UAMI_ASSIGN: ${{ steps.authority.outputs.uami_assign }}
-          UAMI_ASSIGN_ROLES: ${{ steps.authority.outputs.uami_assign_roles }}
           WEBAPP_WRITE: ${{ steps.authority.outputs.webapp_write }}
-          WEBAPP_WRITE_ROLES: ${{ steps.authority.outputs.webapp_write_roles }}
           WEBAPP_CONFIG_WRITE: ${{ steps.authority.outputs.webapp_config_write }}
-          WEBAPP_CONFIG_WRITE_ROLES: ${{ steps.authority.outputs.webapp_config_write_roles }}
           PLAN_JOIN: ${{ steps.authority.outputs.plan_join }}
-          PLAN_JOIN_ROLES: ${{ steps.authority.outputs.plan_join_roles }}
           RBAC_WRITE_KV: ${{ steps.authority.outputs.rbac_write_kv }}
+          RBAC_WRITE_KV_API: ${{ steps.authority.outputs.rbac_write_kv_api }}
+          RBAC_WRITE_KV_CONTEXT: ${{ steps.authority.outputs.rbac_write_kv_role_context }}
           RBAC_WRITE_KV_CONDITIONED: ${{ steps.authority.outputs.rbac_write_kv_conditioned }}
           RBAC_WRITE_KV_ROLES: ${{ steps.authority.outputs.rbac_write_kv_roles }}
           RBAC_WRITE_ACR: ${{ steps.authority.outputs.rbac_write_acr }}
+          RBAC_WRITE_ACR_API: ${{ steps.authority.outputs.rbac_write_acr_api }}
+          RBAC_WRITE_ACR_CONTEXT: ${{ steps.authority.outputs.rbac_write_acr_role_context }}
           RBAC_WRITE_ACR_CONDITIONED: ${{ steps.authority.outputs.rbac_write_acr_conditioned }}
           RBAC_WRITE_ACR_ROLES: ${{ steps.authority.outputs.rbac_write_acr_roles }}
           KV_POLICY_WRITE: ${{ steps.authority.outputs.kv_access_policy_write }}
-          KV_POLICY_WRITE_ROLES: ${{ steps.authority.outputs.kv_access_policy_write_roles }}
         run: |
-          set -euo pipefail
-
+          set -u
+          failed=0
           publish() {
-            local context="$1" value="$2" roles="$3" extra="${4:-}"
-            local state=failure
+            local context="$1" value="$2" extra="${3:-}"
+            local state=failure desc="proven=$value"
             [[ "$value" == true ]] && state=success
-            local desc="proven=$value"
-            [[ -z "$roles" ]] || desc="$desc; roles=$roles"
             [[ -z "$extra" ]] || desc="$desc; $extra"
-            desc="${desc:0:140}"
             gh api --method POST -H 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-              -f state="$state" -f context="$context" -f description="$desc"
+              -f state="$state" -f context="$context" -f description="${desc:0:140}" || failed=1
           }
+          publish azure/oidc-uami-write "$UAMI_WRITE"
+          publish azure/oidc-uami-assign "$UAMI_ASSIGN"
+          publish azure/oidc-webapp-write "$WEBAPP_WRITE"
+          publish azure/oidc-webapp-config-write "$WEBAPP_CONFIG_WRITE"
+          publish azure/oidc-plan-join "$PLAN_JOIN"
+          publish azure/oidc-rbac-write-kv "$RBAC_WRITE_KV" "api=$RBAC_WRITE_KV_API; roleContext=$RBAC_WRITE_KV_CONTEXT; conditionalOnly=$RBAC_WRITE_KV_CONDITIONED; roles=$RBAC_WRITE_KV_ROLES"
+          publish azure/oidc-rbac-write-acr "$RBAC_WRITE_ACR" "api=$RBAC_WRITE_ACR_API; roleContext=$RBAC_WRITE_ACR_CONTEXT; conditionalOnly=$RBAC_WRITE_ACR_CONDITIONED; roles=$RBAC_WRITE_ACR_ROLES"
+          publish azure/oidc-kv-access-policy-write "$KV_POLICY_WRITE"
+          exit "$failed"
 
-          publish azure/oidc-uami-write "$UAMI_WRITE" "$UAMI_WRITE_ROLES"
-          publish azure/oidc-uami-assign "$UAMI_ASSIGN" "$UAMI_ASSIGN_ROLES"
-          publish azure/oidc-webapp-write "$WEBAPP_WRITE" "$WEBAPP_WRITE_ROLES"
-          publish azure/oidc-webapp-config-write "$WEBAPP_CONFIG_WRITE" "$WEBAPP_CONFIG_WRITE_ROLES"
-          publish azure/oidc-plan-join "$PLAN_JOIN" "$PLAN_JOIN_ROLES"
-          publish azure/oidc-rbac-write-kv "$RBAC_WRITE_KV" "$RBAC_WRITE_KV_ROLES" "conditionalOnly=$RBAC_WRITE_KV_CONDITIONED"
-          publish azure/oidc-rbac-write-acr "$RBAC_WRITE_ACR" "$RBAC_WRITE_ACR_ROLES" "conditionalOnly=$RBAC_WRITE_ACR_CONDITIONED"
-          publish azure/oidc-kv-access-policy-write "$KV_POLICY_WRITE" "$KV_POLICY_WRITE_ROLES"
-
-      - name: Publish inspection failure statuses
-        if: always() && steps.authority.outcome != 'success'
+      - name: Finalize authority statuses on inspection or publication failure
+        if: always() && (steps.authority.outcome != 'success' || steps.publish.outcome != 'success')
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -u
           for context in \
             azure/oidc-uami-write \
             azure/oidc-uami-assign \
@@ -328,12 +364,11 @@ jobs:
             azure/oidc-plan-join \
             azure/oidc-rbac-write-kv \
             azure/oidc-rbac-write-acr \
-            azure/oidc-kv-access-policy-write
-          do
+            azure/oidc-kv-access-policy-write; do
             gh api --method POST -H 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
               -f state='failure' -f context="$context" \
-              -f description='authority inspection failed before proof; no mutation performed'
+              -f description='authority proof incomplete; no Azure mutation performed' || true
           done
 
       - name: Record authority summary
@@ -350,7 +385,7 @@ jobs:
           KV_POLICY_WRITE: ${{ steps.authority.outputs.kv_access_policy_write }}
         run: |
           {
-            echo '## GitHub OIDC deployer authority proof'
+            echo '## GitHub OIDC deployer authority proof v2'
             echo '- Azure mutation performed: no'
             echo "- create UAMI: $UAMI_WRITE"
             echo "- assign UAMI: $UAMI_ASSIGN"

--- a/.github/workflows/inspect-control-plane-runtime-access-v2.yml
+++ b/.github/workflows/inspect-control-plane-runtime-access-v2.yml
@@ -1,0 +1,339 @@
+name: Inspect Control Plane Runtime Access v2
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/inspect-control-plane-runtime-access-v2.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/inspect-control-plane-runtime-access-v2.yml'
+
+permissions:
+  contents: read
+  id-token: write
+  statuses: write
+
+concurrency:
+  group: inspect-control-plane-runtime-access-v2
+  cancel-in-progress: false
+
+jobs:
+  validate-contract:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate read-only runtime access inspection
+        shell: bash
+        run: |
+          set -euo pipefail
+          file='.github/workflows/inspect-control-plane-runtime-access-v2.yml'
+          inspect_block="$(awk '/^  inspect-runtime-access:/{found=1} found{print}' "$file")"
+          grep -Fq 'role assignment list' <<<"$inspect_block"
+          grep -Fq -- '--include-inherited' <<<"$inspect_block"
+          grep -Fq -- '--fill-principal-name false' <<<"$inspect_block"
+          grep -Fq 'role definition' <<<"$inspect_block"
+          grep -Fq 'roleAssignmentMode' <<<"$inspect_block"
+          grep -Fq 'microsoft.keyvault/vaults/secrets/getsecret/action' <<<"$inspect_block"
+          grep -Fq 'microsoft.containerregistry/registries/pull/read' <<<"$inspect_block"
+          grep -Fq 'microsoft.containerregistry/registries/repositories/content/read' <<<"$inspect_block"
+          grep -Fq 'azure/runtime-keyvault-secret-get' <<<"$inspect_block"
+          grep -Fq 'azure/runtime-acr-pull' <<<"$inspect_block"
+          grep -Fq 'steps.access.outcome' <<<"$inspect_block"
+          if grep -Eq 'az [^\n]*[[:space:]](create|update|set|delete|assign|add|remove)([[:space:]]|$)|AZURE_CLIENT_SECRET' <<<"$inspect_block"; then
+            echo '::error::Runtime access inspection must remain Azure-read-only and secretless.' >&2
+            exit 1
+          fi
+
+  inspect-runtime-access:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: prod
+    timeout-minutes: 10
+    env:
+      AZURE_RESOURCE_GROUP: rg-t.dealer01-0468
+      AZURE_WEBAPP_NAME: dsg-control-plane
+      AZURE_KEY_VAULT_NAME: dsg-kv-tdealer01-0468
+      AZURE_ACR_NAME: dsgcp50aaef839
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve proven Azure GitHub OIDC identity
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          file='config/azure-github-oidc-identity.json'
+          client_id="$(jq -er '.clientId' "$file")"
+          tenant_id="$(jq -er '.tenantId' "$file")"
+          subscription_id="$(jq -er '.subscriptionId' "$file")"
+          test "$(jq -er '.resourceGroup' "$file")" = "$AZURE_RESOURCE_GROUP"
+          test "$(jq -er '.federatedSubject' "$file")" = 'repo:tdealer01-crypto/tdealer01-crypto-dsg-control-plane:environment:prod'
+          echo "::add-mask::$client_id"
+          echo "::add-mask::$tenant_id"
+          echo "::add-mask::$subscription_id"
+          echo "client_id=$client_id" >> "$GITHUB_OUTPUT"
+          echo "tenant_id=$tenant_id" >> "$GITHUB_OUTPUT"
+          echo "subscription_id=$subscription_id" >> "$GITHUB_OUTPUT"
+
+      - name: Publish pending runtime-access statuses
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for context in azure/runtime-keyvault-secret-get azure/runtime-acr-pull; do
+            gh api --method POST -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state='pending' -f context="$context" \
+              -f description='read-only Azure runtime-access inspection in progress'
+          done
+
+      - name: Login to Azure with GitHub OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ steps.identity.outputs.client_id }}
+          tenant-id: ${{ steps.identity.outputs.tenant_id }}
+          subscription-id: ${{ steps.identity.outputs.subscription_id }}
+
+      - name: Inspect effective production runtime access
+        id: access
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+
+          PRINCIPAL_ID="$(az webapp identity show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_WEBAPP_NAME" --query principalId -o tsv)"
+          test -n "$PRINCIPAL_ID"
+          echo "::add-mask::$PRINCIPAL_ID"
+
+          VAULT_ID="$(az keyvault show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_KEY_VAULT_NAME" --query id -o tsv)"
+          ACR_ID="$(az acr show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_ACR_NAME" --query id -o tsv)"
+          ACR_MODE="$(az acr show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_ACR_NAME" --query roleAssignmentMode -o tsv)"
+          VAULT_RBAC="$(az keyvault show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_KEY_VAULT_NAME" --query properties.enableRbacAuthorization -o tsv)"
+          test -n "$VAULT_ID" && test -n "$ACR_ID" && test -n "$ACR_MODE"
+          [[ -n "$VAULT_RBAC" ]] || VAULT_RBAC=false
+
+          az role assignment list \
+            --assignee-object-id "$PRINCIPAL_ID" \
+            --all \
+            --include-inherited \
+            --fill-principal-name false \
+            -o json > /tmp/runtime-assignments.json
+
+          : > /tmp/runtime-roledefs.jsonl
+          jq -r '.[].roleDefinitionId' /tmp/runtime-assignments.json | sort -u | while IFS= read -r role_definition_id; do
+            [[ -n "$role_definition_id" ]] || continue
+            role_guid="${role_definition_id##*/}"
+            az role definition list --name "$role_guid" -o json \
+              | jq -c --arg id "$role_definition_id" '.[0] | {id: $id, roleName: .roleName, permissions: .permissions}' \
+              >> /tmp/runtime-roledefs.jsonl
+          done
+
+          ACCESS_POLICY_PRESENT=false
+          ACCESS_POLICY_SECRET_PERMS=''
+          if [[ "$VAULT_RBAC" != true ]]; then
+            az keyvault show -g "$AZURE_RESOURCE_GROUP" -n "$AZURE_KEY_VAULT_NAME" -o json > /tmp/runtime-vault.json
+            POLICY_COUNT="$(jq --arg oid "$PRINCIPAL_ID" '[.properties.accessPolicies[]? | select((.objectId | ascii_downcase) == ($oid | ascii_downcase))] | length' /tmp/runtime-vault.json)"
+            if [[ "$POLICY_COUNT" -gt 0 ]]; then
+              ACCESS_POLICY_PRESENT=true
+              ACCESS_POLICY_SECRET_PERMS="$(jq -r --arg oid "$PRINCIPAL_ID" '[.properties.accessPolicies[]? | select((.objectId | ascii_downcase) == ($oid | ascii_downcase)) | .permissions.secrets[]?] | map(ascii_downcase) | sort | unique | join(",")' /tmp/runtime-vault.json)"
+            fi
+          fi
+
+          export VAULT_ID ACR_ID ACR_MODE VAULT_RBAC ACCESS_POLICY_PRESENT ACCESS_POLICY_SECRET_PERMS
+          python3 - <<'PY' > /tmp/runtime-access.json
+          import fnmatch
+          import json
+          import os
+
+          with open('/tmp/runtime-assignments.json', encoding='utf-8') as fh:
+              assignments = json.load(fh)
+          roledefs = {}
+          with open('/tmp/runtime-roledefs.jsonl', encoding='utf-8') as fh:
+              for line in fh:
+                  if line.strip():
+                      item = json.loads(line)
+                      roledefs[item['id'].lower()] = item
+
+          vault_id = os.environ['VAULT_ID'].lower().rstrip('/')
+          acr_id = os.environ['ACR_ID'].lower().rstrip('/')
+          acr_mode = os.environ['ACR_MODE'].strip().lower()
+          vault_rbac = os.environ['VAULT_RBAC'].lower() == 'true'
+          access_policy_present = os.environ['ACCESS_POLICY_PRESENT'].lower() == 'true'
+          access_policy_secret_perms = {
+              p.strip().lower()
+              for p in os.environ.get('ACCESS_POLICY_SECRET_PERMS', '').split(',')
+              if p.strip()
+          }
+
+          kv_target = 'microsoft.keyvault/vaults/secrets/getsecret/action'
+          acr_rbac_target = 'microsoft.containerregistry/registries/pull/read'
+          acr_abac_target = 'microsoft.containerregistry/registries/repositories/content/read'
+          abac = acr_mode == 'rbac-abac'
+          acr_target = acr_abac_target if abac else acr_rbac_target
+          acr_allow_key = 'dataActions' if abac else 'actions'
+          acr_deny_key = 'notDataActions' if abac else 'notActions'
+
+          def matches(pattern, target):
+              return fnmatch.fnmatchcase(target, (pattern or '').lower())
+
+          def scope_applies(assignment_scope, target_scope):
+              assignment_scope = (assignment_scope or '').lower().rstrip('/')
+              return bool(assignment_scope) and (target_scope == assignment_scope or target_scope.startswith(assignment_scope + '/'))
+
+          def role_grants(role, target, allow_key, deny_key):
+              for block in role.get('permissions') or []:
+                  allowed = block.get(allow_key) or []
+                  denied = block.get(deny_key) or []
+                  if any(matches(x, target) for x in allowed) and not any(matches(x, target) for x in denied):
+                      return True
+              return False
+
+          def qualifying(target_scope, target_action, allow_key, deny_key):
+              unconditioned = []
+              conditioned = []
+              for assignment in assignments:
+                  if not scope_applies(assignment.get('scope'), target_scope):
+                      continue
+                  role = roledefs.get((assignment.get('roleDefinitionId') or '').lower())
+                  if not role or not role_grants(role, target_action, allow_key, deny_key):
+                      continue
+                  row = {
+                      'role': role.get('roleName') or assignment.get('roleDefinitionName') or 'unknown',
+                      'scope': assignment.get('scope') or '',
+                  }
+                  if assignment.get('condition'):
+                      conditioned.append(row)
+                  else:
+                      unconditioned.append(row)
+              return unconditioned, conditioned
+
+          kv_roles, kv_conditioned = qualifying(vault_id, kv_target, 'dataActions', 'notDataActions')
+          acr_roles, acr_conditioned = qualifying(acr_id, acr_target, acr_allow_key, acr_deny_key)
+
+          if vault_rbac:
+              kv_model = 'rbac'
+              kv_effective = bool(kv_roles)
+              kv_conditional_only = not kv_roles and bool(kv_conditioned)
+          else:
+              kv_model = 'access-policy'
+              kv_effective = access_policy_present and 'get' in access_policy_secret_perms
+              kv_conditional_only = False
+
+          result = {
+              'keyVaultAccessModel': kv_model,
+              'keyVaultSecretGetEffective': kv_effective,
+              'keyVaultConditionalOnly': kv_conditional_only,
+              'keyVaultRoles': sorted({x['role'] for x in kv_roles}),
+              'keyVaultRoleScopes': sorted({f"{x['role']}@{x['scope']}" for x in kv_roles}),
+              'keyVaultAccessPolicyPresent': access_policy_present,
+              'keyVaultAccessPolicySecretPermissions': sorted(access_policy_secret_perms),
+              'acrRoleAssignmentMode': acr_mode,
+              'acrPermissionTarget': acr_target,
+              'acrPullEffective': bool(acr_roles),
+              'acrConditionalOnly': not acr_roles and bool(acr_conditioned),
+              'acrRoles': sorted({x['role'] for x in acr_roles}),
+              'acrRoleScopes': sorted({f"{x['role']}@{x['scope']}" for x in acr_roles}),
+          }
+          print(json.dumps(result, sort_keys=True, separators=(',', ':')))
+          PY
+
+          KEY_VAULT_MODEL="$(jq -r '.keyVaultAccessModel' /tmp/runtime-access.json)"
+          KEY_VAULT_EFFECTIVE="$(jq -r '.keyVaultSecretGetEffective' /tmp/runtime-access.json)"
+          KEY_VAULT_CONDITIONAL="$(jq -r '.keyVaultConditionalOnly' /tmp/runtime-access.json)"
+          KEY_VAULT_ROLES="$(jq -r '.keyVaultRoles | join(",")' /tmp/runtime-access.json)"
+          KEY_VAULT_POLICY_PERMS="$(jq -r '.keyVaultAccessPolicySecretPermissions | join(",")' /tmp/runtime-access.json)"
+          ACR_MODE_OUT="$(jq -r '.acrRoleAssignmentMode' /tmp/runtime-access.json)"
+          ACR_EFFECTIVE="$(jq -r '.acrPullEffective' /tmp/runtime-access.json)"
+          ACR_CONDITIONAL="$(jq -r '.acrConditionalOnly' /tmp/runtime-access.json)"
+          ACR_ROLES="$(jq -r '.acrRoles | join(",")' /tmp/runtime-access.json)"
+
+          echo "key_vault_model=$KEY_VAULT_MODEL" >> "$GITHUB_OUTPUT"
+          echo "key_vault_effective=$KEY_VAULT_EFFECTIVE" >> "$GITHUB_OUTPUT"
+          echo "key_vault_conditional=$KEY_VAULT_CONDITIONAL" >> "$GITHUB_OUTPUT"
+          echo "key_vault_roles=$KEY_VAULT_ROLES" >> "$GITHUB_OUTPUT"
+          echo "key_vault_policy_perms=$KEY_VAULT_POLICY_PERMS" >> "$GITHUB_OUTPUT"
+          echo "acr_mode=$ACR_MODE_OUT" >> "$GITHUB_OUTPUT"
+          echo "acr_effective=$ACR_EFFECTIVE" >> "$GITHUB_OUTPUT"
+          echo "acr_conditional=$ACR_CONDITIONAL" >> "$GITHUB_OUTPUT"
+          echo "acr_roles=$ACR_ROLES" >> "$GITHUB_OUTPUT"
+
+          rm -f /tmp/runtime-assignments.json /tmp/runtime-roledefs.jsonl /tmp/runtime-vault.json /tmp/runtime-access.json
+
+      - name: Publish proven runtime-access statuses
+        if: steps.access.outcome == 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEY_VAULT_MODEL: ${{ steps.access.outputs.key_vault_model }}
+          KEY_VAULT_EFFECTIVE: ${{ steps.access.outputs.key_vault_effective }}
+          KEY_VAULT_CONDITIONAL: ${{ steps.access.outputs.key_vault_conditional }}
+          KEY_VAULT_ROLES: ${{ steps.access.outputs.key_vault_roles }}
+          KEY_VAULT_POLICY_PERMS: ${{ steps.access.outputs.key_vault_policy_perms }}
+          ACR_MODE: ${{ steps.access.outputs.acr_mode }}
+          ACR_EFFECTIVE: ${{ steps.access.outputs.acr_effective }}
+          ACR_CONDITIONAL: ${{ steps.access.outputs.acr_conditional }}
+          ACR_ROLES: ${{ steps.access.outputs.acr_roles }}
+        run: |
+          set -euo pipefail
+
+          kv_state=failure
+          [[ "$KEY_VAULT_EFFECTIVE" == true ]] && kv_state=success
+          kv_desc="model=$KEY_VAULT_MODEL; get=$KEY_VAULT_EFFECTIVE"
+          if [[ "$KEY_VAULT_MODEL" == rbac && -n "$KEY_VAULT_ROLES" ]]; then
+            kv_desc="$kv_desc; roles=$KEY_VAULT_ROLES"
+          elif [[ "$KEY_VAULT_MODEL" == access-policy ]]; then
+            kv_desc="$kv_desc; perms=$KEY_VAULT_POLICY_PERMS"
+          elif [[ "$KEY_VAULT_CONDITIONAL" == true ]]; then
+            kv_desc="$kv_desc; conditionalOnly=true"
+          fi
+
+          acr_state=failure
+          [[ "$ACR_EFFECTIVE" == true ]] && acr_state=success
+          acr_desc="mode=$ACR_MODE; pull=$ACR_EFFECTIVE"
+          [[ -z "$ACR_ROLES" ]] || acr_desc="$acr_desc; roles=$ACR_ROLES"
+          [[ "$ACR_CONDITIONAL" != true ]] || acr_desc="$acr_desc; conditionalOnly=true"
+
+          gh api --method POST -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$kv_state" -f context='azure/runtime-keyvault-secret-get' \
+            -f description="${kv_desc:0:140}"
+          gh api --method POST -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state="$acr_state" -f context='azure/runtime-acr-pull' \
+            -f description="${acr_desc:0:140}"
+
+      - name: Publish runtime-access inspection failure
+        if: always() && steps.access.outcome != 'success'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for context in azure/runtime-keyvault-secret-get azure/runtime-acr-pull; do
+            gh api --method POST -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+              -f state='failure' -f context="$context" \
+              -f description='runtime-access inspection failed before proof; no mutation performed'
+          done
+
+      - name: Record runtime-access summary
+        if: steps.access.outcome == 'success'
+        shell: bash
+        env:
+          KEY_VAULT_MODEL: ${{ steps.access.outputs.key_vault_model }}
+          KEY_VAULT_EFFECTIVE: ${{ steps.access.outputs.key_vault_effective }}
+          ACR_MODE: ${{ steps.access.outputs.acr_mode }}
+          ACR_EFFECTIVE: ${{ steps.access.outputs.acr_effective }}
+        run: |
+          {
+            echo '## Production runtime identity access proof v2'
+            echo '- Azure mutation performed: no'
+            echo "- Key Vault access model: $KEY_VAULT_MODEL"
+            echo "- Key Vault secret get effective: $KEY_VAULT_EFFECTIVE"
+            echo "- ACR role assignment mode: $ACR_MODE"
+            echo "- ACR pull effective: $ACR_EFFECTIVE"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/inspect-control-plane-runtime-access-v2.yml
+++ b/.github/workflows/inspect-control-plane-runtime-access-v2.yml
@@ -30,9 +30,12 @@ jobs:
           set -euo pipefail
           file='.github/workflows/inspect-control-plane-runtime-access-v2.yml'
           inspect_block="$(awk '/^  inspect-runtime-access:/{found=1} found{print}' "$file")"
+          mutation_re='(^|[^[:alnum:]_])az[[:space:]][^[:cntrl:]]*[[:space:]](create|update|set|delete|assign|add|remove)([[:space:]]|$)'
+
           grep -Fq 'role assignment list' <<<"$inspect_block"
+          grep -Fq -- '--include-groups' <<<"$inspect_block"
           grep -Fq -- '--include-inherited' <<<"$inspect_block"
-          grep -Fq -- '--fill-principal-name false' <<<"$inspect_block"
+          grep -Fq -- '--scope "$scope"' <<<"$inspect_block"
           grep -Fq 'role definition' <<<"$inspect_block"
           grep -Fq 'roleAssignmentMode' <<<"$inspect_block"
           grep -Fq 'microsoft.keyvault/vaults/secrets/getsecret/action' <<<"$inspect_block"
@@ -40,8 +43,22 @@ jobs:
           grep -Fq 'microsoft.containerregistry/registries/repositories/content/read' <<<"$inspect_block"
           grep -Fq 'azure/runtime-keyvault-secret-get' <<<"$inspect_block"
           grep -Fq 'azure/runtime-acr-pull' <<<"$inspect_block"
-          grep -Fq 'steps.access.outcome' <<<"$inspect_block"
-          if grep -Eq 'az [^\n]*[[:space:]](create|update|set|delete|assign|add|remove)([[:space:]]|$)|AZURE_CLIENT_SECRET' <<<"$inspect_block"; then
+          grep -Fq 'steps.publish.outcome' <<<"$inspect_block"
+
+          for sample in \
+            'az identity create -g rg -n uami' \
+            'az role assignment create --role Reader --scope /x' \
+            'x="$(az webapp config appsettings set -g rg -n app --settings A=B)"'; do
+            if ! grep -Eq "$mutation_re" <<<"$sample"; then
+              echo "::error::Mutation guard missed prohibited sample: $sample" >&2
+              exit 1
+            fi
+          done
+          if grep -Eq "$mutation_re" <<< 'az role assignment list --scope /x'; then
+            echo '::error::Mutation guard rejected a read-only Azure command.' >&2
+            exit 1
+          fi
+          if grep -Eq "$mutation_re" <<<"$inspect_block" || grep -Fq 'AZURE_CLIENT_SECRET' <<<"$inspect_block"; then
             echo '::error::Runtime access inspection must remain Azure-read-only and secretless.' >&2
             exit 1
           fi
@@ -78,18 +95,21 @@ jobs:
           echo "subscription_id=$subscription_id" >> "$GITHUB_OUTPUT"
 
       - name: Publish pending runtime-access statuses
+        id: pending
         continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -u
+          failed=0
           for context in azure/runtime-keyvault-secret-get azure/runtime-acr-pull; do
             gh api --method POST -H 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
               -f state='pending' -f context="$context" \
-              -f description='read-only Azure runtime-access inspection in progress'
+              -f description='read-only Azure runtime-access inspection in progress' || failed=1
           done
+          exit "$failed"
 
       - name: Login to Azure with GitHub OIDC
         uses: azure/login@v2
@@ -116,15 +136,29 @@ jobs:
           test -n "$VAULT_ID" && test -n "$ACR_ID" && test -n "$ACR_MODE"
           [[ -n "$VAULT_RBAC" ]] || VAULT_RBAC=false
 
-          az role assignment list \
-            --assignee-object-id "$PRINCIPAL_ID" \
-            --all \
-            --include-inherited \
-            --fill-principal-name false \
-            -o json > /tmp/runtime-assignments.json
+          role_context() {
+            local scope="$1" out="$2"
+            if az role assignment list \
+              --assignee "$PRINCIPAL_ID" \
+              --scope "$scope" \
+              --include-inherited \
+              --include-groups \
+              --fill-principal-name false \
+              --fill-role-definition-name false \
+              -o json > "$out"; then
+              return 0
+            fi
+            printf '[]\n' > "$out"
+            return 1
+          }
+
+          VAULT_ROLE_CONTEXT=true
+          ACR_ROLE_CONTEXT=true
+          role_context "$VAULT_ID" /tmp/runtime-vault-assignments.json || VAULT_ROLE_CONTEXT=false
+          role_context "$ACR_ID" /tmp/runtime-acr-assignments.json || ACR_ROLE_CONTEXT=false
 
           : > /tmp/runtime-roledefs.jsonl
-          jq -r '.[].roleDefinitionId' /tmp/runtime-assignments.json | sort -u | while IFS= read -r role_definition_id; do
+          jq -r '.[].roleDefinitionId' /tmp/runtime-vault-assignments.json /tmp/runtime-acr-assignments.json | sort -u | while IFS= read -r role_definition_id; do
             [[ -n "$role_definition_id" ]] || continue
             role_guid="${role_definition_id##*/}"
             az role definition list --name "$role_guid" -o json \
@@ -143,14 +177,16 @@ jobs:
             fi
           fi
 
-          export VAULT_ID ACR_ID ACR_MODE VAULT_RBAC ACCESS_POLICY_PRESENT ACCESS_POLICY_SECRET_PERMS
+          export ACR_MODE VAULT_RBAC ACCESS_POLICY_PRESENT ACCESS_POLICY_SECRET_PERMS VAULT_ROLE_CONTEXT ACR_ROLE_CONTEXT
           python3 - <<'PY' > /tmp/runtime-access.json
-          import fnmatch
-          import json
-          import os
+          import fnmatch, json, os
 
-          with open('/tmp/runtime-assignments.json', encoding='utf-8') as fh:
-              assignments = json.load(fh)
+          def load(path):
+              with open(path, encoding='utf-8') as fh:
+                  return json.load(fh)
+
+          vault_assignments = load('/tmp/runtime-vault-assignments.json')
+          acr_assignments = load('/tmp/runtime-acr-assignments.json')
           roledefs = {}
           with open('/tmp/runtime-roledefs.jsonl', encoding='utf-8') as fh:
               for line in fh:
@@ -158,8 +194,6 @@ jobs:
                       item = json.loads(line)
                       roledefs[item['id'].lower()] = item
 
-          vault_id = os.environ['VAULT_ID'].lower().rstrip('/')
-          acr_id = os.environ['ACR_ID'].lower().rstrip('/')
           acr_mode = os.environ['ACR_MODE'].strip().lower()
           vault_rbac = os.environ['VAULT_RBAC'].lower() == 'true'
           access_policy_present = os.environ['ACCESS_POLICY_PRESENT'].lower() == 'true'
@@ -168,21 +202,18 @@ jobs:
               for p in os.environ.get('ACCESS_POLICY_SECRET_PERMS', '').split(',')
               if p.strip()
           }
+          vault_context = os.environ['VAULT_ROLE_CONTEXT'].lower() == 'true'
+          acr_context = os.environ['ACR_ROLE_CONTEXT'].lower() == 'true'
 
           kv_target = 'microsoft.keyvault/vaults/secrets/getsecret/action'
-          acr_rbac_target = 'microsoft.containerregistry/registries/pull/read'
-          acr_abac_target = 'microsoft.containerregistry/registries/repositories/content/read'
-          abac = acr_mode == 'rbac-abac'
-          acr_target = acr_abac_target if abac else acr_rbac_target
-          acr_allow_key = 'dataActions' if abac else 'actions'
-          acr_deny_key = 'notDataActions' if abac else 'notActions'
+          acr_abac = acr_mode == 'rbac-abac'
+          acr_target = ('microsoft.containerregistry/registries/repositories/content/read' if acr_abac
+                        else 'microsoft.containerregistry/registries/pull/read')
+          acr_allow = 'dataActions' if acr_abac else 'actions'
+          acr_deny = 'notDataActions' if acr_abac else 'notActions'
 
           def matches(pattern, target):
               return fnmatch.fnmatchcase(target, (pattern or '').lower())
-
-          def scope_applies(assignment_scope, target_scope):
-              assignment_scope = (assignment_scope or '').lower().rstrip('/')
-              return bool(assignment_scope) and (target_scope == assignment_scope or target_scope.startswith(assignment_scope + '/'))
 
           def role_grants(role, target, allow_key, deny_key):
               for block in role.get('permissions') or []:
@@ -192,32 +223,24 @@ jobs:
                       return True
               return False
 
-          def qualifying(target_scope, target_action, allow_key, deny_key):
-              unconditioned = []
-              conditioned = []
+          def qualifying(assignments, target, allow_key, deny_key):
+              unconditioned, conditioned = [], []
               for assignment in assignments:
-                  if not scope_applies(assignment.get('scope'), target_scope):
-                      continue
                   role = roledefs.get((assignment.get('roleDefinitionId') or '').lower())
-                  if not role or not role_grants(role, target_action, allow_key, deny_key):
+                  if not role or not role_grants(role, target, allow_key, deny_key):
                       continue
-                  row = {
-                      'role': role.get('roleName') or assignment.get('roleDefinitionName') or 'unknown',
-                      'scope': assignment.get('scope') or '',
-                  }
-                  if assignment.get('condition'):
-                      conditioned.append(row)
-                  else:
-                      unconditioned.append(row)
+                  role_name = role.get('roleName') or assignment.get('roleDefinitionName') or 'unknown'
+                  row = {'role': role_name, 'scope': assignment.get('scope') or ''}
+                  (conditioned if assignment.get('condition') else unconditioned).append(row)
               return unconditioned, conditioned
 
-          kv_roles, kv_conditioned = qualifying(vault_id, kv_target, 'dataActions', 'notDataActions')
-          acr_roles, acr_conditioned = qualifying(acr_id, acr_target, acr_allow_key, acr_deny_key)
+          kv_roles, kv_conditioned = qualifying(vault_assignments, kv_target, 'dataActions', 'notDataActions') if vault_context else ([], [])
+          acr_roles, acr_conditioned = qualifying(acr_assignments, acr_target, acr_allow, acr_deny) if acr_context else ([], [])
 
           if vault_rbac:
               kv_model = 'rbac'
-              kv_effective = bool(kv_roles)
-              kv_conditional_only = not kv_roles and bool(kv_conditioned)
+              kv_effective = vault_context and bool(kv_roles)
+              kv_conditional_only = vault_context and not kv_roles and bool(kv_conditioned)
           else:
               kv_model = 'access-policy'
               kv_effective = access_policy_present and 'get' in access_policy_secret_perms
@@ -225,99 +248,92 @@ jobs:
 
           result = {
               'keyVaultAccessModel': kv_model,
+              'keyVaultRoleContextAvailable': vault_context,
               'keyVaultSecretGetEffective': kv_effective,
               'keyVaultConditionalOnly': kv_conditional_only,
               'keyVaultRoles': sorted({x['role'] for x in kv_roles}),
-              'keyVaultRoleScopes': sorted({f"{x['role']}@{x['scope']}" for x in kv_roles}),
-              'keyVaultAccessPolicyPresent': access_policy_present,
               'keyVaultAccessPolicySecretPermissions': sorted(access_policy_secret_perms),
               'acrRoleAssignmentMode': acr_mode,
+              'acrRoleContextAvailable': acr_context,
               'acrPermissionTarget': acr_target,
-              'acrPullEffective': bool(acr_roles),
-              'acrConditionalOnly': not acr_roles and bool(acr_conditioned),
+              'acrPullEffective': acr_context and bool(acr_roles),
+              'acrConditionalOnly': acr_context and not acr_roles and bool(acr_conditioned),
               'acrRoles': sorted({x['role'] for x in acr_roles}),
-              'acrRoleScopes': sorted({f"{x['role']}@{x['scope']}" for x in acr_roles}),
           }
           print(json.dumps(result, sort_keys=True, separators=(',', ':')))
           PY
 
-          KEY_VAULT_MODEL="$(jq -r '.keyVaultAccessModel' /tmp/runtime-access.json)"
-          KEY_VAULT_EFFECTIVE="$(jq -r '.keyVaultSecretGetEffective' /tmp/runtime-access.json)"
-          KEY_VAULT_CONDITIONAL="$(jq -r '.keyVaultConditionalOnly' /tmp/runtime-access.json)"
-          KEY_VAULT_ROLES="$(jq -r '.keyVaultRoles | join(",")' /tmp/runtime-access.json)"
-          KEY_VAULT_POLICY_PERMS="$(jq -r '.keyVaultAccessPolicySecretPermissions | join(",")' /tmp/runtime-access.json)"
-          ACR_MODE_OUT="$(jq -r '.acrRoleAssignmentMode' /tmp/runtime-access.json)"
-          ACR_EFFECTIVE="$(jq -r '.acrPullEffective' /tmp/runtime-access.json)"
-          ACR_CONDITIONAL="$(jq -r '.acrConditionalOnly' /tmp/runtime-access.json)"
-          ACR_ROLES="$(jq -r '.acrRoles | join(",")' /tmp/runtime-access.json)"
+          echo "key_vault_model=$(jq -r '.keyVaultAccessModel' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "key_vault_role_context=$(jq -r '.keyVaultRoleContextAvailable' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "key_vault_effective=$(jq -r '.keyVaultSecretGetEffective' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "key_vault_conditional=$(jq -r '.keyVaultConditionalOnly' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "key_vault_roles=$(jq -r '.keyVaultRoles | join(",")' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "key_vault_policy_perms=$(jq -r '.keyVaultAccessPolicySecretPermissions | join(",")' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "acr_mode=$(jq -r '.acrRoleAssignmentMode' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "acr_role_context=$(jq -r '.acrRoleContextAvailable' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "acr_effective=$(jq -r '.acrPullEffective' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "acr_conditional=$(jq -r '.acrConditionalOnly' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
+          echo "acr_roles=$(jq -r '.acrRoles | join(",")' /tmp/runtime-access.json)" >> "$GITHUB_OUTPUT"
 
-          echo "key_vault_model=$KEY_VAULT_MODEL" >> "$GITHUB_OUTPUT"
-          echo "key_vault_effective=$KEY_VAULT_EFFECTIVE" >> "$GITHUB_OUTPUT"
-          echo "key_vault_conditional=$KEY_VAULT_CONDITIONAL" >> "$GITHUB_OUTPUT"
-          echo "key_vault_roles=$KEY_VAULT_ROLES" >> "$GITHUB_OUTPUT"
-          echo "key_vault_policy_perms=$KEY_VAULT_POLICY_PERMS" >> "$GITHUB_OUTPUT"
-          echo "acr_mode=$ACR_MODE_OUT" >> "$GITHUB_OUTPUT"
-          echo "acr_effective=$ACR_EFFECTIVE" >> "$GITHUB_OUTPUT"
-          echo "acr_conditional=$ACR_CONDITIONAL" >> "$GITHUB_OUTPUT"
-          echo "acr_roles=$ACR_ROLES" >> "$GITHUB_OUTPUT"
+          rm -f /tmp/runtime-vault-assignments.json /tmp/runtime-acr-assignments.json /tmp/runtime-roledefs.jsonl /tmp/runtime-vault.json /tmp/runtime-access.json
 
-          rm -f /tmp/runtime-assignments.json /tmp/runtime-roledefs.jsonl /tmp/runtime-vault.json /tmp/runtime-access.json
-
-      - name: Publish proven runtime-access statuses
+      - name: Publish terminal runtime-access statuses
+        id: publish
         if: steps.access.outcome == 'success'
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           KEY_VAULT_MODEL: ${{ steps.access.outputs.key_vault_model }}
+          KEY_VAULT_ROLE_CONTEXT: ${{ steps.access.outputs.key_vault_role_context }}
           KEY_VAULT_EFFECTIVE: ${{ steps.access.outputs.key_vault_effective }}
           KEY_VAULT_CONDITIONAL: ${{ steps.access.outputs.key_vault_conditional }}
           KEY_VAULT_ROLES: ${{ steps.access.outputs.key_vault_roles }}
           KEY_VAULT_POLICY_PERMS: ${{ steps.access.outputs.key_vault_policy_perms }}
           ACR_MODE: ${{ steps.access.outputs.acr_mode }}
+          ACR_ROLE_CONTEXT: ${{ steps.access.outputs.acr_role_context }}
           ACR_EFFECTIVE: ${{ steps.access.outputs.acr_effective }}
           ACR_CONDITIONAL: ${{ steps.access.outputs.acr_conditional }}
           ACR_ROLES: ${{ steps.access.outputs.acr_roles }}
         run: |
-          set -euo pipefail
-
+          set -u
+          failed=0
           kv_state=failure
           [[ "$KEY_VAULT_EFFECTIVE" == true ]] && kv_state=success
-          kv_desc="model=$KEY_VAULT_MODEL; get=$KEY_VAULT_EFFECTIVE"
-          if [[ "$KEY_VAULT_MODEL" == rbac && -n "$KEY_VAULT_ROLES" ]]; then
-            kv_desc="$kv_desc; roles=$KEY_VAULT_ROLES"
-          elif [[ "$KEY_VAULT_MODEL" == access-policy ]]; then
-            kv_desc="$kv_desc; perms=$KEY_VAULT_POLICY_PERMS"
-          elif [[ "$KEY_VAULT_CONDITIONAL" == true ]]; then
-            kv_desc="$kv_desc; conditionalOnly=true"
-          fi
+          kv_desc="model=$KEY_VAULT_MODEL; get=$KEY_VAULT_EFFECTIVE; roleContext=$KEY_VAULT_ROLE_CONTEXT"
+          [[ -z "$KEY_VAULT_ROLES" ]] || kv_desc="$kv_desc; roles=$KEY_VAULT_ROLES"
+          [[ "$KEY_VAULT_MODEL" != access-policy ]] || kv_desc="$kv_desc; perms=$KEY_VAULT_POLICY_PERMS"
+          [[ "$KEY_VAULT_CONDITIONAL" != true ]] || kv_desc="$kv_desc; conditionalOnly=true"
 
           acr_state=failure
           [[ "$ACR_EFFECTIVE" == true ]] && acr_state=success
-          acr_desc="mode=$ACR_MODE; pull=$ACR_EFFECTIVE"
+          acr_desc="mode=$ACR_MODE; pull=$ACR_EFFECTIVE; roleContext=$ACR_ROLE_CONTEXT"
           [[ -z "$ACR_ROLES" ]] || acr_desc="$acr_desc; roles=$ACR_ROLES"
           [[ "$ACR_CONDITIONAL" != true ]] || acr_desc="$acr_desc; conditionalOnly=true"
 
           gh api --method POST -H 'Accept: application/vnd.github+json' \
             "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
             -f state="$kv_state" -f context='azure/runtime-keyvault-secret-get' \
-            -f description="${kv_desc:0:140}"
+            -f description="${kv_desc:0:140}" || failed=1
           gh api --method POST -H 'Accept: application/vnd.github+json' \
             "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
             -f state="$acr_state" -f context='azure/runtime-acr-pull' \
-            -f description="${acr_desc:0:140}"
+            -f description="${acr_desc:0:140}" || failed=1
+          exit "$failed"
 
-      - name: Publish runtime-access inspection failure
-        if: always() && steps.access.outcome != 'success'
+      - name: Finalize runtime-access statuses on inspection or publication failure
+        if: always() && (steps.access.outcome != 'success' || steps.publish.outcome != 'success')
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -u
           for context in azure/runtime-keyvault-secret-get azure/runtime-acr-pull; do
             gh api --method POST -H 'Accept: application/vnd.github+json' \
               "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
               -f state='failure' -f context="$context" \
-              -f description='runtime-access inspection failed before proof; no mutation performed'
+              -f description='runtime-access proof incomplete; no Azure mutation performed' || true
           done
 
       - name: Record runtime-access summary
@@ -330,7 +346,7 @@ jobs:
           ACR_EFFECTIVE: ${{ steps.access.outputs.acr_effective }}
         run: |
           {
-            echo '## Production runtime identity access proof v2'
+            echo '## Production runtime identity access proof v3'
             echo '- Azure mutation performed: no'
             echo "- Key Vault access model: $KEY_VAULT_MODEL"
             echo "- Key Vault secret get effective: $KEY_VAULT_EFFECTIVE"


### PR DESCRIPTION
## Summary
- add a read-only proof workflow for the GitHub OIDC deployer itself
- cross-check Azure Authorization caller-permissions with unconditioned inherited role grants
- prove the exact management actions needed for a B1 shadow-staging path: UAMI create/assign, Web App create/config, App Service plan join, RBAC writes at Key Vault/ACR, and Key Vault access-policy write
- publish pending/final/failure commit statuses so an inspection failure cannot be mistaken for missing evidence

## Safety
- PR event runs static validation only
- Azure inspection runs only on main push after merge, via existing prod OIDC federation
- Azure commands are read-only (`show`, `list`, `get-access-token`, GET REST calls)
- no plan upgrade, no UAMI creation, no Web App creation, no role assignment, no Key Vault policy mutation, no secret value reads

## Truth boundary
This PR proves or rejects mutation authority only. It does not grant permissions and does not create shadow staging or deploy production.