### PR TITLE
[SUPERSEDED] package control-plane governance MCP for AWS Marketplace

### DIFF
--- a/.github/workflows/aws-marketplace-mcp-readiness.yml
+++ b/.github/workflows/aws-marketplace-mcp-readiness.yml
@@ -61,6 +61,26 @@ jobs:
           fi
           echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
           echo "AWS_MARKETPLACE_MCP_BASE_URL=$BASE_URL"
+      - name: Capture Azure production diagnostics
+        env:
+          BASE_URL: ${{ steps.live.outputs.base_url }}
+        shell: bash
+        run: |
+          set -u
+          echo "### AWS Marketplace MCP live diagnostics" >> "$GITHUB_STEP_SUMMARY"
+          for path in /api/health /api/dsg/v1/runtime /api/mcp/governance /api/dsg/governance/openapi; do
+            body="$(mktemp)"
+            headers="$(mktemp)"
+            status="$(curl -sS -L --connect-timeout 10 --max-time 20 -D "$headers" -o "$body" -w '%{http_code}' "$BASE_URL$path" || true)"
+            content_type="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {gsub(/\r/,""); value=$0} END{sub(/^[^:]*:[[:space:]]*/,"",value); print value}' "$headers")"
+            echo "PATH=$path HTTP=${status:-CURL_ERROR} CONTENT_TYPE=${content_type:-unknown}"
+            echo "BODY_BEGIN"
+            head -c 800 "$body" || true
+            echo
+            echo "BODY_END"
+            printf -- '- `%s` → HTTP `%s`, content-type `%s`\n' "$path" "${status:-CURL_ERROR}" "${content_type:-unknown}" >> "$GITHUB_STEP_SUMMARY"
+            rm -f "$body" "$headers"
+          done
       - name: Verify live MCP discovery and OpenAPI surfaces
         env:
           AWS_MARKETPLACE_MCP_BASE_URL: ${{ steps.live.outputs.base_url }}

--- a/.github/workflows/aws-marketplace-mcp-readiness.yml
+++ b/.github/workflows/aws-marketplace-mcp-readiness.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       live_base_url:
-        description: 'Optional exact production origin, e.g. https://host.example.com'
+        description: 'Optional exact production origin override, e.g. https://host.example.com'
         required: false
         type: string
 
@@ -43,14 +43,25 @@ jobs:
         run: node scripts/verify-aws-marketplace-mcp-package.mjs
 
   live-discovery:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.live_base_url != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+      - name: Resolve exact live production origin
+        id: live
+        env:
+          INPUT_LIVE_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.live_base_url || '' }}
+        run: |
+          if [ -n "$INPUT_LIVE_BASE_URL" ]; then
+            BASE_URL="$INPUT_LIVE_BASE_URL"
+          else
+            BASE_URL="$(node -e "const fs=require('fs'); const c=JSON.parse(fs.readFileSync('config/aws-marketplace-mcp-server.json','utf8')); console.log(new URL(c.runtime.candidateEndpointUrl).origin)")"
+          fi
+          echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+          echo "AWS_MARKETPLACE_MCP_BASE_URL=$BASE_URL"
       - name: Verify live MCP discovery and OpenAPI surfaces
         env:
-          AWS_MARKETPLACE_MCP_BASE_URL: ${{ inputs.live_base_url }}
+          AWS_MARKETPLACE_MCP_BASE_URL: ${{ steps.live.outputs.base_url }}
         run: node scripts/verify-aws-marketplace-mcp-package.mjs

--- a/.github/workflows/aws-marketplace-mcp-readiness.yml
+++ b/.github/workflows/aws-marketplace-mcp-readiness.yml
@@ -1,0 +1,56 @@
+name: AWS Marketplace MCP Readiness
+
+on:
+  pull_request:
+    paths:
+      - 'config/aws-marketplace-mcp-server.json'
+      - 'config/production-deployment-target.json'
+      - 'app/api/mcp/governance/**'
+      - 'app/api/dsg/governance/**'
+      - 'lib/dsg/governance-plugin.ts'
+      - 'scripts/verify-aws-marketplace-mcp-package.mjs'
+      - 'docs/AWS_MARKETPLACE_MCP_SERVER_PACKAGE_2026-09-05.md'
+      - '.github/workflows/aws-marketplace-mcp-readiness.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'config/aws-marketplace-mcp-server.json'
+      - 'config/production-deployment-target.json'
+      - 'app/api/mcp/governance/**'
+      - 'app/api/dsg/governance/**'
+      - 'lib/dsg/governance-plugin.ts'
+      - 'scripts/verify-aws-marketplace-mcp-package.mjs'
+      - '.github/workflows/aws-marketplace-mcp-readiness.yml'
+  workflow_dispatch:
+    inputs:
+      live_base_url:
+        description: 'Optional exact production origin, e.g. https://host.example.com'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  static-package-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Verify static AWS Marketplace MCP package contract
+        run: node scripts/verify-aws-marketplace-mcp-package.mjs
+
+  live-discovery:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.live_base_url != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Verify live MCP discovery and OpenAPI surfaces
+        env:
+          AWS_MARKETPLACE_MCP_BASE_URL: ${{ inputs.live_base_url }}
+        run: node scripts/verify-aws-marketplace-mcp-package.mjs

--- a/.github/workflows/aws-marketplace-mcp-readiness.yml
+++ b/.github/workflows/aws-marketplace-mcp-readiness.yml
@@ -10,6 +10,7 @@ on:
       - 'lib/dsg/governance-plugin.ts'
       - 'scripts/verify-aws-marketplace-mcp-package.mjs'
       - 'docs/AWS_MARKETPLACE_MCP_SERVER_PACKAGE_2026-09-05.md'
+      - 'docs/evidence/AWS_MARKETPLACE_MCP_LIVE_BLOCK_2026-09-05.md'
       - '.github/workflows/aws-marketplace-mcp-readiness.yml'
   push:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - 'app/api/dsg/governance/**'
       - 'lib/dsg/governance-plugin.ts'
       - 'scripts/verify-aws-marketplace-mcp-package.mjs'
+      - 'docs/evidence/AWS_MARKETPLACE_MCP_LIVE_BLOCK_2026-09-05.md'
       - '.github/workflows/aws-marketplace-mcp-readiness.yml'
   workflow_dispatch:
     inputs:
@@ -42,14 +44,14 @@ jobs:
       - name: Verify static AWS Marketplace MCP package contract
         run: node scripts/verify-aws-marketplace-mcp-package.mjs
 
-  live-discovery:
+  live-state:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-      - name: Resolve exact live production origin
+      - name: Resolve exact live production origin and declared state
         id: live
         env:
           INPUT_LIVE_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.live_base_url || '' }}
@@ -59,20 +61,27 @@ jobs:
           else
             BASE_URL="$(node -e "const fs=require('fs'); const c=JSON.parse(fs.readFileSync('config/aws-marketplace-mcp-server.json','utf8')); console.log(new URL(c.runtime.candidateEndpointUrl).origin)")"
           fi
+          LIVE_STATUS="$(node -e "const fs=require('fs'); const c=JSON.parse(fs.readFileSync('config/aws-marketplace-mcp-server.json','utf8')); console.log(c.runtime.endpointLiveStatus)")"
           echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+          echo "live_status=$LIVE_STATUS" >> "$GITHUB_OUTPUT"
           echo "AWS_MARKETPLACE_MCP_BASE_URL=$BASE_URL"
+          echo "DECLARED_LIVE_STATUS=$LIVE_STATUS"
       - name: Capture Azure production diagnostics
+        id: diagnostics
         env:
           BASE_URL: ${{ steps.live.outputs.base_url }}
         shell: bash
         run: |
-          set -u
+          set -euo pipefail
           echo "### AWS Marketplace MCP live diagnostics" >> "$GITHUB_STEP_SUMMARY"
-          for path in /api/health /api/dsg/v1/runtime /api/mcp/governance /api/dsg/governance/openapi; do
+          for entry in health:/api/health runtime:/api/dsg/v1/runtime mcp:/api/mcp/governance openapi:/api/dsg/governance/openapi; do
+            key="${entry%%:*}"
+            path="${entry#*:}"
             body="$(mktemp)"
             headers="$(mktemp)"
             status="$(curl -sS -L --connect-timeout 10 --max-time 20 -D "$headers" -o "$body" -w '%{http_code}' "$BASE_URL$path" || true)"
             content_type="$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {gsub(/\r/,""); value=$0} END{sub(/^[^:]*:[[:space:]]*/,"",value); print value}' "$headers")"
+            echo "$key=${status:-CURL_ERROR}" >> "$GITHUB_OUTPUT"
             echo "PATH=$path HTTP=${status:-CURL_ERROR} CONTENT_TYPE=${content_type:-unknown}"
             echo "BODY_BEGIN"
             head -c 800 "$body" || true
@@ -81,7 +90,23 @@ jobs:
             printf -- '- `%s` → HTTP `%s`, content-type `%s`\n' "$path" "${status:-CURL_ERROR}" "${content_type:-unknown}" >> "$GITHUB_STEP_SUMMARY"
             rm -f "$body" "$headers"
           done
