### PR TITLE
feat: Microsoft Foundry DSG governance plugin

### DIFF
--- a/app/api/dsg/governance/live/route.ts
+++ b/app/api/dsg/governance/live/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '@/lib/authz';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const access = await requireOrgRole(
+    ['operator', 'org_admin', 'runtime_auditor', 'reviewer'],
+    request,
+  );
+  if (!access.ok) {
+    return NextResponse.json(
+      { ok: false, error: access.error ?? 'Unauthorized' },
+      { status: access.status },
+    );
+  }
+
+  const rawLimit = Number(request.nextUrl.searchParams.get('limit') ?? '30');
+  const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(Math.trunc(rawLimit), 1), 100) : 30;
+
+  try {
+    const db = getSupabaseAdmin();
+    const { data, error } = await db
+      .from('dsg_audit_events')
+      .select(
+        'id, execution_id, event_type, agent_id, adapter_kind, action_kind, decision, status, policy_version, evidence_hash, previous_hash, current_hash, metadata, occurred_at, created_at',
+      )
+      .eq('event_type', 'governance_preflight')
+      .contains('metadata', { org_id: access.orgId })
+      .order('occurred_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      return NextResponse.json(
+        { ok: false, error: 'GOVERNANCE_FEED_UNAVAILABLE' },
+        { status: 503 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        refresh: 'poll-2s',
+        truthBoundary: 'Feed contains persisted governance_preflight audit rows only; no synthetic events.',
+        items: data ?? [],
+      },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'GOVERNANCE_FEED_UNAVAILABLE' },
+      { status: 503 },
+    );
+  }
+}

--- a/app/api/dsg/governance/openapi/route.ts
+++ b/app/api/dsg/governance/openapi/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
         title: 'DSG Governance Plugin',
         version: '1.0.0',
         description:
-          'Govern an existing AI agent action against an approved DSG plan. Supports observe and enforce modes with structured live governance output.',
+          'Govern an existing AI agent action against an approved DSG plan. Observe/Enforce mode is owned by the DSG organization setting and cannot be overridden by the calling agent.',
       },
       servers: [{ url: origin }],
       paths: {
@@ -40,6 +40,7 @@ export async function GET(request: NextRequest) {
               '400': { description: 'Invalid governance input' },
               '401': { description: 'Invalid or missing DSG credential' },
               '403': { description: 'Authenticated actor lacks route access' },
+              '503': { description: 'Server-side governance mode is unavailable' },
             },
           },
         },
