### PR TITLE
fix(supabase): tolerate legacy UUID policy ids in preview replay

### DIFF
--- a/supabase/migrations/20260323053000_product_loop_scaffold.sql
+++ b/supabase/migrations/20260323053000_product_loop_scaffold.sql
@@ -95,22 +95,45 @@ create index if not exists idx_audit_logs_org_created_at on public.audit_logs(or
 create index if not exists idx_usage_events_agent_created_at on public.usage_events(agent_id, created_at desc);
 create index if not exists idx_usage_counters_agent_period on public.usage_counters(agent_id, billing_period);
 
-insert into public.policies (id, name, version, status, description, config)
-values (
-  'policy_default',
-  'Default DSG Policy',
-  'v1',
-  'active',
-  'Baseline deterministic policy for scaffold execution routes.',
-  jsonb_build_object(
-    'block_risk_score', 0.8,
-    'stabilize_risk_score', 0.4
-  )
-)
-on conflict (id) do update set
-  name = excluded.name,
-  version = excluded.version,
-  status = excluded.status,
-  description = excluded.description,
-  config = excluded.config,
-  updated_at = now();
+-- Legacy preview databases can already contain public.policies with a UUID id
+-- column. CREATE TABLE IF NOT EXISTS preserves that old shape, so inserting the
+-- canonical text id `policy_default` would fail before the later full-schema
+-- sync can rebuild the table. Seed only when the existing id column is
+-- text-compatible; the canonical full-schema migration performs the seed after
+-- recreating public.policies with id text.
+do $$
+declare
+  v_id_type text;
+begin
+  select format_type(a.atttypid, a.atttypmod)
+    into v_id_type
+  from pg_attribute a
+  where a.attrelid = 'public.policies'::regclass
+    and a.attname = 'id'
+    and a.attnum > 0
+    and not a.attisdropped;
+
+  if v_id_type in ('text', 'character varying') then
+    insert into public.policies (id, name, version, status, description, config)
+    values (
+      'policy_default',
+      'Default DSG Policy',
+      'v1',
+      'active',
+      'Baseline deterministic policy for scaffold execution routes.',
+      jsonb_build_object(
+        'block_risk_score', 0.8,
+        'stabilize_risk_score', 0.4
+      )
+    )
+    on conflict (id) do update set
+      name = excluded.name,
+      version = excluded.version,
+      status = excluded.status,
+      description = excluded.description,
+      config = excluded.config,
+      updated_at = now();
+  else
+    raise notice 'Skipping policy_default seed because public.policies.id type is %, expected text-compatible legacy shape', v_id_type;
+  end if;
+end $$;

--- a/supabase/migrations/20260401_schema_policies_table.sql
+++ b/supabase/migrations/20260401_schema_policies_table.sql
@@ -31,14 +31,36 @@ begin
   end if;
 end $$;
 
--- Seed default policy if not present
-insert into public.policies (id, name, version, status, description, config)
-values (
-  'policy_default',
-  'Default DSG Policy',
-  'v1',
-  'active',
-  'Baseline deterministic policy for scaffold execution routes.',
-  jsonb_build_object('block_risk_score', 0.8, 'stabilize_risk_score', 0.4)
-)
-on conflict (id) do nothing;
+-- A legacy preview database can already contain public.policies with a UUID
+-- primary key. CREATE TABLE IF NOT EXISTS preserves that old column type, so
+-- inserting the canonical text id `policy_default` would fail before the later
+-- full-schema sync recreates public.policies with id text. Seed only when the
+-- existing id column is text-compatible. The canonical full-schema migration
+-- performs the baseline seed after rebuilding the table.
+do $$
+declare
+  v_id_type text;
+begin
+  select format_type(a.atttypid, a.atttypmod)
+    into v_id_type
+  from pg_attribute a
+  where a.attrelid = 'public.policies'::regclass
+    and a.attname = 'id'
+    and a.attnum > 0
+    and not a.attisdropped;
+
+  if v_id_type in ('text', 'character varying') then
+    insert into public.policies (id, name, version, status, description, config)
+    values (
+      'policy_default',
+      'Default DSG Policy',
+      'v1',
+      'active',
+      'Baseline deterministic policy for scaffold execution routes.',
+      jsonb_build_object('block_risk_score', 0.8, 'stabilize_risk_score', 0.4)
+    )
+    on conflict (id) do nothing;
+  else
+    raise notice 'Skipping policy_default seed because public.policies.id type is %, expected text-compatible legacy shape', v_id_type;
+  end if;
+end $$;


### PR DESCRIPTION
## Problem
Legacy Supabase preview databases can already contain `public.policies.id` as UUID. Two early idempotent migrations use `CREATE TABLE IF NOT EXISTS`, so they preserve that legacy column type and then unconditionally seed the text identifier `policy_default`, which can fail before the later full-schema sync rebuilds `public.policies` with canonical `id text`.

## Fix
- guard the `policy_default` seed in `20260323053000_product_loop_scaffold.sql`;
- guard the `policy_default` seed in `20260401_schema_policies_table.sql`;
- inspect the actual existing `public.policies.id` type;
- seed normally for `text` / `character varying`;
- skip the early seed with a NOTICE for incompatible legacy types such as UUID;
- leave the later `20260417000000_full_schema_sync.sql` unchanged; it drops/recreates `public.policies` with `id text` and performs the canonical seed.

## Boundary
This is migration replay compatibility only. It does not change landing content, production governance behavior, Stripe, Marketplace, Azure Spacetime, or GitHub Actions quota controls.

## Verification
Use Supabase Preview if provider branching is available. If provider preview is disabled/skipped, do not promote this change to VERIFIED from static inspection alone. GitHub Actions hard-stop must remain enabled.