### PR TITLE
fix(ci): point production E2E at Azure

### DIFF
--- a/.github/workflows/e2e-production.yml
+++ b/.github/workflows/e2e-production.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run infrastructure health checks
         run: npx playwright test tests/e2e/infrastructure.spec.ts --reporter=list
         env:
-          PLAYWRIGHT_BASE_URL: https://tdealer01-crypto-dsg-control-plane.vercel.app
+          PLAYWRIGHT_BASE_URL: https://dsg-control-plane.azurewebsites.net
           SKIP_TUNNEL_HEALTH: 'true'
 
       - name: Run API auth guard tests (no credentials needed)
@@ -52,7 +52,7 @@ jobs:
             tests/e2e/hermes-sessions.spec.ts \
             --reporter=list
         env:
-          PLAYWRIGHT_BASE_URL: https://tdealer01-crypto-dsg-control-plane.vercel.app
+          PLAYWRIGHT_BASE_URL: https://dsg-control-plane.azurewebsites.net
 
       - name: Run public page smoke tests
         run: |
@@ -61,7 +61,7 @@ jobs:
             tests/e2e/support.spec.ts \
             --reporter=list
         env:
-          PLAYWRIGHT_BASE_URL: https://tdealer01-crypto-dsg-control-plane.vercel.app
+          PLAYWRIGHT_BASE_URL: https://dsg-control-plane.azurewebsites.net
 
       - name: Upload test results on failure
         if: failure()

--- a/tests/e2e/infrastructure.spec.ts
+++ b/tests/e2e/infrastructure.spec.ts
@@ -4,12 +4,12 @@
  */
 import { test, expect, request } from '@playwright/test';
 
-const PROD_BASE = 'https://tdealer01-crypto-dsg-control-plane.vercel.app';
+const PROD_BASE = process.env.PLAYWRIGHT_BASE_URL ?? 'https://dsg-control-plane.azurewebsites.net';
 const TUNNEL_URL = process.env.CLOUDFLARE_TUNNEL_URL ?? 'https://shades-powerseller-guys-opposition.trycloudflare.com';
 
 const ENDPOINTS = [
   {
-    label: 'Production Vercel health',
+    label: 'Production Azure App Service health',
     url: `${PROD_BASE}/api/health`,
     skipEnv: undefined,
   },


### PR DESCRIPTION
## Problem
Production E2E was still targeting the retired Vercel hostname and failing with HTTP 402 even though Azure App Service is the authoritative production target.

## Changes
- Point all production E2E workflow suites at `https://dsg-control-plane.azurewebsites.net`.
- Make `tests/e2e/infrastructure.spec.ts` honor `PLAYWRIGHT_BASE_URL` with Azure as the fail-safe default.
- Rename the production health label from Vercel to Azure App Service.

## Evidence before fix
Post-merge run 33487041576 failed its four infrastructure checks against the old Vercel URL with HTTP 402.

No secret, RBAC, database, or Azure resource mutation is included in this PR.