### PR TITLE
fix(supabase): make RLS org comparisons UUID-text compatible

### DIFF
--- a/supabase/migrations/20260323141000_rls_policy_hardening.sql
+++ b/supabase/migrations/20260323141000_rls_policy_hardening.sql
@@ -17,7 +17,7 @@ stable
 security definer
 set search_path = public
 as $$
-  select u.org_id
+  select u.org_id::text
   from public.users u
   where u.auth_user_id = auth.uid()
     and u.is_active = true
@@ -90,6 +90,9 @@ create policy policies_select_active_user
   to authenticated
   using (public.current_user_is_active());
 
+-- Keep the helper return type stable as text while supporting legacy schemas
+-- where org_id is UUID. Casting the row identity to text makes the policy
+-- comparison type-stable for both UUID and text-backed installations.
 drop policy if exists agents_select_same_org on public.agents;
 drop policy if exists agents_select_active_user_same_org on public.agents;
 create policy agents_select_active_user_same_org
@@ -98,7 +101,7 @@ create policy agents_select_active_user_same_org
   to authenticated
   using (
     public.current_user_is_active()
-    and org_id = public.current_user_org_id()
+    and org_id::text = public.current_user_org_id()
   );
 
 drop policy if exists executions_select_same_org on public.executions;
@@ -109,7 +112,7 @@ create policy executions_select_active_user_same_org
   to authenticated
   using (
     public.current_user_is_active()
-    and org_id = public.current_user_org_id()
+    and org_id::text = public.current_user_org_id()
   );
 
 drop policy if exists audit_logs_select_same_org on public.audit_logs;
@@ -120,7 +123,7 @@ create policy audit_logs_select_active_user_same_org
   to authenticated
   using (
     public.current_user_is_active()
-    and org_id = public.current_user_org_id()
+    and org_id::text = public.current_user_org_id()
   );
 
 drop policy if exists usage_events_select_same_org on public.usage_events;
@@ -131,7 +134,7 @@ create policy usage_events_select_active_user_same_org
   to authenticated
   using (
     public.current_user_is_active()
-    and org_id = public.current_user_org_id()
+    and org_id::text = public.current_user_org_id()
   );
 
 drop policy if exists usage_counters_select_same_org on public.usage_counters;
@@ -142,5 +145,5 @@ create policy usage_counters_select_active_user_same_org
   to authenticated
   using (
     public.current_user_is_active()
-    and org_id = public.current_user_org_id()
+    and org_id::text = public.current_user_org_id()
   );


### PR DESCRIPTION
## Provider failure
Supabase migration replay on main commit `024a251d7d12b0643acaf1426be4e722321953a1` failed in `20260323141000_rls_policy_hardening.sql` with `operator does not exist: uuid = text` when policies compared legacy UUID `org_id` columns to `current_user_org_id()` (text).

## Fix
- make `current_user_org_id()` explicitly return `u.org_id::text`;
- compare row identities as `org_id::text = current_user_org_id()` in all affected RLS policies.

This keeps the helper contract stable as text while supporting both UUID-backed legacy schemas and text-backed fresh scaffold schemas.

## Verification
The full modified RLS migration was executed against the current Supabase provider schema inside `BEGIN ... ROLLBACK` and completed successfully with no persistent mutation.

## Boundary
Migration replay compatibility only. No production data/schema commit from the probe; no landing/runtime/Stripe/Marketplace/Azure changes; Actions hard-stop remains enabled.