### PR TITLE
fix: migrate AWS Agent Registry namespace

### DIFF
--- a/docs/AWS_AGENT_REGISTRY_MIGRATION_20260909.md
+++ b/docs/AWS_AGENT_REGISTRY_MIGRATION_20260909.md
@@ -1,0 +1,62 @@
+# AWS Agent Registry namespace migration — 2026-09-09
+
+## Scope
+
+AWS Agent Registry is migrating from the public-preview `bedrock-agentcore` namespace to the dedicated `agent-registry` namespace before the 2026-09-17 shutdown of the old Registry namespace.
+
+This migration applies only to AWS Agent Registry. Other Amazon Bedrock AgentCore services remain on the AgentCore namespace unless AWS documentation explicitly says otherwise.
+
+## Verified account and region
+
+- Region: `us-east-1`
+- Source namespace: `bedrock-agentcore`
+- Source registry ID: `cGcvetJOMzWh3xmj`
+- Source registry name: `registry_zksrh`
+- Source status at migration: `READY`
+- Source record count: `0`
+
+## Destination
+
+- Namespace: `agent-registry`
+- Registry ID: `Bq1kJxIL0SrRPIpe`
+- Registry name: `dsg-agent-registry-dev`
+- Registry ARN namespace: `arn:aws:agent-registry:...`
+- Status after creation: `READY`
+- Destination record count: `0`
+
+The destination preserves the source discovery authorization semantics:
+
+- authorizer type: `CUSTOM_JWT`
+- existing Cognito discovery configuration retained
+- source `autoApproval=true` transformed to `autoApprovalRules=["APPROVE_ALL"]`
+
+No registry records required schema transformation because the source registry contained zero records.
+
+## CloudFormation and IAM migration
+
+`BedrockAgentCoreStack-dev` was updated through an inspected CloudFormation change set.
+
+Verified post-update state:
+
+- stack status: `UPDATE_COMPLETE`
+- `RegistryId-dev` export points to `Bq1kJxIL0SrRPIpe`
+- IAM role trust permits both `bedrock-agentcore.amazonaws.com` and `agent-registry.amazonaws.com` during cutover
+- new `agent-registry:*` record/discovery permissions are present
+- existing AgentCore permissions are retained for non-Registry AgentCore services
+- CloudWatch log permissions include both `/aws/bedrock/agentcore/*` and `/aws/agent-registry/*`
+
+The old registry is intentionally retained during the migration window. Do not delete it until all client/config/IaC references use the new namespace and a final verification pass succeeds.
+
+## Source-of-truth code update
+
+CDK source must prefer `AGENT_REGISTRY_ID`, retain `BEDROCK_REGISTRY_ID` only as a temporary compatibility alias, and default to the migrated registry ID above. Future CDK deployments must preserve the dual-principal cutover policy until the old namespace is retired.
+
+## Final cutover gate
+
+Before removing old namespace compatibility:
+
+1. Confirm the new registry remains `READY`.
+2. Confirm source and destination record counts still match.
+3. Confirm all Registry SDK/CLI/IAM/EventBridge/CloudWatch references use `agent-registry` where applicable.
+4. Confirm no application depends on the old Registry ARN or endpoint.
+5. Remove only Registry-specific old permissions/trust after the cutover; do not remove AgentCore permissions required by Runtime, Gateway, Identity, or other AgentCore services.

--- a/infra/cdk/bin/dsg-one.ts
+++ b/infra/cdk/bin/dsg-one.ts
@@ -23,8 +23,11 @@ new DSGOneStack(app, `DSGOneStack-${environment}`, {
   config,
 });
 
-// Create Bedrock Agent Core stack (for MCP registry + AI governance)
-const registryId = process.env.BEDROCK_REGISTRY_ID || 'cGcvetJOMzWh3xmj';
+// Create Bedrock Agent Core stack (AgentCore + AWS Agent Registry governance)
+const registryId =
+  process.env.AGENT_REGISTRY_ID ||
+  process.env.BEDROCK_REGISTRY_ID ||
+  'Bq1kJxIL0SrRPIpe';
 const cognitoUserPoolId = process.env.COGNITO_USER_POOL_ID || 'us-east-1_ZtxWdHzFJ';
 const cognitoClientId = process.env.COGNITO_CLIENT_ID || '7njqeoh6bq64s6u44oo9vghfcg';
 