+      - name: Verify declared blocked production state
+        if: ${{ steps.live.outputs.live_status == 'BLOCKED_STALE_PRODUCTION_IMAGE_HTTP_404' }}
+        env:
+          HEALTH_HTTP: ${{ steps.diagnostics.outputs.health }}
+          RUNTIME_HTTP: ${{ steps.diagnostics.outputs.runtime }}
+          MCP_HTTP: ${{ steps.diagnostics.outputs.mcp }}
+          OPENAPI_HTTP: ${{ steps.diagnostics.outputs.openapi }}
+        run: |
+          set -euo pipefail
+          test "$HEALTH_HTTP" = "200" || { echo "::error::Declared stale-image block expected health=200, got $HEALTH_HTTP"; exit 1; }
+          test "$RUNTIME_HTTP" = "404" || { echo "::error::Declared stale-image block expected runtime=404, got $RUNTIME_HTTP"; exit 1; }
+          test "$MCP_HTTP" = "404" || { echo "::error::Declared stale-image block expected MCP=404, got $MCP_HTTP"; exit 1; }
+          test "$OPENAPI_HTTP" = "404" || { echo "::error::Declared stale-image block expected OpenAPI=404, got $OPENAPI_HTTP"; exit 1; }
+          echo "AWS_MARKETPLACE_MCP_LIVE_STATE=BLOCKED_AS_DECLARED"
+          echo "This is not a live endpoint PASS. A governed current-main Azure promotion/deployment remains required." >> "$GITHUB_STEP_SUMMARY"
       - name: Verify live MCP discovery and OpenAPI surfaces
+        if: ${{ steps.live.outputs.live_status != 'BLOCKED_STALE_PRODUCTION_IMAGE_HTTP_404' }}
         env:
           AWS_MARKETPLACE_MCP_BASE_URL: ${{ steps.live.outputs.base_url }}
         run: node scripts/verify-aws-marketplace-mcp-package.mjs

--- a/config/aws-marketplace-mcp-server.json
+++ b/config/aws-marketplace-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "dsg.aws-marketplace-mcp-package.v1",
-  "status": "PACKAGING_CANDIDATE_LIVE_AND_SELLER_VALIDATION_REQUIRED",
+  "status": "PACKAGING_READY_LIVE_DEPLOYMENT_BLOCKED",
   "product": {
     "title": "DSG Spacetime — Governed MCP Execution Gateway",
     "deliveryMethod": "API-Based Agents & Tools",
@@ -14,7 +14,16 @@
     "endpointType": "static",
     "endpointPath": "/api/mcp/governance",
     "candidateEndpointUrl": "https://dsg-control-plane.azurewebsites.net/api/mcp/governance",
-    "endpointLiveStatus": "LIVE_VERIFICATION_REQUIRED",
+    "endpointLiveStatus": "BLOCKED_STALE_PRODUCTION_IMAGE_HTTP_404",
+    "liveObservation": {
+      "observedAtUtc": "2026-09-05T08:04:30Z",
+      "evidenceWorkflowRun": 33954260838,
+      "healthHttp": 200,
+      "runtimeProvenanceHttp": 404,
+      "mcpGovernanceHttp": 404,
+      "governanceOpenApiHttp": 404,
+      "interpretation": "Azure App Service is healthy but the deployed image predates current production/runtime and governance MCP routes. A governed current-main promotion/deployment is required before live MCP validation."
+    },
     "openApiPath": "/api/dsg/governance/openapi",
     "openApiCandidateUrl": "https://dsg-control-plane.azurewebsites.net/api/dsg/governance/openapi"
   },
@@ -73,6 +82,7 @@
   "truthBoundary": {
     "staticPackagePassIsMarketplaceEligibility": false,
     "staticPackagePassIsLiveEndpointProof": false,
+    "declaredLiveBlockIsLiveEndpointPass": false,
     "mcpDiscoveryPassIsPaidFulfillmentProof": false,
     "privateOfferReady": false
   }

--- a/config/aws-marketplace-mcp-server.json
+++ b/config/aws-marketplace-mcp-server.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "dsg.aws-marketplace-mcp-package.v1",
+  "status": "PACKAGING_CANDIDATE_LIVE_AND_SELLER_VALIDATION_REQUIRED",
+  "product": {
+    "title": "DSG Spacetime — Governed MCP Execution Gateway",
+    "deliveryMethod": "API-Based Agents & Tools",
+    "integrationProtocol": "MCP",
+    "type": "MCP server",
+    "positioning": "Govern an existing agent action against an approved DSG plan before target execution."
+  },
+  "runtime": {
+    "productionAuthority": "config/production-deployment-target.json",
+    "provider": "AZURE_APP_SERVICE",
+    "endpointType": "static",
+    "endpointPath": "/api/mcp/governance",
+    "candidateEndpointUrl": "https://dsg-control-plane.azurewebsites.net/api/mcp/governance",
+    "endpointLiveStatus": "LIVE_VERIFICATION_REQUIRED",
+    "openApiPath": "/api/dsg/governance/openapi",
+    "openApiCandidateUrl": "https://dsg-control-plane.azurewebsites.net/api/dsg/governance/openapi"
+  },
+  "authentication": {
+    "mode": "API_KEY",
+    "header": "x-dsg-api-key",
+    "keyValidation": "validateStoredUnifiedMcpKey",
+    "oauthTwoLegged": false
+  },
+  "fulfillment": {
+    "recommendedInitialMethod": "REDIRECT_TO_WEBSITE",
+    "reason": "DSG already owns API-key issuance and account onboarding; use the existing customer surface while Marketplace billing identity and entitlement integration are implemented.",
+    "quickLaunchStatus": "NOT_IMPLEMENTED",
+    "deploymentApiStatus": "NOT_IMPLEMENTED"
+  },
+  "agentCore": {
+    "integrationPath": "OPENAPI_FOR_API_KEY_AUTHENTICATED_MCP",
+    "openApiCodeSurface": "app/api/dsg/governance/openapi/route.ts",
+    "status": "CODE_SURFACE_PRESENT_AWS_SIDE_INTEGRATION_UNVERIFIED"
+  },
+  "marketplaceCommercialIntegration": {
+    "status": "BLOCKED_PENDING_IMPLEMENTATION_AND_SELLER_VALIDATION",
+    "sellerEligibility": "UNVERIFIED_EXTERNAL_ACCOUNT_STATE",
+    "sellerTaxBankKyc": "UNVERIFIED_EXTERNAL_ACCOUNT_STATE",
+    "resolveCustomer": "NOT_IMPLEMENTED",
+    "entitlementOrSubscriptionState": "NOT_IMPLEMENTED",
+    "concurrentAgreementSafeIdentity": "NOT_IMPLEMENTED",
+    "metering": "NOT_IMPLEMENTED_IF_USAGE_PRICING_SELECTED",
+    "privateOffer": "BLOCKED_UNTIL_AT_LEAST_ONE_ACTIVE_PUBLIC_LISTING"
+  },
+  "capabilities": {
+    "mcpTool": "dsg.governance.preflight",
+    "decisionStatuses": [
+      "PASS",
+      "BLOCKED",
+      "WAITING_PERMISSION",
+      "UNVERIFIED"
+    ],
+    "proofSurfaces": [
+      "plan alignment",
+      "execution permission",
+      "evidence state",
+      "hash-chained execution audit"
+    ]
+  },
+  "requiredGoEvidence": [
+    "AWS Marketplace seller eligibility is verified in the seller account",
+    "Paid-seller tax, banking, KYC and bank-verification requirements are satisfied when applicable",
+    "AWS Marketplace pricing-model integration is implemented and tested",
+    "Production MCP initialize and tools/list pass against the exact listing endpoint",
+    "An authenticated approved-plan case returns policyAllowsAction=true and shouldBlock=false with persisted audit evidence",
+    "An authenticated outside-plan case returns BLOCKED and shouldBlock=true with persisted audit evidence",
+    "Marketplace customer identity and entitlement/subscription changes fail closed and cannot enter the Stripe billing path",
+    "At least one active public listing exists before a private offer is issued"
+  ],
+  "truthBoundary": {
+    "staticPackagePassIsMarketplaceEligibility": false,
+    "staticPackagePassIsLiveEndpointProof": false,
+    "mcpDiscoveryPassIsPaidFulfillmentProof": false,
+    "privateOfferReady": false
+  }
+}

--- a/config/aws-marketplace-mcp-server.json
+++ b/config/aws-marketplace-mcp-server.json
@@ -27,6 +27,12 @@
     "openApiPath": "/api/dsg/governance/openapi",
     "openApiCandidateUrl": "https://dsg-control-plane.azurewebsites.net/api/dsg/governance/openapi"
   },
