### PR TITLE
ci(npm): migrate DSG ONE SDK publishing to OIDC

### DIFF
--- a/.github/workflows/publish-dsg-one-sdk.yml
+++ b/.github/workflows/publish-dsg-one-sdk.yml
@@ -1,0 +1,81 @@
+name: Publish DSG ONE SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type publish to confirm the npm release"
+        required: true
+        type: string
+  push:
+    tags:
+      - "dsg-one-sdk-v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-dsg-one-sdk
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event_name != 'workflow_dispatch' || inputs.confirm == 'publish'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/dsg-one-sdk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js for npm trusted publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Ensure supported npm CLI
+        run: |
+          npm install --global npm@^11.15.0
+          node --version
+          npm --version
+
+      - name: Verify release tag matches package version
+        if: github.event_name == 'push'
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          EXPECTED_TAG="dsg-one-sdk-v${VERSION}"
+          if [ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} does not match package version ${VERSION}. Expected ${EXPECTED_TAG}."
+            exit 1
+          fi
+
+      - name: Install SDK dependencies
+        run: npm install --package-lock=false --no-audit --no-fund
+
+      - name: Test SDK
+        run: npm test
+
+      - name: Build SDK
+        run: npm run build
+
+      - name: Inspect package contents
+        run: npm pack --dry-run
+
+      - name: Block duplicate version
+        run: |
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json >/tmp/npm-existing-version.json 2>/dev/null; then
+            echo "::error::${PACKAGE_NAME}@${PACKAGE_VERSION} already exists on npm. Bump the version before publishing."
+            cat /tmp/npm-existing-version.json
+            exit 1
+          fi
+          echo "Publishing candidate: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+
+      - name: Publish with npm Trusted Publishing (OIDC)
+        run: npm publish --access public

--- a/packages/dsg-one-sdk/PUBLISHING.md
+++ b/packages/dsg-one-sdk/PUBLISHING.md
@@ -1,128 +1,142 @@
 # Publishing @dsg-one/sdk to npm
 
-This guide explains how to publish the DSG ONE SDK to the npm registry.
+This guide defines the canonical release path for the DSG ONE SDK.
 
-## Prerequisites
+## Canonical release path
 
-- **npm account** with publish permissions for the `@dsg-one` namespace
-- **npm authentication token** (from `npm login` or `~/.npmrc`)
-- **Recent build**: Run `npm run build` to ensure `dist/` is up to date
-- **Commit all changes**: Changes should be committed to git before publishing
+Production npm releases use **GitHub Actions + npm Trusted Publishing (OIDC)** through:
 
-## Publishing Steps
+- Repository: `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`
+- Workflow: `.github/workflows/publish-dsg-one-sdk.yml`
+- Runner: GitHub-hosted `ubuntu-latest`
+- Node.js: 24
+- Authentication: OIDC (`id-token: write`)
+- Long-lived npm publish token: **not used**
 
-### 1. Verify the build
+Do not recreate expired write tokens such as `tar` or `dsg` for this CI publish path.
+
+## One-time npm configuration
+
+Trusted Publishing is configured on npmjs.com for the package, not in GitHub Secrets.
+
+Open the package settings and add a GitHub Actions trusted publisher with these exact values:
+
+| Field | Value |
+|---|---|
+| Organization or user | `tdealer01-crypto` |
+| Repository | `tdealer01-crypto-dsg-control-plane` |
+| Workflow filename | `publish-dsg-one-sdk.yml` |
+| Allowed action | `npm publish` |
+| Environment | Leave empty unless a matching GitHub environment is deliberately added |
+
+The workflow filename is case-sensitive and npm expects only the filename, not `.github/workflows/`.
+
+### First publish bootstrap
+
+npm requires a package to already exist on the registry before a Trusted Publisher can be attached to it.
+
+If `@dsg-one/sdk` has never been published, perform exactly one authenticated maintainer publish first:
 
 ```bash
 cd packages/dsg-one-sdk
+npm install --package-lock=false
+npm test
 npm run build
+npm pack --dry-run
+npm login
+npm publish --access public
 ```
 
-Confirm that `dist/` contains `.js` and `.d.ts` files.
+Complete the interactive 2FA challenge when npm requests it. After the package exists, configure the Trusted Publisher above and use GitHub Actions for subsequent releases.
 
-### 2. Verify package contents
+Do not create a new long-lived CI write token merely to bootstrap Trusted Publishing.
+
+## Release checks
+
+Before releasing, update `version` in `packages/dsg-one-sdk/package.json` and verify the SDK locally:
 
 ```bash
+cd packages/dsg-one-sdk
+npm install --package-lock=false
+npm test
+npm run build
 npm pack --dry-run
 ```
 
