### PR TITLE
Rebrand Control Plane around one governed-action flow

### DIFF
--- a/app/dashboard/integrations/page.tsx
+++ b/app/dashboard/integrations/page.tsx
@@ -24,19 +24,19 @@ const quickstart = [
   {
     title: '1. Register integration',
     description: 'Create the organization binding, managed agent, policy binding, and one-time API key. Store the key once; DSG stores only its hash.',
-    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/register \\\n  -H 'content-type: application/json' \\\n  -d '{\"email\":\"dev@yourcompany.com\",\"app_name\":\"Your App\"}'",
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/register -H 'content-type: application/json' -d '{\"email\":\"dev@yourcompany.com\",\"app_name\":\"Your App\"}'",
     response: 'Returns: org_id, agent_id, api_key',
   },
   {
     title: '2. Attach callback',
     description: 'Register the webhook URL and allowed browser origins so governance decisions can be delivered back to your system.',
-    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/webhooks \\\n  -H 'content-type: application/json' \\\n  -H 'Authorization: Bearer $DSG_API_KEY' \\\n  -d '{\"agent_id\":\"agt_xxx\",\"webhook_url\":\"https://yourapp.com/dsg/events\",\"allowed_origins\":[\"https://yourapp.com\"]}'",
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/webhooks -H 'content-type: application/json' -H 'Authorization: Bearer $DSG_API_KEY' -d '{\"agent_id\":\"agt_xxx\",\"webhook_url\":\"https://yourapp.com/dsg/events\",\"allowed_origins\":[\"https://yourapp.com\"]}'",
     response: 'Returns: integration profile with normalized allowed_origins',
   },
   {
     title: '3. Execute one governed action',
     description: 'Send one action through DSG. Read the decision and decision hash before expanding the rollout.',
-    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/execute \\\n  -H 'content-type: application/json' \\\n  -H 'Authorization: Bearer $DSG_API_KEY' \\\n  -d '{\"agent_id\":\"agt_xxx\",\"action\":\"approve_invoice\",\"input\":{\"invoice_id\":\"INV-001\",\"amount\":1250}}'",
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/execute -H 'content-type: application/json' -H 'Authorization: Bearer $DSG_API_KEY' -d '{\"agent_id\":\"agt_xxx\",\"action\":\"approve_invoice\",\"input\":{\"invoice_id\":\"INV-001\",\"amount\":1250}}'",
     response: 'Returns: decision, latency_ms, policy context, audit evidence',
   },
 ];