+  "mcpCompatibility": {
+    "currentInitializeProtocolVersion": "2024-11-05",
+    "awsMarketplaceCoreRequirements": "JSON_RPC_DISCOVERY_AUTH_ERROR_HANDLING",
+    "awsMarketplaceClientCompatibility": "PENDING_REAL_CLIENT_VALIDATION",
+    "agentCorePath": "API_KEY_PLUS_OPENAPI_NOT_DIRECT_TWO_LEGGED_OAUTH_MCP"
+  },
   "authentication": {
     "mode": "API_KEY",
     "header": "x-dsg-api-key",
@@ -34,10 +40,13 @@
     "oauthTwoLegged": false
   },
   "fulfillment": {
-    "recommendedInitialMethod": "REDIRECT_TO_WEBSITE",
-    "reason": "DSG already owns API-key issuance and account onboarding; use the existing customer surface while Marketplace billing identity and entitlement integration are implemented.",
-    "quickLaunchStatus": "NOT_IMPLEMENTED",
-    "deploymentApiStatus": "NOT_IMPLEMENTED"
+    "selectedMethodForFirstProduct": "REDIRECT_TO_WEBSITE",
+    "selectionStatus": "RECOMMENDED_NOT_PUBLISHED",
+    "reason": "Reuse DSG's existing customer account and API-key lifecycle while minimizing Marketplace-specific delivery work for the first enterprise pilot.",
+    "postPublishMutable": false,
+    "quickLaunchStatus": "NOT_SELECTED_FOR_THIS_PRODUCT",
+    "quickLaunchNote": "AWS does not allow changing fulfillment method after publication. If Quick Launch is required, choose it before publishing this product or create a separate listing strategy; do not claim it can be enabled later on the same published product.",
+    "deploymentApiStatus": "NOT_REQUIRED_FOR_REDIRECT_TO_WEBSITE"
   },
   "agentCore": {
     "integrationPath": "OPENAPI_FOR_API_KEY_AUTHENTICATED_MCP",
@@ -74,6 +83,7 @@
     "Paid-seller tax, banking, KYC and bank-verification requirements are satisfied when applicable",
     "AWS Marketplace pricing-model integration is implemented and tested",
     "Production MCP initialize and tools/list pass against the exact listing endpoint",
+    "A real AWS Marketplace-compatible client validates MCP capability discovery, authentication and error handling against the production endpoint",
     "An authenticated approved-plan case returns policyAllowsAction=true and shouldBlock=false with persisted audit evidence",
     "An authenticated outside-plan case returns BLOCKED and shouldBlock=true with persisted audit evidence",
     "Marketplace customer identity and entitlement/subscription changes fail closed and cannot enter the Stripe billing path",
@@ -83,6 +93,7 @@
     "staticPackagePassIsMarketplaceEligibility": false,
     "staticPackagePassIsLiveEndpointProof": false,
     "declaredLiveBlockIsLiveEndpointPass": false,
+    "mcpDiscoveryPassIsAwsClientCompatibilityProof": false,
     "mcpDiscoveryPassIsPaidFulfillmentProof": false,
     "privateOfferReady": false
   }

--- a/docs/AWS_MARKETPLACE_MCP_SERVER_PACKAGE_2026-09-05.md
+++ b/docs/AWS_MARKETPLACE_MCP_SERVER_PACKAGE_2026-09-05.md
@@ -3,60 +3,58 @@
 **Assessment date:** 2026-09-05  
 **Repository:** `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`  
 **Product candidate:** **DSG Spacetime — Governed MCP Execution Gateway**  
-**Marketplace product path:** **API-Based Agents & Tools → MCP → MCP server**  
-**Decision:** **ACT NOW on packaging; NO-GO for paid public launch until seller + Marketplace commercial integration + live E2E evidence pass.**
+**Marketplace path:** **API-Based Agents & Tools → MCP → MCP server**  
+**Decision:** **GO for packaging; NO-GO for paid launch until live runtime, seller, commercial binding and real E2E gates pass.**
 
-This document supersedes the *packaging decision* in `docs/AWS_MARKETPLACE_PRIVATE_OFFER_READINESS_2026-08-12.md`. That earlier document remains valid historical evidence for the commercial integration gaps it found. It does not need to be deleted.
+This document supersedes the packaging decision in `docs/AWS_MARKETPLACE_PRIVATE_OFFER_READINESS_2026-08-12.md`. The older file remains historical evidence for the commercial integration gaps it identified.
 
-## 1. Why this path is now the shortest valid AWS route
+## 1. Why this is the shortest AWS route
 
-AWS Marketplace now has a dedicated SaaS API-based AI agents and tools listing flow. The listing wizard explicitly supports:
+AWS Marketplace now has a dedicated SaaS API-based AI agents and tools flow that supports:
 
-- Delivery method: API-Based Agents & Tools
-- AI tool type: MCP Server
-- Integration protocol: MCP
-- static or dynamic MCP endpoint URL
-- Redirect to Website or Quick Launch fulfillment
-- API key or OAuth authentication
-- optional Amazon Bedrock AgentCore integration
+- tool type: MCP Server;
+- integration protocol: MCP;
+- static or dynamic endpoints;
+- API key or OAuth authentication;
+- Redirect to Website or Quick Launch fulfillment;
+- optional Amazon Bedrock AgentCore integration.
 
-Official AWS references:
+A vendor-hosted API endpoint can be used. DSG therefore does not need to move the Azure runtime to AWS merely to package this product. The separate **Deployed on AWS** designation is not claimed.
+
+Official references:
 
 - https://docs.aws.amazon.com/marketplace/latest/userguide/listing-saas-ai-agents.html
 - https://docs.aws.amazon.com/marketplace/latest/userguide/integrating-api-ai-agents-tools.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/integrating-mcp.html
 - https://docs.aws.amazon.com/marketplace/latest/userguide/bedrock-agentcore-gateway.html
 - https://docs.aws.amazon.com/marketplace/latest/userguide/seller-eligibility.html
-- https://docs.aws.amazon.com/marketplace/latest/userguide/creating-private-offer.html
 
-AWS also allows the API deployment option to use vendor-hosted endpoints. A product does not need to move its runtime to AWS merely to be an API-based Marketplace product. The separate **Deployed on AWS** designation has stricter hosting requirements and is not claimed here.
+## 2. Existing DSG product surface
 
-## 2. Repo evidence: the MCP product surface already exists
-
-The correct Marketplace surface is **not** the broad `/api/mcp` gateway. The narrow product surface already exists:
+The Marketplace surface should be the narrow governance server, not the broad `/api/mcp` gateway:
 
 ```text
 /api/mcp/governance
 ```
 
-It exposes one focused MCP tool:
+It exposes:
 
 ```text
 dsg.governance.preflight
 ```
 
-The current code provides:
+Verified repository capabilities:
 
-1. MCP JSON-RPC over HTTP
-2. `initialize`
-3. `tools/list`
-4. `tools/call`
-5. API-key authentication through `validateStoredUnifiedMcpKey`
-6. approved-plan lookup
-7. deterministic plan-alignment evaluation
-8. execution-role check
-9. `PASS | BLOCKED | WAITING_PERMISSION | UNVERIFIED`
-10. `DO_NOT_EXECUTE | CONTINUE_TO_TARGET`
-11. persisted hash-linked audit evidence in `dsg_audit_events`
+1. MCP JSON-RPC over HTTP.
+2. `initialize`, `tools/list`, `tools/call`.
+3. API-key authentication through `validateStoredUnifiedMcpKey`.
+4. approved-plan lookup.
+5. deterministic plan-alignment evaluation.
+6. execution-role checks.
+7. `PASS | BLOCKED | WAITING_PERMISSION | UNVERIFIED`.
+8. `DO_NOT_EXECUTE | CONTINUE_TO_TARGET`.
+9. hash-linked audit persistence in `dsg_audit_events`.
+10. OpenAPI 3.1 governance surface with `x-dsg-api-key`.
 
 Relevant code:
 
@@ -64,234 +62,247 @@ Relevant code:
 - `lib/dsg/governance-plugin.ts`
 - `app/api/dsg/governance/openapi/route.ts`
 
-The OpenAPI route already declares `x-dsg-api-key` authentication and the corresponding REST governance preflight operation. This gives DSG a code surface compatible with the AWS-documented AgentCore option for API-key-authenticated MCP/API products, subject to AWS-side validation.
+This is the correct product positioning: **governed execution gateway**, not a generic agent platform.
 
-## 3. Production hosting boundary
+## 3. MCP protocol compatibility boundary
 
-Current production authority is:
+The current dedicated MCP route returns:
+
+```text
+protocolVersion = 2024-11-05
+```
+
+AWS Marketplace's published MCP integration requirements require JSON-RPC 2.0, capability discovery, authentication/session handling, and error handling. The listing documentation does not identify one single MCP protocol version as the only accepted version.
+
+For DSG's current **API key** authentication path, AWS documents AgentCore integration through the existing OpenAPI specification. Direct MCP endpoint integration into AgentCore without OpenAPI is the separate two-legged OAuth path.
+
+Therefore this package does **not** change the protocol version merely to advertise a newer number. A real AWS Marketplace-compatible client validation remains a launch gate. Compatibility must be demonstrated rather than inferred.
+
+## 4. Production hosting and verified live blocker
+
+Production authority:
 
 ```text
 config/production-deployment-target.json
 provider = AZURE_APP_SERVICE
 ```
 
-The repository explicitly states that Vercel and Render are not active DSG production targets.
-
-Marketplace package candidate:
+Candidate origin:
 
 ```text
-Static MCP endpoint path:
-/api/mcp/governance
-
-Candidate Azure origin from current production authority:
 https://dsg-control-plane.azurewebsites.net
+```
 
-Candidate listing endpoint:
+Candidate Marketplace MCP endpoint:
+
+```text
 https://dsg-control-plane.azurewebsites.net/api/mcp/governance
 ```
 
-**Important:** the candidate URL is not marked LIVE merely because the route and Azure origin exist in the repository. Run the live verifier against the exact production origin before entering the URL in AWS Marketplace.
+GitHub Actions run `33954260838` observed on 2026-09-05T08:04:30Z:
 
-## 4. Recommended first listing configuration
+| Path | HTTP |
+|---|---:|
+| `/api/health` | 200 |
+| `/api/dsg/v1/runtime` | 404 |
+| `/api/mcp/governance` | 404 |
+| `/api/dsg/governance/openapi` | 404 |
 
-Use the minimum product surface needed to sell the existing capability:
+The Azure application is alive, but the deployed bundle does not contain the current governance/runtime routes. The governance MCP route entered `main` on 2026-09-01, while the latest checked-in Azure production proof found during this work predates that merge.
 