-This shows exactly what will be published:
-- `dist/` folder with compiled output
-- `README.md`
-- `LICENSE`
-- `package.json`
+The package must include the compiled `dist/`, `README.md`, `LICENSE`, and `package.json`, and must not contain secrets or `node_modules`.
 
-**Important**: Ensure no source files (`.ts`), secrets, or node_modules are included.
+## Publish from GitHub Actions
 
-### 3. Update version (if needed)
+### Option A — release tag
 
-For a new release, bump the version in `package.json`:
+For package version `X.Y.Z`, create the exact tag:
 
-```bash
-npm version patch    # 0.1.0 → 0.1.1
-npm version minor    # 0.1.0 → 0.2.0
-npm version major    # 0.1.0 → 1.0.0
+```text
+dsg-one-sdk-vX.Y.Z
 ```
 
-Or manually edit `"version"` in `package.json`.
+The workflow blocks publication if the tag version does not match `package.json`.
 
-### 4. Publish to npm
+### Option B — manual dispatch
 
-```bash
-npm publish
+Run the **Publish DSG ONE SDK** workflow from GitHub Actions and enter:
+
+```text
+publish
 ```
 
-This command:
-- Validates `package.json`
-- Runs `prepublishOnly` script (which runs `npm run build`)
-- Uploads tarball to npm registry
-- Makes package public (via `publishConfig.access = "public"`)
+in the confirmation input.
 
-### 5. Verify on npm
+Both paths run the same release gates:
 
-After successful publish:
+1. Install a supported npm 11 CLI on Node 24.
+2. Install SDK dependencies.
+3. Run SDK tests.
+4. Build TypeScript output.
+5. Run `npm pack --dry-run`.
+6. Block if the same package version already exists on npm.
+7. Publish with OIDC using `npm publish --access public`.
+
+No `NPM_TOKEN` or `NODE_AUTH_TOKEN` is supplied to the publish step.
+
+## Verify the release
+
+After the workflow succeeds:
 
 ```bash
-# Check npm registry
-npm view @dsg-one/sdk
-
-# Install from npm
+npm view @dsg-one/sdk version
+npm view @dsg-one/sdk dist-tags
 npm install @dsg-one/sdk
 ```
 
-## Authentication
+For releases made through Trusted Publishing from this public GitHub repository, npm generates provenance automatically.
 
-If you haven't logged in:
+## Private dependency exception
 
-```bash
-npm login
-# Enter: username, password, and OTP (if 2FA enabled)
-```
+Trusted Publishing authenticates `npm publish`; it does not authenticate installation of private npm dependencies.
 
-Your token is saved to `~/.npmrc`.
+The SDK currently declares no runtime dependencies and does not require a private-package token for its release workflow. If private dependencies are added later, create a **read-only granular token** restricted to those dependencies and expose it only to the install step as `NPM_READ_TOKEN`. Never reuse that token for publishing.
 
-## Scoped Package Notes
+## Manual Termux fallback
 
-- Package name: `@dsg-one/sdk`
-- Scope: `dsg-one`
-- Access: `public` (configured in `publishConfig`)
-- URL after publish: https://www.npmjs.com/package/@dsg-one/sdk
+`npm-publish-termux.sh` is retained only for first-publish bootstrap or emergency manual releases. It uses interactive npm authentication and does not provision a CI write token.
 
-## Troubleshooting
+`npm-token-fix-termux.sh` is deprecated as a token-creation helper. It now explains the OIDC migration instead of attempting `npm token create`.
 
-| Issue | Solution |
-|-------|----------|
-| `403 Forbidden` | Not logged in, or insufficient permissions for scope |
-| `404 Not Found` | Scope `@dsg-one` doesn't exist yet (create on npmjs.com) |
-| `EEXIST: file already exists` | Version already published; bump version |
-| Build fails | Run `npm run build` manually to see errors |
+## Failure guide
 
-## One-Command Publish (for CI/CD)
+| Failure | Meaning / action |
+|---|---|
+| `ENEEDAUTH` / unable to authenticate | Confirm the npm Trusted Publisher fields exactly match this repository and `publish-dsg-one-sdk.yml` |
+| OIDC error | Confirm workflow has `id-token: write` and runs on GitHub-hosted runner |
+| Package does not exist when configuring trust | Complete the one-time first publish bootstrap, then configure Trusted Publishing |
+| Version already exists | Bump `package.json` version; npm versions are immutable |
+| Tag/version mismatch | Use `dsg-one-sdk-vX.Y.Z` matching `package.json` exactly |
+| Build/test failure | Fix the failing SDK code/test; publishing remains blocked |
+| Private dependency install fails | Add a read-only `NPM_READ_TOKEN` only for the install step if genuinely required |
 
