### PR TITLE
chore: make Vercel optional and keep Azure as production target

### DIFF
--- a/lib/dsg/setup/manifest/vercel.ts
+++ b/lib/dsg/setup/manifest/vercel.ts
@@ -1,5 +1,7 @@
 import type { ConnectorManifest } from '../types';
 
+// Vercel remains available as an optional customer-selected connector.
+// It is not the default production deployment target.
 export const vercelManifest: ConnectorManifest = {
   id: 'vercel',
   name: 'Vercel',
@@ -18,12 +20,12 @@ export const vercelManifest: ConnectorManifest = {
     {
       resource: 'deployment',
       key: 'vercel_deployment_url',
-      description: 'Vercel deployment URL',
+      description: 'Optional Vercel deployment URL',
     },
     {
       resource: 'api_key',
       key: 'vercel_api_key',
-      description: 'Vercel API key for CI/CD',
+      description: 'Optional Vercel API key for customer-selected deployments',
     },
   ],
   requires: [


### PR DESCRIPTION
## Summary
- Keep Vercel connector available for customer-selected deployments.
- Remove ambiguity that Vercel is the production deployment target.
- Mark Vercel deployment outputs as optional.

## Safety
- No secrets changed.
- No production runtime path changed.
- Azure remains the authoritative production target.