-| AWS field | DSG candidate | Current status |
-|---|---|---|
-| Product title | DSG Spacetime — Governed MCP Execution Gateway | LOCKED FOR PACKAGE |
-| Delivery method | API-Based Agents & Tools | PACKAGE PASS |
-| Type | MCP server | PACKAGE PASS |
-| Integration protocol | MCP | PACKAGE PASS |
-| Endpoint | `/api/mcp/governance` on exact production origin | LIVE VERIFY REQUIRED |
-| Endpoint type | Static | RECOMMENDED |
-| Authentication | API Key | CODE EXISTS |
-| Fulfillment | Redirect to Website | RECOMMENDED INITIAL PATH |
-| Quick Launch | Later | NOT IMPLEMENTED |
-| AgentCore integration | OpenAPI path for API-key-authenticated product | CODE SURFACE EXISTS; AWS VALIDATION REQUIRED |
-| Paid pricing | Select only after seller + billing integration design | BLOCKED |
-| Private offer | After active public listing | BLOCKED |
-
-### Why Redirect to Website first
-
-DSG already has its own account and API-key lifecycle. Redirect to Website therefore avoids building Quick Launch delivery before the first Marketplace validation.
-
-This does **not** remove AWS Marketplace billing/customer identity requirements. Once a customer subscribes through Marketplace, DSG still has to perform the AWS-required registration and pricing-model integration instead of treating the customer as an ordinary Stripe buyer.
-
-## 5. Commercial integration gaps that still block paid launch
-
-The direct MCP product type reduces packaging work. It does not make the existing Stripe path an AWS Marketplace fulfillment implementation.
-
-Current repository code search still does **not** prove the following Marketplace integration:
-
-- `ResolveCustomer`
-- contract entitlement verification / subscription state appropriate to the chosen pricing model
-- Concurrent Agreements-safe AWS buyer/agreement identity
-- Marketplace usage metering when usage pricing is selected
-- subscription/entitlement change processing
-- provider isolation proving AWS Marketplace buyers cannot be double-billed through Stripe
-- Quick Launch `PutDeploymentParameter` integration
-
-Therefore the paid product status remains:
+Current machine-readable state:
 
 ```text
-MCP PRODUCT SURFACE:      READY FOR PACKAGE VALIDATION
-LIVE MCP DISCOVERY:       NOT YET PROVED BY THIS PR
+BLOCKED_STALE_PRODUCTION_IMAGE_HTTP_404
+```
+
+See `docs/evidence/AWS_MARKETPLACE_MCP_LIVE_BLOCK_2026-09-05.md`.
+
+## 5. First-product fulfillment decision
+
+Recommended first product:
+
+```text
+Fulfillment = Redirect to Website
+Authentication = API Key
+Endpoint = static /api/mcp/governance
+AgentCore = OpenAPI integration path
+```
+
+Reason: DSG already owns customer onboarding and API-key lifecycle, so Redirect to Website minimizes new delivery work for the first enterprise pilot.
+
+### Important irreversible choice
+
+AWS states that **the fulfillment method cannot be changed after the product is published**.
+
+Therefore:
+
+- `Redirect to Website` is not described as a temporary phase that can later be switched to Quick Launch on the same published product;
+- if Quick Launch is required, choose it before publication or use a separate listing/product strategy;
+- Quick Launch would additionally require the AWS Marketplace Deployment API path and key delivery workflow.
+
+The current package deliberately selects Redirect to Website **before publication**, subject to final seller validation.
+
+## 6. Recommended listing configuration
+
+| AWS field | DSG candidate | Status |
+|---|---|---|
+| Product title | DSG Spacetime — Governed MCP Execution Gateway | PACKAGE LOCKED |
+| Delivery method | API-Based Agents & Tools | PASS |
+| Type | MCP server | PASS |
+| Integration protocol | MCP | PASS |
+| Endpoint | `/api/mcp/governance` on Azure production origin | BLOCKED: LIVE 404 |
+| Endpoint type | Static | SELECTED |
+| Authentication | API Key | CODE EXISTS |
+| Fulfillment | Redirect to Website | SELECTED, NOT PUBLISHED |
+| Quick Launch | Not selected for this product | N/A |
+| AgentCore | OpenAPI path for API-key product | CODE SURFACE EXISTS; AWS VALIDATION PENDING |
+| Pricing | Decide only with commercial adapter design | BLOCKED |
+| Private offer | After public-listing prerequisite | BLOCKED |
+
+## 7. Commercial integration gaps
+
+The direct MCP product type reduces packaging work. It does not turn the Stripe billing path into AWS Marketplace fulfillment.
+
+Repository inspection does not prove implementation of:
+
+- `ResolveCustomer`;
+- contract entitlement/subscription processing for the selected pricing model;
+- AWS account/license/agreement identity suitable for concurrent agreements;
+- Marketplace usage metering when usage pricing is selected;
+- subscription/entitlement change processing;
+- provider isolation proving an AWS Marketplace buyer cannot also enter the Stripe charge path.
+
+The current `billing_subscriptions` model is Stripe-specific (`stripe_subscription_id`, `stripe_customer_id`). The entitlement decision layer can be reused, but AWS Marketplace identity/agreement state should not be forced into Stripe identifiers.
+
+Paid launch status:
+
+```text
+MCP PACKAGE:              READY
+AZURE LIVE MCP:           BLOCKED — stale deployed bundle
+AWS CLIENT COMPATIBILITY: PENDING REAL VALIDATION
 SELLER ELIGIBILITY:       UNVERIFIED OUTSIDE REPO
 AWS COMMERCIAL BINDING:   NOT IMPLEMENTED
 PAID PUBLIC LAUNCH:       NO-GO
 PRIVATE OFFER:            NO-GO
 ```
 
-## 6. Seller eligibility is an external hard gate
+## 8. Seller eligibility boundary
 
-AWS currently requires paid-product sellers to be a permanent resident/citizen of an eligible jurisdiction or a business entity organized/incorporated in an eligible jurisdiction, plus required tax, bank and verification steps.
+Seller eligibility, tax, banking/KYC and AWS Marketplace account approval are external account facts. The repository cannot prove them.
 
-The current AWS eligible-jurisdiction list does **not** include Thailand.
+Do not mark a paid listing eligible until AWS Partner Central / Marketplace seller state is checked directly for the actual selling entity.
 
-This repository does not prove the seller's legal entity, residency, bank jurisdiction, tax status, KYC state or AWS Marketplace seller approval. Therefore:
+## 9. Required E2E evidence
 
-- do **not** mark the paid listing eligible from repo evidence alone;
-- if the intended seller is Thailand-only, AWS's current paid-seller jurisdiction rule is a blocker;
-- if an eligible-jurisdiction business entity/residency exists, verify it directly in AWS Partner Central / Marketplace seller settings before paid listing work proceeds.
-
-A free listing has different eligibility requirements, but it does not satisfy a revenue objective by itself.
-
-## 7. Required E2E proof before Marketplace submission
-
-### A. Discovery proof
+### A. Live discovery
 
 ```text
-AWS test client
-  → GET /api/mcp/governance
+AWS-compatible client
   → POST initialize
   → POST tools/list
-  → dsg.governance.preflight discovered
+  → discovers dsg.governance.preflight
 ```
 
-Evidence required:
+Required evidence:
 
-- exact production URL
-- HTTP status
-- MCP server identity
-- protocol version
-- tool name/schema
-- timestamp / commit SHA where available
+- exact production URL;
+- HTTP status;
+- server identity;
+- protocol version;
+- tool/schema;
+- authentication/error behavior;
+- timestamp and deployed commit where available.
 
-### B. Approved-plan ALLOW proof
+### B. Approved-plan ALLOW
 
 ```text
-real authenticated Marketplace-style client
+real API key
+  → real stored approved planHash
   → dsg.governance.preflight
-  → real approved planHash already persisted for the org
-  → plan alignment PASS
-  → execution permission PASS
   → policyAllowsAction = true
   → shouldBlock = false
   → audit persisted = true
   → CONTINUE_TO_TARGET
 ```
 
-Do not invent an approved plan fixture. Use a real stored plan and a real issued DSG API key.
-
-### C. Outside-plan BLOCK proof
+### C. Outside-plan BLOCK
 
 ```text
-same authenticated client/org in ENFORCE mode
-  → action outside the stored approved plan
+same authenticated org in ENFORCE mode
+  → operation outside approved plan
   → status = BLOCKED
   → shouldBlock = true
   → audit persisted = true
   → DO_NOT_EXECUTE
 ```
 
-Observe mode is not sufficient evidence for this case because Observe intentionally does not block downstream execution.
+No fake plan fixture or API key is permitted. Missing real inputs means the authenticated E2E remains pending.
 
-## 8. Verifier added by this package
+## 10. Verification added in PR #1218
 
-Static verification:
-
-```bash
-node scripts/verify-aws-marketplace-mcp-package.mjs
-```
-
-Expected final line when repository contracts pass:
+Static verifier:
 
 ```text
-AWS_MARKETPLACE_MCP_PACKAGE=STATIC_PASS_LIVE_AND_COMMERCIAL_VALIDATION_PENDING
+scripts/verify-aws-marketplace-mcp-package.mjs
 ```
 
-Live discovery verification:
-
-```bash
-AWS_MARKETPLACE_MCP_BASE_URL=https://<exact-production-origin> \
-  node scripts/verify-aws-marketplace-mcp-package.mjs
-```
-
-Authenticated ALLOW/BLOCK verification additionally requires:
-
-```text
-DSG_MARKETPLACE_MCP_API_KEY
-DSG_MARKETPLACE_ALLOW_CASE_JSON
-DSG_MARKETPLACE_BLOCK_CASE_JSON
-```
-
-The two JSON fixtures must describe real plan-bound cases. The verifier intentionally skips authenticated E2E rather than fabricating data when they are absent.
-
-CI workflow:
+CI:
 
 ```text
 .github/workflows/aws-marketplace-mcp-readiness.yml
 ```
 