-```bash
-cd packages/dsg-one-sdk && npm publish
-```
+## References
 
-In GitHub Actions or similar CI, use:
-
-```yaml
-- run: cd packages/dsg-one-sdk && npm publish
-  env:
-    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-```
-
-## Versioning Strategy
-
-Follow [Semantic Versioning](https://semver.org/):
-
-- `PATCH` (0.1.1): Bug fixes, docs, no API changes
-- `MINOR` (0.2.0): New features, backward compatible
-- `MAJOR` (1.0.0): Breaking changes
-
-Current version: **0.1.0** (pre-release)
-
-## Reference
-
-- [npm publish documentation](https://docs.npmjs.com/cli/v20/commands/npm-publish)
-- [Scoped packages guide](https://docs.npmjs.com/about/scoped-packages)
-- [Publishing to npm](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry)
+- npm Trusted Publishing: https://docs.npmjs.com/trusted-publishers/
+- npm access tokens: https://docs.npmjs.com/creating-and-viewing-access-tokens/
+- npm publish: https://docs.npmjs.com/cli/commands/npm-publish

--- a/packages/dsg-one-sdk/npm-publish-termux.sh
+++ b/packages/dsg-one-sdk/npm-publish-termux.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REGISTRY_HOST="//registry.npmjs.org/"
-NPMRC="${HOME}/.npmrc"
+REGISTRY="https://registry.npmjs.org/"
 
 ensure_node() {
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -12,84 +11,85 @@ ensure_node() {
   fi
 }
 
-open_tokens_page() {
-  URL="https://www.npmjs.com/settings/tokens"
-  echo "[OPEN] $URL"
-  am start -a android.intent.action.VIEW -d "$URL" >/dev/null 2>&1 || true
-  echo "ถ้า browser ไม่เปิด ให้ copy URL นี้ไปเปิดเอง:"
-  echo "$URL"
-}
-
 verify_package() {
   if [ ! -f package.json ]; then
-    echo "[BLOCK] ไม่เจอ package.json"
-    echo "ให้ cd เข้าโฟลเดอร์ package ก่อน เช่น:"
-    echo "cd your-package-folder"
+    echo "[BLOCK] package.json not found"
+    echo "Run this from the package directory, for example:"
+    echo "cd packages/dsg-one-sdk"
     exit 1
   fi
 
   node <<'NODE'
 const fs = require("fs");
 const p = JSON.parse(fs.readFileSync("package.json", "utf8"));
-
 const issues = [];
 if (!p.name) issues.push("missing name");
 if (!p.version) issues.push("missing version");
 if (p.private === true) issues.push("private=true");
-
 if (issues.length) {
-  console.error("[BLOCK] package.json ยังไม่พร้อม:", issues.join(", "));
+  console.error("[BLOCK] package.json is not publishable:", issues.join(", "));
   process.exit(1);
 }
-
 console.log(`[OK] Package: ${p.name}@${p.version}`);
 NODE
 }
 
-set_token() {
-  echo
-  echo "Paste NPM token ที่ขึ้นต้นด้วย npm_"
-  read -r -s -p "NPM_TOKEN: " TOKEN
-  echo
+print_ci_path() {
+  cat <<'EOF'
+[INFO] Canonical production release path:
+  GitHub Actions -> npm Trusted Publishing (OIDC)
+  .github/workflows/publish-dsg-one-sdk.yml
 
-  case "$TOKEN" in
-    npm_*) ;;
-    *)
-      echo "[BLOCK] token ดูไม่ใช่รูปแบบ npm_..."
-      exit 1
-      ;;
-  esac
+This Termux script is only for first-publish bootstrap or emergency manual publishing.
+It does not create or store a dedicated CI publish token.
+EOF
+}
 
-  touch "$NPMRC"
-  chmod 600 "$NPMRC"
+login_interactive() {
+  echo "[LOGIN] Opening interactive npm login for ${REGISTRY}"
+  npm login --registry="$REGISTRY"
+  echo "[CHECK] npm identity:"
+  npm whoami --registry="$REGISTRY"
+}
 
-  sed -i.bak "\|^${REGISTRY_HOST}:_authToken=|d" "$NPMRC" 2>/dev/null || true
-  printf '%s:_authToken=%s\n' "$REGISTRY_HOST" "$TOKEN" >> "$NPMRC"
-
-  unset TOKEN
-
-  echo "[OK] ตั้งค่า token แล้ว"
-  echo "[CHECK] npm whoami:"
-  npm whoami
+verify_release() {
+  verify_package
+  echo "[TEST] Running package tests"
+  npm test
+  echo "[BUILD] Building package"
+  npm run build
+  echo "[DRY RUN] Inspecting npm package contents"
+  npm pack --dry-run
 }
 
 publish_package() {
-  verify_package
+  verify_release
 
-  echo
-  echo "[DRY RUN] ตรวจแพ็กเกจก่อน publish จริง"
-  npm publish --access public --dry-run
+  if ! npm whoami --registry="$REGISTRY" >/dev/null 2>&1; then
+    echo "[BLOCK] No interactive npm session is available."
+    echo "Run option 2 (npm login) first."
+    exit 1
+  fi
 
-  echo
-  read -r -p "ถ้าพร้อม publish จริง พิมพ์ YES: " CONFIRM
-  if [ "$CONFIRM" != "YES" ]; then
-    echo "[CANCEL] ยกเลิก publish"
-    exit 0
+  PACKAGE_NAME="$(node -p "require('./package.json').name")"
+  PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+
+  if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json >/dev/null 2>&1; then
+    echo "[BLOCK] ${PACKAGE_NAME}@${PACKAGE_VERSION} already exists on npm."
+    echo "Bump package.json version before publishing."
+    exit 1
   fi
 
   echo
-  read -r -p "ใส่ OTP 6 หลัก ถ้ามี / ถ้าใช้ token bypass 2FA ให้กด Enter: " OTP
+  echo "[MANUAL RELEASE] ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+  echo "For normal releases, use GitHub Actions OIDC instead."
+  read -r -p "Type YES to publish manually: " CONFIRM
+  if [ "$CONFIRM" != "YES" ]; then
+    echo "[CANCEL] Publish cancelled"
+    exit 0
+  fi
 
+  read -r -p "Enter npm OTP if requested by your account; otherwise press Enter: " OTP
   if [ -n "$OTP" ]; then
     npm publish --access public --otp "$OTP"
   else
@@ -97,35 +97,36 @@ publish_package() {
   fi
 }
 
-remove_token() {
-  npm config delete "${REGISTRY_HOST}:_authToken" 2>/dev/null || true
-  sed -i.bak "\|^${REGISTRY_HOST}:_authToken=|d" "$NPMRC" 2>/dev/null || true
-  echo "[OK] ลบ npm token ออกจาก Termux แล้ว"
+logout_interactive() {
+  npm logout --registry="$REGISTRY" || true
+  echo "[OK] npm interactive session removed where supported by npm."
 }
 
 main() {
   ensure_node
+  verify_package
 
   echo "Node: $(node -v)"
   echo "npm:  $(npm -v)"
   echo
-  echo "เลือกคำสั่ง:"
-  echo "1) เปิดหน้า npm token"
-  echo "2) ตั้งค่า NPM token"
-  echo "3) เช็ก npm whoami"
-  echo "4) publish package ปัจจุบัน"
-  echo "5) ลบ token ออกจาก Termux"
+  echo "1) Show canonical GitHub Actions OIDC release path"
+  echo "2) npm login (interactive bootstrap/fallback)"
+  echo "3) Check npm whoami"
+  echo "4) Test + build + npm pack --dry-run"
+  echo "5) Manual publish (bootstrap/fallback only)"
+  echo "6) npm logout"
   echo
 
-  read -r -p "เลือกเลข: " CHOICE
+  read -r -p "Choose: " CHOICE
 
   case "$CHOICE" in
-    1) open_tokens_page ;;
-    2) set_token ;;
-    3) npm whoami ;;
-    4) publish_package ;;
-    5) remove_token ;;
-    *) echo "[BLOCK] เลือกไม่ถูก"; exit 1 ;;
+    1) print_ci_path ;;
+    2) login_interactive ;;
+    3) npm whoami --registry="$REGISTRY" ;;
+    4) verify_release ;;
+    5) publish_package ;;
+    6) logout_interactive ;;
+    *) echo "[BLOCK] Invalid choice"; exit 1 ;;
   esac
 }
 