@@ -241,7 +241,7 @@ export default function IntegrationsPage() {
           <div className="mt-5 grid gap-3 md:grid-cols-2">
             {productionRequirements.map((item) => (
               <div key={item} className="flex items-start gap-3 rounded-2xl border border-white/[0.07] bg-black/20 p-4">
-                <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-white/15 text-[10px] text-slate-500">✓</span>
+                <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-white/15 text-[10px] text-slate-500">•</span>
                 <p className="text-sm leading-6 text-slate-300">{item}</p>
               </div>
             ))}

--- a/app/dashboard/integrations/page.tsx
+++ b/app/dashboard/integrations/page.tsx
@@ -1,10 +1,8 @@
 import Link from 'next/link';
 import CopyButton from '../../../components/CopyButton';
 
-// Build the Live mode Stripe OAuth install URL from env vars.
-// NEXT_PUBLIC_STRIPE_CLIENT_ID is the canonical variable set in Vercel for
-// the Live mode app client_id (format: ca_...).
-// Falls back to the server-side install route which applies the same logic.
+// Build the Stripe OAuth install URL from deployment environment variables.
+// Falls back to the server-side install route, which applies the same logic.
 function buildStripeInstallUrl(): string {
   const clientId = process.env.NEXT_PUBLIC_STRIPE_CLIENT_ID;
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || '';
@@ -14,11 +12,9 @@ function buildStripeInstallUrl(): string {
       : '/stripe/oauth/callback';
     return `https://marketplace.stripe.com/oauth/v2/authorize?client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}`;
   }
-  // Explicit override (e.g. a branded marketplace listing URL)
   if (process.env.NEXT_PUBLIC_STRIPE_INSTALL_URL) {
     return process.env.NEXT_PUBLIC_STRIPE_INSTALL_URL;
   }
-  // Server-side route builds the correct URL at request time
   return '/api/stripe/connect/install';
 }
 
@@ -26,187 +22,232 @@ const STRIPE_INSTALL_URL = buildStripeInstallUrl();
 
 const quickstart = [
   {
-    title: '1. Register your integration',
-    description: 'Creates an org, managed agent, policy binding, and a one-time API key for server-to-server calls. Store the key once — DSG only keeps a hash.',
-    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/register \
-  -H 'content-type: application/json' \
-  -d '{\"email\":\"dev@yourcompany.com\",\"app_name\":\"Your App\"}'",
+    title: '1. Register integration',
+    description: 'Create the organization binding, managed agent, policy binding, and one-time API key. Store the key once; DSG stores only its hash.',
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/register \\\n  -H 'content-type: application/json' \\\n  -d '{\"email\":\"dev@yourcompany.com\",\"app_name\":\"Your App\"}'",
     response: 'Returns: org_id, agent_id, api_key',
   },
   {
-    title: '2. Attach a webhook callback',
-    description: 'Connect your app back to DSG so governance decisions can be delivered as events. Set the webhook URL and allowed browser origins.',
-    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/webhooks \
-  -H 'content-type: application/json' \
-  -H 'Authorization: Bearer $DSG_API_KEY' \
-  -d '{\"agent_id\":\"agt_xxx\",\"webhook_url\":\"https://yourapp.com/dsg/events\",\"allowed_origins\":[\"https://yourapp.com\"]}'",
+    title: '2. Attach callback',
+    description: 'Register the webhook URL and allowed browser origins so governance decisions can be delivered back to your system.',
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/integrations/webhooks \\\n  -H 'content-type: application/json' \\\n  -H 'Authorization: Bearer $DSG_API_KEY' \\\n  -d '{\"agent_id\":\"agt_xxx\",\"webhook_url\":\"https://yourapp.com/dsg/events\",\"allowed_origins\":[\"https://yourapp.com\"]}'",
     response: 'Returns: integration profile with normalized allowed_origins',
   },
   {
-    title: '3. Run your first governed action',
-    description: 'Send one action through DSG. Verify the ALLOW/REVIEW/BLOCK response and check the decision hash before rolling out to production.',
-    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/execute \
-  -H 'content-type: application/json' \
-  -H 'Authorization: Bearer $DSG_API_KEY' \
-  -d '{\"agent_id\":\"agt_xxx\",\"action\":\"approve_invoice\",\"input\":{\"invoice_id\":\"INV-001\",\"amount\":1250}}'",
-    response: 'Returns: decision (ALLOW/REVIEW/BLOCK), latency_ms, policy context, audit evidence',
+    title: '3. Execute one governed action',
+    description: 'Send one action through DSG. Read the decision and decision hash before expanding the rollout.',
+    command: "curl -s -X POST https://YOUR_DSG_DOMAIN/api/execute \\\n  -H 'content-type: application/json' \\\n  -H 'Authorization: Bearer $DSG_API_KEY' \\\n  -d '{\"agent_id\":\"agt_xxx\",\"action\":\"approve_invoice\",\"input\":{\"invoice_id\":\"INV-001\",\"amount\":1250}}'",
+    response: 'Returns: decision, latency_ms, policy context, audit evidence',
   },
 ];
 
-const connectorCards = [
+const connectors = [
   {
     name: 'Stripe',
-    use: 'Marketplace review, account connection, payment and billing governance',
-    hint: 'Install Stripe / Connect Stripe',
+    label: 'OAuth install',
+    body: 'Connect a Stripe account for payment and billing governance.',
+    href: STRIPE_INSTALL_URL,
+    external: true,
   },
   {
     name: 'REST API',
-    use: 'ERP wrappers, CRM, finance ops, internal services',
-    hint: '/api/integrations/register + /api/execute',
+    label: 'Universal',
+    body: 'Use the register and execute endpoints with ERP, CRM, internal services, or custom agents.',
+    href: '#api-quickstart',
+    external: false,
   },
   {
     name: 'Webhook',
-    use: 'Event-driven apps, callbacks, quick pilots without system replacement',
-    hint: 'Register callback URL + allowed origins',
+    label: 'Event-driven',
+    body: 'Add DSG before the final side effect and receive governance results through your callback.',
+    href: '#api-quickstart',
+    external: false,
   },
   {
-    name: 'Zapier / Make',
-    use: 'Business teams on no-code automation stacks',
-    hint: 'Add DSG as a policy gate before the final action step',
+    name: 'MCP / OpenAPI',
+    label: 'Agent tools',
+    body: 'Route existing agent tool calls through the governance surface without rebuilding the agent.',
+    href: '/docs',
+    external: false,
   },
-  {
-    name: 'n8n / Workato',
-    use: 'Ops teams with existing workflow engines',
-    hint: 'Add DSG as an HTTP node before high-risk actions',
-  },
-  {
-    name: 'GitHub / Vercel',
-    use: 'Release, deploy, and go/no-go controls',
-    hint: 'Route deployment claims through proof checks',
-  },
-  {
-    name: 'CSV / SFTP',
-    use: 'Legacy finance or audit batch workflows',
-    hint: 'Import evidence first, automate the gate later',
-  },
-];
+] as const;
 
-const evidenceChecklist = [
-  { item: 'agent_id is bound to one org', done: true },
-  { item: 'api_key is hashed server-side (never stored in plaintext)', done: true },
-  { item: 'Policy is resolved before every action', done: true },
-  { item: 'Approval state is visible when a review is required', done: true },
-  { item: 'Replay protection: nonce + idempotency key + request hash present', done: true },
-  { item: 'Audit hook visible before production claim', done: true },
-];
+const productionRequirements = [
+  'agent_id is bound to one organization',
+  'API key is stored as a server-side hash, not plaintext',
+  'Policy is resolved before the governed action',
+  'Review-required actions expose approval state',
+  'Replay protection data is present for protected execution paths',
+  'Audit evidence is available before making a production claim',
+] as const;
 
 export default function IntegrationsPage() {
   return (
-    <main className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto max-w-7xl px-6 py-10">
-
-        {/* Hero */}
-        <section className="rounded-3xl border border-white/10 bg-[linear-gradient(135deg,rgba(16,185,129,0.16),rgba(15,23,42,0.92)_45%,rgba(245,197,92,0.08))] p-6">
+    <main className="min-h-screen bg-[#07080b] text-slate-100">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
+        <header className="border-b border-white/[0.07] pb-8">
           <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl">
-              <p className="text-xs font-bold uppercase tracking-[0.24em] text-emerald-200">Enterprise Setup</p>
-              <h1 className="mt-3 text-4xl font-black tracking-tight text-white md:text-5xl">
-                Connect your existing workflow in 3 steps.
-              </h1>
-              <p className="mt-4 text-sm leading-7 text-slate-300">
-                No migration required. Register one integration, attach a callback, run one governed action, then export proof. Works with any system that supports REST or webhooks.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              <a href={STRIPE_INSTALL_URL} target="_blank" rel="noopener noreferrer" className="rounded-2xl bg-amber-300 px-5 py-3 text-sm font-black text-slate-950">
-                Install Stripe
-              </a>
-              <Link href="/enterprise-ready" className="rounded-2xl border border-emerald-300/40 bg-emerald-300/10 px-5 py-3 text-sm font-bold text-emerald-100">
-                View enterprise flow
-              </Link>
-              <Link href="/enterprise-proof/demo" className="rounded-2xl bg-amber-300 px-5 py-3 text-sm font-black text-slate-950">
-                Run proof demo
-              </Link>
-              <Link href="/dashboard" className="rounded-2xl border border-white/15 px-5 py-3 text-sm font-bold text-slate-200">
-                Back to dashboard
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        {/* Stripe install */}
-        <section className="mt-8 rounded-3xl border border-amber-300/25 bg-amber-300/[0.06] p-6 shadow-2xl shadow-amber-950/20">
-          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p className="text-[11px] uppercase tracking-[0.25em] text-amber-200/70">Stripe Marketplace Review</p>
-              <h2 className="mt-2 text-2xl font-black text-amber-50">Install Stripe / Connect Stripe</h2>
-              <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-300">
-                Use this direct install entry point to authorize DSG Governance Gate on a Stripe account. After authorization, Stripe returns to the configured OAuth callback.
-              </p>
-            </div>
-            <a
-              href={STRIPE_INSTALL_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex shrink-0 items-center justify-center rounded-2xl bg-amber-300 px-5 py-4 text-sm font-black text-slate-950 transition hover:bg-amber-200"
-            >
-              Install Stripe / Connect Stripe
-            </a>
-          </div>
-        </section>
-
-        {/* Quickstart steps */}
-        <section className="mt-8 grid gap-4 md:grid-cols-3">
-          {quickstart.map((step) => (
-            <article key={step.title} className="rounded-3xl border border-slate-800 bg-slate-900 p-5">
-              <h2 className="text-base font-black text-white">{step.title}</h2>
-              <p className="mt-2 text-sm leading-6 text-slate-400">{step.description}</p>
-              <div className="relative mt-4">
-                <pre className="overflow-x-auto rounded-2xl border border-slate-700 bg-slate-950 p-4 pr-16 text-xs leading-6 text-emerald-200">
-                  <code>{step.command}</code>
-                </pre>
-                <CopyButton text={step.command} />
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-blue-300/20 bg-blue-300/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.2em] text-blue-100">
+                  Connect
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  Start with one workflow
+                </span>
               </div>
-              <p className="mt-3 rounded-xl border border-emerald-400/10 bg-emerald-400/5 px-3 py-2 text-xs font-medium text-emerald-300">
-                {step.response}
+              <h1 className="mt-5 text-3xl font-bold tracking-[-0.035em] text-white sm:text-5xl">
+                Connect one existing workflow in minutes.
+              </h1>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-400 sm:text-base">
+                Do not migrate the whole stack. Connect one system, execute one governed action, then verify the live decision and evidence before expanding.
               </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link href="/dashboard/governance-live" className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm font-bold text-white">
+                Open live governance
+              </Link>
+              <Link href="/dashboard/integration" className="rounded-xl border border-white/10 px-4 py-3 text-sm font-semibold text-slate-400">
+                System truth
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-8 grid gap-3 lg:grid-cols-3">
+          {[
+            ['01', 'Connect', 'Choose the smallest existing workflow that can produce one real governed event.'],
+            ['02', 'Run', 'Execute one governed action through the same API or tool path your system will actually use.'],
+            ['03', 'Verify', 'Read the decision, reason, evidence, and audit trail before adding more workflows.'],
+          ].map(([index, title, body]) => (
+            <article key={index} className="rounded-2xl border border-white/[0.07] bg-white/[0.025] p-5">
+              <span className="text-xs font-bold text-blue-200">{index}</span>
+              <h2 className="mt-4 text-lg font-bold text-white">{title}</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-500">{body}</p>
             </article>
           ))}
         </section>
 
-        {/* Connector options */}
-        <section className="mt-8 rounded-3xl border border-white/10 bg-[#0b0d10] p-6">
-          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Connector options</p>
-          <h2 className="mt-3 text-2xl font-black text-white">Use your existing stack — no migration required.</h2>
-          <div className="mt-6 grid gap-4 md:grid-cols-3">
-            {connectorCards.map((card) => (
-              <article key={card.name} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
-                <h3 className="text-lg font-black text-white">{card.name}</h3>
-                <p className="mt-2 text-sm leading-6 text-slate-300">{card.use}</p>
-                <p className="mt-3 rounded-xl border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-xs font-semibold text-amber-100">
-                  {card.hint}
+        <section className="mt-10">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-slate-600">Choose a connection</p>
+              <h2 className="mt-2 text-2xl font-bold text-white">Use the stack you already have.</h2>
+            </div>
+            <p className="max-w-xl text-sm leading-6 text-slate-500">Start with the connector that creates the shortest path to one real action. More integrations can be added after the first proof.</p>
+          </div>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            {connectors.map((connector) => {
+              const classes = 'group rounded-2xl border border-white/[0.08] bg-white/[0.025] p-5 transition hover:border-white/15 hover:bg-white/[0.045]';
+              const content = (
+                <>
+                  <div className="flex items-center justify-between gap-4">
+                    <h3 className="text-lg font-bold text-white">{connector.name}</h3>
+                    <span className="rounded-full border border-white/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500">
+                      {connector.label}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-400">{connector.body}</p>
+                  <p className="mt-5 text-xs font-bold text-blue-200 group-hover:text-blue-100">Open setup →</p>
+                </>
+              );
+
+              return connector.external ? (
+                <a key={connector.name} href={connector.href} target="_blank" rel="noopener noreferrer" className={classes}>
+                  {content}
+                </a>
+              ) : (
+                <Link key={connector.name} href={connector.href} className={classes}>
+                  {content}
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+
+        <section id="api-quickstart" className="mt-10 rounded-3xl border border-white/[0.08] bg-[#0a0c10] p-5 sm:p-6">
+          <div className="max-w-3xl">
+            <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-slate-600">API quickstart</p>
+            <h2 className="mt-2 text-2xl font-bold text-white">Three calls to the first governed result.</h2>
+            <p className="mt-3 text-sm leading-7 text-slate-500">
+              These commands are explicit so the user can inspect what will be created and sent. Replace the placeholder domain and values with the deployment you are actually using.
+            </p>
+          </div>
+
+          <div className="mt-6 space-y-3">
+            {quickstart.map((step, index) => (
+              <details key={step.title} open={index === 0} className="group rounded-2xl border border-white/[0.07] bg-white/[0.02] p-4 sm:p-5">
+                <summary className="cursor-pointer list-none">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-bold text-white">{step.title}</h3>
+                      <p className="mt-2 text-sm leading-6 text-slate-500">{step.description}</p>
+                    </div>
+                    <span className="mt-1 text-xs font-bold text-slate-600 group-open:rotate-45">+</span>
+                  </div>
+                </summary>
+                <div className="relative mt-4">
+                  <pre className="overflow-x-auto rounded-xl border border-white/[0.08] bg-black/35 p-4 pr-16 text-xs leading-6 text-emerald-200">
+                    <code>{step.command}</code>
+                  </pre>
+                  <CopyButton text={step.command} />
+                </div>
+                <p className="mt-3 rounded-xl border border-white/[0.07] bg-white/[0.025] px-3 py-2 text-xs font-medium text-slate-400">
+                  {step.response}
                 </p>
-              </article>
+              </details>
             ))}
           </div>
         </section>
 
-        {/* Evidence checklist */}
-        <section className="mt-8 rounded-3xl border border-white/10 bg-white/[0.02] p-6">
-          <p className="text-xs font-bold uppercase tracking-[0.24em] text-slate-500">Before making an enterprise claim</p>
-          <h2 className="mt-3 text-xl font-black text-white">Verify all 6 evidence requirements are met.</h2>
+        <section className="mt-10 grid gap-4 lg:grid-cols-[1.05fr_0.95fr]">
+          <div className="rounded-3xl border border-blue-300/15 bg-blue-300/[0.045] p-6">
+            <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-blue-200">After the first action</p>
+            <h2 className="mt-3 text-xl font-bold text-white">The output should be visible without reading raw logs.</h2>
+            <div className="mt-5 grid gap-3">
+              {[
+                ['/dashboard/governance-live', 'Live decision', 'PASS / BLOCKED / WAITING_PERMISSION / UNVERIFIED plus the five governance stages.'],
+                ['/dashboard/proofs', 'Evidence', 'Supporting proof and evidence references used by the governance result.'],
+                ['/dashboard/audit', 'Audit', 'Persisted execution record for review and follow-up.'],
+              ].map(([href, title, body]) => (
+                <Link key={href} href={href} className="rounded-2xl border border-white/[0.08] bg-black/20 p-4 transition hover:border-white/15">
+                  <p className="text-sm font-bold text-white">{title}</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">{body}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/[0.08] bg-white/[0.025] p-6">
+            <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-amber-200">Quota-aware rollout</p>
+            <h2 className="mt-3 text-xl font-bold text-white">Prove one path before scaling the integration.</h2>
+            <p className="mt-3 text-sm leading-7 text-slate-500">
+              Keep hosting, API, and provider quotas visible during rollout. A larger rollout is not a success if the first governed action cannot be repeated reliably.
+            </p>
+            <ol className="mt-5 space-y-3 text-sm text-slate-400">
+              <li>1. Connect one workflow.</li>
+              <li>2. Run one real governed action.</li>
+              <li>3. Verify decision + evidence + audit.</li>
+              <li>4. Expand only after the same path is repeatable.</li>
+            </ol>
+          </div>
+        </section>
+
+        <section className="mt-10 rounded-3xl border border-white/[0.08] bg-white/[0.02] p-6">
+          <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-slate-600">Production claim boundary</p>
+          <h2 className="mt-3 text-xl font-bold text-white">Verify these requirements before calling the integration production-ready.</h2>
           <div className="mt-5 grid gap-3 md:grid-cols-2">
-            {evidenceChecklist.map(({ item, done }) => (
-              <div key={item} className="flex items-start gap-3 rounded-2xl border border-white/10 bg-black/20 p-4">
-                <span className={`mt-0.5 shrink-0 text-base ${done ? 'text-emerald-400' : 'text-slate-600'}`}>
-                  {done ? '✓' : '○'}
-                </span>
-                <p className="text-sm text-slate-200">{item}</p>
+            {productionRequirements.map((item) => (
+              <div key={item} className="flex items-start gap-3 rounded-2xl border border-white/[0.07] bg-black/20 p-4">
+                <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-white/15 text-[10px] text-slate-500">✓</span>
+                <p className="text-sm leading-6 text-slate-300">{item}</p>
               </div>
             ))}
           </div>
+          <p className="mt-4 text-xs leading-5 text-slate-600">This checklist describes required evidence. It does not claim the current deployment has passed every item.</p>
         </section>
-
       </div>
     </main>
   );

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -14,15 +14,15 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   return (
     <div className="min-h-screen bg-[#07080b] text-white">
-      <header className="sticky top-0 z-40 border-b border-white/[0.07] bg-[#07080b]/92 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-[1480px] items-center gap-5 px-4 py-3 sm:px-6">
-          <Link href="/dashboard/governance-live" className="flex shrink-0 items-center gap-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-300/30 bg-amber-300/10 text-xs font-black tracking-[0.12em] text-amber-100">
+      <header className="sticky top-0 z-40 border-b border-white/[0.07] bg-[#08090c]/92 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-[1480px] items-center gap-4 px-4 py-3 sm:px-6">
+          <Link href="/dashboard/governance-live" className="flex shrink-0 items-center gap-3" aria-label="DSG Control Plane home">
+            <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-blue-300/20 bg-blue-300/[0.07] text-[11px] font-black tracking-[0.12em] text-blue-100">
               DSG
             </span>
-            <span className="hidden sm:block">
-              <span className="block text-xs uppercase tracking-[0.2em] text-slate-500">Control Plane</span>
-              <span className="block text-sm font-semibold text-white">Governance</span>
+            <span className="hidden lg:block">
+              <span className="block text-[10px] font-bold uppercase tracking-[0.22em] text-slate-600">Control Plane</span>
+              <span className="block text-sm font-semibold text-white">Agent Governance</span>
             </span>
           </Link>
 
@@ -39,7 +39,8 @@ export default async function DashboardLayout({ children }: { children: React.Re
           </div>
         </div>
       </header>
-      {children}
+
+      <div className="pb-20 md:pb-0">{children}</div>
       {user && <AgentChatWidget />}
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,14 +8,14 @@ import { ToastProvider } from '../components/ToastProvider';
 import { LanguageProvider } from '@/lib/i18n/language-context';
 
 export const metadata: Metadata = {
-  title: 'DSG ONE — ProofGate Runtime Control Plane',
-  description: 'red, gold, and blue-sapphire runtime governance for AI, workflow, finance, and deployment actions before execution.',
+  title: 'DSG Control Plane — Runtime governance for AI agents',
+  description: 'Connect existing agents and workflows, inspect plan alignment, permissions and evidence, and record auditable execution decisions before downstream actions continue.',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-slate-950 text-slate-100 antialiased">
+      <body className="min-h-screen bg-[#07080b] text-slate-100 antialiased">
         <LanguageProvider>
           <ToastProvider>
             <GlobalNav />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,18 +3,24 @@ import { Suspense } from 'react';
 import RefTracker from '../components/RefTracker';
 
 const stages = [
-  { index: '01', title: 'ACTION', body: 'See exactly what the agent is trying to do.', status: 'CAPTURED' },
-  { index: '02', title: 'PLAN ALIGNMENT', body: 'Check whether the action matches the approved plan.', status: 'CHECKED' },
-  { index: '03', title: 'PERMISSION', body: 'Verify the execution identity and required permission.', status: 'VERIFIED' },
-  { index: '04', title: 'EVIDENCE', body: 'See whether supporting evidence is present for the decision.', status: 'RECORDED' },
-  { index: '05', title: 'EXECUTION / AUDIT', body: 'See the final governance result and persisted audit record.', status: 'PASS / BLOCK' },
+  { index: '01', title: 'ACTION', body: 'What the agent is trying to do', status: 'CAPTURED' },
+  { index: '02', title: 'PLAN ALIGNMENT', body: 'Whether it matches the approved plan', status: 'CHECKED' },
+  { index: '03', title: 'PERMISSION', body: 'Whether this identity may execute it', status: 'VERIFIED' },
+  { index: '04', title: 'EVIDENCE', body: 'Whether the decision has supporting proof', status: 'RECORDED' },
+  { index: '05', title: 'EXECUTION / AUDIT', body: 'What happens next and what was recorded', status: 'PASS / BLOCK' },
 ] as const;
 
-const decisions = [
-  ['PASS', 'The action satisfies the current governance checks.'],
-  ['BLOCKED', 'The action is outside the allowed conditions and should not continue in enforce mode.'],
+const outcomes = [
+  ['PASS', 'The action satisfies the current governance checks and may continue.'],
+  ['BLOCKED', 'The action is outside the approved conditions and is stopped in enforce mode.'],
   ['WAITING_PERMISSION', 'The current execution identity does not have sufficient permission.'],
   ['UNVERIFIED', 'There is not enough verified evidence to support the action or claim.'],
+] as const;
+
+const flow = [
+  ['01', 'Connect one system', 'Route one existing MCP, OpenAPI, REST, or webhook workflow through DSG. Start with a single action instead of migrating your stack.'],
+  ['02', 'Choose control mode', 'Observe records the governance result. Enforce can stop downstream execution when governance requires it.'],
+  ['03', 'Read the decision', 'See the action, plan alignment, permission, evidence, and final execution/audit result in one path.'],
 ] as const;
 
 export default function HomePage() {
@@ -22,67 +28,66 @@ export default function HomePage() {
     <main className="min-h-screen overflow-hidden bg-[#07080b] text-white">
       <Suspense fallback={null}><RefTracker /></Suspense>
 
-      <header className="border-b border-white/[0.07] bg-[#07080b]/95">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-5 py-4 sm:px-6">
-          <Link href="/" className="flex items-center gap-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-300/30 bg-amber-300/10 text-[10px] font-black tracking-[0.12em] text-amber-100">DSG</span>
-            <span>
-              <span className="block text-xs font-bold uppercase tracking-[0.2em] text-white">DSG</span>
-              <span className="block text-[10px] uppercase tracking-[0.18em] text-slate-600">Control Plane</span>
-            </span>
-          </Link>
-          <nav className="flex items-center gap-2">
-            <Link href="#how-it-works" className="hidden rounded-full px-4 py-2 text-sm font-semibold text-slate-400 hover:text-white sm:block">How it works</Link>
-            <Link href="/docs" className="hidden rounded-full px-4 py-2 text-sm font-semibold text-slate-400 hover:text-white sm:block">Docs</Link>
-            <Link href="/login" className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-white">Continue with email</Link>
-          </nav>
-        </div>
-      </header>
-
       <section className="relative border-b border-white/[0.07]">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_16%_12%,rgba(225,6,0,0.16),transparent_28%),radial-gradient(circle_at_84%_10%,rgba(212,175,55,0.13),transparent_31%)]" />
-        <div className="relative mx-auto grid min-h-[720px] max-w-7xl gap-12 px-5 py-16 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:py-24">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_8%,rgba(59,130,246,0.14),transparent_30%),radial-gradient(circle_at_86%_14%,rgba(245,158,11,0.10),transparent_28%)]" />
+        <div className="relative mx-auto grid min-h-[690px] max-w-7xl gap-12 px-5 py-16 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:py-24">
           <div>
-            <p className="inline-flex rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.2em] text-amber-100">Runtime governance for existing agents</p>
-            <h1 className="mt-7 max-w-4xl text-5xl font-bold leading-[0.98] tracking-[-0.04em] text-white sm:text-6xl lg:text-7xl">Know what your AI is about to do.</h1>
-            <p className="mt-6 max-w-2xl text-base leading-8 text-slate-400 sm:text-lg">
-              Connect an agent through MCP or OpenAPI. DSG evaluates actions against the server-side governance context, permissions and available evidence, then records the decision for audit review.
+            <p className="inline-flex rounded-full border border-blue-300/20 bg-blue-300/[0.07] px-4 py-2 text-[11px] font-bold uppercase tracking-[0.2em] text-blue-100">
+              Runtime governance for existing AI systems
             </p>
+            <h1 className="mt-7 max-w-4xl text-5xl font-bold leading-[0.98] tracking-[-0.045em] text-white sm:text-6xl lg:text-7xl">
+              Control what AI agents can do — before they do it.
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-8 text-slate-400 sm:text-lg">
+              DSG sits between an agent and the system it wants to change. It checks plan alignment, permission, and evidence, then records an auditable decision you can act on.
+            </p>
+
             <div className="mt-8 flex flex-wrap gap-3">
-              <Link href="/login?next=/dashboard/integration" className="rounded-2xl bg-amber-300 px-6 py-3.5 text-sm font-bold text-slate-950 transition hover:bg-amber-200">Connect your agent</Link>
-              <Link href="/dashboard/governance-live" className="rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-3.5 text-sm font-bold text-white transition hover:border-white/20">See Live Governance</Link>
+              <Link
+                href="/login?next=/dashboard/integrations"
+                className="rounded-xl bg-white px-5 py-3.5 text-sm font-bold text-slate-950 transition hover:bg-slate-200"
+              >
+                Connect one system
+              </Link>
+              <Link
+                href="/dashboard/governance-live"
+                className="rounded-xl border border-white/12 bg-white/[0.04] px-5 py-3.5 text-sm font-bold text-white transition hover:border-white/20 hover:bg-white/[0.07]"
+              >
+                Open live governance
+              </Link>
             </div>
-            <div className="mt-8 grid max-w-2xl gap-3 sm:grid-cols-3">
-              {[
-                ['CONNECT', 'MCP or OpenAPI'],
-                ['CHOOSE', 'Observe or Enforce'],
-                ['SEE', 'Decision + evidence'],
-              ].map(([label, value]) => (
-                <div key={label} className="rounded-2xl border border-white/[0.07] bg-white/[0.025] p-4">
-                  <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600">{label}</p>
-                  <p className="mt-2 text-sm font-semibold text-slate-200">{value}</p>
-                </div>
-              ))}
+
+            <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-xs font-semibold text-slate-500">
+              <span>MCP / OpenAPI</span>
+              <span>REST / Webhooks</span>
+              <span>Observe / Enforce</span>
+              <span>Evidence + Audit</span>
             </div>
           </div>
 
-          <div className="rounded-[2rem] border border-white/[0.08] bg-black/25 p-4 shadow-2xl shadow-black/30 sm:p-5">
-            <div className="flex items-center justify-between border-b border-white/[0.07] px-2 pb-4">
+          <div className="rounded-[1.75rem] border border-white/[0.08] bg-[#0b0d11]/90 p-4 shadow-2xl shadow-black/30 sm:p-5">
+            <div className="flex items-center justify-between border-b border-white/[0.07] px-1 pb-4">
               <div>
-                <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-slate-600">Live governance</p>
+                <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-slate-600">Decision path</p>
                 <p className="mt-1 text-sm font-semibold text-white">One action · five checks</p>
               </div>
-              <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-3 py-1 text-[10px] font-bold text-emerald-200">REAL EVENTS</span>
+              <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[10px] font-bold text-slate-400">
+                LIVE AFTER CONNECT
+              </span>
             </div>
             <div className="mt-4 space-y-2.5">
               {stages.map((stage) => (
                 <div key={stage.index} className="grid grid-cols-[38px_1fr_auto] items-center gap-3 rounded-2xl border border-white/[0.07] bg-white/[0.025] p-3.5">
-                  <span className="flex h-8 w-8 items-center justify-center rounded-full border border-amber-300/20 bg-amber-300/10 text-[10px] font-bold text-amber-100">{stage.index}</span>
+                  <span className="flex h-8 w-8 items-center justify-center rounded-lg border border-blue-300/15 bg-blue-300/[0.06] text-[10px] font-bold text-blue-100">
+                    {stage.index}
+                  </span>
                   <div className="min-w-0">
                     <p className="text-xs font-bold text-white">{stage.title}</p>
                     <p className="mt-1 truncate text-[11px] text-slate-600">{stage.body}</p>
                   </div>
-                  <span className="hidden rounded-full border border-white/[0.08] bg-black/20 px-2.5 py-1 text-[9px] font-bold text-slate-400 sm:block">{stage.status}</span>
+                  <span className="hidden rounded-full border border-white/[0.08] bg-black/20 px-2.5 py-1 text-[9px] font-bold text-slate-400 sm:block">
+                    {stage.status}
+                  </span>
                 </div>
               ))}
             </div>
@@ -93,19 +98,17 @@ export default function HomePage() {
       <section id="how-it-works" className="border-b border-white/[0.07] bg-[#090a0e]">
         <div className="mx-auto max-w-7xl px-5 py-20 sm:px-6">
           <div className="max-w-3xl">
-            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-100">How it works</p>
-            <h2 className="mt-4 text-3xl font-bold tracking-[-0.03em] text-white sm:text-5xl">Use the systems you already have.</h2>
-            <p className="mt-4 text-base leading-8 text-slate-500">The control plane is organized around the user task: connect, choose control mode, then read the governance decision.</p>
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-blue-200">From connection to proof</p>
+            <h2 className="mt-4 text-3xl font-bold tracking-[-0.03em] text-white sm:text-5xl">One clear path to the first governed action.</h2>
+            <p className="mt-4 text-base leading-8 text-slate-500">
+              The primary workflow is intentionally short: connect, choose control mode, then read the decision and next action.
+            </p>
           </div>
 
           <div className="mt-10 grid gap-4 lg:grid-cols-3">
-            {[
-              ['01', 'Connect', 'Route an existing MCP or OpenAPI action through DSG. You do not need to build a new agent just to use the governance surface.'],
-              ['02', 'Choose control', 'Observe records governance results. Enforce lets the configured governance decision stop downstream execution when required.'],
-              ['03', 'Read the decision', 'Follow Action → Plan Alignment → Permission → Evidence → Execution / Audit without searching through logs.'],
-            ].map(([index, title, body]) => (
+            {flow.map(([index, title, body]) => (
               <article key={index} className="rounded-3xl border border-white/[0.07] bg-white/[0.025] p-6 sm:p-7">
-                <span className="text-xs font-bold text-amber-100">{index}</span>
+                <span className="text-xs font-bold text-blue-200">{index}</span>
                 <h3 className="mt-6 text-xl font-bold text-white">{title}</h3>
                 <p className="mt-3 text-sm leading-7 text-slate-500">{body}</p>
               </article>
@@ -118,12 +121,14 @@ export default function HomePage() {
         <div className="mx-auto max-w-7xl px-5 py-20 sm:px-6">
           <div className="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
             <div>
-              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-100">Clear outcomes</p>
-              <h2 className="mt-4 text-3xl font-bold tracking-[-0.03em] text-white sm:text-5xl">No log archaeology.</h2>
-              <p className="mt-4 max-w-xl text-base leading-8 text-slate-500">Each result should answer what happened, why, whether the action may continue, and what the operator must change when it cannot.</p>
+              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-blue-200">Decision, reason, next step</p>
+              <h2 className="mt-4 text-3xl font-bold tracking-[-0.03em] text-white sm:text-5xl">No log archaeology required.</h2>
+              <p className="mt-4 max-w-xl text-base leading-8 text-slate-500">
+                Each result should tell an operator what happened, whether execution may continue, why, and what must change when it cannot.
+              </p>
             </div>
             <div className="grid gap-3">
-              {decisions.map(([status, body]) => (
+              {outcomes.map(([status, body]) => (
                 <div key={status} className="grid gap-2 rounded-2xl border border-white/[0.07] bg-white/[0.02] p-5 sm:grid-cols-[190px_1fr] sm:items-center">
                   <span className="text-sm font-bold text-white">{status}</span>
                   <span className="text-sm leading-6 text-slate-500">{body}</span>
@@ -137,13 +142,19 @@ export default function HomePage() {
       <section className="bg-[#090a0e]">
         <div className="mx-auto flex max-w-7xl flex-col gap-8 px-5 py-20 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-100">Start with one action</p>
-            <h2 className="mt-3 text-3xl font-bold text-white">Connect. Run one action. See the decision.</h2>
-            <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-500">Technical proof details remain available under Evidence and Audit; they are not required to understand the primary workflow.</p>
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-blue-200">Start with one action</p>
+            <h2 className="mt-3 text-3xl font-bold text-white">Connect one system. Run one action. See the proof.</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-500">
+              Technical details remain available in Evidence and Audit, but the primary workflow does not require the user to search through raw logs.
+            </p>
           </div>
           <div className="flex flex-wrap gap-3">
-            <Link href="/login?next=/dashboard/integration" className="rounded-2xl bg-amber-300 px-6 py-3.5 text-sm font-bold text-slate-950">Connect your agent</Link>
-            <Link href="/docs" className="rounded-2xl border border-white/10 bg-white/[0.03] px-6 py-3.5 text-sm font-bold text-white">Integration docs</Link>
+            <Link href="/login?next=/dashboard/integrations" className="rounded-xl bg-white px-5 py-3.5 text-sm font-bold text-slate-950">
+              Connect one system
+            </Link>
+            <Link href="/docs" className="rounded-xl border border-white/10 bg-white/[0.03] px-5 py-3.5 text-sm font-bold text-white">
+              Integration docs
+            </Link>
           </div>
         </div>
       </section>

--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -1,25 +1,44 @@
 'use client';
 
+import type { ComponentType } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import {
+  Bot,
+  Cable,
+  FileCheck2,
+  RadioTower,
+  ScrollText,
+  Settings2,
+  ShieldCheck,
+} from 'lucide-react';
 
 interface NavItem {
   href: string;
   label: string;
+  icon: ComponentType<{ className?: string }>;
   exact?: boolean;
 }
 
 const PRIMARY: NavItem[] = [
-  { href: '/dashboard/governance-live', label: 'Live' },
-  { href: '/dashboard/agents', label: 'Agents' },
-  { href: '/dashboard/policies', label: 'Plans' },
-  { href: '/dashboard/proofs', label: 'Evidence' },
-  { href: '/dashboard/audit', label: 'Audit' },
+  { href: '/dashboard/governance-live', label: 'Live', icon: RadioTower },
+  { href: '/dashboard/integrations', label: 'Connect', icon: Cable },
+  { href: '/dashboard/agents', label: 'Agents', icon: Bot },
+  { href: '/dashboard/policies', label: 'Plans', icon: ShieldCheck },
+  { href: '/dashboard/proofs', label: 'Evidence', icon: FileCheck2 },
+  { href: '/dashboard/audit', label: 'Audit', icon: ScrollText },
 ];
 
 const SECONDARY: NavItem[] = [
-  { href: '/dashboard/integration', label: 'Connections' },
-  { href: '/dashboard/settings/access', label: 'Settings' },
+  { href: '/dashboard/settings/access', label: 'Settings', icon: Settings2 },
+];
+
+const MOBILE: NavItem[] = [
+  PRIMARY[0],
+  PRIMARY[1],
+  PRIMARY[3],
+  PRIMARY[4],
+  PRIMARY[5],
 ];
 
 function isActive(pathname: string, href: string, exact?: boolean) {
@@ -27,18 +46,22 @@ function isActive(pathname: string, href: string, exact?: boolean) {
   return pathname === href || pathname.startsWith(href + '/');
 }
 
-function NavLink({ item, pathname }: { item: NavItem; pathname: string }) {
+function DesktopLink({ item, pathname }: { item: NavItem; pathname: string }) {
   const active = isActive(pathname, item.href, item.exact);
+  const Icon = item.icon;
+
   return (
     <Link
       href={item.href}
+      aria-current={active ? 'page' : undefined}
       className={[
-        'whitespace-nowrap rounded-full border px-3 py-2 text-sm font-semibold transition-colors',
+        'inline-flex items-center gap-2 whitespace-nowrap rounded-lg border px-3 py-2 text-sm font-semibold transition-colors',
         active
-          ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
-          : 'border-transparent text-slate-400 hover:border-white/10 hover:bg-white/[0.03] hover:text-white',
+          ? 'border-white/12 bg-white/[0.08] text-white'
+          : 'border-transparent text-slate-500 hover:border-white/10 hover:bg-white/[0.04] hover:text-slate-200',
       ].join(' ')}
     >
+      <Icon className="h-4 w-4" />
       {item.label}
     </Link>
   );
@@ -48,17 +71,43 @@ export default function DashboardNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex min-w-0 flex-1 items-center justify-between gap-4 overflow-x-auto pb-0.5">
-      <div className="flex items-center gap-1">
-        {PRIMARY.map((item) => (
-          <NavLink key={item.href} item={item} pathname={pathname} />
-        ))}
-      </div>
-      <div className="flex items-center gap-1 border-l border-white/10 pl-3">
-        {SECONDARY.map((item) => (
-          <NavLink key={item.href} item={item} pathname={pathname} />
-        ))}
-      </div>
-    </nav>
+    <>
+      <nav className="hidden min-w-0 flex-1 items-center justify-between gap-4 overflow-x-auto md:flex">
+        <div className="flex items-center gap-1">
+          {PRIMARY.map((item) => (
+            <DesktopLink key={item.href} item={item} pathname={pathname} />
+          ))}
+        </div>
+        <div className="flex items-center gap-1 border-l border-white/10 pl-3">
+          {SECONDARY.map((item) => (
+            <DesktopLink key={item.href} item={item} pathname={pathname} />
+          ))}
+        </div>
+      </nav>
+
+      <nav
+        aria-label="Primary dashboard navigation"
+        className="fixed inset-x-0 bottom-0 z-50 grid grid-cols-5 border-t border-white/10 bg-[#090a0e]/96 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-2 backdrop-blur-xl md:hidden"
+      >
+        {MOBILE.map((item) => {
+          const active = isActive(pathname, item.href, item.exact);
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={active ? 'page' : undefined}
+              className={[
+                'flex min-h-12 flex-col items-center justify-center gap-1 rounded-xl px-1 py-1.5 text-[10px] font-semibold transition-colors',
+                active ? 'bg-white/[0.08] text-white' : 'text-slate-500 active:bg-white/[0.05]',
+              ].join(' ')}
+            >
+              <Icon className="h-[18px] w-[18px]" />
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
   );
 }

--- a/components/GlobalNav.tsx
+++ b/components/GlobalNav.tsx
@@ -4,70 +4,81 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import {
-  Shield,
   Building2,
-  DollarSign,
-  Zap,
-  ShieldCheck,
   ChevronDown,
-  FileCheck,
+  DollarSign,
+  FileCheck2,
+  Menu,
+  Shield,
+  ShieldCheck,
+  X,
 } from 'lucide-react';
 import { useAppLanguage } from '@/store/useAppLanguage';
 import { languageStore } from '@/store/languageStore';
 
 const PRODUCT_ITEMS_TH = [
-  { href: '/delivery-proof',        icon: FileCheck,  title: 'Delivery Proof',       description: 'รายงาน proof สำหรับ agency และ dev team', highlight: true },
-  { href: '/proofgate',             icon: Shield,     title: 'ProofGate',             description: 'ชั้นควบคุม runtime ของ AI' },
-  { href: '/enterprise-ready',      icon: Building2,  title: 'Enterprise Ready',      description: 'ตั้งค่า enterprise โดยไม่ต้อง migrate' },
-  { href: '/finance-governance',    icon: DollarSign, title: 'Finance Governance',    description: 'ควบคุม payment และการเงิน' },
-  { href: '/finance-approval-gate', icon: DollarSign, title: 'Finance Approval Gate', description: 'ระบบอนุมัติ AI payment' },
-  { href: '/automation',            icon: Zap,        title: 'Automation',            description: 'Webhook และ workflow อัตโนมัติ' },
-  { href: '/ai-compliance',         icon: ShieldCheck, title: 'AI Compliance',        description: 'ISO 42001, NIST AI RMF' },
-  { href: '/eu-ai-act',             icon: Shield,     title: 'EU AI Act',             description: 'บล็อกก่อนเกิดความเสียหาย' },
-];
+  { href: '/proofgate', icon: Shield, title: 'ProofGate', description: 'ควบคุม action ก่อนกระทบระบบจริง' },
+  { href: '/delivery-proof', icon: FileCheck2, title: 'Delivery Proof', description: 'หลักฐานการส่งมอบสำหรับทีมและลูกค้า' },
+  { href: '/finance-approval-gate', icon: DollarSign, title: 'Finance Approval Gate', description: 'อนุมัติหรือหยุด action ด้านการเงิน' },
+  { href: '/enterprise-ready', icon: Building2, title: 'Enterprise Ready', description: 'เชื่อมระบบเดิมโดยไม่ต้องย้ายทั้งหมด' },
+  { href: '/ai-compliance', icon: ShieldCheck, title: 'AI Compliance', description: 'หลักฐานสำหรับกรอบกำกับดูแล AI' },
+] as const;
 
 const PRODUCT_ITEMS_EN = [
-  { href: '/delivery-proof',        icon: FileCheck,  title: 'Delivery Proof',       description: 'AI code proof report for agencies & dev teams', highlight: true },
-  { href: '/proofgate',             icon: Shield,     title: 'ProofGate',             description: 'Runtime control layer for AI' },
-  { href: '/enterprise-ready',      icon: Building2,  title: 'Enterprise Ready',      description: 'No-migration enterprise setup' },
-  { href: '/finance-governance',    icon: DollarSign, title: 'Finance Governance',    description: 'Payment & finance controls' },
-  { href: '/finance-approval-gate', icon: DollarSign, title: 'Finance Approval Gate', description: 'AI payment approval pilot' },
-  { href: '/automation',            icon: Zap,        title: 'Automation',            description: 'Webhook & workflow automation' },
-  { href: '/ai-compliance',         icon: ShieldCheck, title: 'AI Compliance',        description: 'ISO 42001, NIST AI RMF' },
-  { href: '/eu-ai-act',             icon: Shield,     title: 'EU AI Act',             description: 'Block before damage, not after' },
-];
-
-const FLAT_LINKS = [
-  { href: '/blog',       label: 'Blog',       match: (p: string) => p === '/blog' || p.startsWith('/blog/') },
-  { href: '/pricing',    label: 'Pricing',    match: (p: string) => p === '/pricing' },
-  { href: '/docs',       label: 'Docs',       match: (p: string) => p === '/docs' || p.startsWith('/docs/') },
-  { href: '/quickstart', label: 'Quickstart', match: (p: string) => p === '/quickstart' },
-  { href: '/design-system-tool.html', label: '🎨 Design System', match: (p: string) => false, target: '_blank' },
-];
+  { href: '/proofgate', icon: Shield, title: 'ProofGate', description: 'Govern actions before they touch real systems' },
+  { href: '/delivery-proof', icon: FileCheck2, title: 'Delivery Proof', description: 'Delivery evidence for teams and customers' },
+  { href: '/finance-approval-gate', icon: DollarSign, title: 'Finance Approval Gate', description: 'Review or stop governed finance actions' },
+  { href: '/enterprise-ready', icon: Building2, title: 'Enterprise Ready', description: 'Connect existing systems without full migration' },
+  { href: '/ai-compliance', icon: ShieldCheck, title: 'AI Compliance', description: 'Evidence for AI governance frameworks' },
+] as const;
 
 const NAV_T = {
-  th: { product: 'สินค้า', startFree: 'เริ่มใช้ฟรี →', login: 'เข้าสู่ระบบ', openMenu: 'เปิดเมนู', closeMenu: 'ปิดเมนู' },
-  en: { product: 'Product', startFree: 'Start free →', login: 'Login',       openMenu: 'Open menu',  closeMenu: 'Close menu' },
-};
+  th: {
+    product: 'ผลิตภัณฑ์',
+    how: 'วิธีทำงาน',
+    docs: 'เอกสาร',
+    pricing: 'ราคา',
+    connect: 'เชื่อมระบบ',
+    login: 'เข้าสู่ระบบ',
+    openMenu: 'เปิดเมนู',
+    closeMenu: 'ปิดเมนู',
+    productGroup: 'ผลิตภัณฑ์',
+    resources: 'ข้อมูล',
+  },
+  en: {
+    product: 'Product',
+    how: 'How it works',
+    docs: 'Docs',
+    pricing: 'Pricing',
+    connect: 'Connect',
+    login: 'Log in',
+    openMenu: 'Open menu',
+    closeMenu: 'Close menu',
+    productGroup: 'Products',
+    resources: 'Resources',
+  },
+} as const;
+
+function publicLinkClass(active: boolean) {
+  return [
+    'rounded-lg px-3 py-2 text-sm font-semibold transition-colors',
+    active ? 'bg-white/[0.07] text-white' : 'text-slate-400 hover:bg-white/[0.04] hover:text-white',
+  ].join(' ');
+}
 
 export default function GlobalNav() {
   const pathname = usePathname();
   const lang = useAppLanguage();
-  const [mobileOpen, setMobileOpen] = useState(false);
   const [productOpen, setProductOpen] = useState(false);
-  const [mobileProductOpen, setMobileProductOpen] = useState(false);
-
+  const [mobileOpen, setMobileOpen] = useState(false);
   const t = NAV_T[lang];
-  const PRODUCT_ITEMS = lang === 'th' ? PRODUCT_ITEMS_TH : PRODUCT_ITEMS_EN;
+  const productItems = lang === 'th' ? PRODUCT_ITEMS_TH : PRODUCT_ITEMS_EN;
 
   if (pathname === '/dashboard' || pathname.startsWith('/dashboard/')) {
     return null;
   }
 
-  function openMobileMenu() {
-    setMobileOpen(true);
-    setMobileProductOpen(true);
-  }
+  const productActive = productItems.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`));
 
   function closeMobileMenu() {
     setMobileOpen(false);
@@ -75,219 +86,175 @@ export default function GlobalNav() {
 
   return (
     <>
-      <header className="sticky top-0 z-40 border-b border-white/10 bg-[#08090b]/85 backdrop-blur-xl">
-        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-6 py-4">
-          {/* Logo */}
-          <Link href="/" className="flex items-center gap-3">
-            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-amber-300/35 bg-amber-300/10 text-xs font-semibold uppercase tracking-[0.18em] text-amber-100">
+      <header className="sticky top-0 z-40 border-b border-white/[0.07] bg-[#08090c]/92 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
+          <Link href="/" className="flex min-w-0 items-center gap-3" aria-label="DSG Control Plane home">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-blue-300/20 bg-blue-300/[0.07] text-[11px] font-black tracking-[0.12em] text-blue-100">
               DSG
             </span>
-            <div>
-              <p className="text-[10px] uppercase tracking-[0.3em] text-slate-500">DSG ONE</p>
-              <p className="text-sm font-semibold text-slate-100">ProofGate Control Plane</p>
-            </div>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-bold text-white">DSG Control Plane</span>
+              <span className="block truncate text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-600">Agent Governance</span>
+            </span>
           </Link>
 
-          {/* Desktop nav */}
-          <nav className="hidden items-center gap-2 md:flex">
-            {/* Product dropdown */}
+          <nav className="hidden items-center gap-1 md:flex" aria-label="Public navigation">
             <div
               className="relative"
               onMouseEnter={() => setProductOpen(true)}
               onMouseLeave={() => setProductOpen(false)}
             >
               <button
-                className="flex items-center gap-1 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:border-amber-300/30 hover:text-amber-50"
-                onClick={() => setProductOpen((v) => !v)}
+                type="button"
+                onClick={() => setProductOpen((value) => !value)}
                 aria-expanded={productOpen}
-                aria-haspopup="true"
+                aria-haspopup="menu"
+                className={`${publicLinkClass(productActive)} inline-flex items-center gap-1.5`}
               >
                 {t.product}
-                <ChevronDown
-                  className={`h-3.5 w-3.5 transition-transform duration-200 ${
-                    productOpen ? 'rotate-180' : ''
-                  }`}
-                />
+                <ChevronDown className={`h-3.5 w-3.5 transition-transform ${productOpen ? 'rotate-180' : ''}`} />
               </button>
 
               {productOpen && (
-                <div className="absolute left-0 top-full mt-2 w-72 rounded-2xl border border-white/15 bg-[#0c0e12] p-2 shadow-2xl">
-                  {PRODUCT_ITEMS.map((item) => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      onClick={() => setProductOpen(false)}
-                      className={`flex items-start gap-3 rounded-xl px-3 py-2.5 transition hover:bg-white/[0.05] ${'highlight' in item && item.highlight ? 'border border-emerald-400/20 bg-emerald-400/5' : ''}`}
-                    >
-                      <span className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border ${'highlight' in item && item.highlight ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300' : 'border-white/10 bg-white/[0.04] text-amber-300'}`}>
-                        <item.icon className="h-3.5 w-3.5" />
-                      </span>
-                      <span>
-                        <span className="block text-sm font-semibold text-slate-100">
-                          {item.title}
-                          {'highlight' in item && item.highlight && (
-                            <span className="ml-2 rounded-full bg-emerald-400/20 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-emerald-300">New</span>
-                          )}
-                        </span>
-                        <span className="block text-xs text-slate-400">{item.description}</span>
-                      </span>
-                    </Link>
-                  ))}
+                <div className="absolute left-0 top-full w-[330px] pt-2" role="menu">
+                  <div className="rounded-2xl border border-white/[0.09] bg-[#0b0d11] p-2 shadow-2xl shadow-black/35">
+                    {productItems.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Link
+                          key={item.href}
+                          href={item.href}
+                          onClick={() => setProductOpen(false)}
+                          className="flex items-start gap-3 rounded-xl p-3 transition hover:bg-white/[0.05]"
+                          role="menuitem"
+                        >
+                          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-blue-300/15 bg-blue-300/[0.06] text-blue-200">
+                            <Icon className="h-4 w-4" />
+                          </span>
+                          <span>
+                            <span className="block text-sm font-bold text-white">{item.title}</span>
+                            <span className="mt-0.5 block text-xs leading-5 text-slate-500">{item.description}</span>
+                          </span>
+                        </Link>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
             </div>
 
-            {FLAT_LINKS.map(({ href, label, match, target }) => (
-              <Link
-                key={href}
-                href={href}
-                target={target}
-                rel={target === '_blank' ? 'noopener noreferrer' : undefined}
-                className={[
-                  'rounded-xl border px-3 py-2 text-sm font-semibold transition',
-                  match(pathname)
-                    ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
-                    : 'border-white/10 bg-white/[0.03] text-slate-200 hover:border-amber-300/30 hover:text-amber-50',
-                ].join(' ')}
-              >
-                {label}
-              </Link>
-            ))}
+            <Link href="/#how-it-works" className={publicLinkClass(pathname === '/')}>
+              {t.how}
+            </Link>
+            <Link href="/docs" className={publicLinkClass(pathname === '/docs' || pathname.startsWith('/docs/'))}>
+              {t.docs}
+            </Link>
+            <Link href="/pricing" className={publicLinkClass(pathname === '/pricing')}>
+              {t.pricing}
+            </Link>
 
-            {/* Language switcher */}
+            <span className="mx-1 h-5 w-px bg-white/10" aria-hidden="true" />
+
             <button
+              type="button"
               onClick={() => languageStore.setLanguage(lang === 'th' ? 'en' : 'th')}
-              className="rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-sm font-semibold text-slate-400 transition hover:border-amber-300/30 hover:text-amber-100"
+              className="rounded-lg px-2.5 py-2 text-xs font-bold text-slate-500 transition hover:bg-white/[0.04] hover:text-white"
               aria-label="Switch language"
             >
               {lang === 'th' ? 'EN' : 'TH'}
             </button>
-
-            {/* CTAs */}
-            <Link href="/dashboard/integrations" className="dsg-btn-gold text-sm">
-              {t.startFree}
-            </Link>
-            <Link href="/login" className="dsg-btn-blue text-sm">
+            <Link href="/login" className="rounded-lg px-3 py-2 text-sm font-semibold text-slate-300 transition hover:bg-white/[0.04] hover:text-white">
               {t.login}
+            </Link>
+            <Link href="/dashboard/integrations" className="rounded-lg bg-white px-4 py-2.5 text-sm font-bold text-slate-950 transition hover:bg-slate-200">
+              {t.connect}
             </Link>
           </nav>
 
-          {/* Mobile hamburger — always three-line icon; × lives inside overlay */}
           <button
-            onClick={openMobileMenu}
-            className="rounded-lg border border-white/10 bg-white/[0.03] p-2 text-slate-300 md:hidden"
+            type="button"
+            onClick={() => setMobileOpen(true)}
+            className="rounded-lg border border-white/10 bg-white/[0.03] p-2.5 text-slate-300 md:hidden"
             aria-label={t.openMenu}
+            aria-expanded={mobileOpen}
           >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
+            <Menu className="h-5 w-5" />
           </button>
         </div>
       </header>
 
-      {/* Mobile full-screen overlay */}
       {mobileOpen && (
-        <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-[#08090b] md:hidden">
-          {/* Overlay header */}
-          <div className="flex shrink-0 items-center justify-between border-b border-white/10 px-6 py-4">
-            <Link href="/" onClick={closeMobileMenu} className="flex items-center gap-3">
-              <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-amber-300/35 bg-amber-300/10 text-xs font-semibold uppercase tracking-[0.18em] text-amber-100">
+        <div className="fixed inset-0 z-50 flex flex-col bg-[#08090c] md:hidden">
+          <div className="flex items-center justify-between border-b border-white/[0.07] px-4 py-3">
+            <Link href="/" onClick={closeMobileMenu} className="flex min-w-0 items-center gap-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-blue-300/20 bg-blue-300/[0.07] text-[11px] font-black tracking-[0.12em] text-blue-100">
                 DSG
               </span>
-              <div>
-                <p className="text-[10px] uppercase tracking-[0.3em] text-slate-500">DSG ONE</p>
-                <p className="text-sm font-semibold text-slate-100">ProofGate Control Plane</p>
-              </div>
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-bold text-white">DSG Control Plane</span>
+                <span className="block truncate text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-600">Agent Governance</span>
+              </span>
             </Link>
             <button
+              type="button"
               onClick={closeMobileMenu}
-              className="rounded-lg border border-white/10 bg-white/[0.03] p-2 text-slate-300"
+              className="rounded-lg border border-white/10 bg-white/[0.03] p-2.5 text-slate-300"
               aria-label={t.closeMenu}
             >
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <X className="h-5 w-5" />
             </button>
           </div>
 
-          {/* Scrollable nav content */}
-          <div className="flex-1 space-y-2 overflow-y-auto px-6 py-4">
-            {/* Product accordion */}
-            <button
-              onClick={() => setMobileProductOpen((v) => !v)}
-              className="flex w-full items-center justify-between rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-slate-100"
-            >
-              {t.product}
-              <ChevronDown
-                className={`h-4 w-4 transition-transform duration-200 ${
-                  mobileProductOpen ? 'rotate-180' : ''
-                }`}
-              />
-            </button>
+          <div className="flex-1 overflow-y-auto px-4 py-5">
+            <p className="px-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600">{t.resources}</p>
+            <div className="mt-2 grid gap-1">
+              <Link href="/#how-it-works" onClick={closeMobileMenu} className="rounded-xl px-3 py-3 text-sm font-semibold text-slate-200 active:bg-white/[0.05]">
+                {t.how}
+              </Link>
+              <Link href="/docs" onClick={closeMobileMenu} className="rounded-xl px-3 py-3 text-sm font-semibold text-slate-200 active:bg-white/[0.05]">
+                {t.docs}
+              </Link>
+              <Link href="/pricing" onClick={closeMobileMenu} className="rounded-xl px-3 py-3 text-sm font-semibold text-slate-200 active:bg-white/[0.05]">
+                {t.pricing}
+              </Link>
+            </div>
 
-            {mobileProductOpen && (
-              <div className="ml-2 space-y-1 border-l border-white/10 pl-4">
-                {PRODUCT_ITEMS.map((item) => (
+            <p className="mt-7 px-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-600">{t.productGroup}</p>
+            <div className="mt-2 grid gap-1">
+              {productItems.map((item) => {
+                const Icon = item.icon;
+                return (
                   <Link
                     key={item.href}
                     href={item.href}
                     onClick={closeMobileMenu}
-                    className={`flex items-start gap-3 rounded-xl px-3 py-2.5 transition hover:bg-white/[0.05] ${'highlight' in item && item.highlight ? 'border border-emerald-400/20 bg-emerald-400/5' : ''}`}
+                    className="flex items-start gap-3 rounded-xl p-3 active:bg-white/[0.05]"
                   >
-                    <span className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border ${'highlight' in item && item.highlight ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-300' : 'border-white/10 bg-white/[0.04] text-amber-300'}`}>
-                      <item.icon className="h-3.5 w-3.5" />
+                    <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-blue-300/15 bg-blue-300/[0.06] text-blue-200">
+                      <Icon className="h-4 w-4" />
                     </span>
                     <span>
-                      <span className="block text-sm font-semibold text-slate-100">{item.title}</span>
-                      <span className="block text-xs text-slate-400">{item.description}</span>
+                      <span className="block text-sm font-bold text-white">{item.title}</span>
+                      <span className="mt-0.5 block text-xs leading-5 text-slate-500">{item.description}</span>
                     </span>
                   </Link>
-                ))}
-              </div>
-            )}
-
-            {/* Flat links */}
-            {FLAT_LINKS.map(({ href, label, match, target }) => (
-              <Link
-                key={href}
-                href={href}
-                target={target}
-                rel={target === '_blank' ? 'noopener noreferrer' : undefined}
-                onClick={closeMobileMenu}
-                className={[
-                  'block rounded-xl border px-4 py-3 text-sm font-semibold',
-                  href === '/design-system-tool.html'
-                    ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
-                    : match(pathname)
-                    ? 'border-amber-300/40 bg-amber-300/10 text-amber-100'
-                    : 'border-white/10 bg-white/[0.03] text-slate-100',
-                ].join(' ')}
-              >
-                {label}
-              </Link>
-            ))}
+                );
+              })}
+            </div>
           </div>
 
-          {/* Sticky bottom CTAs */}
-          <div className="shrink-0 space-y-2 border-t border-white/10 px-6 py-4">
+          <div className="space-y-2 border-t border-white/[0.07] px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4">
             <button
+              type="button"
               onClick={() => languageStore.setLanguage(lang === 'th' ? 'en' : 'th')}
-              className="block w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-center text-sm font-semibold text-slate-300"
+              className="w-full rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-slate-300"
             >
-              {lang === 'th' ? '🌐 Switch to English' : '🌐 เปลี่ยนเป็นภาษาไทย'}
+              {lang === 'th' ? 'Switch to English' : 'เปลี่ยนเป็นภาษาไทย'}
             </button>
-            <Link
-              href="/dashboard/integrations"
-              onClick={closeMobileMenu}
-              className="block rounded-xl bg-amber-300 px-4 py-3 text-center text-sm font-semibold text-slate-950"
-            >
-              {t.startFree}
+            <Link href="/dashboard/integrations" onClick={closeMobileMenu} className="block rounded-xl bg-white px-4 py-3 text-center text-sm font-bold text-slate-950">
+              {t.connect}
             </Link>
-            <Link
-              href="/login"
-              onClick={closeMobileMenu}
-              className="block rounded-xl border border-blue-300/30 bg-blue-300/10 px-4 py-3 text-center text-sm font-semibold text-blue-200"
-            >
+            <Link href="/login" onClick={closeMobileMenu} className="block rounded-xl border border-white/10 px-4 py-3 text-center text-sm font-semibold text-slate-300">
               {t.login}
             </Link>
           </div>


### PR DESCRIPTION
## Why

The current product surface had two concrete UX problems:

- `/` rendered its own header even though `RootLayout` already renders `GlobalNav`, creating a duplicate navigation layer.
- Primary onboarding links used `/dashboard/integration` (the internal Integration Truth surface) while the repo's audited self-service setup route is `/dashboard/integrations`.

## What changed

- Reworked the landing page around one primary value path: **Connect → choose control mode → read decision**.
- Routed the primary CTA to the real self-service `/dashboard/integrations` flow.
- Added adaptive dashboard navigation: compact desktop navigation and a mobile bottom bar for Live / Connect / Plans / Evidence / Audit.
- Reworked `/dashboard/integrations` into progressive onboarding instead of a wall of connector cards and commands.
- Kept API/runtime contracts intact: existing register, webhook, execute, governance-live, evidence, and audit routes are reused.
- Updated product metadata to describe the current Control Plane purpose rather than making a broader certification or adoption claim.

## User path

`Connect one system → run one governed action → see decision → fix or continue → inspect evidence/audit`

## Truth boundary

- No synthetic customer counts, action volumes, certification claims, or fake live events were added.
- The production checklist is explicitly framed as required evidence, not as a claim that the current deployment already passed every item.
- No React Native migration: this repo is Next.js, so the mobile-app pattern is applied through responsive navigation without adding another runtime or build stack.

## Verification

- Existing UX route-map contract phrases are preserved, including `Connect one existing workflow in minutes.` and `Quota-aware rollout`.
- CI / route-map / type checks should be treated as the merge gate for this PR.