-PR/push runs the static package contract. `workflow_dispatch` can run live discovery against an operator-supplied exact production origin.
+The workflow has two distinct meanings:
 
-## 9. AWS seller/listing execution order
+- static package checks verify repository contracts;
+- live-state checks verify that the declared production state matches observed HTTPS behavior.
+
+When the contract says `BLOCKED_STALE_PRODUCTION_IMAGE_HTTP_404`, CI expects health=200 and the current runtime/MCP/OpenAPI routes=404 and reports:
 
 ```text
-1. Verify AWS Marketplace seller profile/account
-2. Verify paid-seller jurisdiction + tax + banking/KYC state
-3. Run live MCP discovery against exact Azure production endpoint
-4. Create API-Based Agents & Tools product
-5. Select MCP Server + MCP + static endpoint
-6. Choose Redirect to Website for the initial package
-7. Enter usage/auth documentation and existing OpenAPI surface
-8. Choose pricing model
-9. Implement the corresponding AWS Marketplace registration/billing adapter
-10. Prove no Stripe/AWS double billing
-11. Run approved-plan ALLOW E2E with audit evidence
-12. Run outside-plan BLOCK E2E with audit evidence
-13. Submit limited-visibility/test listing and validate AWS review feedback
-14. Publish public listing only after all launch gates pass
-15. Create private offer only after at least one active public listing exists
+AWS_MARKETPLACE_MCP_LIVE_STATE=BLOCKED_AS_DECLARED
 ```
 
-## 10. What not to reuse as proof
+That is **not** a live MCP pass. After a governed Azure deployment changes those responses, CI must fail until the contract is updated and full live discovery succeeds.
 
-Do not use these historical artifacts as current paid-fulfillment proof:
+Authenticated ALLOW/BLOCK verification remains optional only because it requires real secret/plan inputs. Absence of those inputs produces SKIP, never fabricated evidence.
 
-- `docs/analysis/dsg_aws_marketplace_readiness.md` — contains older hosting/packaging assumptions and should not override current Azure production authority.
-- `docs/AWS-MARKETPLACE-WEBHOOK-SETUP.md` — lead-capture webhook documentation is not Marketplace subscription/entitlement fulfillment evidence.
-- Stripe billing implementation — valid for direct Stripe customers, not proof of AWS Marketplace customer entitlement or metering.
+## 11. Execution order
 
-## 11. Go / No-Go matrix
+```text
+1. Merge the packaging PR after relevant CI passes.
+2. Resolve the exact new current-main SHA.
+3. Create the audited pending production promotion through the existing authenticated promotion API.
+4. Run the protected Azure production promotion workflow.
+5. Re-run AWS Marketplace MCP live discovery.
+6. Validate MCP discovery/auth/error handling with a real AWS-compatible client.
+7. Run real approved-plan ALLOW + audit proof.
+8. Run real outside-plan BLOCK + audit proof.
+9. Verify the actual AWS Marketplace seller account/entity eligibility.
+10. Create the API-Based Agents & Tools product with MCP Server + MCP + static endpoint.
+11. Keep Redirect to Website as the chosen fulfillment method for this product.
+12. Choose the pricing model.
+13. Implement the corresponding AWS Marketplace registration/entitlement/metering adapter.
+14. Prove AWS/Stripe provider isolation and no double billing.
+15. Validate the limited-visibility listing with test buyer account(s).
+16. Request public visibility only after all gates pass.
+17. Create private offers only when the AWS prerequisite is actually satisfied.
+```
 
-| Gate | Status |
-|---|---|
-| Focused MCP governance route exists | PASS (code) |
-| Plan alignment + execution decision exists | PASS (code) |
-| Audit persistence path exists | PASS (code) |
-| OpenAPI for API-key surface exists | PASS (code) |
-| Azure production authority exists | PASS (repo authority) |
-| Exact live MCP endpoint discovery | PENDING LIVE TEST |
-| Real ALLOW case + audit | PENDING LIVE TEST |
-| Real BLOCK case + audit | PENDING LIVE TEST |
-| AWS paid-seller eligibility | UNVERIFIED EXTERNAL |
-| AWS Marketplace customer registration/billing adapter | BLOCKER |
-| Provider isolation / no double billing | BLOCKER |
-| Public AWS listing | NOT YET |
-| Private offer | BLOCKED UNTIL PUBLIC LISTING |
+## 12. What is not valid proof
 
-### Current verdict
+Do not use these as paid AWS fulfillment proof:
 
-**GO for AWS Marketplace MCP packaging and validation.**  
-**NO-GO for paid launch/private offer until the external seller gate, AWS commercial binding and live ALLOW/BLOCK evidence pass.**
+- old AWS Marketplace readiness documents with superseded hosting assumptions;
+- lead-capture webhook docs;
+- Stripe checkout/webhook success;
+- static route existence without live deployment;
+- `BLOCKED_AS_DECLARED` CI success;
+- a generic HTTP client test in place of an AWS-compatible client compatibility test.
+
+## Current verdict
+
+**GO:** package DSG Spacetime as an AWS Marketplace MCP Server using the existing governed MCP surface and Azure runtime.  
+**BLOCKED:** current Azure deployment does not yet expose the route.  
+**NO-GO:** paid launch/private offer until live MCP, real ALLOW/BLOCK evidence, seller validation and AWS commercial binding all pass.

