### PR TITLE
fix(sdk): isolate release tests from monorepo vitest config

### DIFF
--- a/packages/dsg-one-sdk/package.json
+++ b/packages/dsg-one-sdk/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "build:dev": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --config vitest.config.ts",
     "prepublishOnly": "npm run build",
     "publish:dry": "npm publish --dry-run"
   },

--- a/packages/dsg-one-sdk/vitest.config.ts
+++ b/packages/dsg-one-sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Failure evidence
Release workflow run `33977367003` failed at `Test SDK` with `Cannot find module 'vitest/config'`. The job installs dependencies only in `packages/dsg-one-sdk`, but Vitest walked up to the repository-level `vitest.config.ts`, whose `vitest/config` import resolves from the root where dependencies are not installed.

## Fix
- add `packages/dsg-one-sdk/vitest.config.ts`
- pin the SDK test script to `vitest run --config vitest.config.ts`
- keep the release job package-local; do not install the entire monorepo dependency graph

This preserves the fail-closed test gate and fixes the actual dependency/config boundary rather than bypassing tests.

No npm publish is triggered by this PR itself.