--- a/packages/dsg-one-sdk/npm-token-fix-termux.sh
+++ b/packages/dsg-one-sdk/npm-token-fix-termux.sh
@@ -1,49 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ ! -f package.json ]; then
-  echo "[BLOCK] ไม่เจอ package.json"
-  echo "ตอนนี้ต้อง cd เข้าโฟลเดอร์ package ก่อน"
-  echo "เช่น: cd packages/dsg-one-sdk"
-  exit 1
+cat <<'EOF'
+[DEPRECATED] npm publish token creation is no longer the DSG ONE CI release path.
+
+Canonical release path:
+  GitHub Actions -> npm Trusted Publishing (OIDC)
+  Workflow: .github/workflows/publish-dsg-one-sdk.yml
+
+Do NOT recreate expired read-write CI tokens such as "tar" or "dsg" for publishing.
+The publish workflow uses short-lived OIDC credentials and does not require NPM_TOKEN.
+
+If @dsg-one/sdk has never been published, use the one-time interactive bootstrap in:
+  packages/dsg-one-sdk/PUBLISHING.md
+
+If a future workflow must install private npm dependencies, create a READ-ONLY granular
+access token on npmjs.com and scope it only to those dependencies. Do not use it to publish.
+
+npm's current documentation says granular access tokens must be created on npmjs.com;
+this helper intentionally does not call `npm token create`.
+EOF
+
+TOKENS_URL="https://www.npmjs.com/settings/tardealer/tokens/granular-access-tokens/new"
+
+echo
+echo "Read-only token page (only if private dependency access is actually required):"
+echo "$TOKENS_URL"
+
+if command -v am >/dev/null 2>&1; then
+  read -r -p "Open npm token page in Android browser? [y/N]: " ANSWER
+  case "$ANSWER" in
+    y|Y)
+      am start -a android.intent.action.VIEW -d "$TOKENS_URL" >/dev/null 2>&1 || true
+      ;;
+  esac
 fi