--- a/docs/AWS_MARKETPLACE_MCP_SERVER_PACKAGE_2026-09-05.md
+++ b/docs/AWS_MARKETPLACE_MCP_SERVER_PACKAGE_2026-09-05.md
@@ -1,0 +1,297 @@
+# DSG Spacetime — AWS Marketplace MCP Server Package
+
+**Assessment date:** 2026-09-05  
+**Repository:** `tdealer01-crypto/tdealer01-crypto-dsg-control-plane`  
+**Product candidate:** **DSG Spacetime — Governed MCP Execution Gateway**  
+**Marketplace product path:** **API-Based Agents & Tools → MCP → MCP server**  
+**Decision:** **ACT NOW on packaging; NO-GO for paid public launch until seller + Marketplace commercial integration + live E2E evidence pass.**
+
+This document supersedes the *packaging decision* in `docs/AWS_MARKETPLACE_PRIVATE_OFFER_READINESS_2026-08-12.md`. That earlier document remains valid historical evidence for the commercial integration gaps it found. It does not need to be deleted.
+
+## 1. Why this path is now the shortest valid AWS route
+
+AWS Marketplace now has a dedicated SaaS API-based AI agents and tools listing flow. The listing wizard explicitly supports:
+
+- Delivery method: API-Based Agents & Tools
+- AI tool type: MCP Server
+- Integration protocol: MCP
+- static or dynamic MCP endpoint URL
+- Redirect to Website or Quick Launch fulfillment
+- API key or OAuth authentication
+- optional Amazon Bedrock AgentCore integration
+
+Official AWS references:
+
+- https://docs.aws.amazon.com/marketplace/latest/userguide/listing-saas-ai-agents.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/integrating-api-ai-agents-tools.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/bedrock-agentcore-gateway.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/seller-eligibility.html
+- https://docs.aws.amazon.com/marketplace/latest/userguide/creating-private-offer.html
+
+AWS also allows the API deployment option to use vendor-hosted endpoints. A product does not need to move its runtime to AWS merely to be an API-based Marketplace product. The separate **Deployed on AWS** designation has stricter hosting requirements and is not claimed here.
+
+## 2. Repo evidence: the MCP product surface already exists
+
+The correct Marketplace surface is **not** the broad `/api/mcp` gateway. The narrow product surface already exists:
+
+```text
+/api/mcp/governance
+```
+
+It exposes one focused MCP tool:
+
+```text
+dsg.governance.preflight
+```
+
+The current code provides:
+
+1. MCP JSON-RPC over HTTP
+2. `initialize`
+3. `tools/list`
+4. `tools/call`
+5. API-key authentication through `validateStoredUnifiedMcpKey`
+6. approved-plan lookup
+7. deterministic plan-alignment evaluation
+8. execution-role check
+9. `PASS | BLOCKED | WAITING_PERMISSION | UNVERIFIED`
+10. `DO_NOT_EXECUTE | CONTINUE_TO_TARGET`
+11. persisted hash-linked audit evidence in `dsg_audit_events`
+
+Relevant code:
+
+- `app/api/mcp/governance/route.ts`
+- `lib/dsg/governance-plugin.ts`
+- `app/api/dsg/governance/openapi/route.ts`
+
+The OpenAPI route already declares `x-dsg-api-key` authentication and the corresponding REST governance preflight operation. This gives DSG a code surface compatible with the AWS-documented AgentCore option for API-key-authenticated MCP/API products, subject to AWS-side validation.
+
+## 3. Production hosting boundary
+
+Current production authority is:
+
+```text
+config/production-deployment-target.json
+provider = AZURE_APP_SERVICE
+```
+
+The repository explicitly states that Vercel and Render are not active DSG production targets.
+
+Marketplace package candidate:
+
+```text
+Static MCP endpoint path:
+/api/mcp/governance
+
+Candidate Azure origin from current production authority:
+https://dsg-control-plane.azurewebsites.net
+
+Candidate listing endpoint:
+https://dsg-control-plane.azurewebsites.net/api/mcp/governance
+```
+
+**Important:** the candidate URL is not marked LIVE merely because the route and Azure origin exist in the repository. Run the live verifier against the exact production origin before entering the URL in AWS Marketplace.
+
+## 4. Recommended first listing configuration
+
+Use the minimum product surface needed to sell the existing capability:
+
+| AWS field | DSG candidate | Current status |
+|---|---|---|
+| Product title | DSG Spacetime — Governed MCP Execution Gateway | LOCKED FOR PACKAGE |
+| Delivery method | API-Based Agents & Tools | PACKAGE PASS |
+| Type | MCP server | PACKAGE PASS |
+| Integration protocol | MCP | PACKAGE PASS |
+| Endpoint | `/api/mcp/governance` on exact production origin | LIVE VERIFY REQUIRED |
+| Endpoint type | Static | RECOMMENDED |
+| Authentication | API Key | CODE EXISTS |
+| Fulfillment | Redirect to Website | RECOMMENDED INITIAL PATH |
+| Quick Launch | Later | NOT IMPLEMENTED |
+| AgentCore integration | OpenAPI path for API-key-authenticated product | CODE SURFACE EXISTS; AWS VALIDATION REQUIRED |
+| Paid pricing | Select only after seller + billing integration design | BLOCKED |
+| Private offer | After active public listing | BLOCKED |
+
+### Why Redirect to Website first
+
+DSG already has its own account and API-key lifecycle. Redirect to Website therefore avoids building Quick Launch delivery before the first Marketplace validation.
+
+This does **not** remove AWS Marketplace billing/customer identity requirements. Once a customer subscribes through Marketplace, DSG still has to perform the AWS-required registration and pricing-model integration instead of treating the customer as an ordinary Stripe buyer.
+
+## 5. Commercial integration gaps that still block paid launch
+
+The direct MCP product type reduces packaging work. It does not make the existing Stripe path an AWS Marketplace fulfillment implementation.
+
+Current repository code search still does **not** prove the following Marketplace integration:
+
+- `ResolveCustomer`
+- contract entitlement verification / subscription state appropriate to the chosen pricing model
+- Concurrent Agreements-safe AWS buyer/agreement identity
+- Marketplace usage metering when usage pricing is selected
+- subscription/entitlement change processing
+- provider isolation proving AWS Marketplace buyers cannot be double-billed through Stripe
+- Quick Launch `PutDeploymentParameter` integration
+
+Therefore the paid product status remains:
+
+```text
+MCP PRODUCT SURFACE:      READY FOR PACKAGE VALIDATION
+LIVE MCP DISCOVERY:       NOT YET PROVED BY THIS PR
+SELLER ELIGIBILITY:       UNVERIFIED OUTSIDE REPO
+AWS COMMERCIAL BINDING:   NOT IMPLEMENTED
+PAID PUBLIC LAUNCH:       NO-GO
+PRIVATE OFFER:            NO-GO
+```
+
+## 6. Seller eligibility is an external hard gate
+
+AWS currently requires paid-product sellers to be a permanent resident/citizen of an eligible jurisdiction or a business entity organized/incorporated in an eligible jurisdiction, plus required tax, bank and verification steps.
+
+The current AWS eligible-jurisdiction list does **not** include Thailand.
+
+This repository does not prove the seller's legal entity, residency, bank jurisdiction, tax status, KYC state or AWS Marketplace seller approval. Therefore:
+
+- do **not** mark the paid listing eligible from repo evidence alone;
+- if the intended seller is Thailand-only, AWS's current paid-seller jurisdiction rule is a blocker;
+- if an eligible-jurisdiction business entity/residency exists, verify it directly in AWS Partner Central / Marketplace seller settings before paid listing work proceeds.
+
+A free listing has different eligibility requirements, but it does not satisfy a revenue objective by itself.
+
+## 7. Required E2E proof before Marketplace submission
+
+### A. Discovery proof
+
+```text
+AWS test client
+  → GET /api/mcp/governance
+  → POST initialize
+  → POST tools/list
+  → dsg.governance.preflight discovered
+```
+
+Evidence required:
+
+- exact production URL
+- HTTP status
+- MCP server identity
+- protocol version
+- tool name/schema
+- timestamp / commit SHA where available
+
+### B. Approved-plan ALLOW proof
+
+```text
+real authenticated Marketplace-style client
+  → dsg.governance.preflight
+  → real approved planHash already persisted for the org
+  → plan alignment PASS
+  → execution permission PASS
+  → policyAllowsAction = true
+  → shouldBlock = false
+  → audit persisted = true
+  → CONTINUE_TO_TARGET
+```
+
+Do not invent an approved plan fixture. Use a real stored plan and a real issued DSG API key.
+
+### C. Outside-plan BLOCK proof
+
+```text
+same authenticated client/org in ENFORCE mode
+  → action outside the stored approved plan
+  → status = BLOCKED
+  → shouldBlock = true
+  → audit persisted = true
+  → DO_NOT_EXECUTE
+```
+
+Observe mode is not sufficient evidence for this case because Observe intentionally does not block downstream execution.
+
+## 8. Verifier added by this package
+
+Static verification:
+
+```bash
+node scripts/verify-aws-marketplace-mcp-package.mjs
+```
+
+Expected final line when repository contracts pass:
+
+```text
+AWS_MARKETPLACE_MCP_PACKAGE=STATIC_PASS_LIVE_AND_COMMERCIAL_VALIDATION_PENDING
+```
+
+Live discovery verification:
+
+```bash
+AWS_MARKETPLACE_MCP_BASE_URL=https://<exact-production-origin> \
+  node scripts/verify-aws-marketplace-mcp-package.mjs
+```
+
+Authenticated ALLOW/BLOCK verification additionally requires:
+
+```text
+DSG_MARKETPLACE_MCP_API_KEY
+DSG_MARKETPLACE_ALLOW_CASE_JSON
+DSG_MARKETPLACE_BLOCK_CASE_JSON
+```
+
+The two JSON fixtures must describe real plan-bound cases. The verifier intentionally skips authenticated E2E rather than fabricating data when they are absent.
+
+CI workflow:
+
+```text
+.github/workflows/aws-marketplace-mcp-readiness.yml
+```
+
+PR/push runs the static package contract. `workflow_dispatch` can run live discovery against an operator-supplied exact production origin.
+
+## 9. AWS seller/listing execution order
+
+```text
+1. Verify AWS Marketplace seller profile/account
+2. Verify paid-seller jurisdiction + tax + banking/KYC state
+3. Run live MCP discovery against exact Azure production endpoint
+4. Create API-Based Agents & Tools product
+5. Select MCP Server + MCP + static endpoint
+6. Choose Redirect to Website for the initial package
+7. Enter usage/auth documentation and existing OpenAPI surface
+8. Choose pricing model
+9. Implement the corresponding AWS Marketplace registration/billing adapter
+10. Prove no Stripe/AWS double billing
+11. Run approved-plan ALLOW E2E with audit evidence
+12. Run outside-plan BLOCK E2E with audit evidence
+13. Submit limited-visibility/test listing and validate AWS review feedback
+14. Publish public listing only after all launch gates pass
+15. Create private offer only after at least one active public listing exists
+```
+
+## 10. What not to reuse as proof
+
+Do not use these historical artifacts as current paid-fulfillment proof:
+
+- `docs/analysis/dsg_aws_marketplace_readiness.md` — contains older hosting/packaging assumptions and should not override current Azure production authority.
+- `docs/AWS-MARKETPLACE-WEBHOOK-SETUP.md` — lead-capture webhook documentation is not Marketplace subscription/entitlement fulfillment evidence.
+- Stripe billing implementation — valid for direct Stripe customers, not proof of AWS Marketplace customer entitlement or metering.
+
+## 11. Go / No-Go matrix
+
+| Gate | Status |
+|---|---|
+| Focused MCP governance route exists | PASS (code) |
+| Plan alignment + execution decision exists | PASS (code) |
+| Audit persistence path exists | PASS (code) |
+| OpenAPI for API-key surface exists | PASS (code) |
+| Azure production authority exists | PASS (repo authority) |
+| Exact live MCP endpoint discovery | PENDING LIVE TEST |
+| Real ALLOW case + audit | PENDING LIVE TEST |
+| Real BLOCK case + audit | PENDING LIVE TEST |
+| AWS paid-seller eligibility | UNVERIFIED EXTERNAL |
+| AWS Marketplace customer registration/billing adapter | BLOCKER |
+| Provider isolation / no double billing | BLOCKER |
+| Public AWS listing | NOT YET |
+| Private offer | BLOCKED UNTIL PUBLIC LISTING |
+
+### Current verdict
+
+**GO for AWS Marketplace MCP packaging and validation.**  
+**NO-GO for paid launch/private offer until the external seller gate, AWS commercial binding and live ALLOW/BLOCK evidence pass.**