@@ -57,7 +58,6 @@ export async function GET(request: NextRequest) {
             type: 'object',
             additionalProperties: false,
             properties: {
-              mode: { type: 'string', enum: ['observe', 'enforce'] },
               eventId: { type: 'string' },
               planHash: { type: 'string', pattern: '^[0-9a-fA-F]{64}$' },
               agentId: { type: 'string' },
@@ -78,7 +78,6 @@ export async function GET(request: NextRequest) {
               evidenceRefs: { type: 'array', items: { type: 'string' } },
             },
             required: [
-              'mode',
               'eventId',
               'planHash',
               'agentId',

--- a/app/api/dsg/governance/openapi/route.ts
+++ b/app/api/dsg/governance/openapi/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const origin = request.nextUrl.origin;
+  return NextResponse.json(
+    {
+      openapi: '3.1.0',
+      info: {
+        title: 'DSG Governance Plugin',
+        version: '1.0.0',
+        description:
+          'Govern an existing AI agent action against an approved DSG plan. Supports observe and enforce modes with structured live governance output.',
+      },
+      servers: [{ url: origin }],
+      paths: {
+        '/api/dsg/governance/preflight': {
+          post: {
+            operationId: 'dsgGovernancePreflight',
+            summary: 'Verify and record an agent action before target execution',
+            security: [{ DsgApiKey: [] }],
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/GovernancePreflightInput' },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'Governance decision and five-panel live status payload',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/GovernancePreflightResult' },
+                  },
+                },
+              },
+              '400': { description: 'Invalid governance input' },
+              '401': { description: 'Invalid or missing DSG credential' },
+              '403': { description: 'Authenticated actor lacks route access' },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          DsgApiKey: {
+            type: 'apiKey',
+            in: 'header',
+            name: 'x-dsg-api-key',
+          },
+        },
+        schemas: {
+          GovernancePreflightInput: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              mode: { type: 'string', enum: ['observe', 'enforce'] },
+              eventId: { type: 'string' },
+              planHash: { type: 'string', pattern: '^[0-9a-fA-F]{64}$' },
+              agentId: { type: 'string' },
+              sessionId: { type: 'string' },
+              actionType: {
+                type: 'string',
+                enum: ['observe', 'read', 'write', 'delete', 'payment', 'deploy', 'admin'],
+              },
+              targetSystemId: { type: 'string' },
+              operationName: { type: 'string' },
+              riskLevel: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+              payloadHash: { type: 'string' },
+              idempotencyKey: { type: 'string' },
+              rollbackPlanId: { type: 'string' },
+              evidenceManifestId: { type: 'string' },
+              policySnapshotHash: { type: 'string' },
+              claimedOutcome: { type: 'string' },
+              evidenceRefs: { type: 'array', items: { type: 'string' } },
+            },
+            required: [
+              'mode',
+              'eventId',
+              'planHash',
+              'agentId',
+              'sessionId',
+              'actionType',
+              'targetSystemId',
+              'operationName',
+              'riskLevel',
+            ],
+          },
+          GovernancePreflightResult: {
+            type: 'object',
+            properties: {
+              ok: { type: 'boolean', const: true },
+              mode: { type: 'string', enum: ['observe', 'enforce'] },
+              status: {
+                type: 'string',
+                enum: ['PASS', 'BLOCKED', 'WAITING_PERMISSION', 'UNVERIFIED'],
+              },
+              policyAllowsAction: { type: 'boolean' },
+              shouldBlock: { type: 'boolean' },
+              claimAllowed: { type: 'boolean' },
+              decisionHash: { type: 'string' },
+              panels: {
+                type: 'object',
+                properties: {
+                  action: { type: 'object', additionalProperties: true },
+                  planAlignment: { type: 'object', additionalProperties: true },
+                  permission: { type: 'object', additionalProperties: true },
+                  evidence: { type: 'object', additionalProperties: true },
+                  executionAudit: { type: 'object', additionalProperties: true },
+                },
+                required: ['action', 'planAlignment', 'permission', 'evidence', 'executionAudit'],
+              },
+            },
+            required: [
+              'ok',
+              'mode',
+              'status',
+              'policyAllowsAction',
+              'shouldBlock',
+              'claimAllowed',
+              'decisionHash',
+              'panels',
+            ],
+          },
+        },
+      },
+    },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/app/api/dsg/governance/preflight/route.ts
+++ b/app/api/dsg/governance/preflight/route.ts
@@ -46,7 +46,9 @@ export async function POST(request: NextRequest) {
 
   const result = await governAction(body, auth);
   if (result.ok === false) {
-    return NextResponse.json(result, { status: 400 });
+    return NextResponse.json(result, {
+      status: result.error === 'GOVERNANCE_MODE_UNAVAILABLE' ? 503 : 400,
+    });
   }
 
   return NextResponse.json(result, {

--- a/app/api/dsg/governance/preflight/route.ts
+++ b/app/api/dsg/governance/preflight/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '@/lib/authz';
+import { governAction, type GovernancePreflightInput } from '@/lib/dsg/governance-plugin';
+import {
+  validateStoredUnifiedMcpKey,
+  type UnifiedAuthContext,
+} from '@/lib/mcp/unified-auth';
+
+export const dynamic = 'force-dynamic';
+
+async function resolveAuth(
+  request: NextRequest,
+): Promise<UnifiedAuthContext | NextResponse> {
+  const stored = await validateStoredUnifiedMcpKey(request, 'dsg.governance.preflight');
+  if (stored.presented) {
+    if (stored.valid === false) {
+      return NextResponse.json({ ok: false, error: stored.reason }, { status: 401 });
+    }
+    return stored.context;
+  }
+
+  const access = await requireOrgRole(['operator', 'org_admin'], request);
+  if (!access.ok) {
+    return NextResponse.json(
+      { ok: false, error: access.error ?? 'Unauthorized' },
+      { status: access.status ?? 401 },
+    );
+  }
+
+  return {
+    source: 'session',
+    actorId: access.userId,
+    orgId: access.orgId,
+    roles: access.grantedRoles,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await resolveAuth(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const body = (await request.json().catch(() => null)) as GovernancePreflightInput | null;
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const result = await governAction(body, auth);
+  if (result.ok === false) {
+    return NextResponse.json(result, { status: 400 });
+  }
+
+  return NextResponse.json(result, {
+    status: 200,
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/app/api/dsg/governance/preflight/route.ts
+++ b/app/api/dsg/governance/preflight/route.ts
@@ -19,7 +19,10 @@ async function resolveAuth(
     return stored.context;
   }
 
-  const access = await requireOrgRole(['operator', 'org_admin'], request);
+  const access = await requireOrgRole(
+    ['operator', 'org_admin', 'reviewer', 'runtime_auditor', 'billing_admin'],
+    request,
+  );
   if (!access.ok) {
     return NextResponse.json(
       { ok: false, error: access.error ?? 'Unauthorized' },

--- a/app/api/dsg/governance/settings/route.ts
+++ b/app/api/dsg/governance/settings/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '@/lib/authz';
+import {
+  getGovernanceMode,
+  setGovernanceMode,
+  type GovernanceMode,
+} from '@/lib/dsg/governance-settings';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const access = await requireOrgRole(
+    ['operator', 'org_admin', 'runtime_auditor', 'reviewer'],
+    request,
+  );
+  if (!access.ok) {
+    return NextResponse.json(
+      { ok: false, error: access.error ?? 'Unauthorized' },
+      { status: access.status },
+    );
+  }
+
+  try {
+    const mode = await getGovernanceMode(access.orgId);
+    return NextResponse.json(
+      { ok: true, mode, mutableBy: 'org_admin' },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'GOVERNANCE_MODE_UNAVAILABLE' },
+      { status: 503 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const access = await requireOrgRole(['org_admin'], request);
+  if (!access.ok) {
+    return NextResponse.json(
+      { ok: false, error: access.error ?? 'Unauthorized' },
+      { status: access.status },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as { mode?: GovernanceMode } | null;
+  if (!body || (body.mode !== 'observe' && body.mode !== 'enforce')) {
+    return NextResponse.json(
+      { ok: false, error: 'mode must be observe or enforce' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await setGovernanceMode(access.orgId, access.userId, body.mode);
+    return NextResponse.json({ ok: true, mode: body.mode });
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'GOVERNANCE_MODE_UPDATE_FAILED' },
+      { status: 503 },
+    );
+  }
+}

--- a/app/api/mcp/governance/route.ts
+++ b/app/api/mcp/governance/route.ts
@@ -1,0 +1,149 @@
+// ERROR_HANDLER_EXEMPT: MCP JSON-RPC protocol requires structured error responses.
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOrgRole } from '@/lib/authz';
+import { governAction, type GovernancePreflightInput } from '@/lib/dsg/governance-plugin';
+import {
+  validateStoredUnifiedMcpKey,
+  type UnifiedAuthContext,
+} from '@/lib/mcp/unified-auth';
+
+export const dynamic = 'force-dynamic';
+
+const TOOL_NAME = 'dsg.governance.preflight';
+const TOOL = {
+  name: TOOL_NAME,
+  description:
+    'Verify an existing agent action against an approved DSG plan. Observe mode records without blocking; Enforce mode blocks only out-of-plan actions or missing execution permission. Unsupported claims remain UNVERIFIED without blocking a plan-authorized action.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      mode: { type: 'string', enum: ['observe', 'enforce'] },
+      eventId: { type: 'string' },
+      planHash: { type: 'string', pattern: '^[0-9a-fA-F]{64}$' },
+      agentId: { type: 'string' },
+      sessionId: { type: 'string' },
+      actionType: {
+        type: 'string',
+        enum: ['observe', 'read', 'write', 'delete', 'payment', 'deploy', 'admin'],
+      },
+      targetSystemId: { type: 'string' },
+      operationName: { type: 'string' },
+      riskLevel: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+      payloadHash: { type: 'string' },
+      idempotencyKey: { type: 'string' },
+      rollbackPlanId: { type: 'string' },
+      evidenceManifestId: { type: 'string' },
+      policySnapshotHash: { type: 'string' },
+      claimedOutcome: { type: 'string' },
+      evidenceRefs: { type: 'array', items: { type: 'string' } },
+    },
+    required: [
+      'mode',
+      'eventId',
+      'planHash',
+      'agentId',
+      'sessionId',
+      'actionType',
+      'targetSystemId',
+      'operationName',
+      'riskLevel',
+    ],
+    additionalProperties: false,
+  },
+} as const;
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: { name?: string; arguments?: Record<string, unknown> };
+};
+
+function result(id: JsonRpcRequest['id'], value: unknown) {
+  return NextResponse.json({ jsonrpc: '2.0', id: id ?? null, result: value });
+}
+
+function error(id: JsonRpcRequest['id'], code: number, message: string) {
+  return NextResponse.json(
+    { jsonrpc: '2.0', id: id ?? null, error: { code, message } },
+    { status: code === -32001 ? 401 : code === -32601 ? 404 : 400 },
+  );
+}
+
+function toolResult(id: JsonRpcRequest['id'], value: unknown, isError = false) {
+  return result(id, {
+    content: [{ type: 'text', text: JSON.stringify(value) }],
+    structuredContent:
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? value
+        : { value },
+    ...(isError ? { isError: true } : {}),
+  });
+}
+
+async function resolveAuth(
+  request: NextRequest,
+): Promise<UnifiedAuthContext | NextResponse> {
+  const stored = await validateStoredUnifiedMcpKey(request, TOOL_NAME);
+  if (stored.presented) {
+    if (stored.valid === false) return error(null, -32001, stored.reason);
+    return stored.context;
+  }
+
+  const access = await requireOrgRole(['operator', 'org_admin'], request);
+  if (!access.ok) return error(null, -32001, access.error ?? 'Unauthorized');
+  return {
+    source: 'session',
+    actorId: access.userId,
+    orgId: access.orgId,
+    roles: access.grantedRoles,
+  };
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    server: 'dsg-governance-plugin',
+    version: '1.0.0',
+    transport: 'MCP JSON-RPC over HTTP',
+    tools: [TOOL],
+    modes: ['observe', 'enforce'],
+    statuses: ['PASS', 'BLOCKED', 'WAITING_PERMISSION', 'UNVERIFIED'],
+    truthBoundary:
+      'Observe never blocks. Enforce blocks out-of-plan or unauthorized execution. UNVERIFIED blocks unsupported claims, not plan-authorized actions.',
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const rpc = (await request.json().catch(() => null)) as JsonRpcRequest | null;
+  if (!rpc || rpc.jsonrpc !== '2.0') return error(null, -32600, 'Invalid JSON-RPC request');
+
+  if (rpc.method === 'initialize') {
+    return result(rpc.id, {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {} },
+      serverInfo: { name: 'dsg-governance-plugin', version: '1.0.0' },
+    });
+  }
+
+  if (rpc.method === 'notifications/initialized') {
+    return new NextResponse(null, { status: 202 });
+  }
+
+  if (rpc.method === 'tools/list') return result(rpc.id, { tools: [TOOL] });
+
+  if (rpc.method === 'tools/call') {
+    if (rpc.params?.name !== TOOL_NAME) return error(rpc.id, -32601, 'Unknown tool');
+    const auth = await resolveAuth(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const governed = await governAction(
+      (rpc.params.arguments ?? {}) as unknown as GovernancePreflightInput,
+      auth,
+    );
+    if (governed.ok === false) return toolResult(rpc.id, governed, true);
+    return toolResult(rpc.id, governed);
+  }
+
+  return error(rpc.id, -32601, 'Method not found');
+}

--- a/app/api/mcp/governance/route.ts
+++ b/app/api/mcp/governance/route.ts
@@ -13,11 +13,10 @@ const TOOL_NAME = 'dsg.governance.preflight';
 const TOOL = {
   name: TOOL_NAME,
   description:
-    'Verify an existing agent action against an approved DSG plan. Observe mode records without blocking; Enforce mode blocks only out-of-plan actions or missing execution permission. Unsupported claims remain UNVERIFIED without blocking a plan-authorized action.',
+    'Verify an existing agent action against an approved DSG plan. The organization owns Observe/Enforce mode; the agent cannot change it. Unsupported claims remain UNVERIFIED without blocking a plan-authorized action.',
   inputSchema: {
     type: 'object',
     properties: {
-      mode: { type: 'string', enum: ['observe', 'enforce'] },
       eventId: { type: 'string' },
       planHash: { type: 'string', pattern: '^[0-9a-fA-F]{64}$' },
       agentId: { type: 'string' },
@@ -38,7 +37,6 @@ const TOOL = {
       evidenceRefs: { type: 'array', items: { type: 'string' } },
     },
     required: [
-      'mode',
       'eventId',
       'planHash',
       'agentId',
@@ -108,6 +106,7 @@ export async function GET() {
     transport: 'MCP JSON-RPC over HTTP',
     tools: [TOOL],
     modes: ['observe', 'enforce'],
+    modeAuthority: 'DSG organization setting; callers cannot override mode',
     statuses: ['PASS', 'BLOCKED', 'WAITING_PERMISSION', 'UNVERIFIED'],
     truthBoundary:
       'Observe never blocks. Enforce blocks out-of-plan or unauthorized execution. UNVERIFIED blocks unsupported claims, not plan-authorized actions.',

--- a/app/api/mcp/governance/route.ts
+++ b/app/api/mcp/governance/route.ts
@@ -88,7 +88,10 @@ async function resolveAuth(
     return stored.context;
   }
 
-  const access = await requireOrgRole(['operator', 'org_admin'], request);
+  const access = await requireOrgRole(
+    ['operator', 'org_admin', 'reviewer', 'runtime_auditor', 'billing_admin'],
+    request,
+  );
   if (!access.ok) return error(null, -32001, access.error ?? 'Unauthorized');
   return {
     source: 'session',

--- a/app/dashboard/governance-live/page.tsx
+++ b/app/dashboard/governance-live/page.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type GovernanceMode = 'observe' | 'enforce';
+type GovernanceStatus = 'PASS' | 'BLOCKED' | 'WAITING_PERMISSION' | 'UNVERIFIED';
+
+type PanelStatuses = {
+  action?: GovernanceStatus;
+  plan_alignment?: GovernanceStatus;
+  permission?: GovernanceStatus;
+  evidence?: GovernanceStatus;
+  execution_audit?: GovernanceStatus;
+};
+
+type AuditMetadata = {
+  mode?: GovernanceMode;
+  plan_hash?: string;
+  target_system_id?: string;
+  operation_name?: string;
+  risk_level?: string;
+  plan_decision?: string;
+  reasons?: string[];
+  policy_allows_action?: boolean;
+  should_block?: boolean;
+  claim_allowed?: boolean;
+  evidence_refs?: string[];
+  roles?: string[];
+  auth_source?: string;
+  panel_statuses?: PanelStatuses;
+};
+
+type AuditRow = {
+  id: string;
+  execution_id: string;
+  agent_id: string;
+  action_kind: string;
+  decision: GovernanceStatus;
+  status: string;
+  evidence_hash: string | null;
+  previous_hash: string | null;
+  current_hash: string;
+  occurred_at: string;
+  metadata: AuditMetadata;
+};
+
+function statusClass(status?: string) {
+  switch (status) {
+    case 'PASS':
+      return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200';
+    case 'BLOCKED':
+      return 'border-red-400/30 bg-red-400/10 text-red-200';
+    case 'WAITING_PERMISSION':
+      return 'border-amber-400/30 bg-amber-400/10 text-amber-200';
+    case 'UNVERIFIED':
+      return 'border-violet-400/30 bg-violet-400/10 text-violet-200';
+    default:
+      return 'border-slate-700 bg-slate-900 text-slate-300';
+  }
+}
+
+function Badge({ status }: { status?: string }) {
+  return (
+    <span className={`rounded-full border px-3 py-1 text-xs font-bold ${statusClass(status)}`}>
+      {status ?? 'NO DATA'}
+    </span>
+  );
+}
+
+function Field({ label, value }: { label: string; value: unknown }) {
+  const text = value === null || value === undefined || value === '' ? '—' : String(value);
+  return (
+    <div className="grid gap-1 border-t border-white/[0.06] py-3 sm:grid-cols-[180px_1fr] sm:gap-4">
+      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className="break-all text-sm text-slate-200">{text}</dd>
+    </div>
+  );
+}
+
+function Panel({
+  index,
+  title,
+  status,
+  children,
+}: {
+  index: number;
+  title: string;
+  status?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-white/[0.08] bg-white/[0.025] p-5 shadow-xl shadow-black/10">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-slate-500">Panel {index}</p>
+          <h2 className="mt-1 text-lg font-bold text-white">{title}</h2>
+        </div>
+        <Badge status={status} />
+      </div>
+      <dl>{children}</dl>
+    </section>
+  );
+}
+
+export default function GovernanceLivePage() {
+  const [mode, setMode] = useState<GovernanceMode>('observe');
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [savingMode, setSavingMode] = useState(false);
+  const [error, setError] = useState('');
+  const [modeError, setModeError] = useState('');
+
+  const loadSettings = useCallback(async () => {
+    const response = await fetch('/api/dsg/governance/settings', {
+      cache: 'no-store',
+      credentials: 'include',
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body?.ok) throw new Error(body?.error ?? 'SETTINGS_UNAVAILABLE');
+    setMode(body.mode === 'enforce' ? 'enforce' : 'observe');
+  }, []);
+
+  const loadFeed = useCallback(async () => {
+    const response = await fetch('/api/dsg/governance/live?limit=30', {
+      cache: 'no-store',
+      credentials: 'include',
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body?.ok) throw new Error(body?.error ?? 'FEED_UNAVAILABLE');
+    setRows(Array.isArray(body.items) ? body.items : []);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([loadSettings(), loadFeed()])
+      .catch((err) => {
+        if (active) setError(err instanceof Error ? err.message : 'GOVERNANCE_LIVE_UNAVAILABLE');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    const timer = window.setInterval(() => {
+      void loadFeed().catch((err) => {
+        if (active) setError(err instanceof Error ? err.message : 'FEED_UNAVAILABLE');
+      });
+    }, 2000);
+
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [loadFeed, loadSettings]);
+
+  const changeMode = useCallback(async (next: GovernanceMode) => {
+    setSavingMode(true);
+    setModeError('');
+    try {
+      const response = await fetch('/api/dsg/governance/settings', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: next }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? 'MODE_UPDATE_FAILED');
+      setMode(body.mode);
+    } catch (err) {
+      setModeError(err instanceof Error ? err.message : 'MODE_UPDATE_FAILED');
+    } finally {
+      setSavingMode(false);
+    }
+  }, []);
+
+  const latest = rows[0] ?? null;
+  const metadata = latest?.metadata ?? {};
+  const statuses = metadata.panel_statuses ?? {};
+  const eventMode = metadata.mode ?? mode;
+  const reasons = useMemo(() => metadata.reasons ?? [], [metadata.reasons]);
+  const evidenceRefs = useMemo(() => metadata.evidence_refs ?? [], [metadata.evidence_refs]);
+
+  return (
+    <main className="min-h-screen bg-[#07080b] text-slate-100">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+        <header className="mb-6">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-500">DSG Governance Plugin</p>
+          <div className="mt-2 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <h1 className="text-3xl font-bold text-white">Live Governance</h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
+                MCP/OpenAPI actions are evaluated against the server-side approved plan, then persisted to the audit ledger. Feed refresh: 2 seconds. No synthetic events.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-3">
+              <p className="mb-2 text-xs font-semibold text-slate-400">Organization mode</p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={savingMode}
+                  onClick={() => void changeMode('observe')}
+                  className={`rounded-xl border px-4 py-2 text-sm font-bold transition ${
+                    mode === 'observe'
+                      ? 'border-blue-400/50 bg-blue-400/15 text-blue-200'
+                      : 'border-white/10 bg-white/5 text-slate-400'
+                  } disabled:opacity-50`}
+                >
+                  OBSERVE
+                </button>
+                <button
+                  type="button"
+                  disabled={savingMode}
+                  onClick={() => void changeMode('enforce')}
+                  className={`rounded-xl border px-4 py-2 text-sm font-bold transition ${
+                    mode === 'enforce'
+                      ? 'border-red-400/50 bg-red-400/15 text-red-200'
+                      : 'border-white/10 bg-white/5 text-slate-400'
+                  } disabled:opacity-50`}
+                >
+                  ENFORCE
+                </button>
+              </div>
+              <p className="mt-2 text-[11px] text-slate-500">Only org_admin can change mode. Agents cannot override it.</p>
+            </div>
+          </div>
+        </header>
+
+        {modeError && (
+          <div className="mb-4 rounded-xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-200">
+            เปลี่ยนโหมดไม่สำเร็จ: {modeError}
+          </div>
+        )}
+        {error && (
+          <div className="mb-4 rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-200">
+            Live feed ไม่พร้อม: {error}
+          </div>
+        )}
+
+        <div className="mb-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <p className="text-xs text-slate-500">Current setting</p>
+            <p className="mt-1 text-lg font-bold text-white">{mode.toUpperCase()}</p>
+          </div>
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <p className="text-xs text-slate-500">Latest event mode</p>
+            <p className="mt-1 text-lg font-bold text-white">{latest ? eventMode.toUpperCase() : 'NO EVENT'}</p>
+          </div>
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
+            <p className="text-xs text-slate-500">Persisted events loaded</p>
+            <p className="mt-1 text-lg font-bold text-white">{loading ? '…' : rows.length}</p>
+          </div>
+        </div>
+
+        {!loading && !latest ? (
+          <div className="rounded-2xl border border-dashed border-slate-700 bg-slate-900/40 p-8 text-center">
+            <p className="font-semibold text-slate-200">ยังไม่มี governance event จริง</p>
+            <p className="mt-2 text-sm text-slate-500">เชื่อม Agent ผ่าน MCP หรือ OpenAPI แล้วเรียก preflight ครั้งแรก ข้อมูลจะแสดงที่นี่</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <Panel index={1} title="ACTION" status={statuses.action ?? latest?.decision}>
+              <Field label="Event" value={latest?.execution_id} />
+              <Field label="Agent" value={latest?.agent_id} />
+              <Field label="Action" value={latest?.action_kind} />
+              <Field label="Target" value={metadata.target_system_id} />
+              <Field label="Operation" value={metadata.operation_name} />
+              <Field label="Risk" value={metadata.risk_level} />
+            </Panel>
+
+            <Panel index={2} title="PLAN ALIGNMENT" status={statuses.plan_alignment}>
+              <Field label="Decision" value={metadata.plan_decision} />
+              <Field label="Plan hash" value={metadata.plan_hash} />
+              <Field label="Action allowed" value={metadata.policy_allows_action === true ? 'YES' : 'NO'} />
+              <Field label="Reasons" value={reasons.length ? reasons.join(' · ') : '—'} />
+            </Panel>
+
+            <Panel index={3} title="PERMISSION" status={statuses.permission}>
+              <Field label="Auth source" value={metadata.auth_source} />
+              <Field label="Roles" value={(metadata.roles ?? []).join(', ')} />
+              <Field label="Meaning" value={statuses.permission === 'WAITING_PERMISSION' ? 'Execution permission is insufficient' : 'Execution role verified'} />
+            </Panel>
+
+            <Panel index={4} title="EVIDENCE" status={statuses.evidence}>
+              <Field label="Claim allowed" value={metadata.claim_allowed === true ? 'YES' : 'NO'} />
+              <Field label="Evidence refs" value={evidenceRefs.length} />
+              <Field label="Refs" value={evidenceRefs.length ? evidenceRefs.join(', ') : 'No evidence reference recorded'} />
+            </Panel>
+
+            <Panel index={5} title="EXECUTION / AUDIT" status={statuses.execution_audit}>
+              <Field label="Mode at decision" value={eventMode.toUpperCase()} />
+              <Field label="Downstream" value={metadata.should_block === true ? 'DO_NOT_EXECUTE' : 'CONTINUE_TO_TARGET'} />
+              <Field label="Audit hash" value={latest?.current_hash} />
+              <Field label="Previous hash" value={latest?.previous_hash} />
+              <Field label="Decision hash" value={latest?.evidence_hash} />
+              <Field label="Recorded at" value={latest?.occurred_at ? new Date(latest.occurred_at).toLocaleString() : '—'} />
+            </Panel>
+          </div>
+        )}
+
+        <section className="mt-6 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-5">
+          <h2 className="text-sm font-bold text-white">Connect existing agent</h2>
+          <div className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+            <div className="rounded-xl border border-white/[0.06] bg-black/20 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Microsoft Foundry / MCP</p>
+              <code className="mt-2 block break-all text-slate-200">/api/mcp/governance</code>
+            </div>
+            <div className="rounded-xl border border-white/[0.06] bg-black/20 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">OpenAPI schema</p>
+              <code className="mt-2 block break-all text-slate-200">/api/dsg/governance/openapi</code>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -29,6 +29,7 @@ const SECTIONS: NavSection[] = [
     id: 'govern',
     label: 'Govern',
     items: [
+      { href: '/dashboard/governance-live', label: 'Governance Live' },
       { href: '/approvals', label: 'Approvals' },
       { href: '/dashboard/audit', label: 'Audit' },
       { href: '/dashboard/policies', label: 'Policies' },

--- a/docs/integrations/MICROSOFT_FOUNDRY_DSG_GOVERNANCE.md
+++ b/docs/integrations/MICROSOFT_FOUNDRY_DSG_GOVERNANCE.md
@@ -1,0 +1,109 @@
+# Microsoft Foundry -> DSG Governance Plugin
+
+## Product contract
+
+Connect an existing agent to DSG before its target action executes.
+
+```text
+Existing Foundry agent / function dispatcher
+  -> DSG governance preflight
+  -> PASS | BLOCKED | WAITING_PERMISSION | UNVERIFIED
+  -> target executor honors shouldBlock
+  -> target API / MCP / workflow
+```
+
+DSG does not create a replacement agent. The customer keeps the existing agent and execution system.
+
+## Connect surfaces
+
+- MCP endpoint: `/api/mcp/governance`
+- OpenAPI schema: `/api/dsg/governance/openapi`
+- REST preflight: `/api/dsg/governance/preflight`
+- Live dashboard: `/dashboard/governance-live`
+
+The MCP endpoint exposes one narrow tool: `dsg.governance.preflight`.
+The OpenAPI schema exposes one operation: `dsgGovernancePreflight`.
+
+Authentication uses the existing DSG MCP API-key/OAuth validation. For Microsoft Foundry, store the DSG key in a Foundry project connection and inject it as the `x-dsg-api-key` header. Do not put the key in prompts, tool arguments, source code, or the OpenAPI document.
+
+## Observe / Enforce ownership
+
+Observe/Enforce is an organization-owned DSG setting. It is not accepted from agent tool arguments.
+
+- `OBSERVE`: evaluate + persist audit, but `shouldBlock=false` even if the action is outside the plan.
+- `ENFORCE`: set `shouldBlock=true` for `BLOCKED` or `WAITING_PERMISSION`.
+- `UNVERIFIED`: a plan-authorized action can continue, but the unsupported claim remains unverified.
+
+Only `org_admin` can change mode. The default for an organization without a settings row is `OBSERVE`.
+
+This prevents an agent from downgrading `ENFORCE` to `OBSERVE` in its own tool call.
+
+## Decision meanings
+
+| Status | Meaning | Downstream action |
+| --- | --- | --- |
+| `PASS` | Action matches approved plan, execution role passes, evidence/claim boundary passes | Continue |
+| `BLOCKED` | Action is outside the approved plan or no valid locked plan exists | Block only in Enforce mode |
+| `WAITING_PERMISSION` | Authenticated actor lacks DSG execution role | Block only in Enforce mode |
+| `UNVERIFIED` | Action is plan-authorized but the claim/evidence boundary is not satisfied | Continue action; do not assert the unsupported claim |
+
+## Five-panel live output
+
+Every persisted `governance_preflight` audit row records explicit status fields used by `/dashboard/governance-live`:
+
+1. ACTION
+2. PLAN ALIGNMENT
+3. PERMISSION
+4. EVIDENCE
+5. EXECUTION / AUDIT
+
+The live feed polls persisted audit rows every two seconds. It does not fabricate events when the feed is empty.
+
+## Microsoft Foundry MCP setup
+
+Use the deployed DSG base URL plus `/api/mcp/governance` as the remote MCP `server_url`.
+
+Recommended first connection:
+
+- project connection auth: custom key header `x-dsg-api-key`
+- `allowed_tools`: only `dsg.governance.preflight`
+- `require_approval`: `always` for first-success validation, then change deliberately for the customer's workflow
+
+Microsoft Foundry can send custom headers to remote MCP servers. The DSG endpoint uses HTTP GET/POST and stateless JSON-RPC handling.
+
+## Microsoft Foundry OpenAPI setup
+
+Fetch the deployed `/api/dsg/governance/openapi` document and add it as an OpenAPI tool using a Foundry project connection for the `x-dsg-api-key` security scheme.
+
+The caller sends action facts only. It does **not** send Observe/Enforce mode; DSG resolves mode server-side from the organization setting.
+
+## Critical enforcement boundary
+
+The current integration is a governance preflight, not a generic network proxy for every customer API.
+
+`ENFORCE` is effective only when the customer's execution adapter treats `shouldBlock=true` as a hard deny **and does not retain a bypass path that can invoke the target directly**.
+
+If an agent still has an independent direct target tool, DSG can record and return the correct decision but cannot physically prevent that separate tool from being called. Such an installation must not be described as interception-complete or network-enforced.
+
+A transparent target proxy / MCP tool mirroring layer would be a separate execution-adapter capability.
+
+## Verified source/runtime facts for this change
+
+- The production source already contains a deterministic plan-alignment gate and server-side plan-contract repository.
+- The live `dsg-control-plane-dev` database was missing `public.dsg_plan_contracts`; the idempotent restore migration was applied before this integration was opened for merge.
+- `public.dsg_governance_settings` was added with RLS enabled so mode is owned server-side.
+- Existing mock/scaffold `lib/spine/tool-handlers.ts` is not used by this integration.
+
+## Merge / production truth rule
+
+Do not claim Microsoft Foundry E2E PASS from source code or database migration alone.
+
+PASS requires, in order:
+
+1. CI typecheck/tests/build pass on the integration branch/PR.
+2. Merge/deploy completes to the intended Azure runtime.
+3. Deployed MCP initialize + `tools/list` succeeds.
+4. Deployed OpenAPI document loads.
+5. A real approved-plan action produces a persisted live audit event.
+6. Negative proof: an out-of-plan action returns `BLOCKED` and, with organization mode set to `ENFORCE`, returns `shouldBlock=true`.
+7. Claim-boundary proof: a plan-authorized action with insufficient claim evidence returns `UNVERIFIED`, `claimAllowed=false`, and `shouldBlock=false`.

--- a/lib/dsg/governance-plugin.ts
+++ b/lib/dsg/governance-plugin.ts
@@ -1,0 +1,307 @@
+import { createHash } from 'node:crypto';
+import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { lookupPlanContract } from './plan-contract-repository';
+import { evaluatePlanAlignment } from './plan-alignment-gate';
+import type { AgentActionType } from './agent-command-gate';
+import type { HermesActionEvent } from './plan-scope-contract';
+
+export type GovernanceMode = 'observe' | 'enforce';
+export type GovernanceStatus = 'PASS' | 'BLOCKED' | 'WAITING_PERMISSION' | 'UNVERIFIED';
+export type GovernanceRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface GovernancePreflightInput {
+  mode: GovernanceMode;
+  eventId: string;
+  planHash: string;
+  agentId: string;
+  sessionId: string;
+  actionType: AgentActionType;
+  targetSystemId: string;
+  operationName: string;
+  riskLevel: GovernanceRiskLevel;
+  payloadHash?: string;
+  idempotencyKey?: string;
+  rollbackPlanId?: string;
+  evidenceManifestId?: string;
+  policySnapshotHash?: string;
+  claimedOutcome?: string;
+  evidenceRefs?: string[];
+}
+
+export interface GovernancePreflightResult {
+  ok: true;
+  mode: GovernanceMode;
+  status: GovernanceStatus;
+  policyAllowsAction: boolean;
+  shouldBlock: boolean;
+  claimAllowed: boolean;
+  decisionHash: string;
+  panels: {
+    action: Record<string, unknown>;
+    planAlignment: Record<string, unknown>;
+    permission: Record<string, unknown>;
+    evidence: Record<string, unknown>;
+    executionAudit: Record<string, unknown>;
+  };
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(sortStable(value))).digest('hex');
+}
+
+function sortStable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortStable);
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortStable((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+function hasExecutionRole(auth: UnifiedAuthContext): boolean {
+  return auth.roles.includes('operator') || auth.roles.includes('org_admin');
+}
+
+function validateInput(input: GovernancePreflightInput): string | null {
+  if (!['observe', 'enforce'].includes(input.mode)) return 'mode must be observe or enforce';
+  if (!input.eventId) return 'eventId is required';
+  if (!/^[0-9a-f]{64}$/i.test(input.planHash)) return 'planHash must be a 64-character SHA-256 hex string';
+  if (!input.agentId) return 'agentId is required';
+  if (!input.sessionId) return 'sessionId is required';
+  if (!['observe', 'read', 'write', 'delete', 'payment', 'deploy', 'admin'].includes(input.actionType)) {
+    return 'actionType is invalid';
+  }
+  if (!input.targetSystemId) return 'targetSystemId is required';
+  if (!input.operationName) return 'operationName is required';
+  if (!['low', 'medium', 'high', 'critical'].includes(input.riskLevel)) return 'riskLevel is invalid';
+  return null;
+}
+
+async function appendAuditEvent(params: {
+  auth: UnifiedAuthContext;
+  input: GovernancePreflightInput;
+  status: GovernanceStatus;
+  policyAllowsAction: boolean;
+  shouldBlock: boolean;
+  claimAllowed: boolean;
+  decisionHash: string;
+  planDecision: string;
+  reasons: string[];
+}): Promise<{ persisted: boolean; auditHash?: string; reason?: string }> {
+  try {
+    const db = getSupabaseAdmin();
+    const latest = await db
+      .from('dsg_audit_events')
+      .select('current_hash')
+      .eq('owner_open_id', params.auth.actorId)
+      .order('occurred_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const previousHash = latest.data?.current_hash ?? null;
+    const occurredAt = new Date().toISOString();
+    const currentHash = sha256({
+      previousHash,
+      occurredAt,
+      actorId: params.auth.actorId,
+      orgId: params.auth.orgId,
+      eventId: params.input.eventId,
+      planHash: params.input.planHash,
+      agentId: params.input.agentId,
+      actionType: params.input.actionType,
+      targetSystemId: params.input.targetSystemId,
+      operationName: params.input.operationName,
+      status: params.status,
+      policyAllowsAction: params.policyAllowsAction,
+      shouldBlock: params.shouldBlock,
+      claimAllowed: params.claimAllowed,
+      decisionHash: params.decisionHash,
+      planDecision: params.planDecision,
+      reasons: params.reasons,
+    });
+
+    const { error } = await db.from('dsg_audit_events').insert({
+      owner_open_id: params.auth.actorId,
+      execution_id: params.input.eventId,
+      attempt_number: 0,
+      event_type: 'governance_preflight',
+      agent_id: params.input.agentId,
+      adapter_kind: 'mcp-openapi-governance-plugin',
+      action_kind: params.input.actionType,
+      decision: params.status,
+      status: params.shouldBlock ? 'BLOCKED' : 'OBSERVED',
+      policy_version: 'dsg-governance-plugin-v1',
+      evidence_hash: params.decisionHash,
+      previous_hash: previousHash,
+      current_hash: currentHash,
+      metadata: {
+        org_id: params.auth.orgId,
+        auth_source: params.auth.source,
+        roles: params.auth.roles,
+        mode: params.input.mode,
+        plan_hash: params.input.planHash,
+        target_system_id: params.input.targetSystemId,
+        operation_name: params.input.operationName,
+        risk_level: params.input.riskLevel,
+        plan_decision: params.planDecision,
+        reasons: params.reasons,
+        policy_allows_action: params.policyAllowsAction,
+        should_block: params.shouldBlock,
+        claim_allowed: params.claimAllowed,
+        evidence_refs: params.input.evidenceRefs ?? [],
+      },
+      occurred_at: occurredAt,
+    });
+
+    if (error) return { persisted: false, reason: error.message };
+    return { persisted: true, auditHash: currentHash };
+  } catch (error) {
+    return { persisted: false, reason: error instanceof Error ? error.message : 'AUDIT_WRITE_FAILED' };
+  }
+}
+
+export async function governAction(
+  input: GovernancePreflightInput,
+  auth: UnifiedAuthContext,
+): Promise<GovernancePreflightResult | { ok: false; error: string }> {
+  const invalid = validateInput(input);
+  if (invalid) return { ok: false, error: invalid };
+
+  const contract = await lookupPlanContract(input.planHash, auth.orgId);
+  const permissionPassed = hasExecutionRole(auth);
+
+  let planDecision = 'OUT_OF_PLAN_DENY';
+  let planReasons = ['plan_contract_not_found'];
+  let policyAllowsAction = false;
+  let claimAllowed = false;
+  let alignmentDecisionHash = sha256({
+    eventId: input.eventId,
+    planHash: input.planHash,
+    decision: planDecision,
+    reasons: planReasons,
+  });
+
+  if (contract) {
+    const event: HermesActionEvent = {
+      eventId: input.eventId,
+      planId: contract.planId,
+      planHash: input.planHash,
+      workspaceId: auth.orgId,
+      agentId: input.agentId,
+      sessionId: input.sessionId,
+      actionType: input.actionType,
+      targetSystemId: input.targetSystemId,
+      operationName: input.operationName,
+      riskLevel: input.riskLevel,
+      payloadHash: input.payloadHash,
+      idempotencyKey: input.idempotencyKey,
+      rollbackPlanId: input.rollbackPlanId,
+      evidenceManifestId: input.evidenceManifestId,
+      policySnapshotHash: input.policySnapshotHash,
+      claimedOutcome: input.claimedOutcome,
+      requestedAt: new Date().toISOString(),
+    };
+
+    const alignment = evaluatePlanAlignment(contract, event);
+    planDecision = alignment.decision;
+    planReasons = alignment.reasons;
+    alignmentDecisionHash = alignment.decisionHash;
+    policyAllowsAction =
+      alignment.decision === 'PLAN_MATCHED_ALLOW_AUDIT' ||
+      alignment.decision === 'CLAIM_EVIDENCE_DENY';
+    claimAllowed = alignment.claimAllowed;
+  }
+
+  const evidenceRefs = input.evidenceRefs ?? [];
+  const claimNeedsEvidence = Boolean(input.claimedOutcome) && evidenceRefs.length === 0;
+  if (claimNeedsEvidence) claimAllowed = false;
+
+  let status: GovernanceStatus;
+  if (!policyAllowsAction) {
+    status = 'BLOCKED';
+  } else if (!permissionPassed) {
+    status = 'WAITING_PERMISSION';
+  } else if (!claimAllowed || planDecision === 'CLAIM_EVIDENCE_DENY') {
+    status = 'UNVERIFIED';
+  } else {
+    status = 'PASS';
+  }
+
+  // Observe mode never blocks the downstream call. Enforce mode blocks only
+  // out-of-plan actions or callers without DSG execution permission.
+  // Unsupported claims remain UNVERIFIED but do not stop a plan-authorized action.
+  const shouldBlock = input.mode === 'enforce' && (status === 'BLOCKED' || status === 'WAITING_PERMISSION');
+  const decisionHash = sha256({
+    alignmentDecisionHash,
+    mode: input.mode,
+    status,
+    permissionPassed,
+    policyAllowsAction,
+    claimAllowed,
+  });
+
+  const audit = await appendAuditEvent({
+    auth,
+    input,
+    status,
+    policyAllowsAction,
+    shouldBlock,
+    claimAllowed,
+    decisionHash,
+    planDecision,
+    reasons: planReasons,
+  });
+
+  return {
+    ok: true,
+    mode: input.mode,
+    status,
+    policyAllowsAction,
+    shouldBlock,
+    claimAllowed,
+    decisionHash,
+    panels: {
+      action: {
+        status,
+        eventId: input.eventId,
+        agentId: input.agentId,
+        actionType: input.actionType,
+        targetSystemId: input.targetSystemId,
+        operationName: input.operationName,
+        riskLevel: input.riskLevel,
+      },
+      planAlignment: {
+        status: policyAllowsAction ? 'PASS' : 'BLOCKED',
+        decision: planDecision,
+        planHash: input.planHash,
+        reasons: planReasons,
+      },
+      permission: {
+        status: permissionPassed ? 'PASS' : 'WAITING_PERMISSION',
+        authenticatedBy: auth.source,
+        roles: auth.roles,
+        actorId: auth.actorId,
+      },
+      evidence: {
+        status: claimAllowed && planDecision !== 'CLAIM_EVIDENCE_DENY' ? 'PASS' : 'UNVERIFIED',
+        claim: input.claimedOutcome ?? null,
+        evidenceRefs,
+        evidenceManifestId: input.evidenceManifestId ?? null,
+        policySnapshotHash: input.policySnapshotHash ?? null,
+      },
+      executionAudit: {
+        status: audit.persisted ? 'PASS' : 'UNVERIFIED',
+        persisted: audit.persisted,
+        auditHash: audit.auditHash ?? null,
+        auditFailure: audit.persisted ? null : audit.reason ?? 'AUDIT_WRITE_FAILED',
+        shouldBlock,
+        downstreamInstruction: shouldBlock ? 'DO_NOT_EXECUTE' : 'CONTINUE_TO_TARGET',
+      },
+    },
+  };
+}

--- a/lib/dsg/governance-plugin.ts
+++ b/lib/dsg/governance-plugin.ts
@@ -87,6 +87,8 @@ async function appendAuditEvent(params: {
   input: GovernancePreflightInput;
   status: GovernanceStatus;
   policyAllowsAction: boolean;
+  permissionPassed: boolean;
+  evidenceStatus: 'PASS' | 'UNVERIFIED';
   shouldBlock: boolean;
   claimAllowed: boolean;
   decisionHash: string;
@@ -118,6 +120,8 @@ async function appendAuditEvent(params: {
       operationName: params.input.operationName,
       status: params.status,
       policyAllowsAction: params.policyAllowsAction,
+      permissionPassed: params.permissionPassed,
+      evidenceStatus: params.evidenceStatus,
       shouldBlock: params.shouldBlock,
       claimAllowed: params.claimAllowed,
       decisionHash: params.decisionHash,
@@ -154,6 +158,13 @@ async function appendAuditEvent(params: {
         should_block: params.shouldBlock,
         claim_allowed: params.claimAllowed,
         evidence_refs: params.input.evidenceRefs ?? [],
+        panel_statuses: {
+          action: params.status,
+          plan_alignment: params.policyAllowsAction ? 'PASS' : 'BLOCKED',
+          permission: params.permissionPassed ? 'PASS' : 'WAITING_PERMISSION',
+          evidence: params.evidenceStatus,
+          execution_audit: 'PASS',
+        },
       },
       occurred_at: occurredAt,
     });
@@ -220,13 +231,15 @@ export async function governAction(
   const evidenceRefs = input.evidenceRefs ?? [];
   const claimNeedsEvidence = Boolean(input.claimedOutcome) && evidenceRefs.length === 0;
   if (claimNeedsEvidence) claimAllowed = false;
+  const evidenceStatus: 'PASS' | 'UNVERIFIED' =
+    claimAllowed && planDecision !== 'CLAIM_EVIDENCE_DENY' ? 'PASS' : 'UNVERIFIED';
 
   let status: GovernanceStatus;
   if (!policyAllowsAction) {
     status = 'BLOCKED';
   } else if (!permissionPassed) {
     status = 'WAITING_PERMISSION';
-  } else if (!claimAllowed || planDecision === 'CLAIM_EVIDENCE_DENY') {
+  } else if (evidenceStatus === 'UNVERIFIED') {
     status = 'UNVERIFIED';
   } else {
     status = 'PASS';
@@ -250,6 +263,8 @@ export async function governAction(
     input,
     status,
     policyAllowsAction,
+    permissionPassed,
+    evidenceStatus,
     shouldBlock,
     claimAllowed,
     decisionHash,
@@ -288,7 +303,7 @@ export async function governAction(
         actorId: auth.actorId,
       },
       evidence: {
-        status: claimAllowed && planDecision !== 'CLAIM_EVIDENCE_DENY' ? 'PASS' : 'UNVERIFIED',
+        status: evidenceStatus,
         claim: input.claimedOutcome ?? null,
         evidenceRefs,
         evidenceManifestId: input.evidenceManifestId ?? null,

--- a/lib/dsg/governance-plugin.ts
+++ b/lib/dsg/governance-plugin.ts
@@ -3,15 +3,14 @@ import type { UnifiedAuthContext } from '@/lib/mcp/unified-auth';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { lookupPlanContract } from './plan-contract-repository';
 import { evaluatePlanAlignment } from './plan-alignment-gate';
+import { getGovernanceMode, type GovernanceMode } from './governance-settings';
 import type { AgentActionType } from './agent-command-gate';
 import type { HermesActionEvent } from './plan-scope-contract';
 
-export type GovernanceMode = 'observe' | 'enforce';
 export type GovernanceStatus = 'PASS' | 'BLOCKED' | 'WAITING_PERMISSION' | 'UNVERIFIED';
 export type GovernanceRiskLevel = 'low' | 'medium' | 'high' | 'critical';
 
 export interface GovernancePreflightInput {
-  mode: GovernanceMode;
   eventId: string;
   planHash: string;
   agentId: string;
@@ -68,7 +67,6 @@ function hasExecutionRole(auth: UnifiedAuthContext): boolean {
 }
 
 function validateInput(input: GovernancePreflightInput): string | null {
-  if (!['observe', 'enforce'].includes(input.mode)) return 'mode must be observe or enforce';
   if (!input.eventId) return 'eventId is required';
   if (!/^[0-9a-f]{64}$/i.test(input.planHash)) return 'planHash must be a 64-character SHA-256 hex string';
   if (!input.agentId) return 'agentId is required';
@@ -85,6 +83,7 @@ function validateInput(input: GovernancePreflightInput): string | null {
 async function appendAuditEvent(params: {
   auth: UnifiedAuthContext;
   input: GovernancePreflightInput;
+  mode: GovernanceMode;
   status: GovernanceStatus;
   policyAllowsAction: boolean;
   permissionPassed: boolean;
@@ -118,6 +117,7 @@ async function appendAuditEvent(params: {
       actionType: params.input.actionType,
       targetSystemId: params.input.targetSystemId,
       operationName: params.input.operationName,
+      mode: params.mode,
       status: params.status,
       policyAllowsAction: params.policyAllowsAction,
       permissionPassed: params.permissionPassed,
@@ -147,7 +147,7 @@ async function appendAuditEvent(params: {
         org_id: params.auth.orgId,
         auth_source: params.auth.source,
         roles: params.auth.roles,
-        mode: params.input.mode,
+        mode: params.mode,
         plan_hash: params.input.planHash,
         target_system_id: params.input.targetSystemId,
         operation_name: params.input.operationName,
@@ -182,6 +182,13 @@ export async function governAction(
 ): Promise<GovernancePreflightResult | { ok: false; error: string }> {
   const invalid = validateInput(input);
   if (invalid) return { ok: false, error: invalid };
+
+  let mode: GovernanceMode;
+  try {
+    mode = await getGovernanceMode(auth.orgId);
+  } catch {
+    return { ok: false, error: 'GOVERNANCE_MODE_UNAVAILABLE' };
+  }
 
   const contract = await lookupPlanContract(input.planHash, auth.orgId);
   const permissionPassed = hasExecutionRole(auth);
@@ -222,9 +229,7 @@ export async function governAction(
     planDecision = alignment.decision;
     planReasons = alignment.reasons;
     alignmentDecisionHash = alignment.decisionHash;
-    policyAllowsAction =
-      alignment.decision === 'PLAN_MATCHED_ALLOW_AUDIT' ||
-      alignment.decision === 'CLAIM_EVIDENCE_DENY';
+    policyAllowsAction = alignment.canProceed;
     claimAllowed = alignment.claimAllowed;
   }
 
@@ -248,10 +253,10 @@ export async function governAction(
   // Observe mode never blocks the downstream call. Enforce mode blocks only
   // out-of-plan actions or callers without DSG execution permission.
   // Unsupported claims remain UNVERIFIED but do not stop a plan-authorized action.
-  const shouldBlock = input.mode === 'enforce' && (status === 'BLOCKED' || status === 'WAITING_PERMISSION');
+  const shouldBlock = mode === 'enforce' && (status === 'BLOCKED' || status === 'WAITING_PERMISSION');
   const decisionHash = sha256({
     alignmentDecisionHash,
-    mode: input.mode,
+    mode,
     status,
     permissionPassed,
     policyAllowsAction,
@@ -261,6 +266,7 @@ export async function governAction(
   const audit = await appendAuditEvent({
     auth,
     input,
+    mode,
     status,
     policyAllowsAction,
     permissionPassed,
@@ -274,7 +280,7 @@ export async function governAction(
 
   return {
     ok: true,
-    mode: input.mode,
+    mode,
     status,
     policyAllowsAction,
     shouldBlock,

--- a/lib/dsg/governance-settings.ts
+++ b/lib/dsg/governance-settings.ts
@@ -2,17 +2,20 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 export type GovernanceMode = 'observe' | 'enforce';
 
+type GovernanceSettingRow = { mode?: string };
+
 export async function getGovernanceMode(orgId: string): Promise<GovernanceMode> {
   const db = getSupabaseAdmin();
   const { data, error } = await db
-    .from('dsg_governance_settings')
+    .from('dsg_governance_settings' as never)
     .select('mode')
     .eq('org_id', orgId)
     .maybeSingle();
 
   if (error) throw new Error('GOVERNANCE_MODE_UNAVAILABLE');
-  if (!data) return 'observe';
-  return data.mode === 'enforce' ? 'enforce' : 'observe';
+  const row = data as GovernanceSettingRow | null;
+  if (!row) return 'observe';
+  return row.mode === 'enforce' ? 'enforce' : 'observe';
 }
 
 export async function setGovernanceMode(
@@ -21,13 +24,13 @@ export async function setGovernanceMode(
   mode: GovernanceMode,
 ): Promise<void> {
   const db = getSupabaseAdmin();
-  const { error } = await db.from('dsg_governance_settings').upsert(
+  const { error } = await db.from('dsg_governance_settings' as never).upsert(
     {
       org_id: orgId,
       mode,
       updated_by: actorId,
       updated_at: new Date().toISOString(),
-    },
+    } as never,
     { onConflict: 'org_id' },
   );
 

--- a/lib/dsg/governance-settings.ts
+++ b/lib/dsg/governance-settings.ts
@@ -1,0 +1,35 @@
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export type GovernanceMode = 'observe' | 'enforce';
+
+export async function getGovernanceMode(orgId: string): Promise<GovernanceMode> {
+  const db = getSupabaseAdmin();
+  const { data, error } = await db
+    .from('dsg_governance_settings')
+    .select('mode')
+    .eq('org_id', orgId)
+    .maybeSingle();
+
+  if (error) throw new Error('GOVERNANCE_MODE_UNAVAILABLE');
+  if (!data) return 'observe';
+  return data.mode === 'enforce' ? 'enforce' : 'observe';
+}
+
+export async function setGovernanceMode(
+  orgId: string,
+  actorId: string,
+  mode: GovernanceMode,
+): Promise<void> {
+  const db = getSupabaseAdmin();
+  const { error } = await db.from('dsg_governance_settings').upsert(
+    {
+      org_id: orgId,
+      mode,
+      updated_by: actorId,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'org_id' },
+  );
+
+  if (error) throw new Error('GOVERNANCE_MODE_UPDATE_FAILED');
+}

--- a/lib/dsg/plan-alignment-gate.ts
+++ b/lib/dsg/plan-alignment-gate.ts
@@ -88,9 +88,11 @@ function seal(
   decidedAt: string,
 ): DsgPlanAlignmentResult {
   const decisionHash = sha256({ decision, planHash: contract.planHash, eventId: event.eventId, reasons, decidedAt });
+  const canProceed =
+    decision === "PLAN_MATCHED_ALLOW_AUDIT" || decision === "CLAIM_EVIDENCE_DENY";
   return {
     decision,
-    canProceed: decision === "PLAN_MATCHED_ALLOW_AUDIT",
+    canProceed,
     planId: contract.planId,
     planHash: contract.planHash,
     scopeHash: contract.scopeHash,

--- a/supabase/migrations/20260901061000_restore_dsg_plan_contracts_for_foundry.sql
+++ b/supabase/migrations/20260901061000_restore_dsg_plan_contracts_for_foundry.sql
@@ -1,0 +1,33 @@
+-- Restore the server-side approved plan contract store on environments whose
+-- migration history diverged before the original 20260603000000 migration.
+-- Idempotent by design so source and live schema can converge safely.
+
+CREATE TABLE IF NOT EXISTS public.dsg_plan_contracts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id TEXT NOT NULL,
+  plan_hash TEXT NOT NULL UNIQUE,
+  scope_hash TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  approved_by TEXT NOT NULL,
+  approved_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ,
+  allowed_action_types JSONB NOT NULL DEFAULT '[]'::jsonb,
+  allowed_target_systems JSONB NOT NULL DEFAULT '[]'::jsonb,
+  allowed_operations JSONB NOT NULL DEFAULT '[]'::jsonb,
+  max_risk_level TEXT NOT NULL,
+  evidence_requirements JSONB NOT NULL,
+  claim_boundary TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dsg_plan_contracts_plan_hash_idx
+  ON public.dsg_plan_contracts (plan_hash);
+CREATE INDEX IF NOT EXISTS dsg_plan_contracts_workspace_idx
+  ON public.dsg_plan_contracts (workspace_id, agent_id);
+
+ALTER TABLE public.dsg_plan_contracts ENABLE ROW LEVEL SECURITY;
+
+-- Deliberately no authenticated/anon policies. Server-side governance routes
+-- use the backend service credential; public clients cannot read or mutate
+-- approved plan contracts directly.

--- a/supabase/migrations/20260901062500_dsg_governance_settings.sql
+++ b/supabase/migrations/20260901062500_dsg_governance_settings.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS public.dsg_governance_settings (
+  org_id TEXT PRIMARY KEY,
+  mode TEXT NOT NULL DEFAULT 'observe' CHECK (mode IN ('observe', 'enforce')),
+  updated_by TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.dsg_governance_settings ENABLE ROW LEVEL SECURITY;
+
+-- Runtime reads/writes are server-side only. No anon/authenticated policies are
+-- created because the API resolves org membership and role before using the
+-- backend service credential.

--- a/tests/dsg/plan-alignment-gate.test.ts
+++ b/tests/dsg/plan-alignment-gate.test.ts
@@ -135,29 +135,33 @@ describe("evaluatePlanAlignment", () => {
     expect(result.reasons.some((r) => r.includes("plan_hash_mismatch"))).toBe(true);
   });
 
-  it("CLAIM_EVIDENCE_DENY when required idempotency key is missing", () => {
+  it("CLAIM_EVIDENCE_DENY keeps plan-authorized action executable when idempotency evidence is missing", () => {
     const event = { ...baseEvent(), idempotencyKey: undefined };
     const result = evaluatePlanAlignment(baseContract, event, fixedNow);
 
     expect(result.decision).toBe("CLAIM_EVIDENCE_DENY");
-    expect(result.canProceed).toBe(false);
+    expect(result.canProceed).toBe(true);
+    expect(result.claimAllowed).toBe(false);
     expect(result.reasons).toContain("idempotency_key_missing");
   });
 
-  it("CLAIM_EVIDENCE_DENY when required evidence manifest is missing", () => {
+  it("CLAIM_EVIDENCE_DENY keeps plan-authorized action executable when evidence manifest is missing", () => {
     const event = { ...baseEvent(), evidenceManifestId: undefined };
     const result = evaluatePlanAlignment(baseContract, event, fixedNow);
 
     expect(result.decision).toBe("CLAIM_EVIDENCE_DENY");
+    expect(result.canProceed).toBe(true);
+    expect(result.claimAllowed).toBe(false);
     expect(result.reasons).toContain("evidence_manifest_missing");
   });
 
-  it("CLAIM_EVIDENCE_DENY when requireAudit is true and audit fields are missing (P2 — enforce audit binding)", () => {
+  it("CLAIM_EVIDENCE_DENY keeps plan-authorized action executable when audit binding is missing", () => {
     const event = { ...baseEvent(), preAuditEventId: undefined, ledgerId: undefined, chainHeadHash: undefined };
     const result = evaluatePlanAlignment(baseContract, event, fixedNow);
 
     expect(result.decision).toBe("CLAIM_EVIDENCE_DENY");
-    expect(result.canProceed).toBe(false);
+    expect(result.canProceed).toBe(true);
+    expect(result.claimAllowed).toBe(false);
     expect(result.reasons).toContain("audit_binding_missing");
   });
 


### PR DESCRIPTION
## Goal
Allow existing Microsoft Foundry / MCP / OpenAPI agents to call DSG as a governance preflight without replacing the customer's agent.

## User-visible flow
Existing agent -> DSG governance preflight -> PASS / BLOCKED / WAITING_PERMISSION / UNVERIFIED -> execution adapter honors `shouldBlock` -> live five-panel audit dashboard.

## Included
- dedicated `/api/mcp/governance` MCP endpoint with one narrow tool: `dsg.governance.preflight`
- OpenAPI 3.1 contract at `/api/dsg/governance/openapi`
- REST preflight at `/api/dsg/governance/preflight`
- owner-controlled Observe/Enforce setting; agent cannot override mode
- `/dashboard/governance-live` with ACTION / PLAN ALIGNMENT / PERMISSION / EVIDENCE / EXECUTION-AUDIT panels
- persisted `governance_preflight` audit rows using existing hash-chain ledger
- restore migration for missing live `dsg_plan_contracts`
- `dsg_governance_settings` migration with RLS
- plan-alignment semantic fix: `CLAIM_EVIDENCE_DENY` keeps an approved-plan action executable while the unsupported claim remains denied/unverified
- tests updated to lock that boundary
- Microsoft Foundry integration/runbook doc

## Live DB evidence before PR
- `public.dsg_plan_contracts` was missing in `dsg-control-plane-dev`; restore migration applied successfully.
- `public.dsg_governance_settings` migration applied successfully.
- RLS verified enabled on both tables.

## Truth boundary
This PR is governance preflight, not a generic target network proxy. Enforce is effective only where the customer execution adapter honors `shouldBlock` and has no bypass path to the target. Do not claim Foundry E2E PASS until CI, Azure deploy, MCP/OpenAPI probes, persisted positive/negative events, and claim-boundary proof all pass.