--- a/infra/cdk/lib/config/dev.ts
+++ b/infra/cdk/lib/config/dev.ts
@@ -77,7 +77,10 @@ export const devConfig: DSGConfig = {
 
   bedrock: {
     enableAgentCore: true,
-    registryId: process.env.BEDROCK_REGISTRY_ID || 'cGcvetJOMzWh3xmj',
+    registryId:
+      process.env.AGENT_REGISTRY_ID ||
+      process.env.BEDROCK_REGISTRY_ID ||
+      'Bq1kJxIL0SrRPIpe',
     cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID || 'us-east-1_ZtxWdHzFJ',
     cognitoClientId: process.env.COGNITO_CLIENT_ID || '7njqeoh6bq64s6u44oo9vghfcg',
     mcpServers: [

--- a/infra/cdk/lib/config/prod.ts
+++ b/infra/cdk/lib/config/prod.ts
@@ -79,7 +79,10 @@ export const prodConfig: DSGConfig = {
 
   bedrock: {
     enableAgentCore: true,
-    registryId: process.env.BEDROCK_REGISTRY_ID || 'cGcvetJOMzWh3xmj',
+    registryId:
+      process.env.AGENT_REGISTRY_ID ||
+      process.env.BEDROCK_REGISTRY_ID ||
+      'Bq1kJxIL0SrRPIpe',
     cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID || 'us-east-1_ZtxWdHzFJ',
     cognitoClientId: process.env.COGNITO_CLIENT_ID || '7njqeoh6bq64s6u44oo9vghfcg',
     mcpServers: [

--- a/infra/cdk/lib/config/staging.ts
+++ b/infra/cdk/lib/config/staging.ts
@@ -77,7 +77,10 @@ export const stagingConfig: DSGConfig = {
 
   bedrock: {
     enableAgentCore: true,
-    registryId: process.env.BEDROCK_REGISTRY_ID || 'cGcvetJOMzWh3xmj',
+    registryId:
+      process.env.AGENT_REGISTRY_ID ||
+      process.env.BEDROCK_REGISTRY_ID ||
+      'Bq1kJxIL0SrRPIpe',
     cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID || 'us-east-1_ZtxWdHzFJ',
     cognitoClientId: process.env.COGNITO_CLIENT_ID || '7njqeoh6bq64s6u44oo9vghfcg',
     mcpServers: [

--- a/infra/cdk/lib/stacks/bedrock-agentcore-stack.ts
+++ b/infra/cdk/lib/stacks/bedrock-agentcore-stack.ts
@@ -20,14 +20,17 @@ export class BedrockAgentCoreStack extends cdk.Stack {
 
     const { environment, registryId, cognitoUserPoolId, cognitoClientId } = props;
 
-    // ✅ Step 1: IAM Role for Bedrock Agent Core
+    // Keep AgentCore compatibility while Agent Registry moves to its dedicated namespace.
     const bedrockRole = new iam.Role(this, 'BedrockAgentCoreRole', {
-      assumedBy: new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),
-      description: 'Role for Bedrock Agent Core MCP Registry and AI operations',
+      assumedBy: new iam.CompositePrincipal(
+        new iam.ServicePrincipal('bedrock-agentcore.amazonaws.com'),
+        new iam.ServicePrincipal('agent-registry.amazonaws.com')
+      ),
+      description: 'Role for Bedrock Agent Core and AWS Agent Registry operations',
       roleName: `bedrock-agentcore-${environment}`,
     });
 
-    // ✅ Bedrock Permissions
+    // Existing AgentCore / preview Registry permissions retained during the migration window.
     bedrockRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -45,7 +48,27 @@ export class BedrockAgentCoreStack extends cdk.Stack {
       })
     );
 
-    // ✅ Cognito Permissions
+    // AWS Agent Registry permissions in the new agent-registry namespace.
+    bedrockRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'agent-registry:CreateRegistryRecord',
+          'agent-registry:GetRegistryRecord',
+          'agent-registry:UpdateRegistryRecord',
+          'agent-registry:ListRegistryRecords',
+          'agent-registry:DeleteRegistryRecord',
+          'agent-registry:SubmitRegistryRecordForApproval',
+          'agent-registry:UpdateRegistryRecordStatus',
+          'agent-registry:SearchDiscoverableRegistryRecords',
+          'agent-registry:ListDiscoverableRegistryRecords',
+          'agent-registry:GetDiscoverableRegistryRecord',
+        ],
+        resources: [`arn:aws:agent-registry:${this.region}:${this.account}:*`],
+      })
+    );
+
+    // Cognito Permissions
     bedrockRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -59,7 +82,7 @@ export class BedrockAgentCoreStack extends cdk.Stack {
       })
     );
 
-    // ✅ CloudWatch Logs for Agent Execution Traces
+    // CloudWatch Logs for AgentCore and Agent Registry traces.
     bedrockRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
@@ -69,18 +92,21 @@ export class BedrockAgentCoreStack extends cdk.Stack {
           'logs:PutLogEvents',
           'logs:DescribeLogStreams',
         ],
-        resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/bedrock/agentcore/*`],
+        resources: [
+          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/bedrock/agentcore/*`,
+          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/agent-registry/*`,
+        ],
       })
     );
 
-    // ✅ Step 2: Cognito User Pool Reference
+    // Cognito User Pool Reference
     const cognitoUserPool = cognito.UserPool.fromUserPoolId(
       this,
       'CognitoUserPool',
       cognitoUserPoolId
     );
 
-    // ✅ Step 3: Outputs for GitHub Actions + Deployment
+    // Outputs for GitHub Actions + Deployment
     new cdk.CfnOutput(this, 'BedrockRoleArn', {
       value: bedrockRole.roleArn,
       description: 'ARN of Bedrock Agent Core IAM Role',
@@ -89,7 +115,7 @@ export class BedrockAgentCoreStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'RegistryId', {
       value: registryId,
-      description: 'Bedrock Agent Core Registry ID',
+      description: 'AWS Agent Registry ID (agent-registry namespace)',
       exportName: `RegistryId-${environment}`,
     });
 
@@ -105,7 +131,7 @@ export class BedrockAgentCoreStack extends cdk.Stack {
       exportName: `CognitoClientId-${environment}`,
     });
 
-    // ✅ Store for access in other stacks
+    // Store for access in other stacks
     this.bedrockRoleArn = bedrockRole.roleArn;
     this.cognitoUserPoolArn = cognitoUserPool.userPoolArn;
     this.registryId = registryId;

--- a/scripts/setup-github-aws-secrets.sh
+++ b/scripts/setup-github-aws-secrets.sh
@@ -30,9 +30,10 @@ echo -e "${BLUE}AWS Account ID: $AWS_ACCOUNT_ID${NC}"
 AWS_REGION="${2:-us-east-1}"
 echo -e "${BLUE}AWS Region: $AWS_REGION${NC}"
 
-# Bedrock Configuration
-BEDROCK_REGISTRY_ID="${3:-cGcvetJOMzWh3xmj}"
-echo -e "${BLUE}Bedrock Registry ID: $BEDROCK_REGISTRY_ID${NC}"
+# AWS Agent Registry configuration. Keep the legacy secret alias during cutover.
+AGENT_REGISTRY_ID="${3:-Bq1kJxIL0SrRPIpe}"
+BEDROCK_REGISTRY_ID="$AGENT_REGISTRY_ID"
+echo -e "${BLUE}Agent Registry ID: $AGENT_REGISTRY_ID${NC}"
 
 # Cognito Configuration
 COGNITO_USER_POOL_ID="${4:-us-east-1_ZtxWdHzFJ}"
@@ -51,9 +52,12 @@ echo -e "${GREEN}✅ AWS_ACCOUNT_ID set${NC}"
 gh secret set AWS_REGION --body "$AWS_REGION" --repo "$REPO"
 echo -e "${GREEN}✅ AWS_REGION set${NC}"
 
-# Set Bedrock secrets
+# Set Agent Registry secrets
+gh secret set AGENT_REGISTRY_ID --body "$AGENT_REGISTRY_ID" --repo "$REPO"
+echo -e "${GREEN}✅ AGENT_REGISTRY_ID set${NC}"
+
 gh secret set BEDROCK_REGISTRY_ID --body "$BEDROCK_REGISTRY_ID" --repo "$REPO"
-echo -e "${GREEN}✅ BEDROCK_REGISTRY_ID set${NC}"
+echo -e "${GREEN}✅ BEDROCK_REGISTRY_ID legacy alias set${NC}"
 
 gh secret set COGNITO_USER_POOL_ID --body "$COGNITO_USER_POOL_ID" --repo "$REPO"
 echo -e "${GREEN}✅ COGNITO_USER_POOL_ID set${NC}"
@@ -64,7 +68,7 @@ echo -e "${GREEN}✅ COGNITO_CLIENT_ID set${NC}"
 # Verify secrets
 echo ""
 echo -e "${BLUE}Verifying secrets:${NC}"
-gh secret list --repo "$REPO" | grep -E "AWS_|BEDROCK_|COGNITO_"
+gh secret list --repo "$REPO" | grep -E "AWS_|AGENT_REGISTRY_|BEDROCK_|COGNITO_"
 
 echo ""
 echo -e "${GREEN}✅ GitHub Secrets Configuration Complete!${NC}"


### PR DESCRIPTION
Synchronizes the CDK/control-plane source with the verified live AWS Agent Registry migration from the public-preview `bedrock-agentcore` namespace to the dedicated `agent-registry` namespace before the 2026-09-17 cutoff.

Live AWS state already verified before this PR:
- new `agent-registry` registry `Bq1kJxIL0SrRPIpe` is READY in us-east-1
- source preview registry `cGcvetJOMzWh3xmj` remains READY for rollback during cutover
- source/destination record counts are 0 -> 0
- `BedrockAgentCoreStack-dev` CloudFormation update completed successfully
- `RegistryId-dev` now points to the new registry
- IAM trust is dual-principal during cutover (`bedrock-agentcore.amazonaws.com` + `agent-registry.amazonaws.com`)
- new `agent-registry:*` record/discovery permissions are present while non-Registry AgentCore permissions are retained

Source changes:
- prefer `AGENT_REGISTRY_ID`, retain `BEDROCK_REGISTRY_ID` as a temporary compatibility alias
- update the default Registry ID to the migrated registry
- make CDK IAM/trust/log configuration match the verified live stack
- update dev/staging/prod config defaults and the GitHub secret helper
- add migration evidence/runbook documentation

Validation boundary:
- branch diff is scoped to Agent Registry migration surfaces
- no hosted GitHub Actions validation is claimed because the account's hosted Actions quota is exhausted
- local clone/build was not claimed because the execution sandbox could not resolve github.com
- live CloudFormation change-set execution and post-update AWS readback are the provider evidence for the infrastructure shape

The old preview registry is intentionally not deleted by this PR.