--- a/docs/evidence/AWS_MARKETPLACE_MCP_LIVE_BLOCK_2026-09-05.md
+++ b/docs/evidence/AWS_MARKETPLACE_MCP_LIVE_BLOCK_2026-09-05.md
@@ -1,0 +1,84 @@
+# AWS Marketplace MCP live blocker evidence — 2026-09-05
+
+## Scope
+
+Candidate Marketplace delivery origin:
+
+`https://dsg-control-plane.azurewebsites.net`
+
+Candidate MCP endpoint:
+
+`/api/mcp/governance`
+
+Candidate OpenAPI endpoint:
+
+`/api/dsg/governance/openapi`
+
+## GitHub Actions evidence
+
+Workflow: **AWS Marketplace MCP Readiness**  
+Run: **33954260838**  
+Observed UTC: **2026-09-05T08:04:30Z**
+
+The GitHub-hosted runner executed public HTTPS probes against the exact Azure production origin recorded in `config/production-deployment-target.json` and `config/aws-marketplace-mcp-server.json`.
+
+Observed responses:
+
+| Path | HTTP | Interpretation |
+|---|---:|---|
+| `/api/health` | 200 | Azure App Service is up and core/readiness checks returned healthy JSON |
+| `/api/dsg/v1/runtime` | 404 | currently deployed image does not expose current runtime provenance route |
+| `/api/mcp/governance` | 404 | currently deployed image does not expose dedicated governance MCP route |
+| `/api/dsg/governance/openapi` | 404 | currently deployed image does not expose governance OpenAPI route |
+
+The 404 responses were Next.js HTML responses from the same live Azure application, not DNS or transport failures.
+
+## Repository chronology
+
+`app/api/mcp/governance/route.ts` entered `main` in commit:
+
+`57b5b2ac99a5bdee4525fbb95c0754ca2f7d1500`
+
+Commit message:
+
+`feat: Microsoft Foundry DSG governance plugin (#1199)`
+
+Merge timestamp: **2026-09-01T06:24:06Z**.
+
+The latest checked-in Azure production deployment proof found during this work is:
+
+`qa-logs/azure-production/20260828T015648Z/DEPLOYMENT_PROOF.md`
+
+That evidence predates the governance MCP merge and records an older production SHA.
+
+## Determination
+
+**BLOCKED_STALE_PRODUCTION_IMAGE_HTTP_404**
+
+This is a deployment-state blocker, not evidence that the MCP implementation is absent from `main`.
+
+Static repository verification passes for:
+
+- dedicated `dsg.governance.preflight` MCP tool
+- MCP initialize / tools/list / tools/call handlers
+- stored DSG API-key validation
+- approved-plan lookup and plan-alignment logic
+- explicit PASS / BLOCKED / WAITING_PERMISSION decisions
+- hash-linked audit persistence
+- OpenAPI 3.1 surface with `x-dsg-api-key`
+
+## Required remediation
+
+Use the repository's governed production path only:
+
+1. ensure the exact target commit is current `main`;
+2. create an audited pending production promotion through `POST /api/agent-workspaces/promotions` as an authenticated `org_admin`;
+3. dispatch `.github/workflows/promoted-production-deploy.yml` with the resulting promotion UUID, exact current-main SHA, and workspace key;
+4. allow the workflow to perform staging provenance, health, proof E2E, slot swap, production provenance and rollback controls;
+5. rerun `AWS Marketplace MCP Readiness`;
+6. change `endpointLiveStatus` only after the MCP/OpenAPI discovery probes return the expected live responses;
+7. run authenticated real-plan ALLOW/BLOCK evidence separately. No fixture is to be invented.
+
+## Truth boundary
+
+`BLOCKED_AS_DECLARED` means the CI verified that production is still blocked in the exact way recorded here. It does **not** mean the Marketplace endpoint is live, seller eligibility is satisfied, AWS commercial fulfillment is implemented, or a private offer is ready.

