### PR TITLE
fix(sdk): isolate tests from root PostCSS config

### DIFF
--- a/packages/dsg-one-sdk/vitest.config.ts
+++ b/packages/dsg-one-sdk/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
## Failure evidence
Release run `33977656454` reached the package-local Vitest config, then failed because Vite searched upward and loaded the repository root `postcss.config.js`, which requires `tailwindcss`. The SDK release job intentionally installs only SDK dependencies, so root Tailwind is unavailable.

## Fix
Configure package-local Vite/Vitest CSS PostCSS settings with an empty plugin list so the SDK test runner does not search/load the monorepo root PostCSS config.

This keeps the SDK release job package-local and preserves the test gate; no tests are bypassed.

No npm publish is triggered by this PR itself.