-
-PKG_NAME="$(node -p "require('./package.json').name")"
-PKG_VERSION="$(node -p "require('./package.json').version")"
-TOKEN_NAME="termux-${PKG_NAME//@/}-${PKG_VERSION}-$(date +%Y%m%d-%H%M)"
-TOKEN_NAME="${TOKEN_NAME//\//-}"
-
-echo "[INFO] package: ${PKG_NAME}@${PKG_VERSION}"
-echo "[INFO] token name: ${TOKEN_NAME}"
-echo
-
-case "$PKG_NAME" in
-  @*/*)
-    SCOPE="${PKG_NAME%%/*}"
-    SCOPE="${SCOPE#@}"
-
-    echo "[CREATE] สร้าง token แบบผูกกับ scope: @${SCOPE}"
-    npm token create \
-      --name "$TOKEN_NAME" \
-      --packages-and-scopes-permission=read-write \
-      --scopes "$SCOPE" \
-      --bypass-2fa \
-      --expires=30
-    ;;
-
-  *)
-    echo "[CREATE] package เป็น unscoped: ${PKG_NAME}"
-    echo "[NOTE] ถ้า package ยังไม่เคย publish มาก่อน npm อาจไม่ยอมสร้าง token ด้วย --packages"
-    echo "[NOTE] ถ้าติด error ให้ใช้ npm login + publish ด้วย OTP ด้านล่าง"
-    npm token create \
-      --name "$TOKEN_NAME" \
-      --packages-and-scopes-permission=read-write \
-      --packages "$PKG_NAME" \
-      --bypass-2fa \
-      --expires=30
-    ;;
-esac
-
-echo
-echo "[DONE] ถ้า npm แสดง token ที่ขึ้นต้น npm_ ให้ copy ทันที"
-echo "ห้ามส่ง token มาในแชต / ห้าม commit ลง GitHub"


### PR DESCRIPTION
## Goal
Replace expired long-lived npm publish tokens with npm Trusted Publishing (OIDC) for the DSG ONE SDK.

## Changes
- add `.github/workflows/publish-dsg-one-sdk.yml`
  - GitHub-hosted runner
  - Node 24
  - npm 11.15+
  - `permissions: id-token: write`
  - test/build/package dry-run gates
  - duplicate-version guard
  - tag/version alignment guard
  - `npm publish --access public` with no `NPM_TOKEN`
- rewrite `packages/dsg-one-sdk/PUBLISHING.md` around Trusted Publishing
- deprecate `npm-token-fix-termux.sh` as a write-token generator
- make `npm-publish-termux.sh` an interactive bootstrap/emergency fallback using `npm login` + 2FA instead of a stored CI token

## Important bootstrap boundary
Current `package.json` names the package `@dsg-one/sdk`. npm requires a package to already exist before a Trusted Publisher can be attached. If that scoped package has never been published, one interactive first publish is required; subsequent releases use OIDC.

## Security outcome
Expired tokens `tar` and `dsg` do not need to be recreated for the CI publish path. If private dependencies are added later, any token should be read-only and limited to installation only.

## Verification requested from CI
This PR changes release automation and shell/docs only. Merge only after repository-required checks are green.