--- a/scripts/verify-aws-marketplace-mcp-package.mjs
+++ b/scripts/verify-aws-marketplace-mcp-package.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const ROOT = process.cwd();
+const read = (path) => readFileSync(`${ROOT}/${path}`, 'utf8');
+const json = (path) => JSON.parse(read(path));
+
+const packageContract = json('config/aws-marketplace-mcp-server.json');
+const productionTarget = json('config/production-deployment-target.json');
+const mcpRoute = read('app/api/mcp/governance/route.ts');
+const openApiRoute = read('app/api/dsg/governance/openapi/route.ts');
+const governancePlugin = read('lib/dsg/governance-plugin.ts');
+
+let failures = 0;
+
+function pass(message) {
+  console.log(`PASS  ${message}`);
+}
+
+function fail(message) {
+  failures += 1;
+  console.error(`FAIL  ${message}`);
+}
+
+function check(condition, message) {
+  if (condition) pass(message);
+  else fail(message);
+}
+
+function contains(source, value) {
+  return source.includes(value);
+}
+
+function sameOrigin(left, right) {
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
+}
+
+console.log('AWS Marketplace MCP package — static verification');
+
+check(
+  packageContract.product?.deliveryMethod === 'API-Based Agents & Tools' &&
+    packageContract.product?.integrationProtocol === 'MCP' &&
+    packageContract.product?.type === 'MCP server',
+  'Package declares API-Based Agents & Tools / MCP / MCP server',
+);
+check(
+  packageContract.product?.title === 'DSG Spacetime — Governed MCP Execution Gateway',
+  'Product positioning is locked to the governed execution gateway',
+);
+check(
+  productionTarget.provider === 'AZURE_APP_SERVICE',
+  'Current production authority is Azure App Service',
+);
+check(
+  packageContract.runtime?.provider === productionTarget.provider,
+  'Marketplace package provider matches production authority',
+);
+check(
+  packageContract.runtime?.endpointType === 'static' &&
+    packageContract.runtime?.endpointPath === '/api/mcp/governance',
+  'Package uses the dedicated static governance MCP endpoint',
+);
+check(
+  sameOrigin(
+    packageContract.runtime?.candidateEndpointUrl,
+    productionTarget.rollbackAdapterEndpoint,
+  ),
+  'Candidate Marketplace endpoint uses the same Azure App Service origin recorded by production authority',
+);
+
+check(contains(mcpRoute, "const TOOL_NAME = 'dsg.governance.preflight'"), 'Dedicated MCP exports dsg.governance.preflight');
+check(contains(mcpRoute, "rpc.method === 'initialize'"), 'Dedicated MCP implements initialize');
+check(contains(mcpRoute, "rpc.method === 'tools/list'"), 'Dedicated MCP implements tools/list');
+check(contains(mcpRoute, "rpc.method === 'tools/call'"), 'Dedicated MCP implements tools/call');
+check(contains(mcpRoute, 'validateStoredUnifiedMcpKey'), 'Dedicated MCP validates stored DSG MCP API keys');
+check(contains(mcpRoute, "transport: 'MCP JSON-RPC over HTTP'"), 'Dedicated endpoint declares MCP JSON-RPC over HTTP');
+
+check(contains(openApiRoute, "openapi: '3.1.0'"), 'Governance OpenAPI surface is present');
+check(contains(openApiRoute, "'/api/dsg/governance/preflight'"), 'OpenAPI exposes governance preflight');
+check(contains(openApiRoute, "name: 'x-dsg-api-key'"), 'OpenAPI declares the DSG API-key header');
+
+check(contains(governancePlugin, 'lookupPlanContract'), 'Governance runtime resolves an approved plan contract');
+check(contains(governancePlugin, 'evaluatePlanAlignment'), 'Governance runtime evaluates plan alignment');
+check(contains(governancePlugin, "status = 'BLOCKED'"), 'Governance runtime has an explicit BLOCKED decision');
+check(contains(governancePlugin, "status = 'WAITING_PERMISSION'"), 'Governance runtime has an explicit WAITING_PERMISSION decision');
+check(contains(governancePlugin, "status = 'PASS'"), 'Governance runtime has an explicit PASS decision');
+check(contains(governancePlugin, ".from('dsg_audit_events').insert"), 'Governance runtime persists execution audit records');
+check(contains(governancePlugin, "'DO_NOT_EXECUTE'"), 'Blocked decisions emit DO_NOT_EXECUTE');
+check(contains(governancePlugin, "'CONTINUE_TO_TARGET'"), 'Plan-authorized decisions can emit CONTINUE_TO_TARGET');
+
+check(
+  packageContract.marketplaceCommercialIntegration?.sellerEligibility === 'UNVERIFIED_EXTERNAL_ACCOUNT_STATE',
+  'Seller eligibility remains explicitly unverified',
+);
+check(
+  packageContract.marketplaceCommercialIntegration?.resolveCustomer === 'NOT_IMPLEMENTED',
+  'ResolveCustomer is not falsely claimed as implemented',
+);
+check(
+  packageContract.marketplaceCommercialIntegration?.entitlementOrSubscriptionState === 'NOT_IMPLEMENTED',
+  'Marketplace entitlement/subscription integration is not falsely claimed as implemented',
+);
+check(
+  packageContract.truthBoundary?.staticPackagePassIsMarketplaceEligibility === false &&
+    packageContract.truthBoundary?.staticPackagePassIsLiveEndpointProof === false &&
+    packageContract.truthBoundary?.privateOfferReady === false,
+  'Truth boundary prevents static packaging from being reported as Marketplace/private-offer readiness',
+);
+
+async function fetchJson(url, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    const text = await response.text();
+    let body;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+    return { response, body };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function verifyLive(baseUrl) {
+  const base = baseUrl.replace(/\/$/, '');
+  const mcpUrl = `${base}/api/mcp/governance`;
+  const openApiUrl = `${base}/api/dsg/governance/openapi`;
+
+  console.log(`\nAWS Marketplace MCP package — live discovery verification: ${base}`);
+
+  const discovery = await fetchJson(mcpUrl);
+  check(discovery.response.ok, `GET ${mcpUrl} returns HTTP success`);
+  check(discovery.body?.server === 'dsg-governance-plugin', 'Live discovery identifies dsg-governance-plugin');
+  check(
+    discovery.body?.tools?.some?.((tool) => tool?.name === 'dsg.governance.preflight'),
+    'Live discovery exposes dsg.governance.preflight',
+  );
+
+  const initialize = await fetchJson(mcpUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'aws-marketplace-init', method: 'initialize', params: {} }),
+  });
+  check(initialize.response.ok, 'Live MCP initialize returns HTTP success');
+  check(
+    initialize.body?.result?.serverInfo?.name === 'dsg-governance-plugin',
+    'Live MCP initialize returns expected server identity',
+  );
+
+  const toolList = await fetchJson(mcpUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'aws-marketplace-list', method: 'tools/list', params: {} }),
+  });
+  check(toolList.response.ok, 'Live MCP tools/list returns HTTP success');
+  check(
+    Array.isArray(toolList.body?.result?.tools) &&
+      toolList.body.result.tools.some((tool) => tool?.name === 'dsg.governance.preflight'),
+    'Live MCP tools/list includes dsg.governance.preflight',
+  );
+
+  const openApi = await fetchJson(openApiUrl);
+  check(openApi.response.ok, `GET ${openApiUrl} returns HTTP success`);
+  check(openApi.body?.openapi === '3.1.0', 'Live OpenAPI document is version 3.1.0');
+  check(
+    Boolean(openApi.body?.paths?.['/api/dsg/governance/preflight']?.post),
+    'Live OpenAPI exposes governance preflight POST',
+  );
+}
+
+function parseCase(envName) {
+  const raw = process.env[envName];
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    fail(`${envName} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+async function callGovernanceCase(baseUrl, apiKey, id, args) {
+  const url = `${baseUrl.replace(/\/$/, '')}/api/mcp/governance`;
+  return fetchJson(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-dsg-api-key': apiKey,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method: 'tools/call',
+      params: { name: 'dsg.governance.preflight', arguments: args },
+    }),
+  });
+}
+
+async function verifyAuthenticatedAllowBlock(baseUrl) {
+  const apiKey = process.env.DSG_MARKETPLACE_MCP_API_KEY;
+  const allowCase = parseCase('DSG_MARKETPLACE_ALLOW_CASE_JSON');
+  const blockCase = parseCase('DSG_MARKETPLACE_BLOCK_CASE_JSON');
+
+  if (!apiKey || !allowCase || !blockCase) {
+    console.log('\nSKIP  Authenticated ALLOW/BLOCK E2E: provide DSG_MARKETPLACE_MCP_API_KEY, DSG_MARKETPLACE_ALLOW_CASE_JSON and DSG_MARKETPLACE_BLOCK_CASE_JSON');
+    return;
+  }
+
+  console.log('\nAWS Marketplace MCP package — authenticated ALLOW/BLOCK verification');
+
+  const allowed = await callGovernanceCase(baseUrl, apiKey, 'aws-marketplace-allow', allowCase);
+  const allowedResult = allowed.body?.result?.structuredContent;
+  check(allowed.response.ok, 'Approved-plan E2E call returns HTTP success');
+  check(allowedResult?.policyAllowsAction === true, 'Approved-plan E2E is policy-authorized');
+  check(allowedResult?.shouldBlock === false, 'Approved-plan E2E is allowed to continue');
+  check(allowedResult?.panels?.executionAudit?.persisted === true, 'Approved-plan E2E persists audit evidence');
+
+  const blocked = await callGovernanceCase(baseUrl, apiKey, 'aws-marketplace-block', blockCase);
+  const blockedResult = blocked.body?.result?.structuredContent;
+  check(blocked.response.ok, 'Outside-plan E2E call returns MCP tool response');
+  check(blockedResult?.status === 'BLOCKED', 'Outside-plan E2E returns BLOCKED');
+  check(blockedResult?.shouldBlock === true, 'Outside-plan E2E emits an enforce-mode block');
+  check(blockedResult?.panels?.executionAudit?.persisted === true, 'Outside-plan E2E persists audit evidence');
+}
+
+const liveBase = process.env.AWS_MARKETPLACE_MCP_BASE_URL;
+if (liveBase) {
+  try {
+    await verifyLive(liveBase);
+    await verifyAuthenticatedAllowBlock(liveBase);
+  } catch (error) {
+    fail(`Live verification failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+} else {
+  console.log('\nSKIP  Live discovery: set AWS_MARKETPLACE_MCP_BASE_URL to the exact production origin');
+  console.log('SKIP  Authenticated ALLOW/BLOCK E2E until live origin + real API key + real plan fixtures are supplied');
+}
+
+if (failures > 0) {
+  console.error(`\nAWS_MARKETPLACE_MCP_PACKAGE=FAIL failures=${failures}`);
+  process.exit(1);
+}
+
+console.log('\nAWS_MARKETPLACE_MCP_PACKAGE=STATIC_PASS_LIVE_AND_COMMERCIAL_VALIDATION_PENDING');

--- a/scripts/verify-aws-marketplace-mcp-package.mjs
+++ b/scripts/verify-aws-marketplace-mcp-package.mjs
@@ -79,6 +79,15 @@ check(contains(mcpRoute, "rpc.method === 'tools/list'"), 'Dedicated MCP implemen
 check(contains(mcpRoute, "rpc.method === 'tools/call'"), 'Dedicated MCP implements tools/call');
 check(contains(mcpRoute, 'validateStoredUnifiedMcpKey'), 'Dedicated MCP validates stored DSG MCP API keys');
 check(contains(mcpRoute, "transport: 'MCP JSON-RPC over HTTP'"), 'Dedicated endpoint declares MCP JSON-RPC over HTTP');
+check(
+  contains(mcpRoute, "protocolVersion: '2024-11-05'") &&
+    packageContract.mcpCompatibility?.currentInitializeProtocolVersion === '2024-11-05',
+  'Package records the exact MCP initialize protocol version implemented by the route',
+);
+check(
+  packageContract.mcpCompatibility?.awsMarketplaceClientCompatibility === 'PENDING_REAL_CLIENT_VALIDATION',
+  'AWS Marketplace client compatibility remains explicitly pending real-client validation',
+);
 
 check(contains(openApiRoute, "openapi: '3.1.0'"), 'Governance OpenAPI surface is present');
 check(contains(openApiRoute, "'/api/dsg/governance/preflight'"), 'OpenAPI exposes governance preflight');
@@ -92,6 +101,18 @@ check(contains(governancePlugin, "status = 'PASS'"), 'Governance runtime has an 
 check(contains(governancePlugin, ".from('dsg_audit_events').insert"), 'Governance runtime persists execution audit records');
 check(contains(governancePlugin, "'DO_NOT_EXECUTE'"), 'Blocked decisions emit DO_NOT_EXECUTE');
 check(contains(governancePlugin, "'CONTINUE_TO_TARGET'"), 'Plan-authorized decisions can emit CONTINUE_TO_TARGET');
+
+check(
+  packageContract.fulfillment?.selectedMethodForFirstProduct === 'REDIRECT_TO_WEBSITE' &&
+    packageContract.fulfillment?.selectionStatus === 'RECOMMENDED_NOT_PUBLISHED',
+  'First-product fulfillment choice is Redirect to Website and is not falsely claimed published',
+);
+check(
+  packageContract.fulfillment?.postPublishMutable === false &&
+    packageContract.fulfillment?.quickLaunchStatus === 'NOT_SELECTED_FOR_THIS_PRODUCT' &&
+    packageContract.fulfillment?.deploymentApiStatus === 'NOT_REQUIRED_FOR_REDIRECT_TO_WEBSITE',
+  'Fulfillment contract prevents the false claim that Quick Launch can be enabled later on the same published product',
+);
 
 check(
   packageContract.marketplaceCommercialIntegration?.sellerEligibility === 'UNVERIFIED_EXTERNAL_ACCOUNT_STATE',
@@ -108,8 +129,10 @@ check(
 check(
   packageContract.truthBoundary?.staticPackagePassIsMarketplaceEligibility === false &&
     packageContract.truthBoundary?.staticPackagePassIsLiveEndpointProof === false &&
+    packageContract.truthBoundary?.declaredLiveBlockIsLiveEndpointPass === false &&
+    packageContract.truthBoundary?.mcpDiscoveryPassIsAwsClientCompatibilityProof === false &&
     packageContract.truthBoundary?.privateOfferReady === false,
-  'Truth boundary prevents static packaging from being reported as Marketplace/private-offer readiness',
+  'Truth boundary prevents static/live-state packaging from being reported as Marketplace, client-compatibility, or private-offer readiness',
 );
 
 async function fetchJson(url, options = {}) {
@@ -154,6 +177,10 @@ async function verifyLive(baseUrl) {
   check(
     initialize.body?.result?.serverInfo?.name === 'dsg-governance-plugin',
     'Live MCP initialize returns expected server identity',
+  );
+  check(
+    initialize.body?.result?.protocolVersion === packageContract.mcpCompatibility?.currentInitializeProtocolVersion,
+    'Live MCP initialize protocol version matches the package contract',
   );
 
   const toolList = await fetchJson(mcpUrl, {


### PR DESCRIPTION
## SUPERSEDED — do not merge

This PR targeted the wrong product surface for the AWS Marketplace workstream.

The canonical commercial product is **DSG Spacetime HTTP MCP** in the private production repository `tdealer01-crypto/DSG-Private-Production-Runtime`, with the existing `/mcp` Streamable HTTP runtime, MCP protocol `2025-06-18`, four Spacetime tools, signed Route entitlements, source-free packaging, evidence chain, and existing generic enterprise marketplace fulfillment core.

Replacement work is in private production PR **#138**:
`feat: package existing DSG Spacetime HTTP MCP for AWS Marketplace`.

The control-plane `/api/mcp/governance` work in this PR remains historical analysis/evidence only and must not be merged as the DSG Spacetime Marketplace product.

No claim is made that the replacement PR is commercially live; external AWS seller, buyer registration, entitlement, listing, billing and live buyer E2E gates remain fail closed.