### PR TITLE
docs: add ClaudePluginHub listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DSG ONE
 
+[![Listed on ClaudePluginHub](https://www.claudepluginhub.com/badge/tdealer01-crypto-dsg-governance)](https://www.claudepluginhub.com/plugins/tdealer01-crypto-dsg-governance?ref=badge)
+
 **Govern AI actions. Prove the result.**
 
 DSG ONE is a governance and evidence layer for AI agents, MCP tools, APIs, browsers, CI/CD and automated workflows. It is designed to sit between an existing agent and execution so operators can answer four questions clearly:


### PR DESCRIPTION
Adds the ClaudePluginHub listing badge for `dsg-governance` near the top of the README.

Verified change scope:
- README.md only
- 2 inserted lines
- manual execution of the repository pre-commit secret scan passed
- `git diff --cached --check` passed

No plugin installation or runtime code changes.