### PR TITLE
fix(sdk): release existing dsg-one-sdk package as 0.1.1

### DIFF
--- a/docs/one-pager-dev-team.md
+++ b/docs/one-pager-dev-team.md
@@ -4,7 +4,7 @@
 ---
 
 ## Hook
-> "Your AI agent (Claude Code, OpenHands, Aider, Cursor) writes code, runs commands, calls APIs — *before you see it*. DSG ONE puts a deterministic gate in front of every action. `npm i @dsg-one/sdk` → governed execution in 10 lines."
+> "Your AI agent (Claude Code, OpenHands, Aider, Cursor) writes code, runs commands, calls APIs — *before you see it*. DSG ONE puts a deterministic gate in front of every action. `npm i dsg-one-sdk` → governed execution in 10 lines."
 
 ---
 
@@ -19,10 +19,10 @@
 ## Solution (SDK-First, Verified)
 ```typescript
 // 1. Install
-npm i @dsg-one/sdk
+npm i dsg-one-sdk
 
 // 2. Initialize (one line with your key)
-import { DsgOneClient } from "@dsg-one/sdk";
+import { DsgOneClient } from "dsg-one-sdk";
 const dsg = new DsgOneClient({ apiKey: "dsg_live_..." });
 
 // 3. Wrap every agent action
@@ -79,7 +79,7 @@ console.log(result.audit_id, result.proof.proof_hash);
 ## SDK Status (Verified)
 | Component | Status |
 |-----------|--------|
-| `@dsg-one/sdk` package | **Built, type-checked, ready for `npm publish`** |
+| `dsg-one-sdk` package | **Published on npm; repository prepared for 0.1.1** |
 | TypeScript definitions | Full types for all requests/responses |
 | Error handling | `DsgOneError` with typed codes (RATE_LIMITED, UNAUTHENTICATED, etc.) |
 | Auth | Bearer `dsg_live_...` + SHA256 key hash |
@@ -110,7 +110,7 @@ console.log(result.audit_id, result.proof.proof_hash);
 ## Setup Time
 | Step | Time |
 |------|------|
-| `npm i @dsg-one/sdk` | 30 sec |
+| `npm i dsg-one-sdk` | 30 sec |
 | Create agent (`dsg.createAgent()`) | 10 sec |
 | First execute() call | 5 min |
 | See Decision Explainer in dashboard | Instant |
@@ -127,14 +127,14 @@ console.log(result.audit_id, result.proof.proof_hash);
 ---
 
 ## CTA
-> `npm i @dsg-one/sdk` → create agent → wrap one action → see gate decision in dashboard → **you're governed**
+> `npm i dsg-one-sdk` → create agent → wrap one action → see gate decision in dashboard → **you're governed**
 
 ---
 
 ## Truth Boundary
 | ✅ Verified | ⏳ Pending |
 |-------------|-----------|
-| SDK builds, types work | **Ready to publish** (npm credentials required; no live npm registry entry yet) |
+| `dsg-one-sdk@0.1.0` exists on npm; repository is prepared for `0.1.1` | Trusted Publisher must be attached to the existing npm package before tokenless CI publishing |
 | Gate returns decision + proof | Metered billing wired into execution; Stripe meter env not yet configured |
 | 2173 tests pass | GitHub App not yet live |
 | Edge gate <50ms latency | PyPI package not built |
@@ -152,4 +152,4 @@ console.log(result.audit_id, result.proof.proof_hash);
 ---
 
 ## Next Step
-**Watch for `@dsg-one/sdk` on npm** (publishing this week) → `npm i @dsg-one/sdk` → governed in 10 min.
+**Install `dsg-one-sdk` from npm** → create agent → wrap one action → governed in 10 min.

--- a/packages/dsg-one-sdk/PUBLISHING.md
+++ b/packages/dsg-one-sdk/PUBLISHING.md
@@ -1,6 +1,17 @@
-# Publishing @dsg-one/sdk to npm
+# Publishing dsg-one-sdk to npm
 
 This guide defines the canonical release path for the DSG ONE SDK.
+
+## Package identity
+
+The production npm package is the existing unscoped package:
+
+- Package: `dsg-one-sdk`
+- Current published baseline: `0.1.0`
+- Repository package path: `packages/dsg-one-sdk`
+- Next repository version: `0.1.1`
+
+Do not use the unavailable `@dsg-one/sdk` scope. The `dsg-one` npm organization name is not available to this account, while `dsg-one-sdk` is already owned by the npm maintainer account used for DSG releases.
 
 ## Canonical release path
 
@@ -15,11 +26,9 @@ Production npm releases use **GitHub Actions + npm Trusted Publishing (OIDC)** t
 
 Do not recreate expired write tokens such as `tar` or `dsg` for this CI publish path.
 
-## One-time npm configuration
+## One-time npm Trusted Publisher configuration
 
-Trusted Publishing is configured on npmjs.com for the package, not in GitHub Secrets.
-
-Open the package settings and add a GitHub Actions trusted publisher with these exact values:
+Because `dsg-one-sdk` already exists on npm, no first-publish bootstrap is required. Open the **dsg-one-sdk** package settings on npmjs.com and add a GitHub Actions trusted publisher with these exact values:
 
 | Field | Value |
 |---|---|
@@ -30,26 +39,6 @@ Open the package settings and add a GitHub Actions trusted publisher with these 
 | Environment | Leave empty unless a matching GitHub environment is deliberately added |
 
 The workflow filename is case-sensitive and npm expects only the filename, not `.github/workflows/`.
-
-### First publish bootstrap
-
-npm requires a package to already exist on the registry before a Trusted Publisher can be attached to it.
-
-If `@dsg-one/sdk` has never been published, perform exactly one authenticated maintainer publish first:
-
-```bash
-cd packages/dsg-one-sdk
-npm install --package-lock=false
-npm test
-npm run build
-npm pack --dry-run
-npm login
-npm publish --access public
-```
-
-Complete the interactive 2FA challenge when npm requests it. After the package exists, configure the Trusted Publisher above and use GitHub Actions for subsequent releases.
-
-Do not create a new long-lived CI write token merely to bootstrap Trusted Publishing.
 
 ## Release checks
 
@@ -104,9 +93,9 @@ No `NPM_TOKEN` or `NODE_AUTH_TOKEN` is supplied to the publish step.
 After the workflow succeeds:
 
 ```bash
