### PR TITLE
Redesign Control Plane landing and governance UX

### DIFF
--- a/app/dashboard/governance-live/page.tsx
+++ b/app/dashboard/governance-live/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 type GovernanceMode = 'observe' | 'enforce';
@@ -44,6 +45,14 @@ type AuditRow = {
   metadata: AuditMetadata;
 };
 
+const PANEL_COPY = [
+  ['ACTION', 'What the agent is trying to do'],
+  ['PLAN ALIGNMENT', 'Whether the action matches the approved plan'],
+  ['PERMISSION', 'Whether the execution identity has permission'],
+  ['EVIDENCE', 'Whether the decision has supporting evidence'],
+  ['EXECUTION / AUDIT', 'What happens next and what was recorded'],
+] as const;
+
 function statusClass(status?: string) {
   switch (status) {
     case 'PASS':
@@ -67,39 +76,72 @@ function Badge({ status }: { status?: string }) {
   );
 }
 
-function Field({ label, value }: { label: string; value: unknown }) {
+function Field({ label, value, mono = false }: { label: string; value: unknown; mono?: boolean }) {
   const text = value === null || value === undefined || value === '' ? '—' : String(value);
   return (
-    <div className="grid gap-1 border-t border-white/[0.06] py-3 sm:grid-cols-[180px_1fr] sm:gap-4">
+    <div className="grid gap-1 border-t border-white/[0.06] py-3 sm:grid-cols-[170px_1fr] sm:gap-4">
       <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</dt>
-      <dd className="break-all text-sm text-slate-200">{text}</dd>
+      <dd className={`break-all text-sm text-slate-200 ${mono ? 'font-mono text-xs' : ''}`}>{text}</dd>
     </div>
   );
 }
 
 function Panel({
   index,
-  title,
   status,
   children,
 }: {
   index: number;
-  title: string;
   status?: string;
   children: React.ReactNode;
 }) {
+  const copy = PANEL_COPY[index - 1];
   return (
-    <section className="rounded-2xl border border-white/[0.08] bg-white/[0.025] p-5 shadow-xl shadow-black/10">
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-slate-500">Panel {index}</p>
-          <h2 className="mt-1 text-lg font-bold text-white">{title}</h2>
+    <section className="rounded-3xl border border-white/[0.08] bg-white/[0.025] p-5 shadow-2xl shadow-black/10 sm:p-6">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div className="flex min-w-0 gap-4">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-amber-300/25 bg-amber-300/10 text-xs font-bold text-amber-100">
+            {String(index).padStart(2, '0')}
+          </span>
+          <div>
+            <h2 className="text-base font-bold tracking-wide text-white">{copy[0]}</h2>
+            <p className="mt-1 text-sm leading-6 text-slate-500">{copy[1]}</p>
+          </div>
         </div>
         <Badge status={status} />
       </div>
       <dl>{children}</dl>
     </section>
   );
+}
+
+function nextAction(status?: GovernanceStatus, reasons: string[] = []) {
+  if (status === 'BLOCKED') {
+    return {
+      title: 'Action stopped',
+      body: reasons[0] ?? 'This action is outside the currently approved governance conditions.',
+      fix: 'Change the action to match the approved plan, or update and approve the plan before trying again.',
+    };
+  }
+  if (status === 'WAITING_PERMISSION') {
+    return {
+      title: 'Permission required',
+      body: 'The action cannot continue with the current execution permission.',
+      fix: 'Grant the required role or capability, then retry the action.',
+    };
+  }
+  if (status === 'UNVERIFIED') {
+    return {
+      title: 'Evidence incomplete',
+      body: 'DSG does not have enough verified evidence to support this action or claim.',
+      fix: 'Attach or produce the required evidence, then run governance again.',
+    };
+  }
+  return {
+    title: 'Action may continue',
+    body: 'The latest governance decision does not require DSG to stop downstream execution.',
+    fix: 'No governance fix is required for this event. Open Audit if you need the recorded proof trail.',
+  };
 }
 
 export default function GovernanceLivePage() {
@@ -178,31 +220,45 @@ export default function GovernanceLivePage() {
   const eventMode = metadata.mode ?? mode;
   const reasons = useMemo(() => metadata.reasons ?? [], [metadata.reasons]);
   const evidenceRefs = useMemo(() => metadata.evidence_refs ?? [], [metadata.evidence_refs]);
+  const outcome = nextAction(statuses.execution_audit ?? latest?.decision, reasons);
 
   return (
     <main className="min-h-screen bg-[#07080b] text-slate-100">
-      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
-        <header className="mb-6">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-500">DSG Governance Plugin</p>
-          <div className="mt-2 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
+        <header className="mb-8 border-b border-white/[0.07] pb-8">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <h1 className="text-3xl font-bold text-white">Live Governance</h1>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
-                MCP/OpenAPI actions are evaluated against the server-side approved plan, then persisted to the audit ledger. Feed refresh: 2 seconds. No synthetic events.
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.22em] text-amber-100">
+                  Live governance
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Real persisted events · refresh 2s
+                </span>
+              </div>
+              <h1 className="mt-5 max-w-3xl text-3xl font-bold leading-tight text-white sm:text-5xl">
+                See what your agent is trying to do — and what DSG decides.
+              </h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-400 sm:text-base">
+                Follow one action through plan alignment, permission, evidence, and the final execution decision. No synthetic events are added to this feed.
               </p>
             </div>
-            <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-3">
-              <p className="mb-2 text-xs font-semibold text-slate-400">Organization mode</p>
-              <div className="flex gap-2">
+
+            <div className="min-w-[280px] rounded-3xl border border-white/[0.08] bg-white/[0.025] p-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-xs font-semibold text-white">Control mode</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">
+                    Observe records decisions. Enforce can stop actions when governance requires it.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2 rounded-2xl border border-white/[0.07] bg-black/20 p-1.5">
                 <button
                   type="button"
                   disabled={savingMode}
                   onClick={() => void changeMode('observe')}
-                  className={`rounded-xl border px-4 py-2 text-sm font-bold transition ${
-                    mode === 'observe'
-                      ? 'border-blue-400/50 bg-blue-400/15 text-blue-200'
-                      : 'border-white/10 bg-white/5 text-slate-400'
-                  } disabled:opacity-50`}
+                  className={`rounded-xl px-4 py-2.5 text-sm font-bold transition ${mode === 'observe' ? 'bg-white/10 text-white' : 'text-slate-500'} disabled:opacity-50`}
                 >
                   OBSERVE
                 </button>
@@ -210,103 +266,125 @@ export default function GovernanceLivePage() {
                   type="button"
                   disabled={savingMode}
                   onClick={() => void changeMode('enforce')}
-                  className={`rounded-xl border px-4 py-2 text-sm font-bold transition ${
-                    mode === 'enforce'
-                      ? 'border-red-400/50 bg-red-400/15 text-red-200'
-                      : 'border-white/10 bg-white/5 text-slate-400'
-                  } disabled:opacity-50`}
+                  className={`rounded-xl px-4 py-2.5 text-sm font-bold transition ${mode === 'enforce' ? 'bg-red-500/15 text-red-200' : 'text-slate-500'} disabled:opacity-50`}
                 >
                   ENFORCE
                 </button>
               </div>
-              <p className="mt-2 text-[11px] text-slate-500">Only org_admin can change mode. Agents cannot override it.</p>
+              <p className="mt-2 text-[11px] text-slate-600">Mode changes remain server-authorized; agents cannot override them.</p>
             </div>
           </div>
         </header>
 
         {modeError && (
-          <div className="mb-4 rounded-xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-200">
-            เปลี่ยนโหมดไม่สำเร็จ: {modeError}
+          <div className="mb-4 rounded-2xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-200">
+            Mode change failed: {modeError}
           </div>
         )}
         {error && (
-          <div className="mb-4 rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-200">
-            Live feed ไม่พร้อม: {error}
+          <div className="mb-4 rounded-2xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-200">
+            Live feed unavailable: {error}
           </div>
         )}
-
-        <div className="mb-5 grid gap-3 sm:grid-cols-3">
-          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
-            <p className="text-xs text-slate-500">Current setting</p>
-            <p className="mt-1 text-lg font-bold text-white">{mode.toUpperCase()}</p>
-          </div>
-          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
-            <p className="text-xs text-slate-500">Latest event mode</p>
-            <p className="mt-1 text-lg font-bold text-white">{latest ? eventMode.toUpperCase() : 'NO EVENT'}</p>
-          </div>
-          <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4">
-            <p className="text-xs text-slate-500">Persisted events loaded</p>
-            <p className="mt-1 text-lg font-bold text-white">{loading ? '…' : rows.length}</p>
-          </div>
-        </div>
 
         {!loading && !latest ? (
-          <div className="rounded-2xl border border-dashed border-slate-700 bg-slate-900/40 p-8 text-center">
-            <p className="font-semibold text-slate-200">ยังไม่มี governance event จริง</p>
-            <p className="mt-2 text-sm text-slate-500">เชื่อม Agent ผ่าน MCP หรือ OpenAPI แล้วเรียก preflight ครั้งแรก ข้อมูลจะแสดงที่นี่</p>
-          </div>
+          <section className="rounded-3xl border border-dashed border-white/15 bg-white/[0.02] p-7 sm:p-10">
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-amber-100">Start here</p>
+            <h2 className="mt-3 text-2xl font-bold text-white">Connect an existing agent to create the first real event.</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-400">
+              This screen intentionally stays empty until a real governance event is persisted. Connect through MCP or OpenAPI, run one preflight action, then return here to see the five-stage decision.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link href="/dashboard/integration" className="rounded-2xl bg-amber-300 px-5 py-3 text-sm font-bold text-slate-950">
+                Connect an agent
+              </Link>
+              <Link href="/docs" className="rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-3 text-sm font-semibold text-slate-200">
+                Read integration docs
+              </Link>
+            </div>
+          </section>
         ) : (
-          <div className="space-y-4">
-            <Panel index={1} title="ACTION" status={statuses.action ?? latest?.decision}>
-              <Field label="Event" value={latest?.execution_id} />
-              <Field label="Agent" value={latest?.agent_id} />
-              <Field label="Action" value={latest?.action_kind} />
-              <Field label="Target" value={metadata.target_system_id} />
-              <Field label="Operation" value={metadata.operation_name} />
-              <Field label="Risk" value={metadata.risk_level} />
-            </Panel>
+          <>
+            <section className="mb-5 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+                <p className="text-xs text-slate-500">Current mode</p>
+                <p className="mt-1 text-lg font-bold text-white">{mode.toUpperCase()}</p>
+              </div>
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+                <p className="text-xs text-slate-500">Latest decision</p>
+                <div className="mt-2"><Badge status={statuses.execution_audit ?? latest?.decision} /></div>
+              </div>
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+                <p className="text-xs text-slate-500">Persisted events loaded</p>
+                <p className="mt-1 text-lg font-bold text-white">{loading ? '…' : rows.length}</p>
+              </div>
+            </section>
 
-            <Panel index={2} title="PLAN ALIGNMENT" status={statuses.plan_alignment}>
-              <Field label="Decision" value={metadata.plan_decision} />
-              <Field label="Plan hash" value={metadata.plan_hash} />
-              <Field label="Action allowed" value={metadata.policy_allows_action === true ? 'YES' : 'NO'} />
-              <Field label="Reasons" value={reasons.length ? reasons.join(' · ') : '—'} />
-            </Panel>
+            <div className="space-y-4">
+              <Panel index={1} status={statuses.action ?? latest?.decision}>
+                <Field label="Agent" value={latest?.agent_id} />
+                <Field label="Action" value={latest?.action_kind} />
+                <Field label="Target" value={metadata.target_system_id} />
+                <Field label="Operation" value={metadata.operation_name} />
+                <Field label="Risk" value={metadata.risk_level} />
+                <Field label="Event ID" value={latest?.execution_id} mono />
+              </Panel>
 
-            <Panel index={3} title="PERMISSION" status={statuses.permission}>
-              <Field label="Auth source" value={metadata.auth_source} />
-              <Field label="Roles" value={(metadata.roles ?? []).join(', ')} />
-              <Field label="Meaning" value={statuses.permission === 'WAITING_PERMISSION' ? 'Execution permission is insufficient' : 'Execution role verified'} />
-            </Panel>
+              <Panel index={2} status={statuses.plan_alignment}>
+                <Field label="Decision" value={metadata.plan_decision} />
+                <Field label="Action allowed" value={metadata.policy_allows_action === true ? 'YES' : 'NO'} />
+                <Field label="Why" value={reasons.length ? reasons.join(' · ') : 'No reason recorded'} />
+                <Field label="Plan hash" value={metadata.plan_hash} mono />
+              </Panel>
 
-            <Panel index={4} title="EVIDENCE" status={statuses.evidence}>
-              <Field label="Claim allowed" value={metadata.claim_allowed === true ? 'YES' : 'NO'} />
-              <Field label="Evidence refs" value={evidenceRefs.length} />
-              <Field label="Refs" value={evidenceRefs.length ? evidenceRefs.join(', ') : 'No evidence reference recorded'} />
-            </Panel>
+              <Panel index={3} status={statuses.permission}>
+                <Field label="Result" value={statuses.permission === 'WAITING_PERMISSION' ? 'Permission is insufficient' : 'Execution role verified'} />
+                <Field label="Roles" value={(metadata.roles ?? []).join(', ') || 'No role recorded'} />
+                <Field label="Auth source" value={metadata.auth_source} />
+              </Panel>
 
-            <Panel index={5} title="EXECUTION / AUDIT" status={statuses.execution_audit}>
-              <Field label="Mode at decision" value={eventMode.toUpperCase()} />
-              <Field label="Downstream" value={metadata.should_block === true ? 'DO_NOT_EXECUTE' : 'CONTINUE_TO_TARGET'} />
-              <Field label="Audit hash" value={latest?.current_hash} />
-              <Field label="Previous hash" value={latest?.previous_hash} />
-              <Field label="Decision hash" value={latest?.evidence_hash} />
-              <Field label="Recorded at" value={latest?.occurred_at ? new Date(latest.occurred_at).toLocaleString() : '—'} />
-            </Panel>
-          </div>
+              <Panel index={4} status={statuses.evidence}>
+                <Field label="Claim allowed" value={metadata.claim_allowed === true ? 'YES' : 'NO'} />
+                <Field label="Evidence records" value={evidenceRefs.length} />
+                <Field label="References" value={evidenceRefs.length ? evidenceRefs.join(', ') : 'No evidence reference recorded'} mono />
+              </Panel>
+
+              <Panel index={5} status={statuses.execution_audit}>
+                <Field label="Mode at decision" value={eventMode.toUpperCase()} />
+                <Field label="Downstream" value={metadata.should_block === true ? 'DO NOT EXECUTE' : 'CONTINUE TO TARGET'} />
+                <Field label="Recorded at" value={latest?.occurred_at ? new Date(latest.occurred_at).toLocaleString() : '—'} />
+                <Field label="Audit hash" value={latest?.current_hash} mono />
+              </Panel>
+            </div>
+
+            <section className={`mt-5 rounded-3xl border p-6 ${statusClass(statuses.execution_audit ?? latest?.decision)}`}>
+              <p className="text-[10px] font-bold uppercase tracking-[0.22em] opacity-70">What this means</p>
+              <h2 className="mt-2 text-xl font-bold">{outcome.title}</h2>
+              <p className="mt-2 text-sm leading-7 opacity-90">{outcome.body}</p>
+              <div className="mt-5 border-t border-current/10 pt-4">
+                <p className="text-xs font-bold uppercase tracking-wide opacity-70">What to do next</p>
+                <p className="mt-2 text-sm leading-7">{outcome.fix}</p>
+              </div>
+              <div className="mt-5 flex flex-wrap gap-3">
+                <Link href="/dashboard/audit" className="rounded-xl border border-current/20 bg-black/15 px-4 py-2 text-sm font-bold">View audit record</Link>
+                <Link href="/dashboard/proofs" className="rounded-xl border border-current/20 bg-black/15 px-4 py-2 text-sm font-bold">View evidence</Link>
+              </div>
+            </section>
+          </>
         )}
 
-        <section className="mt-6 rounded-2xl border border-white/[0.08] bg-white/[0.025] p-5">
-          <h2 className="text-sm font-bold text-white">Connect existing agent</h2>
-          <div className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
-            <div className="rounded-xl border border-white/[0.06] bg-black/20 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Microsoft Foundry / MCP</p>
-              <code className="mt-2 block break-all text-slate-200">/api/mcp/governance</code>
+        <section className="mt-8 border-t border-white/[0.07] pt-8">
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500">Connect existing systems</p>
+              <h2 className="mt-2 text-xl font-bold text-white">MCP or OpenAPI — no new agent required.</h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">
+                Use the integration surface for setup and testing. This page is for reading the resulting governance decision.
+              </p>
             </div>
-            <div className="rounded-xl border border-white/[0.06] bg-black/20 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">OpenAPI schema</p>
-              <code className="mt-2 block break-all text-slate-200">/api/dsg/governance/openapi</code>
-            </div>
+            <Link href="/dashboard/integration" className="rounded-2xl border border-amber-300/30 bg-amber-300/10 px-5 py-3 text-sm font-bold text-amber-100">
+              Open Connections
+            </Link>
           </div>
         </section>
       </div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,11 +1,8 @@
-import { redirect } from 'next/navigation';
 import { createClient } from '../../lib/supabase/server';
 import Link from 'next/link';
 import AgentChatWidget from '../../components/AgentChatWidget';
-import AutoSetupTrigger from '../../components/AutoSetupTrigger';
 import DashboardNav from '../../components/DashboardNav';
 import CommandPalette from '../../components/CommandPalette';
-import NudgeBanner from '../../components/billing/NudgeBanner';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,32 +13,32 @@ export default async function DashboardLayout({ children }: { children: React.Re
   } = await supabase.auth.getUser();
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white">
-      <div className="border-b border-slate-800 bg-slate-950/80">
-        <div
-          className="mx-auto flex items-center justify-between gap-4 px-6 py-3"
-          style={{ maxWidth: 1480 }}
-        >
-          <Link href="/dashboard" className="flex shrink-0 flex-col">
-            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">DSG ONE</p>
-            <p className="text-base font-semibold leading-tight">Command Center</p>
+    <div className="min-h-screen bg-[#07080b] text-white">
+      <header className="sticky top-0 z-40 border-b border-white/[0.07] bg-[#07080b]/92 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-[1480px] items-center gap-5 px-4 py-3 sm:px-6">
+          <Link href="/dashboard/governance-live" className="flex shrink-0 items-center gap-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-300/30 bg-amber-300/10 text-xs font-black tracking-[0.12em] text-amber-100">
+              DSG
+            </span>
+            <span className="hidden sm:block">
+              <span className="block text-xs uppercase tracking-[0.2em] text-slate-500">Control Plane</span>
+              <span className="block text-sm font-semibold text-white">Governance</span>
+            </span>
           </Link>
-          <div className="flex flex-1 items-center justify-between gap-4">
-            <DashboardNav />
-            <CommandPalette />
-          </div>
-          <div className="hidden shrink-0 text-right lg:block">
-            <p className="text-xs text-slate-500">
-              {user ? 'Signed in as' : 'Not signed in'}
+
+          <DashboardNav />
+          <CommandPalette />
+
+          <div className="hidden shrink-0 text-right xl:block">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-slate-600">
+              {user ? 'Signed in' : 'Guest'}
             </p>
-            <p className="max-w-[160px] truncate text-xs font-medium text-slate-300">
-              {user?.email ?? 'guest'}
+            <p className="max-w-[150px] truncate text-xs text-slate-400">
+              {user?.email ?? 'public session'}
             </p>
           </div>
         </div>
-      </div>
-      <AutoSetupTrigger />
-      {user && <NudgeBanner />}
+      </header>
       {children}
       {user && <AgentChatWidget />}
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,621 +1,159 @@
 import Link from 'next/link';
 import { Suspense } from 'react';
-import { ActionPathGraph } from '../components/ActionPathGraph';
-import { ConstraintChecklist } from '../components/ConstraintChecklist';
-import { EvidenceDrawer } from '../components/EvidenceDrawer';
-import { GateResultCard } from '../components/GateResultCard';
 import RefTracker from '../components/RefTracker';
 
-// Zapier webhook integration types added to database.types.ts
+const stages = [
+  { index: '01', title: 'ACTION', body: 'See exactly what the agent is trying to do.', status: 'CAPTURED' },
+  { index: '02', title: 'PLAN ALIGNMENT', body: 'Check whether the action matches the approved plan.', status: 'CHECKED' },
+  { index: '03', title: 'PERMISSION', body: 'Verify the execution identity and required permission.', status: 'VERIFIED' },
+  { index: '04', title: 'EVIDENCE', body: 'See whether supporting evidence is present for the decision.', status: 'RECORDED' },
+  { index: '05', title: 'EXECUTION / AUDIT', body: 'See the final governance result and persisted audit record.', status: 'PASS / BLOCK' },
+] as const;
 
-const trustBar = [
-  'Deterministic Engine — Gap-free sequences · SHA-256 hash chains · Merkle tree proofs · SARIF export',
-  'WORM Audit Trail — Every decision immutable · Chain verification · Tamper detection · Enterprise compliance',
-  'EU AI Act Ready — Art. 12/14 evidence pack · ISO 42001 · CCVS v1.2 · 3,389 tests · 72.08% mutation score',
-];
-
-const painCards = [
-  {
-    title: 'Approvals are scattered',
-    body: 'Finance decisions still happen across email, chat, spreadsheets, ERP notes, and shared folders. That makes policy enforcement inconsistent and hard to prove.',
-  },
-  {
-    title: 'Audit evidence is rebuilt by hand',
-    body: 'When audit asks who approved a payment, why it was approved, and what evidence was reviewed, teams often reconstruct the story after the fact.',
-  },
-  {
-    title: 'Exceptions are risky and invisible',
-    body: 'Urgent payments, missing documents, high-risk vendors, and threshold overrides need controlled escalation before money moves.',
-  },
-];
-
-const howSteps = [
-  'Submit a high-risk AI, workflow, finance, or deployment action.',
-  'DSG ONE resolves policy, entitlement, risk, and approval context.',
-  'The deterministic gate returns PASS, BLOCK, REVIEW, or UNSUPPORTED.',
-  'The system records proof/gate evidence for audit review.',
-];
-
-const launchLinks = [
-  {
-    title: 'AI Delivery Proof',
-    body: 'ออก Proof Report ให้ลูกค้าก่อนส่งงาน — ยืนยันว่าโค้ด/AI agent ผ่านอะไรแล้ว สำหรับ agency, SaaS, dev team.',
-    cta: 'ดู Delivery Proof →',
-    href: '/delivery-proof',
-    highlight: true,
-  },
-  {
-    title: 'Finance Governance Workspace',
-    body: 'See the approval queue, case detail, exception posture, and evidence bundle path.',
-    cta: 'Open finance workspace',
-    href: '/finance-governance/app',
-  },
-  {
-    title: 'Enterprise Pilot',
-    body: 'Start with one invoice or payment approval workflow and prove audit readiness before broad rollout.',
-    cta: 'Request access',
-    href: '/request-access',
-  },
-];
-
-const marketGaps = [
-  {
-    title: 'Decision before the LLM — ~11ms',
-    body: 'DSG evaluates policy in a deterministic gate before any model runs, so the decision path never waits on an LLM round-trip. Agent frameworks route the decision through an LLM (≈0.8–1.5s) and cannot replay it bit-for-bit.',
-  },
-  {
-    title: 'Formal proof, not vibes',
-    body: 'Policy invariants are proved with Z3 (8 theorems proved UNSAT at design time) and multi-agent task assignments are checked by a real Z3 solve. Mainstream agent stacks ship no formal verification.',
-  },
-  {
-    title: 'Evidence that survives an audit',
-    body: 'Every decision is recorded as a tamper-evident SHA-256 hash chain with CCVS L1–L5 artifacts and an EU AI Act Annex IV mapping — replayable years later. LangGraph, OpenAI Agents, and Temporal ship no audit evidence pack.',
-  },
-  {
-    title: 'Fails safe — and speaks Thai',
-    body: 'UNSUPPORTED never becomes PASS: unknown risk maps to REVIEW or BLOCK, never ALLOW. Policy can be written in natural-language Thai or English for the regulated SEA market.',
-  },
-];
-
-const comparisonRows: Array<{ cap: string; dsg: string; lang: string; oai: string; temporal: string }> = [
-  { cap: 'Deterministic replay of a decision', dsg: 'yes', lang: 'partial', oai: 'no', temporal: 'partial' },
-  { cap: 'Formal proof (Z3)', dsg: 'yes', lang: 'no', oai: 'no', temporal: 'no' },
-  { cap: 'Tamper-evident evidence chain', dsg: 'yes', lang: 'no', oai: 'no', temporal: 'no' },
-  { cap: 'Compliance pack (CCVS L1–L5 / EU AI Act)', dsg: 'yes', lang: 'no', oai: 'no', temporal: 'no' },
-  { cap: 'Runtime gate before execution', dsg: 'yes', lang: 'partial', oai: 'no', temporal: 'partial' },
-  { cap: 'Decision latency', dsg: '~11ms', lang: '0.8–1.5s', oai: '0.8–1.5s', temporal: '100–300ms' },
-];
-
-function ComparisonCell({ value }: { value: string }) {
-  if (value === 'yes') return <span className="font-semibold text-emerald-300">✓</span>;
-  if (value === 'no') return <span className="text-slate-300">—</span>;
-  if (value === 'partial') return <span className="text-amber-300">partial</span>;
-  return <span className="text-slate-200">{value}</span>;
-}
-
-const DEMO_LABEL = 'Sample action context (homepage proof rail demo)';
+const decisions = [
+  ['PASS', 'The action satisfies the current governance checks.'],
+  ['BLOCKED', 'The action is outside the allowed conditions and should not continue in enforce mode.'],
+  ['WAITING_PERMISSION', 'The current execution identity does not have sufficient permission.'],
+  ['UNVERIFIED', 'There is not enough verified evidence to support the action or claim.'],
+] as const;
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen overflow-hidden bg-[#07080a] text-white">
+    <main className="min-h-screen overflow-hidden bg-[#07080b] text-white">
       <Suspense fallback={null}><RefTracker /></Suspense>
-      <section className="relative overflow-hidden border-b border-white/10">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(181,18,27,0.3),transparent_26%),radial-gradient(circle_at_82%_10%,rgba(245,197,92,0.17),transparent_30%),linear-gradient(180deg,#090a0d_0%,#0b0d10_55%,#0a0c0f_100%)]" />
-        <div className="absolute inset-y-0 right-0 hidden w-[44%] border-l border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] lg:block" />
 
-        <div className="relative mx-auto grid min-h-[calc(100svh-73px)] max-w-7xl gap-10 px-6 py-14 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+      <header className="border-b border-white/[0.07] bg-[#07080b]/95">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-5 py-4 sm:px-6">
+          <Link href="/" className="flex items-center gap-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-300/30 bg-amber-300/10 text-[10px] font-black tracking-[0.12em] text-amber-100">DSG</span>
+            <span>
+              <span className="block text-xs font-bold uppercase tracking-[0.2em] text-white">DSG</span>
+              <span className="block text-[10px] uppercase tracking-[0.18em] text-slate-600">Control Plane</span>
+            </span>
+          </Link>
+          <nav className="flex items-center gap-2">
+            <Link href="#how-it-works" className="hidden rounded-full px-4 py-2 text-sm font-semibold text-slate-400 hover:text-white sm:block">How it works</Link>
+            <Link href="/docs" className="hidden rounded-full px-4 py-2 text-sm font-semibold text-slate-400 hover:text-white sm:block">Docs</Link>
+            <Link href="/login" className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white">Sign in</Link>
+          </nav>
+        </div>
+      </header>
+
+      <section className="relative border-b border-white/[0.07]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_16%_12%,rgba(225,6,0,0.16),transparent_28%),radial-gradient(circle_at_84%_10%,rgba(212,175,55,0.13),transparent_31%)]" />
+        <div className="relative mx-auto grid min-h-[720px] max-w-7xl gap-12 px-5 py-16 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:py-24">
           <div>
-            <p className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
-              Deterministic Security Gateway · SMT-Verified · WORM Audit
+            <p className="inline-flex rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.2em] text-amber-100">Runtime governance for existing agents</p>
+            <h1 className="mt-7 max-w-4xl text-5xl font-bold leading-[0.98] tracking-[-0.04em] text-white sm:text-6xl lg:text-7xl">Know what your AI is about to do.</h1>
+            <p className="mt-6 max-w-2xl text-base leading-8 text-slate-400 sm:text-lg">
+              Connect an agent through MCP or OpenAPI. DSG evaluates actions against the server-side governance context, permissions and available evidence, then records the decision for audit review.
             </p>
-            <h1 className="mt-7 max-w-5xl text-5xl font-bold leading-[1.02] text-white md:text-7xl">
-              Govern AI actions before they reach production.
-            </h1>
-            <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
-              DSG ONE is a runtime governance gateway driven by a Deterministic Security Gateway — policy invariants verified by SMT Solver, every action gated before execution, every decision recorded as a tamper-evident WORM hash chain. EU AI Act Art. 12/14 evidence pack included.
-            </p>
-
-            <div className="mt-8 rounded-3xl border border-emerald-300/25 bg-emerald-400/10 p-5 shadow-2xl shadow-emerald-950/30">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-200">Try before login</p>
-              <p className="mt-2 text-sm leading-7 text-emerald-50">
-                Had AI break things before? See proof/demo and ask DSG first — public mode does not execute actions and you don&apos;t need to migrate any data.
-              </p>
-              <div className="mt-4 flex flex-wrap gap-3">
-                <Link
-                  href="/demo"
-                  className="rounded-2xl bg-emerald-300 px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-emerald-200"
-                >
-                  Try demo now →
-                </Link>
-                <Link
-                  href="#public-chat"
-                  className="rounded-2xl border border-emerald-200/40 bg-black/20 px-5 py-3 text-sm font-bold text-emerald-100 transition hover:border-emerald-100"
-                >
-                  Ask DSG
-                </Link>
-              </div>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/login?next=/dashboard/integration" className="rounded-2xl bg-amber-300 px-6 py-3.5 text-sm font-bold text-slate-950 transition hover:bg-amber-200">Connect your agent</Link>
+              <Link href="/dashboard/governance-live" className="rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-3.5 text-sm font-bold text-white transition hover:border-white/20">See Live Governance</Link>
             </div>
-
-            <div className="mt-8 flex flex-wrap gap-4">
-              <Link href="/delivery-proof" className="rounded-2xl bg-emerald-400 px-6 py-4 text-base font-bold text-slate-950 transition hover:bg-emerald-300">
-                Delivery Proof →
-              </Link>
-              <Link href="/demo" className="rounded-2xl bg-amber-300 px-6 py-4 text-base font-semibold text-slate-950 transition hover:bg-amber-200">
-                🎬 Try demo
-              </Link>
-              <Link href="/features" className="rounded-2xl border border-emerald-300/30 bg-emerald-300/10 px-6 py-4 text-base font-semibold text-emerald-100 transition hover:border-emerald-300/60">
-                Core Features
-              </Link>
-              <Link href="/pricing" className="rounded-2xl border border-amber-300/30 bg-amber-300/10 px-6 py-4 text-base font-semibold text-amber-100 transition hover:border-amber-300/60">
-                Pricing
-              </Link>
-              <Link href="/use-cases" className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 transition hover:border-white/20">
-                Use Cases
-              </Link>
-              <Link href="/login" className="rounded-2xl border border-white/15 bg-white/[0.03] px-6 py-4 font-semibold text-slate-100 transition hover:border-emerald-300/40">
-                Continue with email
-              </Link>
-            </div>
-
-            <div className="mt-12 grid gap-3 md:grid-cols-3">
-              {trustBar.map((item) => (
-                <div key={item} className="border border-white/10 bg-white/[0.03] px-4 py-4 text-sm text-slate-200">
-                  {item}
+            <div className="mt-8 grid max-w-2xl gap-3 sm:grid-cols-3">
+              {[
+                ['CONNECT', 'MCP or OpenAPI'],
+                ['CHOOSE', 'Observe or Enforce'],
+                ['SEE', 'Decision + evidence'],
+              ].map(([label, value]) => (
+                <div key={label} className="rounded-2xl border border-white/[0.07] bg-white/[0.025] p-4">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600">{label}</p>
+                  <p className="mt-2 text-sm font-semibold text-slate-200">{value}</p>
                 </div>
               ))}
             </div>
           </div>
 
-          <div className="relative">
-            <div className="border border-amber-300/20 bg-black/30 p-6 backdrop-blur-sm">
-              <div className="flex items-center justify-between border-b border-white/10 pb-5">
-                <div>
-                  <p className="text-[11px] uppercase tracking-[0.3em] text-slate-300">Runtime Control Room</p>
-                  <h2 className="mt-2 text-2xl font-semibold text-white">Governed Action Stack</h2>
-                </div>
-                <span className="rounded-full border border-emerald-300/25 bg-emerald-400/10 px-3 py-1 text-xs uppercase tracking-[0.18em] text-emerald-200">
-                  Ready
-                </span>
+          <div className="rounded-[2rem] border border-white/[0.08] bg-black/25 p-4 shadow-2xl shadow-black/30 sm:p-5">
+            <div className="flex items-center justify-between border-b border-white/[0.07] px-2 pb-4">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-slate-600">Live governance</p>
+                <p className="mt-1 text-sm font-semibold text-white">One action · five checks</p>
               </div>
-
-              <div className="mt-6 space-y-4">
-                {howSteps.map((step, index) => (
-                  <div key={step} className="grid grid-cols-[42px_1fr] gap-4 border-l border-amber-300/25 bg-white/[0.02] p-4">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-300/25 bg-amber-300/10 text-sm font-semibold text-amber-100">
-                      {index + 1}
-                    </div>
-                    <p className="text-sm leading-7 text-slate-200">{step}</p>
+              <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-[10px] font-bold text-emerald-200">REAL EVENTS</span>
+            </div>
+            <div className="mt-4 space-y-2.5">
+              {stages.map((stage) => (
+                <div key={stage.index} className="grid grid-cols-[38px_1fr_auto] items-center gap-3 rounded-2xl border border-white/[0.07] bg-white/[0.025] p-3.5">
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full border border-amber-300/20 bg-amber-300/10 text-[10px] font-bold text-amber-100">{stage.index}</span>
+                  <div className="min-w-0">
+                    <p className="text-xs font-bold text-white">{stage.title}</p>
+                    <p className="mt-1 truncate text-[11px] text-slate-600">{stage.body}</p>
                   </div>
-                ))}
-              </div>
-
-              <div className="mt-6 grid gap-3 md:grid-cols-3">
-                <div className="border border-white/10 bg-[#111317] p-4">
-                  <p className="text-[11px] uppercase tracking-[0.22em] text-slate-300">Policy</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-100">Route by policy</p>
+                  <span className="hidden rounded-full border border-white/[0.08] bg-black/20 px-2.5 py-1 text-[9px] font-bold text-slate-400 sm:block">{stage.status}</span>
                 </div>
-                <div className="border border-white/10 bg-[#111317] p-4">
-                  <p className="text-[11px] uppercase tracking-[0.22em] text-slate-300">Evidence</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-100">Evidence at decision time</p>
-                </div>
-                <div className="border border-white/10 bg-[#111317] p-4">
-                  <p className="text-[11px] uppercase tracking-[0.22em] text-slate-300">Exceptions</p>
-                  <p className="mt-2 text-lg font-semibold text-slate-100">Review with controls</p>
-                </div>
-              </div>
+              ))}
             </div>
           </div>
         </div>
       </section>
 
-      <section className="border-b border-amber-300/15 bg-[#0f0a05]">
-        <div className="mx-auto max-w-7xl px-6 py-16">
-          <div className="mb-12">
-            <p className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
-              🚀 AI Infrastructure Control Plane
-            </p>
-            <h2 className="mt-6 text-4xl font-bold leading-tight text-white">
-              From GitHub URL to production in 2–3 minutes
-            </h2>
-            <p className="mt-4 max-w-3xl text-lg leading-7 text-slate-300">
-              DSG Setup analyzes your project, auto-discovers infrastructure needs (Stripe, Vercel, Supabase, GitHub, OpenAI), builds a dependency graph, and provisions everything in one approval.
-            </p>
+      <section id="how-it-works" className="border-b border-white/[0.07] bg-[#090a0e]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-6">
+          <div className="max-w-3xl">
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-100">How it works</p>
+            <h2 className="mt-4 text-3xl font-bold tracking-[-0.03em] text-white sm:text-5xl">Use the systems you already have.</h2>
+            <p className="mt-4 text-base leading-8 text-slate-500">The control plane is organized around the user task: connect, choose control mode, then read the governance decision.</p>
           </div>
 
-          <div className="grid gap-8 lg:grid-cols-3 mb-12">
-            <div className="border border-amber-300/20 bg-amber-400/5 p-6 rounded-2xl">
-              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-400/20 text-xl mb-4">📊</div>
-              <h3 className="text-xl font-bold text-white mb-2">Analyze</h3>
-              <p className="text-sm text-slate-300 mb-4">AI + heuristics scan your project. Detect Next.js, PostgreSQL, Stripe, Redis, and more with confidence scores.</p>
-              <code className="text-xs text-amber-200 bg-black/30 rounded px-2 py-1">POST /api/dsg-setup/analyze</code>
-            </div>
-
-            <div className="border border-amber-300/20 bg-amber-400/5 p-6 rounded-2xl">
-              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-400/20 text-xl mb-4">🗺️</div>
-              <h3 className="text-xl font-bold text-white mb-2">Plan</h3>
-              <p className="text-sm text-slate-300 mb-4">Dependency resolver builds phases. GitHub → Supabase → Stripe → Vercel. Topological sort with parallel safety.</p>
-              <code className="text-xs text-amber-200 bg-black/30 rounded px-2 py-1">POST /api/dsg-setup/plan</code>
-            </div>
-
-            <div className="border border-amber-300/20 bg-amber-400/5 p-6 rounded-2xl">
-              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-400/20 text-xl mb-4">⚡</div>
-              <h3 className="text-xl font-bold text-white mb-2">Execute</h3>
-              <p className="text-sm text-slate-300 mb-4">User approves once. DSG provisions all connectors, stores secrets in vault, rolls back on error.</p>
-              <code className="text-xs text-amber-200 bg-black/30 rounded px-2 py-1">POST /api/dsg-setup/execute</code>
-            </div>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-12">
-            <div className="border border-white/10 bg-white/[0.03] p-4 rounded-lg">
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-300 mb-2">Vault</p>
-              <p className="text-sm font-semibold text-white">AES-256-GCM encrypted credentials</p>
-            </div>
-            <div className="border border-white/10 bg-white/[0.03] p-4 rounded-lg">
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-300 mb-2">Event Bus</p>
-              <p className="text-sm font-semibold text-white">Pub-sub for audit trail</p>
-            </div>
-            <div className="border border-white/10 bg-white/[0.03] p-4 rounded-lg">
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-300 mb-2">Rollback</p>
-              <p className="text-sm font-semibold text-white">Reverse on failure</p>
-            </div>
-            <div className="border border-white/10 bg-white/[0.03] p-4 rounded-lg">
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-300 mb-2">Capability Engine</p>
-              <p className="text-sm font-semibold text-white">Provider-agnostic resolution</p>
-            </div>
-          </div>
-
-          <div className="bg-white/[0.02] border border-amber-300/20 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-white mb-6">7 APIs • 1 Infrastructure OS</h3>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">POST /analyze</code>
-                <p className="text-xs text-slate-400">Discover services & confidence</p>
-              </div>
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">POST /plan</code>
-                <p className="text-xs text-slate-400">Build phases & dependencies</p>
-              </div>
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">POST /approve</code>
-                <p className="text-xs text-slate-400">Verify canonical hash</p>
-              </div>
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">POST /execute</code>
-                <p className="text-xs text-slate-400">Start orchestration</p>
-              </div>
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">GET /status/:id</code>
-                <p className="text-xs text-slate-400">Poll phase progress</p>
-              </div>
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">GET /connectors</code>
-                <p className="text-xs text-slate-400">List providers & capabilities</p>
-              </div>
-              <div className="space-y-2">
-                <code className="text-xs font-mono text-amber-200">GET /vault/secrets</code>
-                <p className="text-xs text-slate-400">Org-scoped credentials</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-12 grid gap-6 md:grid-cols-3">
-            <Link href="/dashboard/setup" className="border border-amber-300/30 bg-amber-300/10 rounded-2xl p-6 hover:border-amber-300/60 transition">
-              <p className="text-sm uppercase tracking-[0.2em] text-amber-200 font-semibold">Get started</p>
-              <h4 className="mt-2 text-lg font-bold text-white">Setup Wizard</h4>
-              <p className="mt-2 text-xs text-slate-300">Step through analyze → plan → approve → execute</p>
-            </Link>
-            <Link href="/docs/DSG_SETUP_GUIDE.md" className="border border-white/10 bg-white/[0.03] rounded-2xl p-6 hover:border-white/20 transition">
-              <p className="text-sm uppercase tracking-[0.2em] text-slate-400 font-semibold">Docs</p>
-              <h4 className="mt-2 text-lg font-bold text-white">Setup Guide</h4>
-              <p className="mt-2 text-xs text-slate-300">Complete API reference with curl examples</p>
-            </Link>
-            <Link href="/docs/LICENSING.md" className="border border-white/10 bg-white/[0.03] rounded-2xl p-6 hover:border-white/20 transition">
-              <p className="text-sm uppercase tracking-[0.2em] text-slate-400 font-semibold">Licensing</p>
-              <h4 className="mt-2 text-lg font-bold text-white">Pricing Tiers</h4>
-              <p className="mt-2 text-xs text-slate-300">Starter, Pro, Enterprise with decision metering</p>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      <section id="public-chat" className="border-b border-emerald-300/15 bg-[#07110f]">
-        <div className="mx-auto grid max-w-7xl gap-6 px-6 py-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-center">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.3em] text-emerald-300">Public DSG Assistant</p>
-            <h2 className="mt-3 text-3xl font-semibold text-white">Ask before logging in — no actions executed</h2>
-            <p className="mt-3 text-sm leading-7 text-slate-300">
-              Use the chat button at the bottom right or start from the demo page to check whether DSG fits your workflow before requesting access or migrating any data.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-3 lg:justify-end">
-            <Link href="/demo" className="rounded-2xl bg-emerald-300 px-6 py-4 font-bold text-slate-950 hover:bg-emerald-200">
-              View demo now
-            </Link>
-            <Link href="/request-access" className="rounded-2xl border border-emerald-300/40 px-6 py-4 font-bold text-emerald-100 hover:bg-emerald-300/10">
-              Request trial access
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      <section className="border-b border-green-300/15 bg-[#050d09]">
-        <div className="mx-auto max-w-7xl px-6 py-20">
-          <div className="mb-12 text-center">
-            <p className="inline-flex rounded-full border border-green-300/30 bg-green-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-green-100 mb-4">
-              ✓ Evidence-Backed Quality
-            </p>
-            <h2 className="text-4xl font-bold text-white mb-4">Production-Ready with Proven Evidence</h2>
-            <p className="max-w-2xl mx-auto text-slate-300">
-              Every claim backed by automated verification. CCVS L1–L5 compliance pipeline runs on every commit.
-            </p>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-12">
-            <div className="border border-green-400/30 bg-green-400/5 rounded-2xl p-6">
-              <div className="mb-4">
-                <div className="text-5xl font-bold text-green-300 font-mono">3,389</div>
-                <div className="text-sm text-slate-400 mt-1">tests passing</div>
-              </div>
-              <p className="text-xs text-slate-300 leading-6">
-                <strong>0 failures</strong> across unit, integration, failure, and E2E test suites. Zero test debt.
-              </p>
-              <div className="mt-4 text-[11px] text-green-200 bg-green-400/10 rounded px-2 py-1 inline-block">
-                Automated on CI/CD
-              </div>
-            </div>
-
-            <div className="border border-blue-400/30 bg-blue-400/5 rounded-2xl p-6">
-              <div className="mb-4">
-                <div className="text-5xl font-bold text-blue-300 font-mono">72.08%</div>
-                <div className="text-sm text-slate-400 mt-1">mutation score</div>
-              </div>
-              <p className="text-xs text-slate-300 leading-6">
-                <strong>High resilience</strong> to code changes. Stryker mutation testing verifies test effectiveness.
-              </p>
-              <div className="mt-4 text-[11px] text-blue-200 bg-blue-400/10 rounded px-2 py-1 inline-block">
-                Per-commit verification
-              </div>
-            </div>
-
-            <div className="border border-purple-400/30 bg-purple-400/5 rounded-2xl p-6">
-              <div className="mb-4">
-                <div className="text-4xl font-bold text-purple-300 font-mono">L1–L5</div>
-                <div className="text-sm text-slate-400 mt-1">CCVS verified</div>
-              </div>
-              <p className="text-xs text-slate-300 leading-6">
-                <strong>Compliance matrix</strong> proves control flow: unit → integration → adversarial → mutation → provenance.
-              </p>
-              <div className="mt-4 text-[11px] text-purple-200 bg-purple-400/10 rounded px-2 py-1 inline-block">
-                Evidence chain
-              </div>
-            </div>
-
-            <div className="border border-amber-400/30 bg-amber-400/5 rounded-2xl p-6">
-              <div className="mb-4">
-                <div className="text-3xl font-bold text-amber-300 font-mono">285</div>
-                <div className="text-sm text-slate-400 mt-1">test files</div>
-              </div>
-              <p className="text-xs text-slate-300 leading-6">
-                <strong>Comprehensive coverage</strong> across deterministic gates, spine execution, and licensing.
-              </p>
-              <div className="mt-4 text-[11px] text-amber-200 bg-amber-400/10 rounded px-2 py-1 inline-block">
-                3,389 total tests
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white/[0.02] border border-green-300/20 rounded-2xl p-8 mb-8">
-            <h3 className="text-2xl font-bold text-white mb-6">CCVS Evidence Pipeline</h3>
-            <div className="grid gap-4 md:grid-cols-5">
-              <div className="text-center">
-                <div className="text-3xl font-bold text-green-300 mb-2">L1</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Unit Tests</strong></p>
-                <p className="text-xs text-slate-500">Isolated component verification</p>
-              </div>
-              <div className="flex items-center justify-center text-slate-300">→</div>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-green-300 mb-2">L2</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Integration</strong></p>
-                <p className="text-xs text-slate-500">Cross-layer behavior</p>
-              </div>
-              <div className="flex items-center justify-center text-slate-300">→</div>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-green-300 mb-2">L3</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Adversarial</strong></p>
-                <p className="text-xs text-slate-500">Failure scenarios</p>
-              </div>
-            </div>
-            <div className="grid gap-4 md:grid-cols-5 mt-6 pt-6 border-t border-white/10">
-              <div className="text-center">
-                <div className="text-3xl font-bold text-purple-300 mb-2">L4</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Mutation</strong></p>
-                <p className="text-xs text-slate-500">Code resilience (72.08%)</p>
-              </div>
-              <div className="flex items-center justify-center text-slate-300">→</div>
-              <div className="text-center">
-                <div className="text-3xl font-bold text-purple-300 mb-2">L5</div>
-                <p className="text-xs text-slate-400 mb-2"><strong>Provenance</strong></p>
-                <p className="text-xs text-slate-500">Build & deploy audit</p>
-              </div>
-              <div className="flex items-center justify-center text-slate-500 col-span-2"></div>
-            </div>
-          </div>
-
-          <div className="border border-slate-500/30 bg-slate-500/5 rounded-lg p-6">
-            <p className="text-sm text-slate-300 leading-7">
-              <strong className="text-slate-100">Claim Boundary:</strong> Production runtime has live policy engine, CCVS v1.2 evidence chain (L1–L5), 3,389 tests (285 files), mutation score 72.08%, EU AI Act Annex IV mapping at <code className="text-emerald-300 bg-black/30 px-1 rounded">/api/compliance-evidence-pack/annex4</code>, and compliance-status API at <code className="text-emerald-300 bg-black/30 px-1 rounded">/api/ccvs/compliance-status</code>. Not claimed: external Z3 per-request invocation, JWT/JWKS standalone auth completion, WORM-certified external storage, third-party certification, or ISO/NIST independent audit.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="border-y border-white/10 bg-[#080a0d]">
-        <div className="mx-auto max-w-7xl px-6 py-20">
-          <div className="mb-12">
-            <p className="inline-flex rounded-full border border-emerald-300/30 bg-emerald-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-100">
-              What the market doesn&apos;t have
-            </p>
-            <h2 className="mt-6 text-4xl font-bold leading-tight text-white">
-              Agent frameworks orchestrate. DSG governs — and proves it.
-            </h2>
-            <p className="mt-4 max-w-3xl text-lg leading-7 text-slate-300">
-              LangGraph, OpenAI Agents, and Temporal help you <em>run</em> an AI workflow. None of them can replay a
-              decision bit-for-bit, prove it against policy, or hand an auditor tamper-evident evidence. That gap is the product.
-            </p>
-          </div>
-
-          <div className="mb-12 grid gap-6 md:grid-cols-2">
-            {marketGaps.map((item) => (
-              <div key={item.title} className="rounded-2xl border border-emerald-300/20 bg-emerald-400/[0.04] p-6">
-                <h3 className="text-lg font-bold text-white">{item.title}</h3>
-                <p className="mt-3 text-sm leading-7 text-slate-300">{item.body}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="overflow-x-auto rounded-2xl border border-white/10 bg-white/[0.02]">
-            <table className="w-full min-w-[640px] text-left text-sm">
-              <thead>
-                <tr className="border-b border-white/10 text-slate-400">
-                  <th className="px-5 py-4 font-semibold">Capability</th>
-                  <th className="px-5 py-4 font-semibold text-emerald-200">DSG ONE</th>
-                  <th className="px-5 py-4 font-semibold">LangGraph</th>
-                  <th className="px-5 py-4 font-semibold">OpenAI Agents</th>
-                  <th className="px-5 py-4 font-semibold">Temporal</th>
-                </tr>
-              </thead>
-              <tbody>
-                {comparisonRows.map((row) => (
-                  <tr key={row.cap} className="border-b border-white/[0.06] last:border-0">
-                    <td className="px-5 py-4 text-slate-200">{row.cap}</td>
-                    <td className="px-5 py-4"><ComparisonCell value={row.dsg} /></td>
-                    <td className="px-5 py-4"><ComparisonCell value={row.lang} /></td>
-                    <td className="px-5 py-4"><ComparisonCell value={row.oai} /></td>
-                    <td className="px-5 py-4"><ComparisonCell value={row.temporal} /></td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <p className="mt-4 text-xs leading-6 text-slate-300">
-            Comparison reflects each product&apos;s default, documented capabilities for governed AI execution. Latency figures
-            are from <Link href="/showcase" className="text-emerald-300 underline">the live gate benchmark</Link>; competitor
-            values are typical LLM-in-the-loop ranges. Z3 proves policy invariants at design time and verifies multi-agent
-            assignments at runtime; the per-request gate route does not invoke an external Z3 solver.
-          </p>
-        </div>
-      </section>
-
-      <section className="mx-auto max-w-7xl px-6 py-16">
-        <div className="grid gap-5 lg:grid-cols-3">
-          {painCards.map((card) => (
-            <article key={card.title} className="border-t border-red-400/30 bg-white/[0.02] px-0 py-0">
-              <div className="p-6">
-                <p className="text-[11px] uppercase tracking-[0.28em] text-slate-300">Risk Signal</p>
-                <h2 className="mt-4 text-2xl font-semibold text-amber-50">{card.title}</h2>
-                <p className="mt-4 text-sm leading-7 text-slate-300">{card.body}</p>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="border-y border-white/10 bg-[#0b0d10]">
-        <div className="mx-auto grid max-w-7xl gap-6 px-6 py-16 lg:grid-cols-[0.9fr_1.1fr]">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.3em] text-slate-300">Launch Paths</p>
-            <h2 className="mt-4 text-4xl font-semibold leading-tight text-white">Move from one governed workflow to a real operating surface.</h2>
-            <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300">
-              Finance Governance is one governed workflow under DSG ONE. Start with a single invoice or payment path, prove control quality in a bounded pilot, then expand into the daily approval workspace with shared evidence and runtime checks.
-            </p>
-          </div>
-          <div className="grid gap-4 md:grid-cols-3">
-            {launchLinks.map((item) => (
-              <article key={item.title} className={'highlight' in item && item.highlight ? 'border border-emerald-400/30 bg-emerald-400/5 p-6' : 'border border-white/10 bg-white/[0.03] p-6'}>
-                <p className="text-[11px] uppercase tracking-[0.22em] text-slate-300">
-                  {'highlight' in item && item.highlight ? '🆕 New' : 'Path'}
-                </p>
-                <h3 className="mt-4 text-2xl font-semibold text-white">{item.title}</h3>
-                <p className="mt-3 min-h-[110px] text-sm leading-7 text-slate-300">{item.body}</p>
-                <Link href={item.href} className={'highlight' in item && item.highlight ? 'mt-5 inline-flex border-b border-emerald-300 pb-1 text-sm font-semibold text-emerald-200' : 'mt-5 inline-flex border-b border-amber-300 pb-1 text-sm font-semibold text-amber-100'}>
-                  {item.cta}
-                </Link>
+          <div className="mt-10 grid gap-4 lg:grid-cols-3">
+            {[
+              ['01', 'Connect', 'Route an existing MCP or OpenAPI action through DSG. You do not need to build a new agent just to use the governance surface.'],
+              ['02', 'Choose control', 'Observe records governance results. Enforce lets the configured governance decision stop downstream execution when required.'],
+              ['03', 'Read the decision', 'Follow Action → Plan Alignment → Permission → Evidence → Execution / Audit without searching through logs.'],
+            ].map(([index, title, body]) => (
+              <article key={index} className="rounded-3xl border border-white/[0.07] bg-white/[0.025] p-6 sm:p-7">
+                <span className="text-xs font-bold text-amber-100">{index}</span>
+                <h3 className="mt-6 text-xl font-bold text-white">{title}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-500">{body}</p>
               </article>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 py-16">
-        <p className="text-[11px] uppercase tracking-[0.3em] text-emerald-300">Homepage proof rail</p>
-        <h2 className="mt-3 text-3xl font-semibold text-white">Live deterministic gate evidence</h2>
-        <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-300">
-          Sample action context demonstrating the policy engine decision path. Fields reflect the live production policy engine output format.
-        </p>
-        <div className="mt-6 grid gap-4 lg:grid-cols-2">
-          <GateResultCard
-            status="PASS"
-            summary="policyVersion 1.0 loaded and all 8 configured deterministic constraints evaluated as pass for this sample request."
-            reason="No threshold, actor-role, or replay-protection violations were detected in the sample action context."
-            ruleRefs={['policyVersion:1.0', 'solver:static_check@dsg-deterministic-ts-2.6.1', 'constraintsChecked:8']}
-            demoLabel={DEMO_LABEL}
-          />
-          <ActionPathGraph
-            actor={{ id: 'actor-1', title: 'AP Maker (sample)', subtitle: 'role: finance_maker' }}
-            action={{ id: 'action-1', title: 'Submit invoice approval request', subtitle: 'sample amount within configured threshold' }}
-            policies={[
-              { id: 'p-1', title: 'Policy version', subtitle: '1.0 observed' },
-              { id: 'p-2', title: 'Replay protection', subtitle: 'nonce/idempotency/request hash present' },
-              { id: 'p-3', title: 'Constraint engine', subtitle: 'static_check deterministic evaluation' },
-            ]}
-            gateResult="PASS"
-            finalDecision="ALLOW in sample action context"
-            demoLabel={DEMO_LABEL}
-          />
-          <ConstraintChecklist
-            demoLabel={DEMO_LABEL}
-            items={[
-              { id: 'c1', label: 'Policy version resolved', detail: 'policyVersion observed as 1.0.', state: 'pass' },
-              { id: 'c2', label: 'Input hash recorded', detail: 'inputHash present in policy engine output.', state: 'pass' },
-              { id: 'c3', label: 'Constraint set hash recorded', detail: 'constraintSetHash present in policy engine output.', state: 'pass' },
-              { id: 'c4', label: 'Proof hash recorded', detail: 'proofHash present in policy engine output.', state: 'pass' },
-              { id: 'c5', label: 'Structured constraint results', detail: 'Per-constraint deterministic pass/fail structure present.', state: 'pass' },
-              { id: 'c6', label: 'Replay nonce present', detail: 'replayProtection.nonce present.', state: 'pass' },
-              { id: 'c7', label: 'Idempotency key present', detail: 'replayProtection.idempotencyKey present.', state: 'pass' },
-              { id: 'c8', label: 'Request hash present', detail: 'replayProtection.requestHash present.', state: 'pass' },
-            ]}
-          />
-          <EvidenceDrawer
-            title="Evidence availability"
-            demoLabel={DEMO_LABEL}
-            fields={[
-              { key: 'policyVersion', label: 'policyVersion', availability: 'present', detail: 'Observed value: 1.0.' },
-              { key: 'inputHash', label: 'inputHash', availability: 'present', detail: 'Hash value present in policy engine response.' },
-              { key: 'constraintSetHash', label: 'constraintSetHash', availability: 'present', detail: 'Hash value present in policy engine response.' },
-              { key: 'proofHash', label: 'proofHash', availability: 'present', detail: 'Hash value present in policy engine response.' },
-              { key: 'constraintResults', label: 'structured constraint results', availability: 'present', detail: 'Per-constraint structured outcomes are present.' },
-              { key: 'nonce', label: 'replayProtection.nonce', availability: 'present', detail: 'Replay nonce present.' },
-              { key: 'idempotency', label: 'replayProtection.idempotencyKey', availability: 'present', detail: 'Idempotency key present.' },
-              { key: 'requestHash', label: 'replayProtection.requestHash', availability: 'present', detail: 'Request hash present.' },
-              { key: 'solverName', label: 'solver.name', availability: 'present', detail: 'Observed solver.name: static_check.' },
-              { key: 'solverVersion', label: 'solver.version', availability: 'present', detail: 'Observed solver.version: dsg-deterministic-ts-2.6.1.' },
-              { key: 'constraintsChecked', label: 'constraintsChecked', availability: 'present', detail: 'Observed constraintsChecked: 8.' },
-              { key: 'externalZ3', label: 'External Z3 production invocation', availability: 'unsupported', detail: 'Z3 runs at design time (8 theorems: 5 core policy + 3 DeFi, proved UNSAT); not invoked per-request in production.' },
-              { key: 'jwtJwks', label: 'JWT/JWKS auth completion', availability: 'planned', detail: 'Supabase session auth is live; full JWT/JWKS standalone completion not yet claimed.' },
-              { key: 'worm', label: 'WORM-certified storage', availability: 'planned', detail: 'SHA-256 hash chain is tamper-evident by construction; WORM-certified external storage not yet claimed.' },
-            ]}
-          />
+      <section className="border-b border-white/[0.07]">
+        <div className="mx-auto max-w-7xl px-5 py-20 sm:px-6">
+          <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+            <div>
+              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-100">Clear outcomes</p>
+              <h2 className="mt-4 text-3xl font-bold tracking-[-0.03em] text-white sm:text-5xl">No log archaeology.</h2>
+              <p className="mt-4 max-w-xl text-base leading-8 text-slate-500">Each result should answer what happened, why, whether the action may continue, and what the operator must change when it cannot.</p>
+            </div>
+            <div className="grid gap-3">
+              {decisions.map(([status, body]) => (
+                <div key={status} className="grid gap-2 rounded-2xl border border-white/[0.07] bg-white/[0.02] p-5 sm:grid-cols-[190px_1fr] sm:items-center">
+                  <span className="text-sm font-bold text-white">{status}</span>
+                  <span className="text-sm leading-6 text-slate-500">{body}</span>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 pb-20">
-        <div className="border border-amber-300/30 bg-amber-300/10 p-6 text-sm leading-7 text-amber-50">
-          <p className="text-[11px] uppercase tracking-[0.3em] text-amber-200">Claim Boundary</p>
-          <p className="mt-3">Production runtime: live policy engine, CCVS v1.2 evidence chain (L1–L5), 3,389 tests (285 files), mutation score 72.08%, EU AI Act Annex IV mapping at <code className="text-amber-200">/api/compliance-evidence-pack/annex4</code>, and compliance-status API at <code className="text-amber-200">/api/ccvs/compliance-status</code>. Not claimed: external Z3 per-request invocation, JWT/JWKS standalone auth completion, WORM-certified external storage, third-party certification, or ISO/NIST independent audit.</p>
+      <section className="bg-[#090a0e]">
+        <div className="mx-auto flex max-w-7xl flex-col gap-8 px-5 py-20 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-100">Start with one action</p>
+            <h2 className="mt-3 text-3xl font-bold text-white">Connect. Run one action. See the decision.</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-500">Technical proof details remain available under Evidence and Audit; they are not required to understand the primary workflow.</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link href="/login?next=/dashboard/integration" className="rounded-2xl bg-amber-300 px-6 py-3.5 text-sm font-bold text-slate-950">Connect your agent</Link>
+            <Link href="/docs" className="rounded-2xl border border-white/10 bg-white/[0.03] px-6 py-3.5 text-sm font-bold text-white">Integration docs</Link>
+          </div>
         </div>
       </section>
 
+      <footer className="border-t border-white/[0.07] bg-[#07080b]">
+        <div className="mx-auto flex max-w-7xl flex-col gap-3 px-5 py-8 text-xs text-slate-600 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+          <span>DSG Control Plane</span>
+          <span>Governance decisions should be backed by current runtime evidence.</span>
+        </div>
+      </footer>
     </main>
   );
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default function HomePage() {
           <nav className="flex items-center gap-2">
             <Link href="#how-it-works" className="hidden rounded-full px-4 py-2 text-sm font-semibold text-slate-400 hover:text-white sm:block">How it works</Link>
             <Link href="/docs" className="hidden rounded-full px-4 py-2 text-sm font-semibold text-slate-400 hover:text-white sm:block">Docs</Link>
-            <Link href="/login" className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white">Sign in</Link>
+            <Link href="/login" className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white">Continue with email</Link>
           </nav>
         </div>
       </header>

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
 
 interface NavItem {
   href: string;
@@ -10,72 +9,17 @@ interface NavItem {
   exact?: boolean;
 }
 
-interface NavSection {
-  id: string;
-  label: string;
-  items: NavItem[];
-}
+const PRIMARY: NavItem[] = [
+  { href: '/dashboard/governance-live', label: 'Live' },
+  { href: '/dashboard/agents', label: 'Agents' },
+  { href: '/dashboard/policies', label: 'Plans' },
+  { href: '/dashboard/proofs', label: 'Evidence' },
+  { href: '/dashboard/audit', label: 'Audit' },
+];
 
-const SECTIONS: NavSection[] = [
-  {
-    id: 'overview',
-    label: 'Overview',
-    items: [
-      { href: '/dashboard', label: 'Dashboard', exact: true },
-      { href: '/demo', label: 'Demo' },
-    ],
-  },
-  {
-    id: 'govern',
-    label: 'Govern',
-    items: [
-      { href: '/dashboard/governance-live', label: 'Governance Live' },
-      { href: '/approvals', label: 'Approvals' },
-      { href: '/dashboard/audit', label: 'Audit' },
-      { href: '/dashboard/policies', label: 'Policies' },
-      { href: '/dashboard/verification', label: 'Verification' },
-      { href: '/dashboard/proofs', label: 'Proofs' },
-      { href: '/dashboard/breach-signal', label: 'Breach Signal' },
-    ],
-  },
-  {
-    id: 'finance',
-    label: 'Finance',
-    items: [
-      { href: '/finance-governance/app', label: 'Finance Governance' },
-      { href: '/dashboard/billing', label: 'Billing' },
-      { href: '/dashboard/payout-safety', label: 'Payout Safety' },
-      { href: '/dashboard/capacity', label: 'Capacity' },
-      { href: '/dashboard/ledger', label: 'Ledger' },
-    ],
-  },
-  {
-    id: 'build',
-    label: 'Build',
-    items: [
-      { href: '/dashboard/agents', label: 'Agents' },
-      { href: '/dashboard/executions', label: 'Executions' },
-      { href: '/dashboard/live-control', label: 'Live Control' },
-      { href: '/dashboard/integration', label: 'Integrations' },
-      { href: '/dashboard/skills', label: 'Skills' },
-      { href: '/marketplace/skills', label: 'Skills Marketplace' },
-      { href: '/dashboard/hermes/agents', label: 'Multi-Agent' },
-      { href: '/app-shell', label: 'App Shell' },
-    ],
-  },
-  {
-    id: 'manage',
-    label: 'Manage',
-    items: [
-      { href: '/dashboard/settings/access', label: 'Access' },
-      { href: '/dashboard/settings/security', label: 'Security' },
-      { href: '/dashboard/operations', label: 'Operations' },
-      { href: '/dashboard/trinity', label: '🔱 Trinity AI' },
-      { href: '/dashboard/command-center', label: 'Command Center' },
-      { href: '/dashboard/missions', label: 'Mission' },
-      { href: '/dashboard/referrals', label: 'Referrals' },
-    ],
-  },
+const SECONDARY: NavItem[] = [
+  { href: '/dashboard/integration', label: 'Connections' },
+  { href: '/dashboard/settings/access', label: 'Settings' },
 ];
 
 function isActive(pathname: string, href: string, exact?: boolean) {
@@ -83,67 +27,38 @@ function isActive(pathname: string, href: string, exact?: boolean) {
   return pathname === href || pathname.startsWith(href + '/');
 }
 
+function NavLink({ item, pathname }: { item: NavItem; pathname: string }) {
+  const active = isActive(pathname, item.href, item.exact);
+  return (
+    <Link
+      href={item.href}
+      className={[
+        'whitespace-nowrap rounded-full border px-3 py-2 text-sm font-semibold transition-colors',
+        active
+          ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
+          : 'border-transparent text-slate-400 hover:border-white/10 hover:bg-white/[0.03] hover:text-white',
+      ].join(' ')}
+    >
+      {item.label}
+    </Link>
+  );
+}
+
 export default function DashboardNav() {
   const pathname = usePathname();
-  const [expandedSection, setExpandedSection] = useState<string | null>(null);
-
-  const getActiveSectionId = () => {
-    for (const section of SECTIONS) {
-      if (section.items.some((item) => isActive(pathname, item.href, item.exact))) {
-        return section.id;
-      }
-    }
-    return null;
-  };
-
-  const activeSectionId = getActiveSectionId();
 
   return (
-    <nav className="flex items-center gap-1 overflow-x-auto pb-0.5">
-      {SECTIONS.map((section) => {
-        const sectionIsActive = expandedSection === section.id || activeSectionId === section.id;
-        return (
-          <div key={section.id} className="relative">
-            <button
-              onClick={() =>
-                setExpandedSection(
-                  expandedSection === section.id ? null : section.id
-                )
-              }
-              className={[
-                'whitespace-nowrap rounded-xl border px-3 py-2 text-sm font-semibold transition-colors',
-                sectionIsActive || activeSectionId === section.id
-                  ? 'border-emerald-400/50 bg-emerald-400/10 text-emerald-200'
-                  : 'border-slate-800 bg-slate-900 text-slate-300 hover:border-emerald-400/30 hover:text-slate-100',
-              ].join(' ')}
-            >
-              {section.label} {expandedSection === section.id ? '▴' : '▾'}
-            </button>
-            {expandedSection === section.id && (
-              <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-2xl border border-slate-800 bg-slate-900 py-2 shadow-2xl">
-                {section.items.map((item) => {
-                  const itemActive = isActive(pathname, item.href, item.exact);
-                  return (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      onClick={() => setExpandedSection(null)}
-                      className={[
-                        'block px-4 py-2 text-sm font-medium transition-colors',
-                        itemActive
-                          ? 'bg-emerald-400/10 text-emerald-200'
-                          : 'text-slate-300 hover:bg-white/5 hover:text-slate-100',
-                      ].join(' ')}
-                    >
-                      {item.label}
-                    </Link>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        );
-      })}
+    <nav className="flex min-w-0 flex-1 items-center justify-between gap-4 overflow-x-auto pb-0.5">
+      <div className="flex items-center gap-1">
+        {PRIMARY.map((item) => (
+          <NavLink key={item.href} item={item} pathname={pathname} />
+        ))}
+      </div>
+      <div className="flex items-center gap-1 border-l border-white/10 pl-3">
+        {SECONDARY.map((item) => (
+          <NavLink key={item.href} item={item} pathname={pathname} />
+        ))}
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## What changed
- Replaces the landing page with a single truthful Control Plane journey: Connect → Observe/Enforce → five-stage decision.
- Simplifies dashboard navigation to Live / Agents / Plans / Evidence / Audit / Connections / Settings.
- Makes Live Governance the primary product surface without changing governance APIs or decision logic.
- Adds operator-facing explanations for PASS, BLOCKED, WAITING_PERMISSION, and UNVERIFIED, including what to do next.
- Removes global AutoSetup/Nudge mounts from the dashboard shell so onboarding does not interrupt every protected page.

## Truth boundary
- Removes homepage claims that required separate fresh evidence (for example certification/WORM/external solver style marketing claims).
- Keeps copy grounded in current persisted governance feed, MCP/OpenAPI integration, server-authorized Observe/Enforce mode, evidence references, and audit records.

## Scope
Frontend UX/UI only. Existing governance endpoints and runtime decision logic are unchanged.

## Verification needed
CI/build must pass before merge. Runtime UX should then be checked against a real persisted governance event.