-npm view @dsg-one/sdk version
-npm view @dsg-one/sdk dist-tags
-npm install @dsg-one/sdk
+npm view dsg-one-sdk version
+npm view dsg-one-sdk dist-tags
+npm install dsg-one-sdk
 ```
 
 For releases made through Trusted Publishing from this public GitHub repository, npm generates provenance automatically.
@@ -119,21 +108,21 @@ The SDK currently declares no runtime dependencies and does not require a privat
 
 ## Manual Termux fallback
 
-`npm-publish-termux.sh` is retained only for first-publish bootstrap or emergency manual releases. It uses interactive npm authentication and does not provision a CI write token.
+`npm-publish-termux.sh` is retained only for emergency manual releases. It uses `npm login --auth-type=web`, keeps the test/build/pack/version guards, and does not provision a CI write token or pass a custom `--otp` value.
 
-`npm-token-fix-termux.sh` is deprecated as a token-creation helper. It now explains the OIDC migration instead of attempting `npm token create`.
+`npm-token-fix-termux.sh` is deprecated as a token-creation helper. It explains the OIDC migration instead of attempting `npm token create`.
 
 ## Failure guide
 
 | Failure | Meaning / action |
 |---|---|
-| `ENEEDAUTH` / unable to authenticate | Confirm the npm Trusted Publisher fields exactly match this repository and `publish-dsg-one-sdk.yml` |
-| OIDC error | Confirm workflow has `id-token: write` and runs on GitHub-hosted runner |
-| Package does not exist when configuring trust | Complete the one-time first publish bootstrap, then configure Trusted Publishing |
+| `ENEEDAUTH` / unable to authenticate | Confirm the npm Trusted Publisher fields exactly match `dsg-one-sdk`, this repository, and `publish-dsg-one-sdk.yml` |
+| OIDC error | Confirm workflow has `id-token: write` and runs on a GitHub-hosted runner |
 | Version already exists | Bump `package.json` version; npm versions are immutable |
 | Tag/version mismatch | Use `dsg-one-sdk-vX.Y.Z` matching `package.json` exactly |
 | Build/test failure | Fix the failing SDK code/test; publishing remains blocked |
 | Private dependency install fails | Add a read-only `NPM_READ_TOKEN` only for the install step if genuinely required |
+| `404 Scope not found` for `@dsg-one/sdk` | Wrong package identity; use the existing unscoped `dsg-one-sdk` package |
 
 ## References
 

--- a/packages/dsg-one-sdk/README.md
+++ b/packages/dsg-one-sdk/README.md
@@ -7,11 +7,11 @@ TypeScript client for the **DSG ONE** (Deterministic Security Gateway) governed 
 ## Installation
 
 ```bash
-npm install @dsg-one/sdk
+npm install dsg-one-sdk
 # or
-yarn add @dsg-one/sdk
+yarn add dsg-one-sdk
 # or
-pnpm add @dsg-one/sdk
+pnpm add dsg-one-sdk
 ```
 
 Requires Node.js 18+
@@ -19,7 +19,7 @@ Requires Node.js 18+
 ## Quick Start
 
 ```typescript
-import { DsgOneClient } from "@dsg-one/sdk";
+import { DsgOneClient } from "dsg-one-sdk";
 
 // Initialize with your API key (format: dsg_live_...)
 const client = new DsgOneClient({ 

--- a/packages/dsg-one-sdk/npm-token-fix-termux.sh
+++ b/packages/dsg-one-sdk/npm-token-fix-termux.sh
@@ -7,12 +7,13 @@ cat <<'EOF'
 Canonical release path:
   GitHub Actions -> npm Trusted Publishing (OIDC)
   Workflow: .github/workflows/publish-dsg-one-sdk.yml
+  Package: dsg-one-sdk
 
 Do NOT recreate expired read-write CI tokens such as "tar" or "dsg" for publishing.
 The publish workflow uses short-lived OIDC credentials and does not require NPM_TOKEN.
 
-If @dsg-one/sdk has never been published, use the one-time interactive bootstrap in:
-  packages/dsg-one-sdk/PUBLISHING.md
+The existing npm package is dsg-one-sdk. Do not use the unavailable @dsg-one/sdk scope.
+Configure Trusted Publishing on the existing dsg-one-sdk package, then release through GitHub Actions.
 
 If a future workflow must install private npm dependencies, create a READ-ONLY granular
 access token on npmjs.com and scope it only to those dependencies. Do not use it to publish.

--- a/packages/dsg-one-sdk/package.json
+++ b/packages/dsg-one-sdk/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@dsg-one/sdk",
-  "version": "0.1.0",
+  "name": "dsg-one-sdk",
+  "version": "0.1.1",
   "description": "DSG ONE SDK - TypeScript client for the Deterministic Security Gateway governed execution API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why
The attempted `@dsg-one/sdk@0.1.0` publish failed with npm `404 Scope not found` because the `dsg-one` scope is unavailable to the current npm account. The existing npm package `dsg-one-sdk@0.1.0` is already owned by the maintainer account and is the correct production package identity.

## Changes
- change `package.json` from `@dsg-one/sdk@0.1.0` to `dsg-one-sdk@0.1.1`
- update SDK install/import examples to `dsg-one-sdk`
- update publishing guide to configure Trusted Publishing on the existing package instead of bootstrapping a new scope
- update deprecated token helper guidance
- update developer one-pager package identity and current publication status

## Release path
The existing `.github/workflows/publish-dsg-one-sdk.yml` already reads package name/version dynamically from `package.json`, uses Node 24 + npm 11, runs test/build/pack/duplicate-version gates, and publishes with OIDC without `NPM_TOKEN`.

## Truth boundary
The framework integration page still contains `@dsg-one/sdk` examples that also use a `DSGGate` API not exported by the current SDK. Those examples are intentionally not renamed in this PR because changing only the package string would preserve a non-working example. They require a separate API-parity fix.

No npm publish is triggered by this PR itself.